### PR TITLE
Do not redirect after importing

### DIFF
--- a/src/controllers/postProjects.ts
+++ b/src/controllers/postProjects.ts
@@ -53,21 +53,14 @@ const postProjects = async (request: HttpRequest) => {
 
   return importProjectsResult.match({
     ok: (result) => {
-      const { appelOffreId, periodeId, unnotifiedProjects, savedProjects } = result || {}
-      return Redirect(
-        savedProjects && savedProjects > 0 && savedProjects === unnotifiedProjects
-          ? ROUTES.ADMIN_NOTIFY_CANDIDATES()
-          : ROUTES.ADMIN_LIST_PROJECTS,
-        {
-          appelOffreId,
-          periodeId,
-          success: savedProjects
-            ? `${savedProjects} projet(s) ont bien été importé(s) ou mis à jour${
-                unnotifiedProjects ? ` dont ${unnotifiedProjects} à notifier` : ''
-              }.`
-            : "L'import est un succès mais le fichier importé n'a pas donné lieu à des changements dans la base de projets.",
-        }
-      )
+      const { unnotifiedProjects, savedProjects } = result || {}
+      return Redirect(ROUTES.IMPORT_PROJECTS, {
+        success: savedProjects
+          ? `${savedProjects} projet(s) ont bien été importé(s) ou mis à jour${
+              unnotifiedProjects ? ` dont ${unnotifiedProjects} à notifier` : ''
+            }.`
+          : "L'import est un succès mais le fichier importé n'a pas donné lieu à des changements dans la base de projets.",
+      })
     },
     err: (e: Error) => {
       logger.error(e)

--- a/src/views/pages/importCandidates.tsx
+++ b/src/views/pages/importCandidates.tsx
@@ -18,6 +18,15 @@ export default function AdminListProjects({ request }: AdminListProjectsProps) {
           <h3>Importer des candidats</h3>
         </div>
         <form action={ROUTES.IMPORT_PROJECTS_ACTION} method="post" encType="multipart/form-data">
+          {success ? (
+            <>
+              <div className="notification success" {...dataId('success-message')}>
+                {success}
+              </div>
+            </>
+          ) : (
+            ''
+          )}
           {error ? (
             <div className="notification error" {...dataId('error-message')}>
               {error.split('\n').map((piece) => (


### PR DESCRIPTION
Previous version redirected to projects or notification pages after import was a
success, leading to unpredictable behaviour. It's simpler to stay on the import
page after success and let the user navigate afterwards.