### PR TITLE
Enable the failed emails page

### DIFF
--- a/src/config/queries.config.ts
+++ b/src/config/queries.config.ts
@@ -1,5 +1,6 @@
 export {
   getFailedNotifications,
+  getFailedNotificationDetails,
   getUnnotifiedProjectsForPeriode,
   getStats,
   getFileProject,

--- a/src/controllers/getNotificationListPage.ts
+++ b/src/controllers/getNotificationListPage.ts
@@ -1,8 +1,9 @@
 import { makePagination } from '../helpers/paginate'
-import { Redirect, Success } from '../helpers/responses'
+import { Redirect, Success, SystemError } from '../helpers/responses'
 import ROUTES from '../routes'
 import { HttpRequest, Pagination } from '../types'
 import { NotificationListPage } from '../views/pages'
+import { getFailedNotificationDetails } from '../config'
 
 const defaultPagination: Pagination = {
   page: 0,
@@ -16,13 +17,18 @@ const getNotificationListPage = async (request: HttpRequest) => {
 
   const pagination = makePagination(request.query, defaultPagination)
 
-  // TOFIX: query new notification service and return a DTO
-
-  return Success(
-    NotificationListPage({
-      request,
-      notifications: { items: [], pagination, pageCount: 0, itemCount: 0 },
-    })
+  return await getFailedNotificationDetails(pagination).match(
+    (notifications) =>
+      Success(
+        NotificationListPage({
+          request,
+          notifications,
+        })
+      ),
+    (e) => {
+      console.error(e)
+      return SystemError('Impossible de charger la liste des notifications en erreur.')
+    }
   )
 }
 

--- a/src/infra/sequelize/projections/notification/queries/getFailedNotificationDetails.integration.ts
+++ b/src/infra/sequelize/projections/notification/queries/getFailedNotificationDetails.integration.ts
@@ -1,0 +1,79 @@
+import { makeGetFailedNotificationDetails } from './getFailedNotificationDetails'
+import models from '../../../models'
+import { sequelize } from '../../../../../sequelize.config'
+import { UniqueEntityID } from '../../../../../core/domain'
+
+const fakeNotificationArgs = {
+  message: {
+    email: 'email@test.test',
+    name: 'testname',
+    subject: 'testsubject',
+  },
+  type: 'password-reset',
+  context: {
+    passwordRetrievalId: 'passwordRetrievalId',
+    userId: 'userId',
+  },
+  variables: {
+    password_reset_link: 'resetLink',
+  },
+  createdAt: new Date(123),
+  status: 'sent',
+}
+
+describe('Sequelize getFailedNotificationDetails', () => {
+  const getFailedNotificationDetails = makeGetFailedNotificationDetails(models)
+
+  beforeAll(async () => {
+    // Create the tables and remove all data
+    await sequelize.sync({ force: true })
+  })
+
+  describe('getFailedNotificationDetails()', () => {
+    const targetId = new UniqueEntityID().toString()
+
+    beforeAll(async () => {
+      const NotificationModel = models.Notification
+      await NotificationModel.create({
+        ...fakeNotificationArgs,
+        id: targetId,
+        createdAt: new Date(456),
+        status: 'error',
+        error: 'errorMessage',
+      })
+      await NotificationModel.create({
+        ...fakeNotificationArgs,
+        id: new UniqueEntityID().toString(),
+        status: 'sent',
+      })
+      await NotificationModel.create({
+        ...fakeNotificationArgs,
+        id: new UniqueEntityID().toString(),
+        status: 'retried',
+      })
+    })
+
+    it('should return the details of the notifications with status of error', async () => {
+      const pagination = {
+        page: 0,
+        pageSize: 50,
+      }
+
+      const { items, itemCount } = (await getFailedNotificationDetails(pagination))._unsafeUnwrap()
+
+      expect(itemCount).toEqual(1)
+      expect(items).toEqual([
+        {
+          id: targetId,
+          recipient: {
+            email: 'email@test.test',
+            name: 'testname',
+          },
+          type: 'password-reset',
+          createdAt: new Date(456),
+          error: 'errorMessage',
+        },
+      ])
+    })
+  })
+})

--- a/src/infra/sequelize/projections/notification/queries/getFailedNotificationDetails.ts
+++ b/src/infra/sequelize/projections/notification/queries/getFailedNotificationDetails.ts
@@ -19,7 +19,7 @@ export const makeGetFailedNotificationDetails = (models): GetFailedNotificationD
       ...paginate(pagination),
     }),
     (e: any) => {
-      console.log('getFailedNotifications error', e)
+      console.error(e)
       return new InfraNotAvailableError()
     }
   ).map(({ count, rows }) =>

--- a/src/infra/sequelize/projections/notification/queries/getFailedNotificationDetails.ts
+++ b/src/infra/sequelize/projections/notification/queries/getFailedNotificationDetails.ts
@@ -13,7 +13,11 @@ export const makeGetFailedNotificationDetails = (models): GetFailedNotificationD
   if (!NotificationModel) return errAsync(new InfraNotAvailableError())
 
   return ResultAsync.fromPromise(
-    NotificationModel.findAndCountAll({ where: { status: 'error' }, ...paginate(pagination) }),
+    NotificationModel.findAndCountAll({
+      where: { status: 'error' },
+      order: [['createdAt', 'DESC']],
+      ...paginate(pagination),
+    }),
     (e: any) => {
       console.log('getFailedNotifications error', e)
       return new InfraNotAvailableError()

--- a/src/infra/sequelize/projections/notification/queries/getFailedNotificationDetails.ts
+++ b/src/infra/sequelize/projections/notification/queries/getFailedNotificationDetails.ts
@@ -1,0 +1,42 @@
+import { errAsync, ResultAsync } from '../../../../../core/utils'
+import { makePaginatedList, paginate } from '../../../../../helpers/paginate'
+import {
+  FailedNotificationDTO,
+  GetFailedNotificationDetails,
+} from '../../../../../modules/notification'
+import { InfraNotAvailableError } from '../../../../../modules/shared'
+
+export const makeGetFailedNotificationDetails = (models): GetFailedNotificationDetails => (
+  pagination
+) => {
+  const NotificationModel = models.Notification
+  if (!NotificationModel) return errAsync(new InfraNotAvailableError())
+
+  return ResultAsync.fromPromise(
+    NotificationModel.findAndCountAll({ where: { status: 'error' }, ...paginate(pagination) }),
+    (e: any) => {
+      console.log('getFailedNotifications error', e)
+      return new InfraNotAvailableError()
+    }
+  ).map(({ count, rows }) =>
+    makePaginatedList(
+      rows
+        .map((item) => item.get())
+        .map(
+          ({ id, message, type, createdAt, error }) =>
+            ({
+              id,
+              recipient: {
+                email: message.email,
+                name: message.name || '',
+              },
+              type,
+              createdAt,
+              error,
+            } as FailedNotificationDTO)
+        ),
+      count,
+      pagination
+    )
+  )
+}

--- a/src/infra/sequelize/projections/notification/queries/index.ts
+++ b/src/infra/sequelize/projections/notification/queries/index.ts
@@ -1,4 +1,6 @@
 import models from '../../../models'
 import { makeGetFailedNotifications } from './getFailedNotifications'
+import { makeGetFailedNotificationDetails } from './getFailedNotificationDetails'
 
 export const getFailedNotifications = makeGetFailedNotifications(models)
+export const getFailedNotificationDetails = makeGetFailedNotificationDetails(models)

--- a/src/modules/notification/dtos/FailedNotificationDTO.ts
+++ b/src/modules/notification/dtos/FailedNotificationDTO.ts
@@ -1,0 +1,10 @@
+export interface FailedNotificationDTO {
+  id: string
+  recipient: {
+    email: string
+    name: string
+  }
+  type: string
+  createdAt: Date
+  error: string
+}

--- a/src/modules/notification/dtos/index.ts
+++ b/src/modules/notification/dtos/index.ts
@@ -1,0 +1,1 @@
+export * from './FailedNotificationDTO'

--- a/src/modules/notification/index.ts
+++ b/src/modules/notification/index.ts
@@ -1,3 +1,4 @@
+export * from './dtos'
 export * from './eventHandlers'
 export * from './queries'
 export * from './Notification'

--- a/src/modules/notification/queries/GetFailedNotificationDetails.ts
+++ b/src/modules/notification/queries/GetFailedNotificationDetails.ts
@@ -1,0 +1,8 @@
+import { ResultAsync } from '../../../core/utils'
+import { PaginatedList, Pagination } from '../../../types'
+import { InfraNotAvailableError } from '../../shared'
+import { FailedNotificationDTO } from '../dtos'
+
+export type GetFailedNotificationDetails = (
+  pagination: Pagination
+) => ResultAsync<PaginatedList<FailedNotificationDTO>, InfraNotAvailableError>

--- a/src/modules/notification/queries/index.ts
+++ b/src/modules/notification/queries/index.ts
@@ -1,1 +1,2 @@
+export * from './GetFailedNotificationDetails'
 export * from './GetFailedNotifications'

--- a/src/views/pages/notificationList.tsx
+++ b/src/views/pages/notificationList.tsx
@@ -1,23 +1,14 @@
-import AdminDashboard from '../components/adminDashboard'
-import Pagination from '../components/pagination'
-import { Notification } from '../../modules/notification'
-
 import React from 'react'
 import { formatDate } from '../../helpers/formatDate'
-
-import { Project, AppelOffre, Periode, Famille } from '../../entities'
-import ROUTES from '../../routes'
 import { dataId } from '../../helpers/testId'
-import { asLiteral } from '../../helpers/asLiteral'
-
-import { adminActions } from '../components/actions'
+import { FailedNotificationDTO } from '../../modules/notification'
+import ROUTES from '../../routes'
 import { HttpRequest, PaginatedList } from '../../types'
-import { isFunction } from 'util'
-import { date } from 'yup'
-
+import AdminDashboard from '../components/adminDashboard'
+import Pagination from '../components/pagination'
 interface NotificationListProps {
   request: HttpRequest
-  notifications: PaginatedList<Notification>
+  notifications: PaginatedList<FailedNotificationDTO>
 }
 
 /* Pure component */
@@ -29,7 +20,7 @@ export default function NotificationList({ request, notifications }: Notificatio
       <div className="panel">
         <div className="panel__header">
           <h3>Notifications en erreur</h3>
-          <p>Sont listées uniquement les notifications qui ont un status "erreur".</p>
+          <p>Sont listées uniquement les notifications qui ont un status &quot;erreur&quot;.</p>
         </div>
         <div className="panel__header">
           <form
@@ -98,44 +89,20 @@ export default function NotificationList({ request, notifications }: Notificatio
                       {...dataId('notificationList-item')}
                     >
                       <td>
-                        {notification.message.email} {notification.message.name}
+                        {notification.recipient.email} {notification.recipient.name}
                       </td>
                       <td>{notification.type}</td>
                       <td>
                         {notification.createdAt
                           ? formatDate(notification.createdAt, 'DD/MM/YYYY HH:mm')
                           : ''}
-                        {notification.status === 'retried' ? (
-                          <div
-                            style={{
-                              fontStyle: 'italic',
-                              lineHeight: 'normal',
-                              fontSize: 12,
-                            }}
-                          >
-                            renvoyé le{' '}
-                            {notification.updatedAt
-                              ? formatDate(notification.updatedAt, 'DD/MM/YYYY HH:mm')
-                              : ''}
-                          </div>
-                        ) : (
-                          ''
-                        )}
                       </td>
                       <td
                         valign="top"
-                        className={
-                          'notification ' +
-                          (notification.status === 'sent'
-                            ? 'success'
-                            : notification.status === 'retried'
-                            ? 'warning'
-                            : 'error')
-                        }
+                        className="notification error"
                         style={{ position: 'relative' }}
                       >
-                        <div>{notification.status}</div>
-
+                        <div>Echec de l‘envoi</div>
                         <div
                           style={{
                             fontStyle: 'italic',


### PR DESCRIPTION
This page was disabled in a previous refactoring of the `Notification` module. 