### PR TITLE
:bug:  Remove creation of legacy ProjectEvents

### DIFF
--- a/src/dataAccess/db/project.ts
+++ b/src/dataAccess/db/project.ts
@@ -335,12 +335,6 @@ export default function makeProjectRepo({ sequelizeInstance, appelOffreRepo }): 
 
       const projectWithAppelOffre = await addAppelOffreToProject(projectInstance.unwrap())
 
-      if (includeHistory) {
-        projectWithAppelOffre.history = (await projectInDb.getProjectEvents()).map((item) =>
-          item.get()
-        )
-      }
-
       return projectWithAppelOffre
     } catch (error) {
       if (CONFIG.logDbErrors) logger.error(error)


### PR DESCRIPTION
This table had varchar fields that would result in errors when the content is too long. It has been effectively replaced by event sourcing.

[Example](https://sentry.io/organizations/potentiel-prod/issues/2219194579/events/a2349525e4aa41f2b31184c57817ad11/)