### PR TITLE
:wrench:  Disable HSTS for subdomains to allow http redirections

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -32,6 +32,7 @@ export async function makeServer(port: number, sessionSecret: string) {
           hsts: {
             maxAge: 63072000,
             includeSubDomains: false,
+            preload: true,
           },
         })
       )

--- a/src/server.ts
+++ b/src/server.ts
@@ -29,6 +29,10 @@ export async function makeServer(port: number, sessionSecret: string) {
           //   // See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy
           //   // Only send refererer for same origin and transport (HTTPS->HTTPS)
           referrerPolicy: { policy: 'strict-origin' },
+          hsts: {
+            maxAge: 63072000,
+            includeSubDomains: false,
+          },
         })
       )
     }


### PR DESCRIPTION
Pour avoir des liens de suivi  personnalisés sur mailjet, il faut que les utilisateurs puissent passer par un lien de type `http://lien.potentiel.beta.gouv.fr/lnk/...` or la politique HSTS actuelle sur le site force le passage à `https` immédiatement, ce qui casse ce genre de lien (pour lesquels il n'y a pas de certification ssl).

En rajoutant `includeSubdomains: false` sur `helmet`, la politique http=>https ne devrait pas s'appliquer sur le sous-domaine `lien.potentiel.beta.gouv.fr`.