### PR TITLE
Fix mailjet api key injection from env variables

### DIFF
--- a/src/config/emails.config.ts
+++ b/src/config/emails.config.ts
@@ -10,7 +10,7 @@ let sendEmail: SendEmail = fakeSendEmail
 
 if (isProdEnv || isStagingEnv) {
   const { MJ_APIKEY_PUBLIC, MJ_APIKEY_PRIVATE, AUTHORIZED_TEST_EMAILS } = process.env
-  const authorizedTestEmails = (AUTHORIZED_TEST_EMAILS && AUTHORIZED_TEST_EMAILS.split(',')) || []
+  const authorizedTestEmails = AUTHORIZED_TEST_EMAILS?.split(',') || []
 
   if (!MJ_APIKEY_PRIVATE || !MJ_APIKEY_PUBLIC) {
     console.error('Missing MJ_APIKEY_PRIVATE and/or MJ_APIKEY_PUBLIC env variables. Aborting.')

--- a/src/config/emails.config.ts
+++ b/src/config/emails.config.ts
@@ -1,12 +1,38 @@
 import { fakeSendEmail } from '../infra/mail/fakeEmailService'
-import { sendEmailFromMailjet } from '../infra/mail/mailjet'
+import { makeSendEmailFromMailjet } from '../infra/mail/mailjet'
 
 import { makeNotificationService, SendEmail } from '../modules/notification'
 import { isProdEnv, isStagingEnv } from './env.config'
 import { notificationRepo } from './repos.config'
 import { getFailedNotifications } from './queries.config'
 
-const sendEmail: SendEmail = isProdEnv || isStagingEnv ? sendEmailFromMailjet : fakeSendEmail
+let sendEmail: SendEmail = fakeSendEmail
+
+if (isProdEnv || isStagingEnv) {
+  const { MJ_APIKEY_PUBLIC, MJ_APIKEY_PRIVATE, AUTHORIZED_TEST_EMAILS } = process.env
+  const authorizedTestEmails = (AUTHORIZED_TEST_EMAILS && AUTHORIZED_TEST_EMAILS.split(',')) || []
+
+  if (!MJ_APIKEY_PRIVATE || !MJ_APIKEY_PUBLIC) {
+    console.error('Missing MJ_APIKEY_PRIVATE and/or MJ_APIKEY_PUBLIC env variables. Aborting.')
+    process.exit(1)
+  }
+
+  try {
+    sendEmail = makeSendEmailFromMailjet({
+      MJ_APIKEY_PUBLIC,
+      MJ_APIKEY_PRIVATE,
+      authorizedTestEmails,
+      isProduction: isProdEnv,
+    })
+    console.log('Emails will be sent through MAILJET')
+    if (isStagingEnv) console.log('Outgoing emails will be restricted to:', authorizedTestEmails)
+  } catch (e) {
+    console.error('Unable to create mailjet sendEmail. Aborting.', e)
+    process.exit(1)
+  }
+} else {
+  console.log('Emails will go through a FAKE email service (no mails sent).')
+}
 
 if (!process.env.SEND_EMAILS_FROM) {
   console.log('ERROR: SEND_EMAILS_FROM is not set')

--- a/src/infra/mail/mailjet.ts
+++ b/src/infra/mail/mailjet.ts
@@ -69,7 +69,7 @@ export const makeSendEmailFromMailjet = (deps: SendEmailFromMailjetDeps): SendEm
       (err: any) => new Error(err.message)
     ).andThen((result: any) => {
       const sentMessage = result.body.Messages[0]
-      if (sentMessage && sentMessage.Status === 'error') {
+      if (sentMessage?.Status === 'error') {
         const errorMessage = sentMessage.Errors.map((e) => e.ErrorMessage).join('; ')
         console.error('Mailjet returned an error', errorMessage)
         return err(new Error(errorMessage))


### PR DESCRIPTION
The mailjet module tried reading `process.env` but failed to do so because it was loaded before `dotenv` could load up the `.env` file. The mailjet API keys were therefor empty which resulted in emails not being sent.

I refactored the mailjet module to accept the dependant keys as arguments. Env variables are injected at the config layer, which calls `dotenv`. 