### PR TITLE
Make sure routes.ts can be imported on frontend and backend

### DIFF
--- a/src/__tests__/fixtures/project.ts
+++ b/src/__tests__/fixtures/project.ts
@@ -28,6 +28,7 @@ export default function makeFakeProject(overrides?) {
     isFinancementParticipatif: false,
     engagementFournitureDePuissanceAlaPointe: false,
     newRulesOptIn: false,
+    potentielIdentifier: 'ref-potentiel',
   }
 
   return {

--- a/src/controllers/garantiesFinancieres/getModeleMiseEnDemeure.ts
+++ b/src/controllers/garantiesFinancieres/getModeleMiseEnDemeure.ts
@@ -1,16 +1,15 @@
+import asyncHandler from 'express-async-handler'
 import moment from 'moment'
 import os from 'os'
 import path from 'path'
 import sanitize from 'sanitize-filename'
 import { userRepo } from '../../dataAccess'
-import { makeProjectIdentifier } from '../../entities/project'
 import { fillDocxTemplate } from '../../helpers/fillDocxTemplate'
 import { formatDate } from '../../helpers/formatDate'
 import routes from '../../routes'
 import { getUserProject } from '../../useCases'
 import { ensureLoggedIn, ensureRole } from '../auth'
 import { v1Router } from '../v1Router'
-import asyncHandler from 'express-async-handler'
 
 v1Router.get(
   routes.TELECHARGER_MODELE_MISE_EN_DEMEURE(),
@@ -59,7 +58,7 @@ v1Router.get(
         dreal,
         dateMiseEnDemeure: formatDate(Date.now()),
         contactDreal: request.user.email,
-        referenceProjet: makeProjectIdentifier(project),
+        referenceProjet: project.potentielIdentifier,
         titreAppelOffre: project.appelOffre?.title || '!!!AO NON DISPONIBLE!!!',
         dateLancementAppelOffre: project.appelOffre?.launchDate || '!!!AO NON DISPONIBLE!!!',
         nomProjet: project.nomProjet,

--- a/src/dataAccess/db/project.ts
+++ b/src/dataAccess/db/project.ts
@@ -1,7 +1,16 @@
 import { DataTypes, Op, where, col } from 'sequelize'
 import { ContextSpecificProjectListFilter, ProjectFilters, ProjectRepo } from '../'
 import { logger } from '../../core/utils'
-import { AppelOffre, DREAL, Famille, makeProject, Periode, User, Project } from '../../entities'
+import {
+  AppelOffre,
+  DREAL,
+  Famille,
+  makeProject,
+  Periode,
+  User,
+  Project,
+  makeProjectIdentifier,
+} from '../../entities'
 import { makePaginatedList, paginate } from '../../helpers/paginate'
 import { mapExceptError } from '../../helpers/results'
 import { Err, Ok, PaginatedList, Pagination, ResultAsync } from '../../types'
@@ -33,6 +42,7 @@ const deserialize = (item) => ({
   dcrNumeroDossier: item.dcr?.details.numeroDossier,
   completionDueOn: item.completionDueOn || 0,
   abandonedOn: item.abandonedOn || 0,
+  potentielIdentifier: makeProjectIdentifier(item),
 })
 
 export default function makeProjectRepo({ sequelizeInstance, appelOffreRepo }): ProjectRepo {
@@ -192,7 +202,7 @@ export default function makeProjectRepo({ sequelizeInstance, appelOffreRepo }): 
     newRulesOptIn: {
       type: DataTypes.BOOLEAN,
       allowNull: false,
-      defaultValue: false
+      defaultValue: false,
     },
   })
 

--- a/src/entities/project.ts
+++ b/src/entities/project.ts
@@ -69,6 +69,7 @@ const baseProjectSchema = SchemaRecord({
   abandonedOn: Number,
   numeroGestionnaire: String,
   newRulesOptIn: Boolean,
+  potentielIdentifier: String,
 })
 const projectSchema = baseProjectSchema.And(
   SchemaPartial({
@@ -94,6 +95,8 @@ const fields: string[] = [
   'createdAt',
   'updatedAt',
   'gf',
+  'newRulesOptIn',
+  'potentielIdentifier',
   ...Object.keys(baseProjectSchema.fields),
 ]
 
@@ -118,6 +121,7 @@ type BaseProject = Static<typeof projectSchema> & {
     user: { fullName: string }
   }
   newRulesOptIn: boolean
+  readonly potentielIdentifier: string
 }
 
 type ProjectEvent = {

--- a/src/infra/sequelize/queries/getModificationRequestDataForResponseTemplate.integration.ts
+++ b/src/infra/sequelize/queries/getModificationRequestDataForResponseTemplate.integration.ts
@@ -5,7 +5,7 @@ import makeFakeFile from '../../../__tests__/fixtures/file'
 import makeFakeUser from '../../../__tests__/fixtures/user'
 import { makeGetModificationRequestDataForResponseTemplate } from './getModificationRequestDataForResponseTemplate'
 import { UniqueEntityID } from '../../../core/domain'
-import { makeProjectIdentifier, makeUser } from '../../../entities'
+import { makeUser } from '../../../entities'
 import { formatDate } from '../../../helpers/formatDate'
 import moment from 'moment'
 import { okAsync } from 'neverthrow'
@@ -117,7 +117,7 @@ describe('Sequelize getModificationRequestDataForResponseTemplate', () => {
       expect(modificationRequestDTO).toMatchObject({
         suiviPar: 'John Doe',
         suiviParEmail: dgecEmail,
-        refPotentiel: makeProjectIdentifier(project),
+        refPotentiel: project.potentielIdentifier,
 
         status: 'envoyée',
 

--- a/src/infra/sequelize/queries/getProjectDataForProjectPage.ts
+++ b/src/infra/sequelize/queries/getProjectDataForProjectPage.ts
@@ -1,5 +1,6 @@
 import { err, errAsync, ok, wrapInfra } from '../../../core/utils'
 import { getAppelOffre } from '../../../dataAccess/inMemory'
+import { makeProjectIdentifier } from '../../../entities'
 import { ProjectDataForProjectPage } from '../../../modules/project/dtos'
 import { GetProjectDataForProjectPage } from '../../../modules/project/queries/GetProjectDataForProjectPage'
 import { EntityNotFoundError, InfraNotAvailableError } from '../../../modules/shared'
@@ -147,6 +148,7 @@ export const makeGetProjectDataForProjectPage = (models): GetProjectDataForProje
 
     const result: any = {
       id,
+      potentielIdentifier: makeProjectIdentifier(projectRaw.get()),
       appelOffreId,
       periodeId,
       familleId,

--- a/src/modules/project/dtos/ProjectDataForProjectPage.ts
+++ b/src/modules/project/dtos/ProjectDataForProjectPage.ts
@@ -2,6 +2,7 @@ import { ProjectAppelOffre } from '../../../entities'
 
 export type ProjectDataForProjectPage = {
   id: string
+  potentielIdentifier: string
 
   appelOffre: ProjectAppelOffre
 

--- a/src/modules/project/utils/makeCertificateFilename.ts
+++ b/src/modules/project/utils/makeCertificateFilename.ts
@@ -1,7 +1,5 @@
 import sanitize from 'sanitize-filename'
 
-import { makeProjectIdentifier } from '../../../entities'
-
 export const makeCertificateFilename = (
   project: {
     email: string
@@ -11,10 +9,11 @@ export const makeCertificateFilename = (
     familleId: string | undefined
     numeroCRE: string
     id: string
+    potentielIdentifier: string
   },
   forAdmin?: true
 ) => {
   return sanitize(
-    makeProjectIdentifier(project) + '-' + (forAdmin ? project.email : project.nomProjet) + '.pdf'
+    project.potentielIdentifier + '-' + (forAdmin ? project.email : project.nomProjet) + '.pdf'
   )
 }

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,4 +1,4 @@
-import { Project, makeProjectIdentifier } from './entities'
+import { Project } from './entities'
 import querystring from 'querystring'
 import sanitize from 'sanitize-filename'
 import { makeCertificateFilename } from './modules/project/utils'
@@ -57,7 +57,8 @@ class routes {
     projectAdmissionKey: string
   }>('/enregistrement.html')
 
-  static IMPORT_PROJECTS = '/admin/importer-candidats.html' // Keep separate from ADMIN_DASHBOARD, may change
+  static IMPORT_PROJECTS_ACTION = '/admin/importer-candidats.html'
+  static IMPORT_PROJECTS = '/admin/importer-candidats.html'
 
   static PROJECT_DETAILS = (projectId?: Project['id']) => {
     const route = '/projet/:projectId/details.html'
@@ -68,7 +69,6 @@ class routes {
 
   static DOWNLOAD_PROJECTS_CSV = '/export-projets.csv'
   static ADMIN_DOWNLOAD_PROJECTS_LAUREATS_CSV = '/export-projets-laureats.csv'
-  static IMPORT_PROJECTS_ACTION = '/admin/importProjects'
   static ADMIN_LIST_PROJECTS = '/admin/dashboard.html'
   static ADMIN_LIST_REQUESTS = '/admin/demandes.html'
   static ADMIN_REGENERATE_CERTIFICATES = '/admin/regenerer-attestations.html'
@@ -90,6 +90,7 @@ class routes {
     numeroCRE: string
     email: string
     nomProjet: string
+    potentielIdentifier: string
   }) => {
     const route = '/previsualiser-attestation/:projectId/*'
     if (project) {
@@ -121,6 +122,7 @@ class routes {
     numeroCRE: string
     email: string
     nomProjet: string
+    potentielIdentifier: string
   }) =>
     routes.DOWNLOAD_CERTIFICATE_FILE(
       project.id,
@@ -140,6 +142,7 @@ class routes {
     numeroCRE: string
     email: string
     nomProjet: string
+    potentielIdentifier: string
   }) =>
     routes.DOWNLOAD_CERTIFICATE_FILE(
       project.id,
@@ -256,9 +259,9 @@ class routes {
         .replace(
           ':filename',
           sanitize(
-            `${now.getFullYear()}-${
-              now.getMonth() + 1
-            }-${now.getDate()} - Réponse demande - ${makeProjectIdentifier(project)}.docx`
+            `${now.getFullYear()}-${now.getMonth() + 1}-${now.getDate()} - Réponse demande - ${
+              project.potentielIdentifier
+            }.docx`
           )
         )
     } else return route

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,4 +1,4 @@
-import { Project } from './entities'
+import type { Project } from './entities'
 import querystring from 'querystring'
 import sanitize from 'sanitize-filename'
 import { makeCertificateFilename } from './modules/project/utils'

--- a/src/useCases/relanceGarantiesFinancieres.spec.ts
+++ b/src/useCases/relanceGarantiesFinancieres.spec.ts
@@ -1,7 +1,7 @@
 import moment from 'moment'
 import { DomainEvent } from '../core/domain'
 import { okAsync } from '../core/utils'
-import { makeProject, makeProjectIdentifier, makeUser, Project } from '../entities'
+import { makeProject, makeUser, Project } from '../entities'
 import { EventBus } from '../modules/eventStore'
 import { ProjectGFReminded } from '../modules/project/events'
 import { InfraNotAvailableError } from '../modules/shared'
@@ -77,7 +77,7 @@ describe('relanceGarantiesFinancieres use-case', () => {
       },
       variables: {
         nom_projet: fakeProject.nomProjet,
-        code_projet: makeProjectIdentifier(fakeProject),
+        code_projet: fakeProject.potentielIdentifier,
         date_designation: '28/07/2020',
         paragraphe_cdc: '5.3 et 6.2', // Cf AO Fessenheim
         duree_garanties: '42', // Cf AO Fessenheim

--- a/src/useCases/relanceGarantiesFinancieres.ts
+++ b/src/useCases/relanceGarantiesFinancieres.ts
@@ -1,7 +1,7 @@
 import moment from 'moment'
 import { logger } from '../core/utils'
 import { ProjectRepo } from '../dataAccess'
-import { applyProjectUpdate, makeProjectIdentifier } from '../entities'
+import { applyProjectUpdate } from '../entities'
 import { EventBus } from '../modules/eventStore'
 import { NotificationService } from '../modules/notification'
 import { ProjectGFReminded } from '../modules/project/events'
@@ -64,7 +64,7 @@ export default function makeRelanceGarantiesFinancieres({
               },
               variables: {
                 nom_projet: project.nomProjet,
-                code_projet: makeProjectIdentifier(project),
+                code_projet: project.potentielIdentifier,
                 date_designation: moment(project.notifiedOn).format('DD/MM/YYYY'),
                 paragraphe_cdc:
                   project.appelOffre?.renvoiRetraitDesignationGarantieFinancieres || '',

--- a/src/views/components/actions/admin.ts
+++ b/src/views/components/actions/admin.ts
@@ -13,6 +13,7 @@ const adminActions = (project: {
   numeroCRE: string
   email: string
   nomProjet: string
+  potentielIdentifier: string
 }) => {
   const canDownloadCertificate = !!project.certificateFile
 

--- a/src/views/components/projectList.tsx
+++ b/src/views/components/projectList.tsx
@@ -1,15 +1,14 @@
 import React from 'react'
 import { logger } from '../../core/utils'
-import { makeProjectIdentifier, Project, User } from '../../entities'
+import { Project, User } from '../../entities'
 import { formatDate } from '../../helpers/formatDate'
 import { dataId } from '../../helpers/testId'
+import ROUTES from '../../routes'
 import { PaginatedList } from '../../types'
 import { ACTION_BY_ROLE } from './actions'
+import { DownloadIcon } from './downloadIcon'
 import Pagination from './pagination'
 import ProjectActions from './projectActions'
-import ROUTES from '../../routes'
-import { DownloadIcon } from './downloadIcon'
-import moment from 'moment'
 
 type Columns =
   | 'Projet'
@@ -37,7 +36,7 @@ const ColumnComponent: Record<Columns, ColumnRenderer> = {
           <span {...dataId('projectList-item-communeProjet')}>{project.communeProjet}</span>,{' '}
           <span {...dataId('projectList-item-departementProjet')}>{project.departementProjet}</span>
           , <span {...dataId('projectList-item-regionProjet')}>{project.regionProjet}</span>
-          <div style={{ marginTop: 5, fontStyle: 'normal' }}>{makeProjectIdentifier(project)}</div>
+          <div style={{ marginTop: 5, fontStyle: 'normal' }}>{project.potentielIdentifier}</div>
         </div>
       </td>
     )

--- a/src/views/pages/candidateCertificate.tsx
+++ b/src/views/pages/candidateCertificate.tsx
@@ -1,9 +1,8 @@
+import ReactPDF, { Document, Font, Image, Page, Text, View } from '@react-pdf/renderer'
 import React from 'react'
-import { Page, Text, View, Document, StyleSheet, Image, Font } from '@react-pdf/renderer'
-import ReactPDF from '@react-pdf/renderer'
-import { Project, AppelOffre, Periode, makeProjectIdentifier } from '../../entities'
-import { formatDate } from '../../helpers/formatDate'
 import { logger } from '../../core/utils'
+import { AppelOffre, Periode, Project } from '../../entities'
+import { formatDate } from '../../helpers/formatDate'
 
 Font.register({
   family: 'Arial',
@@ -456,7 +455,7 @@ const Certificate = ({
             left: 65,
           }}
         >
-          <Text style={{ fontSize: 8 }}>Code Potentiel: {makeProjectIdentifier(project)}</Text>
+          <Text style={{ fontSize: 8 }}>Code Potentiel: {project.potentielIdentifier}</Text>
           <Text style={{ fontSize: 8 }}>
             Dossier suivi par : aopv.dgec@developpement-durable.gouv.fr
           </Text>

--- a/src/views/pages/projectDetails/sections/ProjectHeader.tsx
+++ b/src/views/pages/projectDetails/sections/ProjectHeader.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { makeProjectIdentifier, User } from '../../../../entities'
+import { User } from '../../../../entities'
 import { ProjectDataForProjectPage } from '../../../../modules/project/dtos'
 import ProjectActions from '../../../components/projectActions'
 
@@ -28,7 +28,7 @@ export const ProjectHeader = ({ project, user, cahiersChargesURLs }: ProjectHead
       {project.communeProjet}, {project.departementProjet}, {project.regionProjet}
     </span>
     <div style={{ fontSize: 13 }}>
-      {makeProjectIdentifier(project)}{' '}
+      {project.potentielIdentifier}{' '}
       {cahiersChargesURLs && (
         <>
           {'('}


### PR DESCRIPTION
Before this PR, `routes.ts` (which is imported by multiple views), imports `makeProjectIdentifier` which relies `crypto` which itself only exists on `nodejs`.

In order to have views that can be run on the clientside, we need to have an isomorphic `routes.ts`.

To achieve this, I removed the dependency to `makeProjectIdentifier` and instead included the `potentielIdentifier` in the DTOs passed to the views.