### PR TITLE
Add wrapInfra helper to make safer calls to infra layers (db, apis, ...)

### DIFF
--- a/src/core/utils/index.ts
+++ b/src/core/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './Queue'
 export * from './Result'
-export * from './validators'
 export * from './logger'
+export * from './validators'
+export * from './wrapInfra'

--- a/src/core/utils/wrapInfra.ts
+++ b/src/core/utils/wrapInfra.ts
@@ -1,0 +1,13 @@
+import { InfraNotAvailableError } from '../../modules/shared'
+import { ResultAsync } from './Result'
+import { logger } from './logger'
+
+/**
+ * Wrap an infrastructure promise (db query, api call, ...) in a ResultAsync
+ * @param infraPromise promise to be wrapped
+ */
+export const wrapInfra = <T>(infraPromise: Promise<T>): ResultAsync<T, InfraNotAvailableError> =>
+  ResultAsync.fromPromise(infraPromise, (e: any) => {
+    logger.error(e)
+    return new InfraNotAvailableError()
+  })

--- a/src/infra/sequelize/queries/getFailedNotificationDetails.ts
+++ b/src/infra/sequelize/queries/getFailedNotificationDetails.ts
@@ -1,4 +1,4 @@
-import { errAsync, logger, ResultAsync } from '../../../core/utils'
+import { errAsync, wrapInfra } from '../../../core/utils'
 import { makePaginatedList, paginate } from '../../../helpers/paginate'
 import { FailedNotificationDTO, GetFailedNotificationDetails } from '../../../modules/notification'
 import { InfraNotAvailableError } from '../../../modules/shared'
@@ -9,16 +9,12 @@ export const makeGetFailedNotificationDetails = (models): GetFailedNotificationD
   const NotificationModel = models.Notification
   if (!NotificationModel) return errAsync(new InfraNotAvailableError())
 
-  return ResultAsync.fromPromise(
+  return wrapInfra(
     NotificationModel.findAndCountAll({
       where: { status: 'error' },
       order: [['createdAt', 'DESC']],
       ...paginate(pagination),
-    }),
-    (e: any) => {
-      logger.error(e)
-      return new InfraNotAvailableError()
-    }
+    })
   ).map(({ count, rows }) =>
     makePaginatedList(
       rows

--- a/src/infra/sequelize/queries/getFileProject.ts
+++ b/src/infra/sequelize/queries/getFileProject.ts
@@ -1,5 +1,5 @@
 import { UniqueEntityID } from '../../../core/domain'
-import { err, errAsync, ok, ResultAsync } from '../../../core/utils'
+import { err, errAsync, ok, wrapInfra } from '../../../core/utils'
 import { FileNotFoundError, GetFileProject } from '../../../modules/file'
 import { InfraNotAvailableError } from '../../../modules/shared'
 
@@ -7,10 +7,7 @@ export const makeGetFileProject = (models): GetFileProject => (fileId: UniqueEnt
   const FileModel = models.File
   if (!FileModel) return errAsync(new InfraNotAvailableError())
 
-  return ResultAsync.fromPromise(
-    FileModel.findByPk(fileId.toString()),
-    () => new InfraNotAvailableError()
-  ).andThen((file: any) => {
+  return wrapInfra(FileModel.findByPk(fileId.toString())).andThen((file: any) => {
     if (!file) return err(new FileNotFoundError())
 
     if (file.forProject) return ok(new UniqueEntityID(file.forProject))

--- a/src/infra/sequelize/queries/getInfoForModificationRequested.ts
+++ b/src/infra/sequelize/queries/getInfoForModificationRequested.ts
@@ -1,4 +1,4 @@
-import { err, errAsync, ok, ResultAsync, logger } from '../../../core/utils'
+import { err, errAsync, ok, wrapInfra } from '../../../core/utils'
 import { GetInfoForModificationRequested } from '../../../modules/notification'
 import { EntityNotFoundError, InfraNotAvailableError } from '../../../modules/shared'
 
@@ -9,24 +9,16 @@ export const makeGetInfoForModificationRequested = (models): GetInfoForModificat
   const { Project, User } = models
   if (!Project || !User) return errAsync(new InfraNotAvailableError())
 
-  return ResultAsync.fromPromise(
+  return wrapInfra(
     Project.findByPk(projectId, {
       attributes: ['nomProjet'],
-    }),
-    (e: Error) => {
-      logger.error(e)
-      return new InfraNotAvailableError()
-    }
+    })
   )
     .andThen((project: any) => {
-      return ResultAsync.fromPromise(
+      return wrapInfra(
         User.findByPk(userId, {
           attributes: ['fullName', 'email'],
-        }),
-        (e: Error) => {
-          logger.error(e)
-          return new InfraNotAvailableError()
-        }
+        })
       ).map((user: any) => ({ user, project }))
     })
     .andThen(({ user, project }) => {

--- a/src/infra/sequelize/queries/getModificationRequestDetails.ts
+++ b/src/infra/sequelize/queries/getModificationRequestDetails.ts
@@ -1,8 +1,8 @@
-import { err, errAsync, logger, ok, ResultAsync } from '../../../core/utils'
+import { err, errAsync, ok, wrapInfra } from '../../../core/utils'
 import { getAppelOffre } from '../../../dataAccess/inMemory/appelOffre'
 import {
-  ModificationRequestPageDTO,
   GetModificationRequestDetails,
+  ModificationRequestPageDTO,
 } from '../../../modules/modificationRequest'
 import { EntityNotFoundError, InfraNotAvailableError } from '../../../modules/shared'
 
@@ -13,7 +13,7 @@ export const makeGetModificationRequestDetails = (models): GetModificationReques
   if (!ModificationRequest || !Project || !File || !User)
     return errAsync(new InfraNotAvailableError())
 
-  return ResultAsync.fromPromise(
+  return wrapInfra(
     ModificationRequest.findByPk(modificationRequestId, {
       include: [
         {
@@ -50,11 +50,7 @@ export const makeGetModificationRequestDetails = (models): GetModificationReques
           attributes: ['fullName'],
         },
       ],
-    }),
-    (e: Error) => {
-      logger.error(e)
-      return new InfraNotAvailableError()
-    }
+    })
   ).andThen((modificationRequestRaw: any) => {
     if (!modificationRequestRaw) return err(new EntityNotFoundError())
 

--- a/src/infra/sequelize/queries/getModificationRequestInfoForStatusNotification.ts
+++ b/src/infra/sequelize/queries/getModificationRequestInfoForStatusNotification.ts
@@ -1,4 +1,4 @@
-import { err, errAsync, logger, ok, ResultAsync } from '../../../core/utils'
+import { err, errAsync, ok, wrapInfra } from '../../../core/utils'
 import {
   GetModificationRequestInfoForStatusNotification,
   ModificationRequestInfoForStatusNotificationDTO,
@@ -11,7 +11,7 @@ export const makeGetModificationRequestUpdateInfo = (
   const { ModificationRequest, Project, User } = models
   if (!ModificationRequest || !Project || !User) return errAsync(new InfraNotAvailableError())
 
-  return ResultAsync.fromPromise(
+  return wrapInfra(
     ModificationRequest.findByPk(modificationRequestId, {
       include: [
         {
@@ -25,11 +25,7 @@ export const makeGetModificationRequestUpdateInfo = (
           attributes: ['fullName', 'email', 'id'],
         },
       ],
-    }),
-    (e: Error) => {
-      logger.error(e)
-      return new InfraNotAvailableError()
-    }
+    })
   ).andThen((modificationRequestRaw: any) => {
     if (!modificationRequestRaw) return err(new EntityNotFoundError())
 

--- a/src/infra/sequelize/queries/getModificationRequestListForUser.ts
+++ b/src/infra/sequelize/queries/getModificationRequestListForUser.ts
@@ -1,8 +1,8 @@
-import { errAsync, ok, ResultAsync } from '../../../core/utils'
+import { errAsync, ok, wrapInfra } from '../../../core/utils'
+import { getAppelOffre } from '../../../dataAccess/inMemory/appelOffre'
 import { makePaginatedList, paginate } from '../../../helpers/paginate'
 import { GetModificationRequestListForUser } from '../../../modules/modificationRequest'
 import { InfraNotAvailableError } from '../../../modules/shared'
-import { getAppelOffre } from '../../../dataAccess/inMemory/appelOffre'
 
 function _getPuissanceForAppelOffre(args: { appelOffreId; periodeId }): string {
   return getAppelOffre(args)?.unitePuissance || 'unité de puissance'
@@ -22,7 +22,7 @@ export const makeGetModificationRequestListForUser = (
     userClause = {}
   }
 
-  return ResultAsync.fromPromise(
+  return wrapInfra(
     ModificationRequest.findAndCountAll({
       ...userClause,
       include: [
@@ -54,11 +54,7 @@ export const makeGetModificationRequestListForUser = (
         },
       ],
       ...paginate(pagination),
-    }),
-    (e) => {
-      console.error(e)
-      return new InfraNotAvailableError()
-    }
+    })
   ).andThen((res: any) => {
     const { count, rows } = res
 

--- a/src/infra/sequelize/queries/getModificationRequestStatus.ts
+++ b/src/infra/sequelize/queries/getModificationRequestStatus.ts
@@ -1,4 +1,4 @@
-import { errAsync, ResultAsync } from '../../../core/utils'
+import { errAsync, wrapInfra } from '../../../core/utils'
 import { GetModificationRequestStatus } from '../../../modules/modificationRequest'
 import { InfraNotAvailableError } from '../../../modules/shared'
 
@@ -8,8 +8,7 @@ export const makeGetModificationRequestStatus = (models): GetModificationRequest
   const ModificationRequestModel = models.ModificationRequest
   if (!ModificationRequestModel) return errAsync(new InfraNotAvailableError())
 
-  return ResultAsync.fromPromise(
-    ModificationRequestModel.findByPk(modificationRequestId),
-    () => new InfraNotAvailableError()
-  ).map(({ status }) => status)
+  return wrapInfra(ModificationRequestModel.findByPk(modificationRequestId)).map(
+    ({ status }) => status
+  )
 }

--- a/src/infra/sequelize/queries/getProjectDataForProjectPage.ts
+++ b/src/infra/sequelize/queries/getProjectDataForProjectPage.ts
@@ -1,7 +1,7 @@
-import { err, errAsync, logger, ok, ResultAsync } from '../../../core/utils'
+import { err, errAsync, ok, wrapInfra } from '../../../core/utils'
 import { getAppelOffre } from '../../../dataAccess/inMemory'
 import { GetProjectDataForProjectPage } from '../../../modules/project/queries/GetProjectDataForProjectPage'
-import { InfraNotAvailableError, EntityNotFoundError } from '../../../modules/shared'
+import { EntityNotFoundError, InfraNotAvailableError } from '../../../modules/shared'
 
 export const makeGetProjectDataForProjectPage = (models): GetProjectDataForProjectPage => ({
   projectId,
@@ -11,7 +11,7 @@ export const makeGetProjectDataForProjectPage = (models): GetProjectDataForProje
   if (!Project || !File || !User || !UserProjects || !ProjectAdmissionKey || !ProjectStep)
     return errAsync(new InfraNotAvailableError())
 
-  return ResultAsync.fromPromise(
+  return wrapInfra(
     Project.findByPk(projectId, {
       include: [
         {
@@ -74,11 +74,7 @@ export const makeGetProjectDataForProjectPage = (models): GetProjectDataForProje
           ],
         },
       ],
-    }),
-    (e: Error) => {
-      logger.error(e)
-      return new InfraNotAvailableError()
-    }
+    })
   ).andThen((projectRaw: any) => {
     if (!projectRaw) return err(new EntityNotFoundError())
 

--- a/src/infra/sequelize/queries/getProjectIdForAdmissionKey.ts
+++ b/src/infra/sequelize/queries/getProjectIdForAdmissionKey.ts
@@ -1,4 +1,4 @@
-import { err, errAsync, logger, ok, ResultAsync } from '../../../core/utils'
+import { err, errAsync, ok, wrapInfra } from '../../../core/utils'
 import { GetProjectIdForAdmissionKey } from '../../../modules/authorization/queries'
 import { EntityNotFoundError, InfraNotAvailableError } from '../../../modules/shared'
 
@@ -8,14 +8,10 @@ export const makeGetProjectIdForAdmissionKey = (models): GetProjectIdForAdmissio
   const { ProjectAdmissionKey } = models
   if (!ProjectAdmissionKey) return errAsync(new InfraNotAvailableError())
 
-  return ResultAsync.fromPromise(
+  return wrapInfra(
     ProjectAdmissionKey.findByPk(projectAdmissionKeyId, {
       attributes: ['projectId'],
-    }),
-    (e: Error) => {
-      logger.error(e)
-      return new InfraNotAvailableError()
-    }
+    })
   ).andThen((projectAdmissionKey: any) => {
     if (!projectAdmissionKey) return err(new EntityNotFoundError())
 

--- a/src/infra/sequelize/queries/getStats.ts
+++ b/src/infra/sequelize/queries/getStats.ts
@@ -1,4 +1,4 @@
-import { errAsync, ResultAsync } from '../../../core/utils'
+import { errAsync, wrapInfra } from '../../../core/utils'
 import { Op, QueryTypes } from 'sequelize'
 import { InfraNotAvailableError } from '../../../modules/shared'
 import { GetStats } from '../../../modules/stats/GetStats'
@@ -114,7 +114,7 @@ export const getStats: GetStats = () => {
       }
     )
 
-  return ResultAsync.fromPromise(
+  return wrapInfra(
     Promise.all([
       _getProjetsTotal(),
       _getProjetsLaureats(),
@@ -128,8 +128,7 @@ export const getStats: GetStats = () => {
       _getDcrDeposees(),
       _getDcrDues(),
       _getDemandes(),
-    ]),
-    (e: any) => new InfraNotAvailableError()
+    ])
   ).map(
     ([
       projetsTotal,

--- a/src/infra/sequelize/queries/getUnnotifiedProjectsForPeriode.ts
+++ b/src/infra/sequelize/queries/getUnnotifiedProjectsForPeriode.ts
@@ -1,4 +1,4 @@
-import { errAsync, ResultAsync } from '../../../core/utils'
+import { errAsync, wrapInfra } from '../../../core/utils'
 import { AppelOffre, Periode } from '../../../entities'
 import { GetUnnotifiedProjectsForPeriode } from '../../../modules/project/queries'
 import { InfraNotAvailableError } from '../../../modules/shared'
@@ -10,15 +10,13 @@ export const makeGetUnnotifiedProjectsForPeriode = (models): GetUnnotifiedProjec
   const ProjectModel = models.Project
   if (!ProjectModel) return errAsync(new InfraNotAvailableError())
 
-  return ResultAsync.fromPromise(
-    ProjectModel.findAll({ where: { notifiedOn: 0, appelOffreId, periodeId } }),
-    () => new InfraNotAvailableError()
-  ).map((projects: any) =>
-    projects.map((project) => ({
-      projectId: project.id,
-      candidateEmail: project.email,
-      candidateName: project.nomRepresentantLegal,
-      familleId: project.familleId,
-    }))
+  return wrapInfra(ProjectModel.findAll({ where: { notifiedOn: 0, appelOffreId, periodeId } })).map(
+    (projects: any) =>
+      projects.map((project) => ({
+        projectId: project.id,
+        candidateEmail: project.email,
+        candidateName: project.nomRepresentantLegal,
+        familleId: project.familleId,
+      }))
   )
 }

--- a/src/modules/authorization/useCases/cancelInvitationToProject.ts
+++ b/src/modules/authorization/useCases/cancelInvitationToProject.ts
@@ -1,5 +1,5 @@
 import { errAsync } from 'neverthrow'
-import { logger, ResultAsync } from '../../../core/utils'
+import { ResultAsync, wrapInfra } from '../../../core/utils'
 import { User } from '../../../entities'
 import { EventBus } from '../../eventStore'
 import { EntityNotFoundError, InfraNotAvailableError, UnauthorizedError } from '../../shared'
@@ -27,13 +27,7 @@ export const makeCancelInvitationToProject = (deps: CancelInvitationToProjectDep
   return deps
     .getProjectIdForAdmissionKey(projectAdmissionKeyId)
     .andThen((projectId) => {
-      return ResultAsync.fromPromise(
-        deps.shouldUserAccessProject({ projectId, user: cancelledBy }),
-        (e: Error) => {
-          logger.error(e)
-          return new InfraNotAvailableError()
-        }
-      )
+      return wrapInfra(deps.shouldUserAccessProject({ projectId, user: cancelledBy }))
     })
     .andThen((userHasRightsToProject) =>
       userHasRightsToProject

--- a/src/modules/file/loadFileForUser.ts
+++ b/src/modules/file/loadFileForUser.ts
@@ -1,4 +1,4 @@
-import { errAsync, okAsync, ResultAsync } from '../../core/utils'
+import { errAsync, okAsync, ResultAsync, wrapInfra } from '../../core/utils'
 import { Repository, UniqueEntityID } from '../../core/domain'
 import { User } from '../../entities'
 import { ShouldUserAccessProject } from '../authorization'
@@ -41,9 +41,8 @@ export const makeLoadFileForUser = (deps: LoadFileForUserDeps): LoadFileForUser 
           return errAsync(new FileAccessDeniedError())
         }
 
-        return ResultAsync.fromPromise(
-          deps.shouldUserAccessProject.check({ projectId: projectId.toString(), user }),
-          () => new InfraNotAvailableError()
+        return wrapInfra(
+          deps.shouldUserAccessProject.check({ projectId: projectId.toString(), user })
         )
       }
     )

--- a/src/modules/project/useCases/removeStep.ts
+++ b/src/modules/project/useCases/removeStep.ts
@@ -1,4 +1,4 @@
-import { errAsync, logger, okAsync, ResultAsync } from '../../../core/utils'
+import { errAsync, logger, okAsync, ResultAsync, wrapInfra } from '../../../core/utils'
 import { User } from '../../../entities'
 import { EventBus } from '../../eventStore'
 import { InfraNotAvailableError, UnauthorizedError } from '../../shared'
@@ -20,13 +20,7 @@ export const makeRemoveStep = (deps: RemoveStepDeps) => ({
   projectId,
   removedBy,
 }: RemoveStepArgs): ResultAsync<null, InfraNotAvailableError | UnauthorizedError> => {
-  return ResultAsync.fromPromise(
-    deps.shouldUserAccessProject({ projectId, user: removedBy }),
-    (e: Error) => {
-      logger.error(e)
-      return new InfraNotAvailableError()
-    }
-  ).andThen(
+  return wrapInfra(deps.shouldUserAccessProject({ projectId, user: removedBy })).andThen(
     (userHasRightsToProject): ResultAsync<null, InfraNotAvailableError | UnauthorizedError> => {
       if (!userHasRightsToProject) return errAsync(new UnauthorizedError())
 

--- a/src/modules/project/useCases/submitStep.ts
+++ b/src/modules/project/useCases/submitStep.ts
@@ -1,5 +1,5 @@
 import { Repository, UniqueEntityID } from '../../../core/domain'
-import { logger, ResultAsync, okAsync, errAsync } from '../../../core/utils'
+import { logger, ResultAsync, okAsync, errAsync, wrapInfra } from '../../../core/utils'
 import { User } from '../../../entities'
 import { EventBus } from '../../eventStore'
 import { FileContents, FileObject, makeFileObject } from '../../file'
@@ -32,13 +32,7 @@ export const makeSubmitStep = (deps: SubmitStepDeps) => ({
 }: SubmitStepArgs): ResultAsync<null, InfraNotAvailableError | UnauthorizedError> => {
   const { filename, contents } = file
 
-  return ResultAsync.fromPromise(
-    deps.shouldUserAccessProject({ projectId, user: submittedBy }),
-    (e: Error) => {
-      logger.error(e)
-      return new InfraNotAvailableError()
-    }
-  )
+  return wrapInfra(deps.shouldUserAccessProject({ projectId, user: submittedBy }))
     .andThen(
       (userHasRightsToProject): ResultAsync<string, InfraNotAvailableError | UnauthorizedError> => {
         if (!userHasRightsToProject) return errAsync(new UnauthorizedError())


### PR DESCRIPTION
In order to transform a `Promise` coming from third-party libs, what we did was use `ResultAsync.fromPromise`.

Example:
```ts
const res = ResultAsync.fromPromise(project.findById(projectId), (e: Error) => { logger.error(e); return new InfraNotAvailableError(); })
```

This code was repetitive, verbose and sometimes we could forget the `logger.error(e)` part.

`wrapInfra` is a wrapper that does exactly the same thing, but factored in.

Updated example:
```ts
const res = wrapInfra(project.findById(projectId))
```