### PR TITLE
:star2:  importProjects should check familleId

### DIFF
--- a/src/dataAccess/inMemory/appelsOffres/commonDataFields.ts
+++ b/src/dataAccess/inMemory/appelsOffres/commonDataFields.ts
@@ -3,11 +3,6 @@ import toTypeLiteral from './helpers/toTypeLiteral'
 const commonDataFields = [
   { field: 'numeroCRE', type: toTypeLiteral('string'), column: 'N°CRE' },
   {
-    field: 'familleId',
-    type: toTypeLiteral('string'),
-    column: 'Famille',
-  },
-  {
     field: 'nomCandidat',
     type: toTypeLiteral('orStringInColumn'),
     column: 'Nom (personne physique) ou raison sociale (personne morale) :',

--- a/src/useCases/importProjects.ts
+++ b/src/useCases/importProjects.ts
@@ -147,14 +147,37 @@ export default function makeImportProjects({
           return makeErrorForLine(new Error('Période introuvable'), index + 2, currentResults)
         }
 
+        // Check the famille
+        const familleId = line.Famille
+        if (familleId) {
+          const famille = appelOffre.familles.find((famille) => famille.id === familleId)
+          if (!famille) {
+            console.log('famille erronnée', familleId)
+            return makeErrorForLine(
+              new Error('Famille inconnue pour cet appel d‘offre'),
+              index + 2,
+              currentResults
+            )
+          }
+        }
+        if (appelOffre.familles.length && !familleId) {
+          console.log('famille manquante', appelOffre)
+          return makeErrorForLine(
+            new Error('Famille manquante (cette appel d‘offre requiert une famille)'),
+            index + 2,
+            currentResults
+          )
+        }
+
         // Keep track of all the columns that where picked from the line
         // We will use this to gather all the "other" columns in the project.details section
-        const pickedColumns: Array<string> = ["Appel d'offres", 'Période']
+        const pickedColumns: Array<string> = ["Appel d'offres", 'Période', 'Famille']
 
         // All good, try to make the project
         const projectData: Partial<Project> = {
           appelOffreId,
           periodeId,
+          familleId: familleId || '',
           ...appelOffre.dataFields.reduce((properties, dataField) => {
             const { field, column, type, value, defaultValue } = dataField
 

--- a/src/useCases/importProjects.ts
+++ b/src/useCases/importProjects.ts
@@ -121,6 +121,9 @@ export default function makeImportProjects({
     // Check individual lines (use makeProject on each)
     const projects = lines.reduce<Result<Array<Partial<Project>>, Array<Error>>>(
       (currentResults, line, index) => {
+        // The actual line number is removed by 2 because of the csv file header lines
+        const lineIndex = index + 2
+
         // Find the corresponding appelOffre
         const appelOffreId = line["Appel d'offres"]
         const appelOffre = appelsOffre.find((appelOffre) => appelOffre.id === appelOffreId)
@@ -129,7 +132,7 @@ export default function makeImportProjects({
           console.log('Appel offre introuvable', appelOffreId)
           return makeErrorForLine(
             new Error("Appel d'offre introuvable " + appelOffreId),
-            index + 2,
+            lineIndex,
             currentResults
           )
         }
@@ -144,7 +147,7 @@ export default function makeImportProjects({
             periodeId,
             appelOffre.periodes.map((item) => item.id)
           )
-          return makeErrorForLine(new Error('Période introuvable'), index + 2, currentResults)
+          return makeErrorForLine(new Error('Période introuvable'), lineIndex, currentResults)
         }
 
         // Check the famille
@@ -155,7 +158,7 @@ export default function makeImportProjects({
             console.log('famille erronnée', familleId)
             return makeErrorForLine(
               new Error('Famille inconnue pour cet appel d‘offre'),
-              index + 2,
+              lineIndex,
               currentResults
             )
           }
@@ -163,8 +166,8 @@ export default function makeImportProjects({
         if (appelOffre.familles.length && !familleId) {
           console.log('famille manquante', appelOffre)
           return makeErrorForLine(
-            new Error('Famille manquante (cette appel d‘offre requiert une famille)'),
-            index + 2,
+            new Error('Famille manquante (cet appel d‘offre requiert une famille)'),
+            lineIndex,
             currentResults
           )
         }


### PR DESCRIPTION
I noticed that importProjects accepted csv files with familleId that did not exist for the appel d'offre. 
This adds a check that throws an error if such a line is in the file.