### PR TITLE
Authentification should fail safe if db unavailable

### DIFF
--- a/src/controllers/authentication.ts
+++ b/src/controllers/authentication.ts
@@ -40,7 +40,7 @@ const registerAuth = ({ app, loginRoute, successRoute }: RegisterAuthProps) => {
 
     if (userResult.is_none()) {
       console.log('Authentication: Found user session id but no matching user')
-      done(null, null)
+      return done(null, null)
     }
 
     done(null, userResult.unwrap())


### PR DESCRIPTION
In the passport auth middleware, when `userResult` was `None`, the method called the `done` callback but continued to call `done` a second time because the `return` statement was missing.