### PR TITLE
After period notification, hide notification button to avoid double-notify

### DIFF
--- a/src/controllers/postSendCandidateNotifications.ts
+++ b/src/controllers/postSendCandidateNotifications.ts
@@ -50,9 +50,15 @@ const postSendCandidateNotifications = async (request: HttpRequest) => {
 
   return result.match(
     () =>
-      Redirect(ROUTES.ADMIN_NOTIFY_CANDIDATES(), {
-        success: 'La période a bien été notifiée.',
-      }),
+      Redirect(
+        ROUTES.ADMIN_NOTIFY_CANDIDATES({
+          appelOffreId,
+          periodeId,
+        }),
+        {
+          success: 'La période a bien été notifiée.',
+        }
+      ),
     (e: Error) => {
       console.log('sendCandidateNotifications failed', e)
       return Redirect(

--- a/src/views/pages/adminNotifyCandidates.tsx
+++ b/src/views/pages/adminNotifyCandidates.tsx
@@ -172,7 +172,7 @@ export default function AdminNotifyCandidates({ request, results }: AdminNotifyC
               ))}
             </select>
           </div>
-          {projectsInPeriodCount ? (
+          {projectsInPeriodCount && !success ? (
             <div className="form__group">
               <label htmlFor="notificationDate">Date désignation (format JJ/MM/AAAA)</label>
               <input


### PR DESCRIPTION
After an admin notifies a period, they are redirected to the notification page and if the
page is not up to date (periode notification is an async process), they shouldn't be able to re-notify the
same period. In order to avoid this situation, hide the 'notify' button when there is a success message.