### PR TITLE
Refactor projections

### DIFF
--- a/RECIPES.md
+++ b/RECIPES.md
@@ -1,0 +1,84 @@
+# Recettes pour le développeur
+
+- (Créer une nouvelle projection)[#Créer une nouvelle projection]
+
+## Créer une nouvelle projection
+
+Appelons cette projection `maproj` et imaginons qu'il s'agisse d'une projection sur l'infra `sequelize`.
+
+- Créer un dossier `src/infra/sequelize/projections/maproj`
+- Créer le fichier `src/infra/sequelize/projections/maproj/maproj.model.ts` de la forme:
+
+```ts
+import { DataTypes } from 'sequelize'
+import { makeProjector } from '../../helpers'
+
+export const maprojProjector = makeProjector()
+
+export const makeMaprojModel = (sequelize) => {
+  const model = sequelize.define('maproj', {
+    id: {
+      type: DataTypes.UUID,
+      primaryKey: true,
+    },
+    // ... autres champs
+  })
+
+  model.associate = (models) => {
+    // Associations avec d'autres models
+    // Exemple:
+    // const { Other } = models
+    // model.hasMany(Other)
+  }
+
+  model.projector = maprojProjector
+
+  return model
+}
+```
+
+- Mettre à jour `src/infra/sequelize/projections/index.ts` pour inclure le nouveau dossier (barrel)
+
+- `npx sequelize-cli migration:generate --name create-maproj` puis éditer le fichier généré pour ajouter la table avec le schéma contenu dans `maproj.model.ts`
+  Penser à rajouter les colonnes:
+
+```ts
+  createdAt: Sequelize.DataTypes.DATE,
+  updatedAt: Sequelize.DataTypes.DATE,
+```
+
+- Dans le fichier `src/infra/sequelize/models.ts`, ajouter la ligne:
+
+```ts
+export const models = {
+  // ...autres models
+  Maproj: makeMaproj,
+}
+```
+
+## Ajout d'un événement de mise à jour de projection
+
+Soient la projection `maproj` et l'événement `MyEvent`.
+
+- Créer le fichier `src/infra/sequelize/projections/maproj/updates/onMyEvent.ts` de la forme:
+
+```ts
+import { maprojProjector } from '../maproj.model'
+
+// Pour une création
+export const onMyEvent = maprojProjector
+  .on(MyEvent)
+  .insert(({ payload: { id, name }, occurredAt }) => ({
+    id,
+    name,
+    createdAt: occurredAt,
+  }))
+
+// Pour une mise à jour
+export const onMyEvent = maprojProjector.on(MyEvent).update({
+  where: ({ payload: { id } }) => ({ id }),
+  delta: ({ payload: { name } }) => ({ name }),
+})
+```
+
+- Mettre à jour `src/infra/sequelize/projections/maproj/updates/index.ts` (barrel)

--- a/src/config/projections.config.ts
+++ b/src/config/projections.config.ts
@@ -1,6 +1,11 @@
-import { initProjections } from '../infra/sequelize'
+import { initProjections, initProjectors } from '../infra/sequelize'
 import { eventStore } from './eventStore.config'
 
+// This is legacy
 initProjections(eventStore)
+
+// This is initProjections replacement
+const projectors = initProjectors(eventStore)
+console.log(`Initialized projectors: ${projectors.join(', ')}`)
 
 console.log('Projections initialized')

--- a/src/helpers/isObject.ts
+++ b/src/helpers/isObject.ts
@@ -1,0 +1,6 @@
+/**
+ * Detect if the argument is a simple object created from Object() or as {...} (not a Date, Array, etc.)
+ * @param obj the object to be tested
+ * @returns boolean
+ */
+export const isObject = (obj) => Object.getPrototypeOf(obj) === Object.prototype

--- a/src/infra/sequelize/helpers/index.ts
+++ b/src/infra/sequelize/helpers/index.ts
@@ -1,1 +1,3 @@
-export * from './resetDatabase'
+export * from './tests';
+export * from './projector';
+export * from './resetDatabase';

--- a/src/infra/sequelize/helpers/projector.spec.ts
+++ b/src/infra/sequelize/helpers/projector.spec.ts
@@ -1,0 +1,142 @@
+import { BaseDomainEvent, DomainEvent } from '../../../core/domain'
+import { makeProjector } from './projector'
+
+export interface FakeEventPayload {
+  param: string
+}
+export class FakeEvent extends BaseDomainEvent<FakeEventPayload> implements DomainEvent {
+  public static type: 'FakeEvent' = 'FakeEvent'
+  public type = FakeEvent.type
+  currentVersion = 1
+
+  aggregateIdFromPayload(payload: FakeEventPayload) {
+    return undefined
+  }
+}
+
+describe('projector', () => {
+  describe('on(Event).create', () => {
+    const projector = makeProjector()
+    const fakeModel = {
+      create: jest.fn(),
+    }
+
+    const fakeEventBus = {
+      subscribe: jest.fn(),
+      publish: jest.fn(),
+    }
+    projector.initModel(fakeModel)
+    projector.initEventBus(fakeEventBus)
+
+    const fakeCallback = jest.fn((event: FakeEvent) => ({ param1: 'value1' }))
+
+    beforeAll(() => {
+      projector.on(FakeEvent).create(fakeCallback)
+    })
+
+    it('should add a listener for the FakeEvent', () => {
+      expect(fakeEventBus.subscribe).toHaveBeenCalledTimes(1)
+
+      const eventType = fakeEventBus.subscribe.mock.calls[0][0]
+      expect(eventType).toEqual(FakeEvent.type)
+    })
+
+    it('should add a listener that calls model.create with the value returned by the callback', () => {
+      const listener = fakeEventBus.subscribe.mock.calls[0][1]
+
+      // Call the listener with a fake event
+      const fakeEvent = new FakeEvent({ payload: { param: '123' } })
+      listener(fakeEvent)
+
+      expect(fakeCallback).toHaveBeenCalledWith(fakeEvent)
+      expect(fakeModel.create).toHaveBeenCalledWith({ param1: 'value1' })
+    })
+  })
+
+  describe('on(Event).delete', () => {
+    const projector = makeProjector()
+    const fakeModel = {
+      destroy: jest.fn(),
+    }
+
+    const fakeEventBus = {
+      subscribe: jest.fn(),
+      publish: jest.fn(),
+    }
+    projector.initModel(fakeModel)
+    projector.initEventBus(fakeEventBus)
+
+    const fakeWhere = jest.fn((event: FakeEvent) => ({ id: 'value1' }))
+
+    beforeAll(() => {
+      projector.on(FakeEvent).delete(fakeWhere)
+    })
+
+    it('should add a listener for the FakeEvent', () => {
+      expect(fakeEventBus.subscribe).toHaveBeenCalledTimes(1)
+
+      const eventType = fakeEventBus.subscribe.mock.calls[0][0]
+      expect(eventType).toEqual(FakeEvent.type)
+    })
+
+    it('should add a listener that calls model.destroy with the where clause', () => {
+      const listener = fakeEventBus.subscribe.mock.calls[0][1]
+
+      // Call the listener with a fake event
+      const fakeEvent = new FakeEvent({ payload: { param: '123' } })
+      listener(fakeEvent)
+
+      expect(fakeWhere).toHaveBeenCalledWith(fakeEvent)
+      expect(fakeModel.destroy).toHaveBeenCalledWith({ where: { id: 'value1' } })
+    })
+  })
+
+  describe('on(Event).update', () => {
+    const projector = makeProjector()
+
+    const fakeInstance = {
+      save: jest.fn(() => Promise.resolve()),
+      set: jest.fn((key: string, value: any) => {}),
+      get: jest.fn(() => undefined),
+    }
+    const fakeModel = {
+      findOne: jest.fn((args: any) => Promise.resolve(fakeInstance)),
+    }
+
+    const fakeEventBus = {
+      subscribe: jest.fn(),
+      publish: jest.fn(),
+    }
+    projector.initModel(fakeModel)
+    projector.initEventBus(fakeEventBus)
+
+    const fakeDeltaCallback = jest.fn((event: FakeEvent) => ({ param1: 'value1' }))
+    const fakeWhereCallback = jest.fn((event: FakeEvent) => ({ id: '1234' }))
+
+    beforeAll(() => {
+      projector.on(FakeEvent).update({ where: fakeWhereCallback, delta: fakeDeltaCallback })
+    })
+
+    it('should add a listener for the FakeEvent', () => {
+      expect(fakeEventBus.subscribe).toHaveBeenCalledTimes(1)
+
+      const eventType = fakeEventBus.subscribe.mock.calls[0][0]
+      expect(eventType).toEqual(FakeEvent.type)
+    })
+
+    it('should add a listener that calls model.findOne with the where value from the callback, apply the delta value from the callback to it and then call instance.save', async () => {
+      const listener = fakeEventBus.subscribe.mock.calls[0][1]
+
+      // Call the listener with a fake event
+      const fakeEvent = new FakeEvent({ payload: { param: '123' } })
+      await listener(fakeEvent)
+
+      expect(fakeDeltaCallback).toHaveBeenCalledWith(fakeEvent)
+      expect(fakeWhereCallback).toHaveBeenCalledWith(fakeEvent)
+
+      expect(fakeModel.findOne).toHaveBeenCalledWith({ where: { id: '1234' } })
+      expect(fakeInstance.set).toHaveBeenCalledWith('param1', 'value1')
+      expect(fakeInstance.save).toHaveBeenCalled()
+    })
+  })
+})

--- a/src/infra/sequelize/helpers/projector.ts
+++ b/src/infra/sequelize/helpers/projector.ts
@@ -1,0 +1,112 @@
+import { merge } from 'lodash'
+
+import { BaseDomainEvent, DomainEvent } from '../../../core/domain'
+import { logger } from '../../../core/utils'
+import { EventBus } from '../../../modules/eventStore'
+
+interface HasType {
+  type: string
+}
+
+interface Constructor<T> {
+  new (args: any): T
+}
+
+interface Handler<Event> {
+  (event: Event): any
+}
+
+export const makeProjector = () => {
+  const handlers: any[] = []
+  let eventBus: EventBus
+  let model: any
+
+  function subscribe<Event extends DomainEvent>(
+    eventType: string,
+    handler: (event: Event) => unknown
+  ) {
+    if (eventBus) {
+      eventBus.subscribe(eventType, handler)
+    } else {
+      handlers.push({
+        eventType,
+        handler,
+      })
+    }
+
+    // Returning handler allows projection handlers to export the result of the subscription
+    return handler
+  }
+
+  const on = <Payload, Event extends BaseDomainEvent<Payload>>(
+    eventClass: Constructor<Event> & HasType
+  ) => ({
+    create(cb: Handler<Event>) {
+      const eventHandler = async (event) => {
+        try {
+          await model.create(cb(event))
+        } catch (e) {
+          logger.error(e)
+        }
+      }
+      return subscribe(eventClass.type, eventHandler) as Handler<Event>
+    },
+    update(args: { where: Handler<Event>; delta: Handler<Event> }) {
+      const { where, delta } = args
+      const eventHandler = async (event) => {
+        try {
+          const instance = await model.findOne({ where: where(event) })
+
+          if (instance === null) {
+            logger.error(
+              `${model?.name}.on${eventClass.type} failed to find item to update (where: ${where(
+                event
+              )})`
+            )
+            return
+          }
+
+          for (const [key, value] of Object.entries(delta(event))) {
+            instance.set(key, isObject(value) ? merge({}, instance.get(key) || {}, value) : value)
+          }
+
+          await instance.save()
+        } catch (e) {
+          logger.error(e)
+        }
+      }
+      return subscribe(eventClass.type, eventHandler) as Handler<Event>
+    },
+    delete(where: Handler<Event>) {
+      const eventHandler = async (event) => {
+        try {
+          await model.destroy({ where: where(event) })
+        } catch (e) {
+          logger.error(e)
+        }
+      }
+      return subscribe(eventClass.type, eventHandler) as Handler<Event>
+    },
+  })
+
+  const initModel = (_model: any) => {
+    model = _model
+  }
+
+  const initEventBus = (_eventBus: EventBus) => {
+    eventBus = _eventBus
+    handlers.forEach(({ eventType, handler }) => {
+      eventBus.subscribe(eventType, handler)
+    })
+  }
+
+  return {
+    on,
+    initModel,
+    initEventBus,
+  }
+}
+
+function isObject(obj) {
+  return Object.getPrototypeOf(obj) === Object.prototype
+}

--- a/src/infra/sequelize/helpers/projector.ts
+++ b/src/infra/sequelize/helpers/projector.ts
@@ -1,8 +1,10 @@
 import { merge } from 'lodash'
+import { AnyRecordWithTtl } from 'node:dns'
 
 import { BaseDomainEvent, DomainEvent } from '../../../core/domain'
 import { logger } from '../../../core/utils'
 import { EventBus } from '../../../modules/eventStore'
+import { isObject } from '../../../helpers/isObject'
 
 interface HasType {
   type: string
@@ -21,10 +23,7 @@ export const makeProjector = () => {
   let eventBus: EventBus
   let model: any
 
-  function subscribe<Event extends DomainEvent>(
-    eventType: string,
-    handler: (event: Event) => unknown
-  ) {
+  function subscribe<Event extends DomainEvent>(eventType: string, handler: Handler<Event>) {
     if (eventBus) {
       eventBus.subscribe(eventType, handler)
     } else {
@@ -105,8 +104,4 @@ export const makeProjector = () => {
     initModel,
     initEventBus,
   }
-}
-
-function isObject(obj) {
-  return Object.getPrototypeOf(obj) === Object.prototype
 }

--- a/src/infra/sequelize/helpers/tests/describeProjector.ts
+++ b/src/infra/sequelize/helpers/tests/describeProjector.ts
@@ -69,7 +69,7 @@ export const describeProjector = <Event extends { type: string }>(
 
           const actuallyRemainingItems = await model.findAll()
 
-          expect(actuallyRemainingItems).toHaveLength(remaining ? remaining.length : 0)
+          expect(actuallyRemainingItems).toHaveLength(remaining?.length || 0)
           if (remaining) {
             for (const remainingItem of remaining) {
               expect(actuallyRemainingItems.some(matches(remainingItem))).toBe(true)

--- a/src/infra/sequelize/helpers/tests/describeProjector.ts
+++ b/src/infra/sequelize/helpers/tests/describeProjector.ts
@@ -1,0 +1,82 @@
+import { matches } from 'lodash'
+import { resetDatabase } from '../resetDatabase'
+
+interface ShouldCreateProps {
+  model: any
+  id: string
+  value: any
+}
+
+interface ShouldUpdateProps {
+  model: any
+  id: string
+  before: any
+  after: any
+}
+
+interface ShouldDeleteProps {
+  model: any
+  prior: any[]
+  remaining?: any[]
+}
+
+export const describeProjector = <Event extends { type: string }>(
+  projector: (event: Event) => any
+) => ({
+  onEvent: (testEvent: Event) => ({
+    shouldCreate: ({ model, id, value }: ShouldCreateProps) => {
+      describe(`${model.name}.on${testEvent.type}`, () => {
+        beforeAll(async () => {
+          await resetDatabase()
+        })
+
+        it(`should create a ${model.name}`, async () => {
+          await projector(testEvent)
+
+          const createdItem = await model.findByPk(id)
+
+          expect(createdItem).not.toBe(null)
+          expect(createdItem).toMatchObject(value)
+        })
+      })
+    },
+    shouldUpdate: ({ model, id, before, after }: ShouldUpdateProps) => {
+      describe(`${model.name}.on${testEvent.type}`, () => {
+        beforeAll(async () => {
+          await resetDatabase()
+          await model.create(before)
+        })
+
+        it(`should update the ${model.name}`, async () => {
+          await projector(testEvent)
+
+          const updatedItem = await model.findByPk(id)
+
+          expect(updatedItem).not.toBe(null)
+          expect(updatedItem).toMatchObject(after)
+        })
+      })
+    },
+    shouldDelete: ({ model, prior, remaining }: ShouldDeleteProps) => {
+      describe(`${model.name}.on${testEvent.type}`, () => {
+        beforeAll(async () => {
+          await resetDatabase()
+          await model.bulkCreate(prior)
+        })
+
+        it(`should delete the designated ${model.name}`, async () => {
+          await projector(testEvent)
+
+          const actuallyRemainingItems = await model.findAll()
+
+          expect(actuallyRemainingItems).toHaveLength(remaining ? remaining.length : 0)
+          if (remaining) {
+            for (const remainingItem of remaining) {
+              expect(actuallyRemainingItems.some(matches(remainingItem))).toBe(true)
+            }
+          }
+        })
+      })
+    },
+  }),
+})

--- a/src/infra/sequelize/helpers/tests/index.ts
+++ b/src/infra/sequelize/helpers/tests/index.ts
@@ -1,0 +1,1 @@
+export * from './describeProjector';

--- a/src/infra/sequelize/index.ts
+++ b/src/infra/sequelize/index.ts
@@ -10,6 +10,7 @@ import {
   initAppelOffreProjections,
 } from './projections'
 
+export { initProjectors } from './models'
 export const sequelizeEventStore = new SequelizeEventStore(models)
 
 export const initProjections = (eventStore: EventStore) => {

--- a/src/infra/sequelize/projections/appelOffre/appelOffre.model.ts
+++ b/src/infra/sequelize/projections/appelOffre/appelOffre.model.ts
@@ -1,4 +1,7 @@
 import { DataTypes } from 'sequelize'
+import { makeProjector } from '../../helpers'
+
+export const appelOffreProjector = makeProjector()
 
 export const MakeAppelOffreModel = (sequelize) => {
   const AppelOffre = sequelize.define(
@@ -21,6 +24,8 @@ export const MakeAppelOffreModel = (sequelize) => {
   AppelOffre.associate = (models) => {
     // Add belongsTo etc. statements here
   }
+
+  AppelOffre.projector = appelOffreProjector
 
   return AppelOffre
 }

--- a/src/infra/sequelize/projections/appelOffre/periode.model.ts
+++ b/src/infra/sequelize/projections/appelOffre/periode.model.ts
@@ -1,4 +1,7 @@
 import { DataTypes } from 'sequelize'
+import { makeProjector } from '../../helpers'
+
+export const periodeProjector = makeProjector()
 
 export const MakePeriodeModel = (sequelize) => {
   const Periode = sequelize.define(
@@ -25,6 +28,8 @@ export const MakePeriodeModel = (sequelize) => {
   Periode.associate = (models) => {
     // Add belongsTo etc. statements here
   }
+
+  Periode.projector = periodeProjector
 
   return Periode
 }

--- a/src/infra/sequelize/projections/appelOffre/updates/onAppelOffreCreated.integration.ts
+++ b/src/infra/sequelize/projections/appelOffre/updates/onAppelOffreCreated.integration.ts
@@ -1,38 +1,33 @@
-import models from '../../../models'
-import { resetDatabase } from '../../../helpers'
-import { onAppelOffreCreated } from './onAppelOffreCreated'
-import { AppelOffreCreated } from '../../../../../modules/appelOffre/events'
 import { UniqueEntityID } from '../../../../../core/domain'
+import { AppelOffreCreated } from '../../../../../modules/appelOffre/events'
+import { describeProjector } from '../../../helpers'
+import models from '../../../models'
+import { onAppelOffreCreated } from './onAppelOffreCreated'
 
-describe('appelOffre.onAppelOffreCreated', () => {
-  const { AppelOffre } = models
+const { AppelOffre } = models
 
-  const appelOffreId = new UniqueEntityID().toString()
+const appelOffreId = new UniqueEntityID().toString()
 
-  beforeAll(async () => {
-    // Create the tables and remove all data
-    await resetDatabase()
-  })
-
-  it('should create the appel offre', async () => {
-    await onAppelOffreCreated(models)(
-      new AppelOffreCreated({
-        payload: {
-          appelOffreId,
-          createdBy: '',
-          data: {
-            param1: 'value1',
-            param2: 'value2',
-          },
+describeProjector(onAppelOffreCreated)
+  .onEvent(
+    new AppelOffreCreated({
+      payload: {
+        appelOffreId,
+        createdBy: '',
+        data: {
+          param1: 'value1',
+          param2: 'value2',
         },
-      })
-    )
-
-    const createdAppelOffre = await AppelOffre.findByPk(appelOffreId)
-    expect(createdAppelOffre).not.toBe(null)
-    expect(createdAppelOffre.data).toEqual({
-      param1: 'value1',
-      param2: 'value2',
+      },
     })
+  )
+  .shouldCreate({
+    model: AppelOffre,
+    id: appelOffreId,
+    value: {
+      data: {
+        param1: 'value1',
+        param2: 'value2',
+      },
+    },
   })
-})

--- a/src/infra/sequelize/projections/appelOffre/updates/onAppelOffreCreated.ts
+++ b/src/infra/sequelize/projections/appelOffre/updates/onAppelOffreCreated.ts
@@ -1,19 +1,9 @@
-import { logger } from '../../../../../core/utils'
 import { AppelOffreCreated } from '../../../../../modules/appelOffre'
+import { appelOffreProjector } from '../appelOffre.model'
 
-export const onAppelOffreCreated = (models) => async (event: AppelOffreCreated) => {
-  const { AppelOffre } = models
-
-  const {
-    payload: { appelOffreId, data },
-  } = event
-  try {
-    await AppelOffre.create({
-      id: appelOffreId,
-      data,
-    })
-  } catch (e) {
-    logger.error(e)
-    logger.info('Error: onAppelOffreCreated projection failed to create appel offre :', event)
-  }
-}
+export const onAppelOffreCreated = appelOffreProjector
+  .on(AppelOffreCreated)
+  .create(({ payload: { appelOffreId, data } }) => ({
+    id: appelOffreId,
+    data,
+  }))

--- a/src/infra/sequelize/projections/appelOffre/updates/onAppelOffreRemoved.integration.ts
+++ b/src/infra/sequelize/projections/appelOffre/updates/onAppelOffreRemoved.integration.ts
@@ -1,47 +1,40 @@
 import models from '../../../models'
-import { resetDatabase } from '../../../helpers'
+import { describeProjector, resetDatabase } from '../../../helpers'
 import { onAppelOffreRemoved } from './onAppelOffreRemoved'
 import { AppelOffreRemoved } from '../../../../../modules/appelOffre/events'
 import { UniqueEntityID } from '../../../../../core/domain'
 
-describe('appelOffre.onAppelOffreRemoved', () => {
-  const { AppelOffre, Periode } = models
+const { AppelOffre, Periode } = models
 
-  const appelOffreId = new UniqueEntityID().toString()
-  const periodeId = new UniqueEntityID().toString()
+const appelOffreId = new UniqueEntityID().toString()
+const otherAppelOffreId = new UniqueEntityID().toString()
+const periodeId = new UniqueEntityID().toString()
 
-  beforeAll(async () => {
-    // Create the tables and remove all data
-    await resetDatabase()
-
-    await AppelOffre.create({
-      id: appelOffreId,
-      data: { param2: 'value2', param3: 'value3' },
+describeProjector(onAppelOffreRemoved)
+  .onEvent(
+    new AppelOffreRemoved({
+      payload: {
+        appelOffreId,
+        removedBy: '',
+      },
     })
-
-    await Periode.create({
-      appelOffreId,
-      periodeId,
-      data: {},
-    })
-
-    await onAppelOffreRemoved(models)(
-      new AppelOffreRemoved({
-        payload: {
-          appelOffreId,
-          removedBy: '',
-        },
-      })
-    )
+  )
+  .shouldDelete({
+    model: AppelOffre,
+    prior: [
+      {
+        id: appelOffreId,
+        data: {},
+      },
+      {
+        id: otherAppelOffreId,
+        data: {},
+      },
+    ],
+    remaining: [
+      {
+        id: otherAppelOffreId,
+        data: {},
+      },
+    ],
   })
-
-  it('should remove the appel offre', async () => {
-    const appelOffre = await AppelOffre.findByPk(appelOffreId)
-    expect(appelOffre).toBeNull()
-  })
-
-  it('should remove the periodes of the appel offre', async () => {
-    const periode = await Periode.findOne({ where: { appelOffreId, periodeId } })
-    expect(periode).toBeNull()
-  })
-})

--- a/src/infra/sequelize/projections/appelOffre/updates/onAppelOffreRemoved.integration.ts
+++ b/src/infra/sequelize/projections/appelOffre/updates/onAppelOffreRemoved.integration.ts
@@ -1,6 +1,6 @@
 import models from '../../../models'
 import { describeProjector, resetDatabase } from '../../../helpers'
-import { onAppelOffreRemoved } from './onAppelOffreRemoved'
+import { onAppelOffreRemoved, onAppelOffreRemovedRemovePeriodes } from './onAppelOffreRemoved'
 import { AppelOffreRemoved } from '../../../../../modules/appelOffre/events'
 import { UniqueEntityID } from '../../../../../core/domain'
 
@@ -34,6 +34,38 @@ describeProjector(onAppelOffreRemoved)
     remaining: [
       {
         id: otherAppelOffreId,
+        data: {},
+      },
+    ],
+  })
+
+describeProjector(onAppelOffreRemovedRemovePeriodes)
+  .onEvent(
+    new AppelOffreRemoved({
+      payload: {
+        appelOffreId,
+        removedBy: '',
+      },
+    })
+  )
+  .shouldDelete({
+    model: Periode,
+    prior: [
+      {
+        periodeId,
+        appelOffreId,
+        data: {},
+      },
+      {
+        periodeId,
+        appelOffreId: otherAppelOffreId,
+        data: {},
+      },
+    ],
+    remaining: [
+      {
+        periodeId,
+        appelOffreId: otherAppelOffreId,
         data: {},
       },
     ],

--- a/src/infra/sequelize/projections/appelOffre/updates/onAppelOffreRemoved.ts
+++ b/src/infra/sequelize/projections/appelOffre/updates/onAppelOffreRemoved.ts
@@ -1,28 +1,12 @@
 import { logger } from '../../../../../core/utils'
 import { AppelOffreRemoved } from '../../../../../modules/appelOffre'
 import { appelOffreProjector } from '../appelOffre.model'
+import { periodeProjector } from '../periode.model'
 
 export const onAppelOffreRemoved = appelOffreProjector
   .on(AppelOffreRemoved)
   .delete(({ payload: { appelOffreId } }) => ({ id: appelOffreId }))
 
-// export const onAppelOffreRemoved = (models) => async (event: AppelOffreRemoved) => {
-//   const { AppelOffre, Periode } = models
-//   const { appelOffreId } = event.payload
-//   const instance = await AppelOffre.findByPk(appelOffreId)
-
-//   if (!instance) {
-//     logger.error(
-//       `Error: onAppelOffreRemoved projection failed to retrieve project from db ${event}`
-//     )
-//     return
-//   }
-
-//   try {
-//     await instance.destroy()
-//     await Periode.destroy({ where: { appelOffreId } })
-//   } catch (e) {
-//     logger.error(e)
-//     logger.info('Error: onAppelOffreRemoved projection failed to update appel offre :', event)
-//   }
-// }
+export const onAppelOffreRemovedRemovePeriodes = periodeProjector
+  .on(AppelOffreRemoved)
+  .delete(({ payload: { appelOffreId } }) => ({ appelOffreId }))

--- a/src/infra/sequelize/projections/appelOffre/updates/onAppelOffreRemoved.ts
+++ b/src/infra/sequelize/projections/appelOffre/updates/onAppelOffreRemoved.ts
@@ -1,23 +1,28 @@
 import { logger } from '../../../../../core/utils'
 import { AppelOffreRemoved } from '../../../../../modules/appelOffre'
+import { appelOffreProjector } from '../appelOffre.model'
 
-export const onAppelOffreRemoved = (models) => async (event: AppelOffreRemoved) => {
-  const { AppelOffre, Periode } = models
-  const { appelOffreId } = event.payload
-  const instance = await AppelOffre.findByPk(appelOffreId)
+export const onAppelOffreRemoved = appelOffreProjector
+  .on(AppelOffreRemoved)
+  .delete(({ payload: { appelOffreId } }) => ({ id: appelOffreId }))
 
-  if (!instance) {
-    logger.error(
-      `Error: onAppelOffreRemoved projection failed to retrieve project from db ${event}`
-    )
-    return
-  }
+// export const onAppelOffreRemoved = (models) => async (event: AppelOffreRemoved) => {
+//   const { AppelOffre, Periode } = models
+//   const { appelOffreId } = event.payload
+//   const instance = await AppelOffre.findByPk(appelOffreId)
 
-  try {
-    await instance.destroy()
-    await Periode.destroy({ where: { appelOffreId } })
-  } catch (e) {
-    logger.error(e)
-    logger.info('Error: onAppelOffreRemoved projection failed to update appel offre :', event)
-  }
-}
+//   if (!instance) {
+//     logger.error(
+//       `Error: onAppelOffreRemoved projection failed to retrieve project from db ${event}`
+//     )
+//     return
+//   }
+
+//   try {
+//     await instance.destroy()
+//     await Periode.destroy({ where: { appelOffreId } })
+//   } catch (e) {
+//     logger.error(e)
+//     logger.info('Error: onAppelOffreRemoved projection failed to update appel offre :', event)
+//   }
+// }

--- a/src/infra/sequelize/projections/appelOffre/updates/onAppelOffreUpdated.integration.ts
+++ b/src/infra/sequelize/projections/appelOffre/updates/onAppelOffreUpdated.integration.ts
@@ -1,43 +1,38 @@
-import models from '../../../models'
-import { resetDatabase } from '../../../helpers'
-import { onAppelOffreUpdated } from './onAppelOffreUpdated'
-import { AppelOffreUpdated } from '../../../../../modules/appelOffre/events'
 import { UniqueEntityID } from '../../../../../core/domain'
+import { AppelOffreUpdated } from '../../../../../modules/appelOffre/events'
+import { describeProjector } from '../../../helpers'
+import models from '../../../models'
+import { onAppelOffreUpdated } from './onAppelOffreUpdated'
 
-describe('appelOffre.onAppelOffreUpdated', () => {
-  const { AppelOffre } = models
+const { AppelOffre } = models
 
-  const appelOffreId = new UniqueEntityID().toString()
+const appelOffreId = new UniqueEntityID().toString()
 
-  beforeAll(async () => {
-    // Create the tables and remove all data
-    await resetDatabase()
-
-    await AppelOffre.create({
+describeProjector(onAppelOffreUpdated)
+  .onEvent(
+    new AppelOffreUpdated({
+      payload: {
+        appelOffreId,
+        updatedBy: '',
+        delta: {
+          param1: 'value1',
+          param2: 'newvalue2',
+        },
+      },
+    })
+  )
+  .shouldUpdate({
+    model: AppelOffre,
+    id: appelOffreId,
+    before: {
       id: appelOffreId,
       data: { param2: 'value2', param3: 'value3' },
-    })
+    },
+    after: {
+      data: {
+        param1: 'value1',
+        param2: 'newvalue2',
+        param3: 'value3',
+      },
+    },
   })
-
-  it('should update the appel offre data with the delta', async () => {
-    await onAppelOffreUpdated(models)(
-      new AppelOffreUpdated({
-        payload: {
-          appelOffreId,
-          updatedBy: '',
-          delta: {
-            param1: 'value1',
-            param2: 'newvalue2',
-          },
-        },
-      })
-    )
-
-    const updatedAppelOffre = await AppelOffre.findByPk(appelOffreId)
-    expect(updatedAppelOffre.data).toEqual({
-      param1: 'value1',
-      param2: 'newvalue2',
-      param3: 'value3',
-    })
-  })
-})

--- a/src/infra/sequelize/projections/appelOffre/updates/onAppelOffreUpdated.ts
+++ b/src/infra/sequelize/projections/appelOffre/updates/onAppelOffreUpdated.ts
@@ -1,29 +1,8 @@
 import { logger } from '../../../../../core/utils'
 import { AppelOffreUpdated } from '../../../../../modules/appelOffre'
+import { appelOffreProjector } from '../appelOffre.model'
 
-export const onAppelOffreUpdated = (models) => async (event: AppelOffreUpdated) => {
-  const { AppelOffre } = models
-  const instance = await AppelOffre.findByPk(event.payload.appelOffreId)
-
-  if (!instance) {
-    logger.error(
-      `Error: onAppelOffreUpdated projection failed to retrieve project from db ${event}`
-    )
-    return
-  }
-
-  const {
-    payload: { delta },
-  } = event
-
-  Object.assign(instance, {
-    data: { ...instance.data, ...delta },
-  })
-
-  try {
-    await instance.save()
-  } catch (e) {
-    logger.error(e)
-    logger.info('Error: onAppelOffreUpdated projection failed to update appel offre :', event)
-  }
-}
+export const onAppelOffreUpdated = appelOffreProjector.on(AppelOffreUpdated).update({
+  where: ({ payload: { appelOffreId } }) => ({ id: appelOffreId }),
+  delta: ({ payload: { delta } }) => ({ data: delta }),
+})


### PR DESCRIPTION
Cette PR est une proposition de refactoring des projections sequelize.

Actuellement, chaque mise à jour de projections est une méthode qui prend les `models` et qui utilise les méthodes de sequelize pour effectuer un changement.

J'ai remarqué que les projections sont en général des opérations simples de type Create/Update/Delete. Le code d'implémentation des projections est très répétitif et il en est de même pour le code des tests d'intégration qui vont avec.

Dans cette PR, je propose un projecteur générique qui mets en oeuvre les trois opérations typiques.
En utilisant ce projecteur générique, le code d'implémentation de chaque projection se limite aux éléments nécessaires pour chaque opération et devient très rapide à coder.

Chaque projection dispose de son projecteur (singleton) qui est rattaché à son `model` sequelize. Les scripts d'initialisation des models est amendé pour initialiser également les projecteurs attachés (qui ont besoin du model mais aussi de l'eventBus).
De cette manière, la création d'une nouvelle projection ou l'ajout d'une opération de mise à jour sur une projection ne nécessite plus de branchement sur l'eventStore ou d'initialisation.

J'ai créé un fichier `RECIPES.md` qui reprend la marche à suivre pour la création d'une projection et/ou d'une nouvelle opération de mise à jour (update) de cette projection.

Je propose par ailleurs, un utilitaire `describeProjector` qui permet de coder les tests d'intégration relatifs aux opérations de mise à jour de projection de manière grandement simplifiée.

Dans le cadre de cette PR, j'ai refactoré la projection `appelOffre` pour montrer à quoi ressemblerait la mise en oeuvre de ce projecteur générique et les tests d'intégrations pour les trois opérations.