### PR TITLE
388 je peux valider les demandes traitées en dehors du processus de validation des demandes

### DIFF
--- a/src/__tests__/fixtures/aggregates/makeFakeModificationRequest.ts
+++ b/src/__tests__/fixtures/aggregates/makeFakeModificationRequest.ts
@@ -4,6 +4,7 @@ import { DomainEvent, UniqueEntityID } from '../../../core/domain'
 export const makeFakeModificationRequest = () => ({
   accept: jest.fn(() => ok<null, never>(null)),
   reject: jest.fn(() => ok<null, never>(null)),
+  updateStatus: jest.fn(() => ok<null, never>(null)),
   projectId: new UniqueEntityID(),
   pendingEvents: [] as DomainEvent[],
   lastUpdatedOn: new Date(0),

--- a/src/config/useCases.config.ts
+++ b/src/config/useCases.config.ts
@@ -28,6 +28,7 @@ import { eventStore } from './eventStore.config'
 import {
   makeAcceptModificationRequest,
   makeRejectModificationRequest,
+  makeUpdateModificationRequestStatus,
 } from '../modules/modificationRequest'
 
 export const shouldUserAccessProject = new BaseShouldUserAccessProject(
@@ -60,6 +61,9 @@ export const acceptModificationRequest = makeAcceptModificationRequest({
 })
 export const rejectModificationRequest = makeRejectModificationRequest({
   fileRepo,
+  modificationRequestRepo,
+})
+export const updateModificationRequestStatus = makeUpdateModificationRequestStatus({
   modificationRequestRepo,
 })
 

--- a/src/infra/sequelize/projections/modificationRequest/updates/index.ts
+++ b/src/infra/sequelize/projections/modificationRequest/updates/index.ts
@@ -4,10 +4,12 @@ import {
   ModificationRequestAccepted,
   ModificationRequestInstructionStarted,
   ModificationRequestRejected,
+  ModificationRequestStatusUpdated,
 } from '../../../../../modules/modificationRequest'
 import { onModificationRequested } from './onModificationRequested'
 import { onModificationRequestAccepted } from './onModificationRequestAccepted'
 import { onModificationRequestRejected } from './onModificationRequestRejected'
+import { onModificationRequestStatusUpdated } from './onModificationRequestStatusUpdated'
 import { onModificationRequestInstructionStarted } from './onModificationRequestInstructionStarted'
 import { logger } from '../../../../../core/utils'
 
@@ -18,6 +20,10 @@ export const initModificationRequestProjections = (eventBus: EventBus, models) =
   eventBus.subscribe(
     ModificationRequestInstructionStarted.type,
     onModificationRequestInstructionStarted(models)
+  )
+  eventBus.subscribe(
+    ModificationRequestStatusUpdated.type,
+    onModificationRequestStatusUpdated(models)
   )
 
   logger.info('Initialized ModificationRequest projections')

--- a/src/infra/sequelize/projections/modificationRequest/updates/onModificationRequestStatusUpdated.integration.ts
+++ b/src/infra/sequelize/projections/modificationRequest/updates/onModificationRequestStatusUpdated.integration.ts
@@ -1,0 +1,51 @@
+import models from '../../../models'
+import { resetDatabase } from '../../../helpers'
+import { onModificationRequestStatusUpdated } from './onModificationRequestStatusUpdated'
+import { ModificationRequestStatusUpdated } from '../../../../../modules/modificationRequest/events'
+import { UniqueEntityID } from '../../../../../core/domain'
+
+describe('modificationRequest.onModificationRequestStatusUpdated', () => {
+  const ModificationRequestModel = models.ModificationRequest
+
+  const modificationRequestId = new UniqueEntityID().toString()
+  const projectId = new UniqueEntityID().toString()
+  const userId = new UniqueEntityID().toString()
+
+  beforeAll(async () => {
+    // Create the tables and remove all data
+    await resetDatabase()
+
+    await ModificationRequestModel.create({
+      id: modificationRequestId,
+      projectId,
+      userId,
+      type: 'recours',
+      status: 'envoyée',
+      requestedOn: 1,
+      requestedBy: userId,
+    })
+  })
+
+  it('should update status', async () => {
+    await onModificationRequestStatusUpdated(models)(
+      new ModificationRequestStatusUpdated({
+        payload: {
+          modificationRequestId,
+          updatedBy: userId,
+          newStatus: 'acceptée',
+        },
+        original: {
+          occurredAt: new Date(123),
+          version: 1,
+        },
+      })
+    )
+
+    const updatedModificationRequest = await ModificationRequestModel.findByPk(
+      modificationRequestId
+    )
+    expect(updatedModificationRequest.status).toEqual('acceptée')
+    expect(updatedModificationRequest.respondedBy).toEqual(userId)
+    expect(updatedModificationRequest.respondedOn).toEqual(123)
+  })
+})

--- a/src/infra/sequelize/projections/modificationRequest/updates/onModificationRequestStatusUpdated.ts
+++ b/src/infra/sequelize/projections/modificationRequest/updates/onModificationRequestStatusUpdated.ts
@@ -1,0 +1,38 @@
+import { logger } from '../../../../../core/utils'
+import { ModificationRequestStatusUpdated } from '../../../../../modules/modificationRequest/events'
+
+export const onModificationRequestStatusUpdated = (models) => async (
+  event: ModificationRequestStatusUpdated
+) => {
+  const ModificationRequestModel = models.ModificationRequest
+  const instance = await ModificationRequestModel.findByPk(event.payload.modificationRequestId)
+
+  if (!instance) {
+    logger.error(
+      `Error: onModificationRequestStatusUpdated projection failed to retrieve project from db ${event}`
+    )
+    return
+  }
+
+  const {
+    occurredAt,
+    payload: { updatedBy, newStatus },
+  } = event
+
+  Object.assign(instance, {
+    status: newStatus,
+    respondedOn: occurredAt.getTime(),
+    respondedBy: updatedBy,
+    versionDate: occurredAt,
+  })
+
+  try {
+    await instance.save()
+  } catch (e) {
+    logger.error(e)
+    logger.info(
+      'Error: onModificationRequestStatusUpdated projection failed to update project :',
+      event
+    )
+  }
+}

--- a/src/modules/modificationRequest/ModificationRequest.updateStatus.spec.ts
+++ b/src/modules/modificationRequest/ModificationRequest.updateStatus.spec.ts
@@ -1,0 +1,49 @@
+import { UniqueEntityID } from '../../core/domain'
+import { UnwrapForTest } from '../../core/utils'
+import { makeUser } from '../../entities'
+import { UnwrapForTest as OldUnwrapForTest } from '../../types'
+import makeFakeUser from '../../__tests__/fixtures/user'
+import { ModificationRequested, ModificationRequestStatusUpdated } from './events'
+import { makeModificationRequest } from './ModificationRequest'
+
+describe('Modification.updateStatus()', () => {
+  const modificationRequestId = new UniqueEntityID()
+  const fakeUser = OldUnwrapForTest(makeUser(makeFakeUser()))
+
+  it('should emit ModificationRequestStatusUpdated', () => {
+    const fakeModificationRequest = UnwrapForTest(
+      makeModificationRequest({
+        modificationRequestId,
+        history: [
+          new ModificationRequested({
+            payload: {
+              modificationRequestId: modificationRequestId.toString(),
+              projectId: '',
+              type: 'recours',
+              requestedBy: fakeUser.id,
+            },
+          }),
+        ],
+      })
+    )
+
+    expect(fakeModificationRequest.pendingEvents).toHaveLength(0)
+
+    const res = fakeModificationRequest.updateStatus({ updatedBy: fakeUser, newStatus: 'acceptée' })
+
+    expect(res.isOk()).toBe(true)
+
+    expect(fakeModificationRequest.pendingEvents).toHaveLength(1)
+    const targetEvent = fakeModificationRequest.pendingEvents.find(
+      (item) => item.type === ModificationRequestStatusUpdated.type
+    ) as ModificationRequestStatusUpdated | undefined
+    expect(targetEvent).toBeDefined()
+    if (!targetEvent) return
+
+    expect(targetEvent.payload).toMatchObject({
+      modificationRequestId: modificationRequestId.toString(),
+      updatedBy: fakeUser.id,
+      newStatus: 'acceptée',
+    })
+  })
+})

--- a/src/modules/modificationRequest/events/ModificationRequestStatusUpdated.ts
+++ b/src/modules/modificationRequest/events/ModificationRequestStatusUpdated.ts
@@ -1,0 +1,18 @@
+import { BaseDomainEvent, DomainEvent } from '../../../core/domain/DomainEvent'
+
+export interface ModificationRequestStatusUpdatedPayload {
+  modificationRequestId: string
+  updatedBy: string
+  newStatus: string
+}
+export class ModificationRequestStatusUpdated
+  extends BaseDomainEvent<ModificationRequestStatusUpdatedPayload>
+  implements DomainEvent {
+  public static type: 'ModificationRequestStatusUpdated' = 'ModificationRequestStatusUpdated'
+  public type = ModificationRequestStatusUpdated.type
+  currentVersion = 1
+
+  aggregateIdFromPayload(payload: ModificationRequestStatusUpdatedPayload) {
+    return payload.modificationRequestId
+  }
+}

--- a/src/modules/modificationRequest/events/index.ts
+++ b/src/modules/modificationRequest/events/index.ts
@@ -1,5 +1,6 @@
 export * from './ModificationRequestAccepted'
 export * from './ModificationRequestInstructionStarted'
 export * from './ModificationRequestRejected'
+export * from './ModificationRequestStatusUpdated'
 export * from './ModificationRequested'
 export * from './ResponseTemplateDownloaded'

--- a/src/modules/modificationRequest/useCases/index.ts
+++ b/src/modules/modificationRequest/useCases/index.ts
@@ -1,2 +1,3 @@
 export * from './acceptModificationRequest'
 export * from './rejectModificationRequest'
+export * from './updateModificationRequestStatus'

--- a/src/modules/modificationRequest/useCases/updateModificationRequestStatus.spec.ts
+++ b/src/modules/modificationRequest/useCases/updateModificationRequestStatus.spec.ts
@@ -1,0 +1,99 @@
+import { logger } from '../../../core/utils'
+import { makeUser } from '../../../entities'
+import { UnwrapForTest } from '../../../types'
+import { fakeRepo, makeFakeModificationRequest } from '../../../__tests__/fixtures/aggregates'
+import makeFakeUser from '../../../__tests__/fixtures/user'
+import { AggregateHasBeenUpdatedSinceError, UnauthorizedError } from '../../shared'
+import { ModificationRequest } from '../ModificationRequest'
+import { makeUpdateModificationRequestStatus } from './updateModificationRequestStatus'
+
+describe('updateModificationRequestStatus use-case', () => {
+  describe('when user is admin', () => {
+    const fakeUser = UnwrapForTest(makeUser(makeFakeUser({ role: 'admin' })))
+    const fakeModificationRequest = {
+      ...makeFakeModificationRequest(),
+    }
+    const modificationRequestRepo = fakeRepo(fakeModificationRequest as ModificationRequest)
+
+    const updateModificationRequestStatus = makeUpdateModificationRequestStatus({
+      modificationRequestRepo,
+    })
+
+    beforeAll(async () => {
+      const res = await updateModificationRequestStatus({
+        modificationRequestId: fakeModificationRequest.id,
+        versionDate: fakeModificationRequest.lastUpdatedOn,
+        newStatus: 'acceptée',
+        submittedBy: fakeUser,
+      })
+
+      if (res.isErr()) logger.error(res.error)
+      expect(res.isOk()).toEqual(true)
+    })
+
+    it('should call updateStatus on modificationRequest', () => {
+      expect(fakeModificationRequest.updateStatus).toHaveBeenCalledTimes(1)
+      expect(fakeModificationRequest.updateStatus).toHaveBeenCalledWith({
+        updatedBy: fakeUser,
+        newStatus: 'acceptée',
+      })
+    })
+
+    it('should save the modificationRequest', () => {
+      expect(modificationRequestRepo.save).toHaveBeenCalled()
+      expect(modificationRequestRepo.save.mock.calls[0][0]).toEqual(fakeModificationRequest)
+    })
+  })
+
+  describe('when user is not admin', () => {
+    const fakeUser = UnwrapForTest(makeUser(makeFakeUser({ role: 'porteur-projet' })))
+
+    const fakeModificationRequest = {
+      ...makeFakeModificationRequest(),
+    }
+    const modificationRequestRepo = fakeRepo(fakeModificationRequest as ModificationRequest)
+
+    const updateModificationRequestStatus = makeUpdateModificationRequestStatus({
+      modificationRequestRepo,
+    })
+
+    it('should return UnauthorizedError', async () => {
+      const res = await updateModificationRequestStatus({
+        modificationRequestId: fakeModificationRequest.id,
+        versionDate: fakeModificationRequest.lastUpdatedOn,
+        newStatus: 'acceptée',
+        submittedBy: fakeUser,
+      })
+
+      expect(res.isErr()).toEqual(true)
+      if (res.isOk()) return
+
+      expect(res.error).toBeInstanceOf(UnauthorizedError)
+    })
+  })
+
+  describe('when versionDate is different than current versionDate', () => {
+    const fakeUser = UnwrapForTest(makeUser(makeFakeUser({ role: 'admin' })))
+    const fakeModificationRequest = {
+      ...makeFakeModificationRequest(),
+    }
+    const modificationRequestRepo = fakeRepo(fakeModificationRequest as ModificationRequest)
+
+    const updateModificationRequestStatus = makeUpdateModificationRequestStatus({
+      modificationRequestRepo,
+    })
+
+    it('should return AggregateHasBeenUpdatedSinceError', async () => {
+      const res = await updateModificationRequestStatus({
+        modificationRequestId: fakeModificationRequest.id,
+        versionDate: new Date(1),
+        newStatus: 'acceptée',
+        submittedBy: fakeUser,
+      })
+
+      expect(res.isErr()).toEqual(true)
+      if (res.isOk()) return
+      expect(res.error).toBeInstanceOf(AggregateHasBeenUpdatedSinceError)
+    })
+  })
+})

--- a/src/modules/modificationRequest/useCases/updateModificationRequestStatus.ts
+++ b/src/modules/modificationRequest/useCases/updateModificationRequestStatus.ts
@@ -1,0 +1,55 @@
+import { Repository, UniqueEntityID } from '../../../core/domain'
+import { err, errAsync, Result, ResultAsync } from '../../../core/utils'
+import { User } from '../../../entities'
+import {
+  AggregateHasBeenUpdatedSinceError,
+  EntityNotFoundError,
+  InfraNotAvailableError,
+  UnauthorizedError,
+} from '../../shared'
+import { ModificationRequest, ModificationRequestStatus } from '../ModificationRequest'
+
+interface UpdateModificationRequestStatusDeps {
+  modificationRequestRepo: Repository<ModificationRequest>
+}
+
+interface UpdateModificationRequestStatusArgs {
+  modificationRequestId: UniqueEntityID
+  versionDate: Date
+  submittedBy: User
+  newStatus: ModificationRequestStatus
+}
+
+export const makeUpdateModificationRequestStatus = (deps: UpdateModificationRequestStatusDeps) => (
+  args: UpdateModificationRequestStatusArgs
+): ResultAsync<
+  null,
+  | AggregateHasBeenUpdatedSinceError
+  | InfraNotAvailableError
+  | EntityNotFoundError
+  | UnauthorizedError
+> => {
+  const { modificationRequestRepo } = deps
+  const { modificationRequestId, versionDate, newStatus, submittedBy } = args
+
+  if (!['admin', 'dgec'].includes(submittedBy.role)) {
+    return errAsync(new UnauthorizedError())
+  }
+
+  return modificationRequestRepo
+    .load(modificationRequestId)
+    .andThen(
+      (modificationRequest): Result<ModificationRequest, AggregateHasBeenUpdatedSinceError> => {
+        if (modificationRequest.lastUpdatedOn.getTime() !== versionDate.getTime()) {
+          return err(new AggregateHasBeenUpdatedSinceError())
+        }
+
+        return modificationRequest
+          .updateStatus({ updatedBy: submittedBy, newStatus })
+          .map(() => modificationRequest)
+      }
+    )
+    .andThen((modificationRequest) => {
+      return modificationRequestRepo.save(modificationRequest)
+    })
+}

--- a/src/modules/modificationRequest/useCases/updateModificationRequestStatus.ts
+++ b/src/modules/modificationRequest/useCases/updateModificationRequestStatus.ts
@@ -29,6 +29,7 @@ export const makeUpdateModificationRequestStatus = (deps: UpdateModificationRequ
   | EntityNotFoundError
   | UnauthorizedError
 > => {
+  console.log('updateModificationRequestStatus', args)
   const { modificationRequestRepo } = deps
   const { modificationRequestId, versionDate, newStatus, submittedBy } = args
 

--- a/src/modules/modificationRequest/useCases/updateModificationRequestStatus.ts
+++ b/src/modules/modificationRequest/useCases/updateModificationRequestStatus.ts
@@ -29,7 +29,6 @@ export const makeUpdateModificationRequestStatus = (deps: UpdateModificationRequ
   | EntityNotFoundError
   | UnauthorizedError
 > => {
-  console.log('updateModificationRequestStatus', args)
   const { modificationRequestRepo } = deps
   const { modificationRequestId, versionDate, newStatus, submittedBy } = args
 

--- a/src/public/scripts.js
+++ b/src/public/scripts.js
@@ -506,7 +506,7 @@ function addStatusOnlyHandler() {
     statusOnlyField.addEventListener('change', (event) => {
       if (event.currentTarget.checked) {
         otherFields.forEach((field) => {
-          if (field !== statusOnlyField) field.disabled = true
+          if (field !== statusOnlyField && field.type !== 'hidden') field.disabled = true
         })
       } else {
         otherFields.forEach((field) => {

--- a/src/public/scripts.js
+++ b/src/public/scripts.js
@@ -1,6 +1,7 @@
 // All this to avoid a SPA...
 
 window.initHandlers = function () {
+  addStatusOnlyHandler()
   addFriseToggleHandler()
   addFriseHiddenContentToggleHandler()
   addDateValidationHandler()
@@ -486,6 +487,31 @@ function addPuissanceModificationHandler() {
         disable(submitButton, true)
         show(outOfBounds, false)
         show(wrongFormat, true)
+      }
+    })
+  }
+}
+
+//
+// Modification request details page
+//
+
+function addStatusOnlyHandler() {
+  const statusOnlyField = document.querySelector(
+    '[data-testid=modificationRequest-statusUpdateOnlyField]'
+  )
+
+  if (statusOnlyField) {
+    const otherFields = statusOnlyField.closest('form').querySelectorAll('input')
+    statusOnlyField.addEventListener('change', (event) => {
+      if (event.currentTarget.checked) {
+        otherFields.forEach((field) => {
+          if (field !== statusOnlyField) field.disabled = true
+        })
+      } else {
+        otherFields.forEach((field) => {
+          field.disabled = false
+        })
       }
     })
   }

--- a/src/views/pages/modificationRequestDetails/index.tsx
+++ b/src/views/pages/modificationRequestDetails/index.tsx
@@ -188,18 +188,6 @@ export default function AdminModificationRequestPage({ request, modificationRequ
           ['recours', 'delai'].includes(type) && !modificationRequest.respondedOn ? (
             <div className="panel__header">
               <h4>Répondre</h4>
-              <div style={{ marginBottom: 10 }}>
-                <DownloadIcon />
-                <a
-                  href={ROUTES.TELECHARGER_MODELE_REPONSE(
-                    (project as unknown) as Project,
-                    modificationRequest.id
-                  )}
-                  download={true}
-                >
-                  Télécharger un modèle de réponse
-                </a>
-              </div>
 
               <form
                 action={ROUTES.ADMIN_REPLY_TO_MODIFICATION_REQUEST}
@@ -210,6 +198,34 @@ export default function AdminModificationRequestPage({ request, modificationRequ
                 <input type="hidden" name="modificationRequestId" value={modificationRequest.id} />
                 <input type="hidden" name="type" value={modificationRequest.type} />
                 <input type="hidden" name="versionDate" value={versionDate.getTime()} />
+
+                <div className="form__group" style={{ marginBottom: 20 }}>
+                  <label htmlFor="statusUpdateOnly">
+                    <input
+                      type="checkbox"
+                      name="statusUpdateOnly"
+                      {...dataId('modificationRequest-statusUpdateOnlyField')}
+                    />
+                    Demande traitée hors Potentiel
+                  </label>
+                  <div style={{ fontSize: 11, lineHeight: '1.5em', marginTop: 3 }}>
+                    En cochant cette case, seul le statut de la demande sera mise à jour. La réponse
+                    n‘aura pas d‘impact sur le projet et le porteur de projet ne sera pas notifié.
+                  </div>
+                </div>
+
+                <div style={{ marginBottom: 5 }}>
+                  <DownloadIcon />
+                  <a
+                    href={ROUTES.TELECHARGER_MODELE_REPONSE(
+                      (project as unknown) as Project,
+                      modificationRequest.id
+                    )}
+                    download={true}
+                  >
+                    Télécharger un modèle de réponse
+                  </a>
+                </div>
 
                 <div className="form__group">
                   <label htmlFor="file">Réponse signée (fichier pdf)</label>

--- a/src/views/pages/modificationRequestDetails/index.tsx
+++ b/src/views/pages/modificationRequestDetails/index.tsx
@@ -309,7 +309,9 @@ export default function AdminModificationRequestPage({ request, modificationRequ
             {ModificationRequestStatusTitle[status]}
           </span>{' '}
           {respondedOn && respondedBy ? `par ${respondedBy} le ${formatDate(respondedOn)}` : ''}
-          {modificationRequest.type === 'delai' && modificationRequest.status === 'acceptée' ? (
+          {modificationRequest.type === 'delai' &&
+          modificationRequest.status === 'acceptée' &&
+          modificationRequest.acceptanceParams ? (
             <div>
               L‘administration vous accorde un délai{' '}
               <b>


### PR DESCRIPTION
L'idée est que l'administrateur peut passer le statut d'une demande à acceptée/rejetée sans déclencher le changement sur le projet ni l'envoi d'une nouvelle attestation au porteur de projet.

Pour cela, j'ai créé un nouvel événement `ModificationRequestStatusUpdated` qui est déclenché lors de l'appel à la nouvelle commande `ModificationRequest.updateStatus`. 
Cette commande est appelée par le use-case `updateModificationRequestStatus` (qui fait aussi la vérification du role de l'utilisateur et du numéro de version de la `ModificationRequest` - pour être sur que la demande n'a pas été mise à jour entre temps).

J'ai rajouté une case à cocher sur le formulaire de réponse à une demande pour que le controller `postReplyToModificationRequest` sache qu'il doit appeler `updateModificationRequestStatus` au lieu de `accept/reject...`. 

J'ai opté pour la création d'une nouvelle chaine pour ce cas de figure plutôt que de mettre un flag dans les use-case d'acceptation/rejet pour réduire la complexité.