### PR TITLE
473 entetes appel offre periode

### DIFF
--- a/src/controllers/admin/getAppelOffreCsv.ts
+++ b/src/controllers/admin/getAppelOffreCsv.ts
@@ -13,7 +13,11 @@ v1Router.get(
   asyncHandler(async (request, response) => {
     await getAppelOffreList().match(
       async (appelOffreList) => {
-        const csv = await parseAsync(appelOffreList, { delimiter: ';' })
+        const reformatedAppelOffreList = appelOffreList.map(({ appelOffreId, ...data }) => ({
+          "Appel d'offres": appelOffreId,
+          ...data,
+        }))
+        const csv = await parseAsync(reformatedAppelOffreList, { delimiter: ';' })
         response.type('text/csv').send(csv)
         return
       },

--- a/src/controllers/admin/getPeriodesCsv.ts
+++ b/src/controllers/admin/getPeriodesCsv.ts
@@ -13,7 +13,13 @@ v1Router.get(
   asyncHandler(async (request, response) => {
     await getPeriodeList().match(
       async (periodeList) => {
-        const csv = await parseAsync(periodeList, { delimiter: ';' })
+        const reformatedPeriodeList = periodeList.map(({ appelOffreId, periodeId, ...data }) => ({
+          "Appel d'offres": appelOffreId,
+          Période: periodeId,
+          ...data,
+        }))
+
+        const csv = await parseAsync(reformatedPeriodeList, { delimiter: ';' })
         response.type('text/csv').send(csv)
         return
       },

--- a/src/modules/appelOffre/useCases/importAppelOffreData.spec.ts
+++ b/src/modules/appelOffre/useCases/importAppelOffreData.spec.ts
@@ -28,7 +28,7 @@ describe('importAppelOffreData use-case', () => {
 
     it('should publish AppelOffreCreated', async () => {
       const res = await importAppelOffreData({
-        dataLines: [{ appelOffreId: 'appelOffreId', other: 'param' }],
+        dataLines: [{ "Appel d'offres": 'appelOffreId', other: 'param' }],
         importedBy: user,
       })
 
@@ -63,7 +63,7 @@ describe('importAppelOffreData use-case', () => {
 
     it('should call update on the appelOffre and save it', async () => {
       const res = await importAppelOffreData({
-        dataLines: [{ appelOffreId: 'appelOffreId', other: 'param' }],
+        dataLines: [{ "Appel d'offres": 'appelOffreId', other: 'param' }],
         importedBy: user,
       })
 

--- a/src/modules/appelOffre/useCases/importAppelOffreData.ts
+++ b/src/modules/appelOffre/useCases/importAppelOffreData.ts
@@ -28,7 +28,7 @@ export const makeImportAppelOffreData = (deps: ImportAppelOffreDataDeps) => ({
     null,
     InfraNotAvailableError | UnauthorizedError | MissingAppelOffreIdError
   >[] = dataLines.map((dataLine, index) => {
-    const { appelOffreId, ...data } = dataLine
+    const { "Appel d'offres": appelOffreId, ...data } = dataLine
 
     if (!appelOffreId) {
       return errAsync(new MissingAppelOffreIdError(index + 1))

--- a/src/modules/appelOffre/useCases/importPeriodeData.spec.ts
+++ b/src/modules/appelOffre/useCases/importPeriodeData.spec.ts
@@ -33,7 +33,7 @@ describe('importPeriodeData use-case', () => {
 
     it('should call updatePeriode on the appelOffre and save it', async () => {
       const res = await importPeriodeData({
-        dataLines: [{ appelOffreId: 'appelOffreId', periodeId: 'periodeId', other: 'param' }],
+        dataLines: [{ "Appel d'offres": 'appelOffreId', Période: 'periodeId', other: 'param' }],
         importedBy: user,
       })
 
@@ -93,7 +93,7 @@ describe('importPeriodeData use-case', () => {
 
     it('should return a AppelOffreDoesNotExistError', async () => {
       const res = await importPeriodeData({
-        dataLines: [{ appelOffreId: 'appelOffreId', other: 'param' }],
+        dataLines: [{ "Appel d'offres": 'appelOffreId', other: 'param' }],
         importedBy: user,
       })
 
@@ -119,7 +119,7 @@ describe('importPeriodeData use-case', () => {
 
     it('should return a AppelOffreDoesNotExistError', async () => {
       const res = await importPeriodeData({
-        dataLines: [{ appelOffreId: 'appelOffreId', periodeId: 'periodeId', other: 'param' }],
+        dataLines: [{ "Appel d'offres": 'appelOffreId', Période: 'periodeId', other: 'param' }],
         importedBy: user,
       })
 

--- a/src/modules/appelOffre/useCases/importPeriodeData.ts
+++ b/src/modules/appelOffre/useCases/importPeriodeData.ts
@@ -32,7 +32,7 @@ export const makeImportPeriodeData = (deps: ImportPeriodeDataDeps) => ({
     null,
     InfraNotAvailableError | UnauthorizedError | MissingAppelOffreIdError
   >[] = dataLines.map((dataLine, index) => {
-    const { appelOffreId, periodeId, ...data } = dataLine
+    const { "Appel d'offres": appelOffreId, Période: periodeId, ...data } = dataLine
 
     if (!appelOffreId) {
       return errAsync(new MissingAppelOffreIdError(index + 1))


### PR DESCRIPTION
Plutôt que d'utiliser `appelOffreId` et `periodeId` comme en-têtes de colonne, conserver `Appel d'offres` et `Période` comme dans les fichiers circulants dans le drive.