### PR TITLE
Refacto Project Page data query

### DIFF
--- a/src/infra/sequelize/projections/project/project.model.ts
+++ b/src/infra/sequelize/projections/project/project.model.ts
@@ -191,22 +191,38 @@ export const MakeProjectModel = (sequelize) => {
   )
 
   Project.associate = (models) => {
-    const FileModel = models.File
-    Project.belongsTo(FileModel, {
+    const { File, UserProjects, ProjectAdmissionKey } = models
+    Project.belongsTo(File, {
       foreignKey: 'garantiesFinancieresFileId',
       as: 'garantiesFinancieresFileRef',
     })
 
-    Project.belongsTo(FileModel, {
+    Project.belongsTo(File, {
       foreignKey: 'dcrFileId',
       as: 'dcrFileRef',
     })
 
-    Project.belongsTo(FileModel, {
+    Project.belongsTo(File, {
       foreignKey: 'certificateFileId',
       as: 'certificateFile',
     })
-    // Add belongsTo etc. statements here
+
+    Project.hasMany(UserProjects, {
+      as: 'users',
+    })
+
+    // All invitations for this specific project
+    Project.hasMany(ProjectAdmissionKey, {
+      as: 'invitations',
+      foreignKey: 'projectId',
+    })
+
+    // All invitations for same email
+    Project.hasMany(ProjectAdmissionKey, {
+      as: 'invitationsForProjectEmail',
+      foreignKey: 'email',
+      sourceKey: 'email',
+    })
   }
 
   return Project

--- a/src/infra/sequelize/projections/userProjects/userProjects.model.ts
+++ b/src/infra/sequelize/projections/userProjects/userProjects.model.ts
@@ -21,7 +21,9 @@ export const MakeUserProjectsModel = (sequelize) => {
   )
 
   UserProjects.associate = (models) => {
-    // Add belongsTo etc. statements here
+    const { User } = models
+
+    UserProjects.belongsTo(User, { foreignKey: 'userId' })
   }
 
   return UserProjects

--- a/src/infra/sequelize/queries/getProjectDataForProjectPage.integration.ts
+++ b/src/infra/sequelize/queries/getProjectDataForProjectPage.integration.ts
@@ -1,0 +1,300 @@
+import models from '../models'
+import { resetDatabase } from '../helpers'
+import makeFakeProject from '../../../__tests__/fixtures/project'
+import makeFakeUser from '../../../__tests__/fixtures/user'
+import makeFakeFile from '../../../__tests__/fixtures/file'
+import { makeUser } from '../../../entities'
+import { UniqueEntityID } from '../../../core/domain'
+import { makeGetProjectDataForProjectPage } from './getProjectDataForProjectPage'
+
+const { Project, File, User, UserProjects, ProjectAdmissionKey } = models
+const certificateFileId = new UniqueEntityID().toString()
+
+const projectId = new UniqueEntityID().toString()
+const projectInfo = {
+  id: projectId,
+  numeroCRE: 'numeroCRE',
+  nomProjet: 'nomProjet',
+  nomCandidat: 'nomCandidat',
+  adresseProjet: 'adresse',
+  codePostalProjet: '12345',
+  communeProjet: 'communeProjet',
+  departementProjet: 'departementProjet',
+  regionProjet: 'regionProjet',
+  territoireProjet: 'territoireProjet',
+  puissance: 123,
+  prixReference: 456,
+  appelOffreId: 'Fessenheim',
+  periodeId: '1',
+  familleId: 'familleId',
+  engagementFournitureDePuissanceAlaPointe: false,
+  isFinancementParticipatif: false,
+  isInvestissementParticipatif: true,
+  nomRepresentantLegal: 'representantLegal',
+  email: 'test@test.test',
+  fournisseur: 'fournisseur',
+  evaluationCarbone: 132,
+  note: 10,
+
+  details: {
+    detail1: 'valeurDetail1',
+  },
+
+  notifiedOn: new Date(321).getTime(),
+
+  certificateFileId: certificateFileId,
+
+  classe: 'Classé',
+  motifsElimination: 'motifsElimination',
+}
+
+const user = makeUser(makeFakeUser({ role: 'admin' })).unwrap()
+
+describe('Sequelize getProjectDataForProjectPage', () => {
+  const getProjectDataForProjectPage = makeGetProjectDataForProjectPage(models)
+
+  it('should return a ProjectDataForProjectPage dto', async () => {
+    await resetDatabase()
+
+    await Project.create(makeFakeProject(projectInfo))
+    await File.create(makeFakeFile({ id: certificateFileId, filename: 'filename' }))
+
+    const res = (await getProjectDataForProjectPage({ projectId, user }))._unsafeUnwrap()
+
+    expect(res).toMatchObject({
+      id: projectId,
+
+      appelOffreId: 'Fessenheim',
+      periodeId: '1',
+      familleId: 'familleId',
+      numeroCRE: 'numeroCRE',
+
+      puissance: 123,
+      prixReference: 456,
+
+      engagementFournitureDePuissanceAlaPointe: false,
+      isFinancementParticipatif: false,
+      isInvestissementParticipatif: true,
+
+      adresseProjet: 'adresse',
+      codePostalProjet: '12345',
+      communeProjet: 'communeProjet',
+      departementProjet: 'departementProjet',
+      regionProjet: 'regionProjet',
+      territoireProjet: 'territoireProjet',
+
+      nomProjet: 'nomProjet',
+      nomCandidat: 'nomCandidat',
+      nomRepresentantLegal: 'representantLegal',
+      email: 'test@test.test',
+      fournisseur: 'fournisseur',
+      evaluationCarbone: 132,
+      note: 10,
+
+      details: {
+        detail1: 'valeurDetail1',
+      },
+
+      notifiedOn: new Date(321),
+
+      certificateFile: {
+        id: certificateFileId,
+        filename: 'filename',
+      },
+
+      isClasse: true,
+
+      motifsElimination: 'motifsElimination',
+    })
+
+    expect(res).not.toHaveProperty([
+      'garantiesFinancieresSubmittedOn',
+      'garantiesFinancieresDueOn',
+      'garantiesFinancieresDate',
+      'garantiesFinancieresFile',
+    ])
+
+    expect(res).not.toHaveProperty([
+      'dcrSubmittedOn',
+      'dcrDueOn',
+      'dcrDate',
+      'dcrFile',
+      'dcrNumeroDossier',
+    ])
+  })
+
+  it('should include a list of users that have access to this project', async () => {
+    const userId = new UniqueEntityID().toString()
+
+    await resetDatabase()
+
+    await Project.create(makeFakeProject(projectInfo))
+    await User.create(makeFakeUser({ id: userId, fullName: 'username', email: 'user@test.test' }))
+    await UserProjects.create({
+      userId,
+      projectId,
+    })
+
+    const res = await getProjectDataForProjectPage({ projectId, user })
+
+    expect(res._unsafeUnwrap()).toMatchObject({
+      users: [{ id: userId, fullName: 'username', email: 'user@test.test' }],
+    })
+  })
+
+  it('should include a list of pending invitations to this project', async () => {
+    const invitationId1 = new UniqueEntityID().toString()
+    const invitationId2 = new UniqueEntityID().toString()
+
+    await resetDatabase()
+
+    await Project.create(makeFakeProject(projectInfo))
+    await ProjectAdmissionKey.bulkCreate([
+      {
+        id: invitationId1,
+        projectId,
+        email: 'invitation@test.test',
+        fullName: '',
+        lastUsedAt: 0,
+        cancelled: false,
+      },
+      {
+        // Invitation for project but already used
+        id: new UniqueEntityID().toString(),
+        projectId,
+        email: 'other@test.test',
+        fullName: '',
+        lastUsedAt: 1,
+      },
+      {
+        // Invitation for project but cancelled
+        id: new UniqueEntityID().toString(),
+        projectId,
+        email: 'other@test.test',
+        fullName: '',
+        cancelled: true,
+      },
+      {
+        // Invitation for project email
+        id: invitationId2,
+        email: 'test@test.test',
+        fullName: '',
+        lastUsedAt: 0,
+        cancelled: false,
+      },
+      {
+        // Invitation for project email but already used
+        id: new UniqueEntityID().toString(),
+        email: 'test@test.test',
+        fullName: '',
+        lastUsedAt: 1,
+        cancelled: false,
+      },
+      {
+        // Invitation for project email but cancelled
+        id: new UniqueEntityID().toString(),
+        email: 'test@test.test',
+        fullName: '',
+        lastUsedAt: 0,
+        cancelled: true,
+      },
+    ])
+
+    const res = await getProjectDataForProjectPage({ projectId, user })
+
+    expect(res._unsafeUnwrap()).toMatchObject({
+      invitations: [
+        { id: invitationId1, email: 'invitation@test.test' },
+        { id: invitationId2, email: 'test@test.test' },
+      ],
+    })
+  })
+
+  describe('when garantie financiere has been submitted', () => {
+    const gfFileId = new UniqueEntityID().toString()
+
+    it('should include garantie financiere info', async () => {
+      await resetDatabase()
+
+      await Project.create(
+        makeFakeProject({
+          ...projectInfo,
+          garantiesFinancieresSubmittedOn: 345,
+          garantiesFinancieresDueOn: 34,
+          garantiesFinancieresDate: 45,
+          garantiesFinancieresFileId: gfFileId,
+        })
+      )
+      await File.create(makeFakeFile({ id: certificateFileId, filename: 'filename' }))
+      await File.create(makeFakeFile({ id: gfFileId, filename: 'filename' }))
+
+      const res = await getProjectDataForProjectPage({ projectId, user })
+
+      expect(res._unsafeUnwrap()).toMatchObject({
+        garantiesFinancieresSubmittedOn: new Date(345),
+        garantiesFinancieresDueOn: new Date(34),
+        garantiesFinancieresDate: new Date(45),
+        garantiesFinancieresFile: {
+          id: gfFileId,
+          filename: 'filename',
+        },
+      })
+    })
+  })
+
+  describe('when dcr has been submitted', () => {
+    const dcrFileId = new UniqueEntityID().toString()
+
+    it('should include dcr info', async () => {
+      await resetDatabase()
+
+      await Project.create(
+        makeFakeProject({
+          ...projectInfo,
+          dcrSubmittedOn: 345,
+          dcrDueOn: 34,
+          dcrDate: 45,
+          dcrFileId: dcrFileId,
+          dcrNumeroDossier: 'numeroDossier',
+        })
+      )
+      await File.create(makeFakeFile({ id: certificateFileId, filename: 'filename' }))
+      await File.create(makeFakeFile({ id: dcrFileId, filename: 'filename' }))
+
+      const res = await getProjectDataForProjectPage({ projectId, user })
+
+      expect(res._unsafeUnwrap()).toMatchObject({
+        dcrSubmittedOn: new Date(345),
+        dcrDueOn: new Date(34),
+        dcrDate: new Date(45),
+        dcrFile: {
+          id: dcrFileId,
+          filename: 'filename',
+        },
+        dcrNumeroDossier: 'numeroDossier',
+      })
+    })
+  })
+
+  describe('when user is dreal', () => {
+    const user = makeUser(makeFakeUser({ role: 'dreal' })).unwrap()
+
+    beforeAll(async () => {
+      await resetDatabase()
+
+      await Project.create(makeFakeProject(projectInfo))
+      await File.create(makeFakeFile({ id: certificateFileId, filename: 'filename' }))
+    })
+
+    it('should not include the prixReference', async () => {
+      const res = (await getProjectDataForProjectPage({ projectId, user }))._unsafeUnwrap()
+
+      expect(res).not.toHaveProperty('prixReference')
+    })
+    it('should not include the certificate', async () => {
+      const res = (await getProjectDataForProjectPage({ projectId, user }))._unsafeUnwrap()
+
+      expect(res).not.toHaveProperty('certificateFile')
+    })
+  })
+})

--- a/src/infra/sequelize/queries/getProjectDataForProjectPage.ts
+++ b/src/infra/sequelize/queries/getProjectDataForProjectPage.ts
@@ -150,7 +150,7 @@ export const makeGetProjectDataForProjectPage = (models): GetProjectDataForProje
       notifiedOn: notifiedOn ? new Date(notifiedOn) : undefined,
       isClasse: classe === 'Classé',
       motifsElimination,
-      users: users && users.map((user) => user.user),
+      users: users?.map((user) => user.user),
       invitations: allInvitations,
     }
 
@@ -158,32 +158,32 @@ export const makeGetProjectDataForProjectPage = (models): GetProjectDataForProje
       result.prixReference = prixReference
     }
 
-    if (notifiedOn) {
-      if (certificateFile && user.role !== 'dreal') {
-        result.certificateFile = certificateFile.get()
+    if (!notifiedOn) return ok(result)
+
+    if (certificateFile && user.role !== 'dreal') {
+      result.certificateFile = certificateFile.get()
+    }
+
+    if (garantiesFinancieresDueOn) {
+      result.garantiesFinancieresDueOn = new Date(garantiesFinancieresDueOn)
+
+      if (garantiesFinancieresSubmittedOn) {
+        result.garantiesFinancieresSubmittedOn = new Date(garantiesFinancieresSubmittedOn)
+        result.garantiesFinancieresDate =
+          garantiesFinancieresDate && new Date(garantiesFinancieresDate)
+        result.garantiesFinancieresFile =
+          garantiesFinancieresFileRef && garantiesFinancieresFileRef.get()
       }
+    }
 
-      if (garantiesFinancieresDueOn) {
-        result.garantiesFinancieresDueOn = new Date(garantiesFinancieresDueOn)
+    if (dcrDueOn) {
+      result.dcrDueOn = new Date(dcrDueOn)
 
-        if (garantiesFinancieresSubmittedOn) {
-          result.garantiesFinancieresSubmittedOn = new Date(garantiesFinancieresSubmittedOn)
-          result.garantiesFinancieresDate =
-            garantiesFinancieresDate && new Date(garantiesFinancieresDate)
-          result.garantiesFinancieresFile =
-            garantiesFinancieresFileRef && garantiesFinancieresFileRef.get()
-        }
-      }
-
-      if (dcrDueOn) {
-        result.dcrDueOn = new Date(dcrDueOn)
-
-        if (dcrSubmittedOn) {
-          result.dcrSubmittedOn = new Date(dcrSubmittedOn)
-          result.dcrDate = dcrDate && new Date(dcrDate)
-          result.dcrFile = dcrFileRef && dcrFileRef.get()
-          result.dcrNumeroDossier = dcrNumeroDossier
-        }
+      if (dcrSubmittedOn) {
+        result.dcrSubmittedOn = new Date(dcrSubmittedOn)
+        result.dcrDate = dcrDate && new Date(dcrDate)
+        result.dcrFile = dcrFileRef && dcrFileRef.get()
+        result.dcrNumeroDossier = dcrNumeroDossier
       }
     }
 

--- a/src/infra/sequelize/queries/getProjectDataForProjectPage.ts
+++ b/src/infra/sequelize/queries/getProjectDataForProjectPage.ts
@@ -1,0 +1,192 @@
+import { err, errAsync, logger, ok, ResultAsync } from '../../../core/utils'
+import { getAppelOffre } from '../../../dataAccess/inMemory'
+import { GetProjectDataForProjectPage } from '../../../modules/project/queries/GetProjectDataForProjectPage'
+import { InfraNotAvailableError, EntityNotFoundError } from '../../../modules/shared'
+
+export const makeGetProjectDataForProjectPage = (models): GetProjectDataForProjectPage => ({
+  projectId,
+  user,
+}) => {
+  const { Project, File, User, UserProjects, ProjectAdmissionKey } = models
+  if (!Project || !File || !User || !UserProjects || !ProjectAdmissionKey)
+    return errAsync(new InfraNotAvailableError())
+
+  return ResultAsync.fromPromise(
+    Project.findByPk(projectId, {
+      include: [
+        {
+          model: File,
+          as: 'certificateFile',
+          attributes: ['id', 'filename'],
+        },
+        {
+          model: File,
+          as: 'garantiesFinancieresFileRef',
+          attributes: ['id', 'filename'],
+        },
+        {
+          model: File,
+          as: 'dcrFileRef',
+          attributes: ['id', 'filename'],
+        },
+        {
+          model: UserProjects,
+          as: 'users',
+          where: { projectId },
+          required: false,
+          include: [
+            {
+              model: User,
+              attributes: ['id', 'fullName', 'email'],
+            },
+          ],
+        },
+        {
+          model: ProjectAdmissionKey,
+          as: 'invitations',
+          where: {
+            cancelled: false,
+            lastUsedAt: 0,
+          },
+          attributes: ['id', 'email'],
+          required: false,
+        },
+        {
+          model: ProjectAdmissionKey,
+          as: 'invitationsForProjectEmail',
+          where: {
+            cancelled: false,
+            lastUsedAt: 0,
+          },
+          attributes: ['id', 'email'],
+          required: false,
+        },
+      ],
+    }),
+    (e: Error) => {
+      logger.error(e)
+      return new InfraNotAvailableError()
+    }
+  ).andThen((projectRaw: any) => {
+    if (!projectRaw) return err(new EntityNotFoundError())
+
+    const {
+      id,
+      appelOffreId,
+      periodeId,
+      familleId,
+      numeroCRE,
+      puissance,
+      prixReference,
+      engagementFournitureDePuissanceAlaPointe,
+      isFinancementParticipatif,
+      isInvestissementParticipatif,
+      adresseProjet,
+      codePostalProjet,
+      communeProjet,
+      departementProjet,
+      regionProjet,
+      territoireProjet,
+      nomProjet,
+      nomCandidat,
+      nomRepresentantLegal,
+      email,
+      fournisseur,
+      evaluationCarbone,
+      note,
+      details,
+      notifiedOn,
+      certificateFile,
+      classe,
+      motifsElimination,
+      garantiesFinancieresFileRef,
+      garantiesFinancieresDueOn,
+      garantiesFinancieresSubmittedOn,
+      garantiesFinancieresDate,
+      dcrFileRef,
+      dcrDueOn,
+      dcrSubmittedOn,
+      dcrDate,
+      dcrNumeroDossier,
+      users,
+      invitations,
+      invitationsForProjectEmail,
+    } = projectRaw.get()
+
+    let allInvitations: any[] = []
+    if (invitations) {
+      allInvitations = [...allInvitations, ...invitations.map((item) => item.get())]
+    }
+
+    if (invitationsForProjectEmail) {
+      allInvitations = [...allInvitations, ...invitationsForProjectEmail.map((item) => item.get())]
+    }
+
+    const result: any = {
+      id,
+      appelOffreId,
+      periodeId,
+      familleId,
+      appelOffre: getAppelOffre({ appelOffreId, periodeId, familleId }),
+      numeroCRE,
+      puissance,
+      engagementFournitureDePuissanceAlaPointe,
+      isFinancementParticipatif,
+      isInvestissementParticipatif,
+      adresseProjet,
+      codePostalProjet,
+      communeProjet,
+      departementProjet,
+      regionProjet,
+      territoireProjet,
+      nomProjet,
+      nomCandidat,
+      nomRepresentantLegal,
+      email,
+      fournisseur,
+      evaluationCarbone,
+      note,
+      details,
+      notifiedOn: notifiedOn ? new Date(notifiedOn) : undefined,
+      isClasse: classe === 'Classé',
+      motifsElimination,
+      users: users && users.map((user) => user.user),
+      invitations: allInvitations,
+    }
+
+    if (user.role !== 'dreal') {
+      result.prixReference = prixReference
+    }
+
+    if (notifiedOn) {
+      if (certificateFile && user.role !== 'dreal') {
+        result.certificateFile = certificateFile.get()
+      }
+
+      if (garantiesFinancieresDueOn) {
+        result.garantiesFinancieresDueOn = new Date(garantiesFinancieresDueOn)
+
+        if (garantiesFinancieresSubmittedOn) {
+          result.garantiesFinancieresSubmittedOn = new Date(garantiesFinancieresSubmittedOn)
+          result.garantiesFinancieresDate =
+            garantiesFinancieresDate && new Date(garantiesFinancieresDate)
+          result.garantiesFinancieresFile =
+            garantiesFinancieresFileRef && garantiesFinancieresFileRef.get()
+        }
+      }
+
+      if (dcrDueOn) {
+        result.dcrDueOn = new Date(dcrDueOn)
+
+        if (dcrSubmittedOn) {
+          result.dcrSubmittedOn = new Date(dcrSubmittedOn)
+          result.dcrDate = dcrDate && new Date(dcrDate)
+          result.dcrFile = dcrFileRef && dcrFileRef.get()
+          result.dcrNumeroDossier = dcrNumeroDossier
+        }
+      }
+    }
+
+    return ok(result)
+  })
+}

--- a/src/infra/sequelize/queries/getProjectDataForProjectPage.ts
+++ b/src/infra/sequelize/queries/getProjectDataForProjectPage.ts
@@ -150,7 +150,7 @@ export const makeGetProjectDataForProjectPage = (models): GetProjectDataForProje
       notifiedOn: notifiedOn ? new Date(notifiedOn) : undefined,
       isClasse: classe === 'Classé',
       motifsElimination,
-      users: users?.map((user) => user.user),
+      users: users?.map(({ user }) => user),
       invitations: allInvitations,
     }
 

--- a/src/infra/sequelize/queries/index.ts
+++ b/src/infra/sequelize/queries/index.ts
@@ -9,6 +9,7 @@ import { makeGetFailedNotificationDetails } from './getFailedNotificationDetails
 import { makeGetModificationRequestListForUser } from './getModificationRequestListForUser'
 import { makeGetInfoForModificationRequested } from './getInfoForModificationRequested'
 import { makeGetProjectIdForAdmissionKey } from './getProjectIdForAdmissionKey'
+import { makeGetProjectDataForProjectPage } from './getProjectDataForProjectPage'
 
 export const getUnnotifiedProjectsForPeriode = makeGetUnnotifiedProjectsForPeriode(models)
 export const getModificationRequestDetails = makeGetModificationRequestDetails(models)
@@ -24,3 +25,4 @@ export const getFailedNotificationsForRetry = makeGetFailedNotificationsForRetry
 export const getFailedNotificationDetails = makeGetFailedNotificationDetails(models)
 export const getInfoForModificationRequested = makeGetInfoForModificationRequested(models)
 export const getProjectIdForAdmissionKey = makeGetProjectIdForAdmissionKey(models)
+export const getProjectDataForProjectPage = makeGetProjectDataForProjectPage(models)

--- a/src/modules/project/dtos/ProjectDataForProjectPage.ts
+++ b/src/modules/project/dtos/ProjectDataForProjectPage.ts
@@ -35,7 +35,8 @@ export type ProjectDataForProjectPage = {
   details: Record<string, any>
 
   updatedAt?: Date
-} & (IsNotified | IsNotNotified)
+} & (IsNotified | IsNotNotified) &
+  (IsClasse | IsElimine)
 
 type IsNotNotified = {
   notifiedOn: undefined
@@ -47,8 +48,7 @@ type IsNotified = {
     id: string
     filename: string
   }
-} & (IsClasse | IsElimine) &
-  Users &
+} & Users &
   Invitations
 
 type IsClasse = {

--- a/src/modules/project/dtos/ProjectDataForProjectPage.ts
+++ b/src/modules/project/dtos/ProjectDataForProjectPage.ts
@@ -1,0 +1,118 @@
+import { ProjectAppelOffre } from '../../../entities'
+
+export type ProjectDataForProjectPage = {
+  id: string
+
+  appelOffre: ProjectAppelOffre
+
+  appelOffreId: string
+  periodeId: string
+  familleId: string
+  numeroCRE: string
+
+  puissance: number
+  prixReference?: number
+
+  engagementFournitureDePuissanceAlaPointe: boolean
+  isFinancementParticipatif: boolean
+  isInvestissementParticipatif: boolean
+
+  adresseProjet: string
+  codePostalProjet: string
+  communeProjet: string
+  departementProjet: string
+  regionProjet: string
+  territoireProjet?: string
+
+  nomCandidat: string
+  nomProjet: string
+  nomRepresentantLegal: string
+  email: string
+  fournisseur: string
+  evaluationCarbone: number
+  note: number
+
+  details: Record<string, any>
+
+  updatedAt?: Date
+} & (IsNotified | IsNotNotified)
+
+type IsNotNotified = {
+  notifiedOn: undefined
+}
+
+type IsNotified = {
+  notifiedOn: Date
+  certificateFile?: {
+    id: string
+    filename: string
+  }
+} & (IsClasse | IsElimine) &
+  Users &
+  Invitations
+
+type IsClasse = {
+  isClasse: true
+} & GarantieFinanciere &
+  DCR
+
+type IsElimine = {
+  isClasse: false
+  motifsElimination: string
+}
+
+type DCR = DCRSubmitted | DCRPending
+
+type DCRSubmitted = {
+  dcrDueOn: Date
+  dcrSubmittedOn: Date
+  dcrDate: Date
+  dcrFile: {
+    id: string
+    filename: string
+  }
+  dcrNumeroDossier: string
+}
+
+type DCRPending = {
+  dcrDueOn: Date
+  dcrSubmittedOn: undefined
+}
+
+type GarantieFinanciere = RequiresGF | DoesNotRequireGF
+
+type DoesNotRequireGF = {
+  garantiesFinancieresDueOn: undefined
+}
+
+type RequiresGF = {
+  garantiesFinancieresDueOn: Date
+} & (GFSubmitted | GFPending)
+
+type GFSubmitted = {
+  garantiesFinancieresSubmittedOn: Date
+  garantiesFinancieresDate: Date
+  garantiesFinancieresFile: {
+    id: string
+    filename: string
+  }
+}
+
+type GFPending = {
+  garantiesFinancieresSubmittedOn: undefined
+}
+
+type Users = {
+  users: Array<{
+    id: string
+    fullName: string
+    email: string
+  }>
+}
+
+type Invitations = {
+  invitations: Array<{
+    id: string
+    email: string
+  }>
+}

--- a/src/modules/project/dtos/index.ts
+++ b/src/modules/project/dtos/index.ts
@@ -1,2 +1,3 @@
 export * from './GarantiesFinancieresList'
 export * from './ProjectDataForCertificate'
+export * from './ProjectDataForProjectPage'

--- a/src/modules/project/queries/GetProjectDataForProjectPage.ts
+++ b/src/modules/project/queries/GetProjectDataForProjectPage.ts
@@ -1,0 +1,8 @@
+import { ResultAsync } from '../../../core/utils'
+import { InfraNotAvailableError, EntityNotFoundError } from '../../shared'
+import { ProjectDataForProjectPage } from '../dtos'
+
+export type GetProjectDataForProjectPage = ({
+  projectId: string,
+  user: User,
+}) => ResultAsync<ProjectDataForProjectPage, EntityNotFoundError | InfraNotAvailableError>

--- a/src/modules/project/utils/makeCertificateFilename.ts
+++ b/src/modules/project/utils/makeCertificateFilename.ts
@@ -1,8 +1,19 @@
 import sanitize from 'sanitize-filename'
 
-import { makeProjectIdentifier, Project } from '../../../entities'
+import { makeProjectIdentifier } from '../../../entities'
 
-export const makeCertificateFilename = (project: Project, forAdmin?: true) => {
+export const makeCertificateFilename = (
+  project: {
+    email: string
+    nomProjet: string
+    appelOffreId: string
+    periodeId: string
+    familleId: string | undefined
+    numeroCRE: string
+    id: string
+  },
+  forAdmin?: true
+) => {
   return sanitize(
     makeProjectIdentifier(project) + '-' + (forAdmin ? project.email : project.nomProjet) + '.pdf'
   )

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -62,7 +62,19 @@ class routes {
     periodeId: string
   }>('/admin/notifier-candidats.html')
 
-  static PREVIEW_CANDIDATE_CERTIFICATE = (project?: Project) => {
+  static PREVIEW_CANDIDATE_CERTIFICATE = (project?: {
+    id: string
+    certificateFile?: {
+      id: string
+      filename: string
+    }
+    appelOffreId: string
+    periodeId: string
+    familleId: string | undefined
+    numeroCRE: string
+    email: string
+    nomProjet: string
+  }) => {
     const route = '/previsualiser-attestation/:projectId/*'
     if (project) {
       return route
@@ -81,14 +93,38 @@ class routes {
     } else return route
   }
 
-  static CANDIDATE_CERTIFICATE_FOR_ADMINS = (project: Project) =>
+  static CANDIDATE_CERTIFICATE_FOR_ADMINS = (project: {
+    id: string
+    certificateFile?: {
+      id: string
+      filename: string
+    }
+    appelOffreId: string
+    periodeId: string
+    familleId: string | undefined
+    numeroCRE: string
+    email: string
+    nomProjet: string
+  }) =>
     routes.DOWNLOAD_CERTIFICATE_FILE(
       project.id,
       project.certificateFile?.id,
       makeCertificateFilename(project, true)
     )
 
-  static CANDIDATE_CERTIFICATE_FOR_CANDIDATES = (project: Project) =>
+  static CANDIDATE_CERTIFICATE_FOR_CANDIDATES = (project: {
+    id: string
+    certificateFile?: {
+      id: string
+      filename: string
+    }
+    appelOffreId: string
+    periodeId: string
+    familleId: string | undefined
+    numeroCRE: string
+    email: string
+    nomProjet: string
+  }) =>
     routes.DOWNLOAD_CERTIFICATE_FILE(
       project.id,
       project.certificateFile?.id,
@@ -153,7 +189,7 @@ class routes {
     } else return route
   }
 
-  static TELECHARGER_MODELE_MISE_EN_DEMEURE = (project?: Project) => {
+  static TELECHARGER_MODELE_MISE_EN_DEMEURE = (project?: { id: string; nomProjet: string }) => {
     const route = '/projet/:projectId/telecharger-mise-en-demeure/:filename'
     if (project) {
       return route

--- a/src/views/components/actions/admin.ts
+++ b/src/views/components/actions/admin.ts
@@ -1,7 +1,19 @@
-import { Project } from '../../../entities'
 import ROUTES from '../../../routes'
 
-const adminActions = (project: Project) => {
+const adminActions = (project: {
+  id: string
+  certificateFile?: {
+    id: string
+    filename: string
+  }
+  notifiedOn: Date | null
+  appelOffreId: string
+  periodeId: string
+  familleId: string | undefined
+  numeroCRE: string
+  email: string
+  nomProjet: string
+}) => {
   const canDownloadCertificate = !!project.certificateFile
 
   const actions: any = []

--- a/src/views/components/actions/porteurProjet.ts
+++ b/src/views/components/actions/porteurProjet.ts
@@ -1,10 +1,23 @@
-import { Project } from '../../../entities'
 import ROUTES from '../../../routes'
 
-const porteurProjetActions = (project: Project) => {
+const porteurProjetActions = (project: {
+  id: string
+  isClasse: boolean
+  certificateFile?: {
+    id: string
+    filename: string
+  }
+  notifiedOn: Date | null
+  appelOffreId: string
+  periodeId: string
+  familleId: string | undefined
+  numeroCRE: string
+  email: string
+  nomProjet: string
+}) => {
   const canDownloadCertificate = !!project.certificateFile
 
-  if (project.classe === 'Eliminé') {
+  if (!project.isClasse) {
     return [
       {
         title: 'Télécharger mon attestation',

--- a/src/views/components/projectActions.tsx
+++ b/src/views/components/projectActions.tsx
@@ -1,11 +1,35 @@
 import React from 'react'
-import { AppelOffre, Project } from '../../entities'
+import { AppelOffre } from '../../entities'
 import { dataId } from '../../helpers/testId'
 
 interface Props {
-  project: Project
+  project: {
+    id: string
+    certificateFile?: {
+      id: string
+      filename: string
+    }
+    appelOffreId: string
+    periodeId: string
+    familleId: string | undefined
+    numeroCRE: string
+    email: string
+    nomProjet: string
+  }
   projectActions?: (
-    project: Project,
+    project: {
+      id: string
+      certificateFile?: {
+        id: string
+        filename: string
+      }
+      appelOffreId: string
+      periodeId: string
+      familleId: string | undefined
+      numeroCRE: string
+      email: string
+      nomProjet: string
+    },
     appelOffre?: AppelOffre
   ) => Array<{
     title: string
@@ -42,7 +66,7 @@ const ProjectActions = ({ project, projectActions }: Props) => {
       </svg>
       <ul className="list--action-menu" {...dataId('action-menu')}>
         {actions.map(({ title, actionId, projectId, link, disabled, isDownload }, actionIndex) => (
-          <li key={'notif_' + project.id + '_' + actionIndex}>
+          <li key={'notif_' + projectId + '_' + actionIndex}>
             {disabled ? (
               <i>{title}</i>
             ) : (

--- a/src/views/pages/projectDetails/components/NoteElement.tsx
+++ b/src/views/pages/projectDetails/components/NoteElement.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
-import { Project } from '../../../../entities'
 
 interface NoteElementProps {
-  project: Project
+  project: {
+    details: Record<string, any>
+  }
   column: string
 }
 export const NoteElement = ({ project, column }: NoteElementProps) => {

--- a/src/views/pages/projectDetails/index.tsx
+++ b/src/views/pages/projectDetails/index.tsx
@@ -1,29 +1,22 @@
+import { Request } from 'express'
 import React from 'react'
 import { logger } from '../../../core/utils'
-import { Project, ProjectAdmissionKey, User } from '../../../entities'
 import { dataId } from '../../../helpers/testId'
+import { ProjectDataForProjectPage } from '../../../modules/project/dtos'
 import ROUTES from '../../../routes'
-import { Request } from 'express'
 import { SuccessErrorBox } from '../../components'
 import AdminDashboard from '../../components/adminDashboard'
 import UserDashboard from '../../components/userDashboard'
 import { NoteElement, Section } from './components'
-import { ProjectFrise, ProjectHeader, EditProjectData } from './sections'
+import { EditProjectData, ProjectFrise, ProjectHeader } from './sections'
 
 interface ProjectDetailsProps {
   request: Request
-  project: Project
-  projectUsers: Array<User>
-  projectInvitations: Array<ProjectAdmissionKey>
+  project: ProjectDataForProjectPage
 }
 
 /* Pure component */
-export default function ProjectDetails({
-  request,
-  project,
-  projectUsers,
-  projectInvitations,
-}: ProjectDetailsProps) {
+export default function ProjectDetails({ request, project }: ProjectDetailsProps) {
   const { user } = request
   const { error, success } = request.query || {}
 
@@ -68,69 +61,73 @@ export default function ProjectDetails({
               <div>{project.nomRepresentantLegal}</div>
               <div>{project.email}</div>
             </div>
-            <div>
-              <h5 style={{ marginBottom: 5, marginTop: 15 }}>Comptes ayant accès à ce projet</h5>
-              <ul style={{ marginTop: 5, marginBottom: 5 }}>
-                {projectUsers.map(({ id, fullName, email }) => (
-                  <li key={'project_user_' + id}>
-                    {fullName} - {email}
-                    {id !== user.id ? (
-                      <a
-                        href={ROUTES.REVOKE_USER_RIGHTS_TO_PROJECT_ACTION({
-                          projectId: project.id,
-                          userId: id,
-                        })}
-                        style={{ marginLeft: 5 }}
-                        data-confirm={`Etes-vous sur de vouloir retirer les droits à ce projet à ${fullName} ?`}
-                      >
-                        retirer
-                      </a>
-                    ) : (
-                      ''
-                    )}
-                  </li>
-                ))}
-                {projectInvitations.map(({ id, email }) => (
-                  <li key={'project_invitation_' + email}>
-                    {email} (
-                    {user.role === 'admin' ? (
-                      <a
-                        href={ROUTES.PROJECT_INVITATION({
-                          projectAdmissionKey: id,
-                        })}
-                      >
-                        invitation envoyée
-                      </a>
-                    ) : (
-                      <i>invitation envoyée</i>
-                    )}
-                    )
-                    {email !== project.email ? (
-                      <a
-                        href={ROUTES.CANCEL_INVITATION_TO_PROJECT_ACTION({
-                          projectAdmissionKeyId: id,
-                          projectId: project.id,
-                        })}
-                        style={{ marginLeft: 5 }}
-                        data-confirm={`Etes-vous sur de vouloir annuler l‘invitation à ${email} ?`}
-                      >
-                        annuler
-                      </a>
-                    ) : (
-                      ''
-                    )}
-                  </li>
-                ))}
-                {!projectUsers.length && !projectInvitations.length ? (
-                  <>
-                    <li>Aucun utilisateur n‘a accès à ce projet pour le moment.</li>
-                  </>
-                ) : (
-                  ''
-                )}
-              </ul>
-            </div>
-            {user.role !== 'dreal' ? (
+            {project.notifiedOn ? (
+              <div>
+                <h5 style={{ marginBottom: 5, marginTop: 15 }}>Comptes ayant accès à ce projet</h5>
+                <ul style={{ marginTop: 5, marginBottom: 5 }}>
+                  {project.users.map(({ id, fullName, email }) => (
+                    <li key={'project_user_' + id}>
+                      {fullName} - {email}
+                      {id !== user.id ? (
+                        <a
+                          href={ROUTES.REVOKE_USER_RIGHTS_TO_PROJECT_ACTION({
+                            projectId: project.id,
+                            userId: id,
+                          })}
+                          style={{ marginLeft: 5 }}
+                          data-confirm={`Etes-vous sur de vouloir retirer les droits à ce projet à ${fullName} ?`}
+                        >
+                          retirer
+                        </a>
+                      ) : (
+                        ''
+                      )}
+                    </li>
+                  ))}
+                  {project.invitations.map(({ id, email }) => (
+                    <li key={'project_invitation_' + email}>
+                      {email} (
+                      {user.role === 'admin' ? (
+                        <a
+                          href={ROUTES.PROJECT_INVITATION({
+                            projectAdmissionKey: id,
+                          })}
+                        >
+                          invitation envoyée
+                        </a>
+                      ) : (
+                        <i>invitation envoyée</i>
+                      )}
+                      )
+                      {email !== project.email ? (
+                        <a
+                          href={ROUTES.CANCEL_INVITATION_TO_PROJECT_ACTION({
+                            projectAdmissionKeyId: id,
+                            projectId: project.id,
+                          })}
+                          style={{ marginLeft: 5 }}
+                          data-confirm={`Etes-vous sur de vouloir annuler l‘invitation à ${email} ?`}
+                        >
+                          annuler
+                        </a>
+                      ) : (
+                        ''
+                      )}
+                    </li>
+                  ))}
+                  {!project.users.length && !project.invitations.length ? (
+                    <>
+                      <li>Aucun utilisateur n‘a accès à ce projet pour le moment.</li>
+                    </>
+                  ) : (
+                    ''
+                  )}
+                </ul>
+              </div>
+            ) : (
+              ''
+            )}
+            {['admin', 'dgec', 'porteur-projet'].includes(user.role) ? (
               <div {...dataId('invitation-form')}>
                 <a
                   href="#"

--- a/src/views/pages/projectDetails/sections/EditProjectData.tsx
+++ b/src/views/pages/projectDetails/sections/EditProjectData.tsx
@@ -1,19 +1,22 @@
+import { Request } from 'express'
 import React from 'react'
-import { Project } from '../../../../entities'
+import { appelsOffreStatic } from '../../../../dataAccess/inMemory/appelOffre'
 import { formatDate } from '../../../../helpers/formatDate'
 import { dataId } from '../../../../helpers/testId'
+import { ProjectDataForProjectPage } from '../../../../modules/project/dtos'
 import ROUTES from '../../../../routes'
 
-import { appelsOffreStatic } from '../../../../dataAccess/inMemory/appelOffre'
-import { Request } from 'express'
-
 interface EditProjectDataProps {
-  project: Project
+  project: ProjectDataForProjectPage
   request: Request
 }
 
 export const EditProjectData = ({ project, request }: EditProjectDataProps) => {
   const { query } = request
+
+  if (!project.notifiedOn) {
+    return <div>Projet non-notifié</div>
+  }
 
   return (
     <div>
@@ -183,7 +186,7 @@ export const EditProjectData = ({ project, request }: EditProjectDataProps) => {
             <option value={'investissement'}>Investissement participatif</option>
           </select>
         </div>
-        {project.classe === 'Eliminé' ? (
+        {!project.isClasse ? (
           <>
             <div className="form__group">
               <label>Classement</label>
@@ -215,7 +218,8 @@ export const EditProjectData = ({ project, request }: EditProjectDataProps) => {
             id="notificationDate"
             {...dataId('date-field')}
             defaultValue={
-              query.notificationDate || formatDate(new Date(project.notifiedOn), 'DD/MM/YYYY')
+              query.notificationDate ||
+              (project.notifiedOn && formatDate(project.notifiedOn, 'DD/MM/YYYY'))
             }
             style={{ width: 'auto' }}
           />

--- a/src/views/pages/projectDetails/sections/ProjectHeader.tsx
+++ b/src/views/pages/projectDetails/sections/ProjectHeader.tsx
@@ -1,10 +1,11 @@
 import React from 'react'
-import { makeProjectIdentifier, Project, User } from '../../../../entities'
+import { makeProjectIdentifier, User } from '../../../../entities'
+import { ProjectDataForProjectPage } from '../../../../modules/project/dtos'
+import { adminActions, porteurProjetActions } from '../../../components/actions'
 import ProjectActions from '../../../components/projectActions'
-import { porteurProjetActions, adminActions } from '../../../components/actions'
 
 interface ProjectHeaderProps {
-  project: Project
+  project: ProjectDataForProjectPage
   user: User
 }
 
@@ -15,7 +16,8 @@ export const ProjectHeader = ({ project, user }: ProjectHeaderProps) => (
       position: 'relative',
       padding: '1.5em',
       paddingBottom: 0,
-      backgroundColor: project.classe === 'Classé' ? '#daf5e7' : 'hsla(5,70%,79%,.45882)',
+      backgroundColor:
+        project.notifiedOn && project.isClasse ? '#daf5e7' : 'hsla(5,70%,79%,.45882)',
     }}
   >
     <h3>{project.nomProjet}</h3>
@@ -26,10 +28,10 @@ export const ProjectHeader = ({ project, user }: ProjectHeaderProps) => (
     <div
       style={{
         fontWeight: 'bold',
-        color: project.classe === 'Classé' ? 'rgb(56, 118, 29)' : 'rgb(204, 0, 0)',
+        color: project.notifiedOn && project.isClasse ? 'rgb(56, 118, 29)' : 'rgb(204, 0, 0)',
       }}
     >
-      {project.classe === 'Classé' ? 'Actif' : 'Eliminé'}
+      {project.notifiedOn && project.isClasse ? 'Actif' : 'Eliminé'}
     </div>
     <div style={{ position: 'absolute', right: '1.5em', bottom: 25 }}>
       <ProjectActions

--- a/src/views/pages/projectDetails/sections/ProjectHeader.tsx
+++ b/src/views/pages/projectDetails/sections/ProjectHeader.tsx
@@ -16,8 +16,7 @@ export const ProjectHeader = ({ project, user }: ProjectHeaderProps) => (
       position: 'relative',
       padding: '1.5em',
       paddingBottom: 0,
-      backgroundColor:
-        project.notifiedOn && project.isClasse ? '#daf5e7' : 'hsla(5,70%,79%,.45882)',
+      backgroundColor: project.isClasse ? '#daf5e7' : 'hsla(5,70%,79%,.45882)',
     }}
   >
     <h3>{project.nomProjet}</h3>
@@ -28,10 +27,10 @@ export const ProjectHeader = ({ project, user }: ProjectHeaderProps) => (
     <div
       style={{
         fontWeight: 'bold',
-        color: project.notifiedOn && project.isClasse ? 'rgb(56, 118, 29)' : 'rgb(204, 0, 0)',
+        color: project.isClasse ? 'rgb(56, 118, 29)' : 'rgb(204, 0, 0)',
       }}
     >
-      {project.notifiedOn && project.isClasse ? 'Actif' : 'Eliminé'}
+      {project.isClasse ? 'Actif' : 'Eliminé'}
     </div>
     <div style={{ position: 'absolute', right: '1.5em', bottom: 25 }}>
       <ProjectActions


### PR DESCRIPTION
Instead of sending the complete Project object to the view, create a DTO from a query packed with all necessary data.

This approach moves the logic from the old architecture to the new, enabling the addition of more data to this project page (PTF,...) without adding more code on the legacy side. 