### PR TITLE
:bug:  User should be able to upload GF and DCR

### DIFF
--- a/src/dataAccess/db/project.ts
+++ b/src/dataAccess/db/project.ts
@@ -812,7 +812,13 @@ export default function makeProjectRepo({ sequelizeInstance, appelOffreRepo }): 
       const existingProject = await ProjectModel.findByPk(project.id)
 
       if (existingProject) {
-        await existingProject.update(project)
+        const updates = project.history?.reduce(
+          (delta, event) => ({ ...delta, ...event.after }),
+          {}
+        )
+        if (updates) {
+          await existingProject.update(updates)
+        }
       } else {
         // TODO PA : est-ce qu'on garde cette partie telle quelle ou on l'améliore ?
         ;[


### PR DESCRIPTION
Avec la mise en place de postgres, le script qui fait la mise à jour de l'instance projet essayait de mettre à jour les champs uuid qui sont vides avec des chaines de caractère vides.

Ceci est un correctif qui assure que lors d'une mise à jour, on essaye simplement de mettre à jour les champs concernés et pas un delta calculé à la volée par sequelize. 