### PR TITLE
518 Calcul date d'achèvement

### DIFF
--- a/src/infra/sequelize/migrations/20211013142007-fix-completionDueDate-one-day-offset.js
+++ b/src/infra/sequelize/migrations/20211013142007-fix-completionDueDate-one-day-offset.js
@@ -1,0 +1,45 @@
+'use strict'
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    const transaction = await queryInterface.sequelize.transaction()
+    try {
+      const CompletionDueDateSetEvents = await queryInterface.sequelize.query(
+        'SELECT * FROM "eventStores" WHERE type = ?',
+        {
+          type: queryInterface.sequelize.QueryTypes.SELECT,
+          replacements: ['ProjectCompletionDueDateSet'],
+          transaction,
+        }
+      )
+
+      for (const event of CompletionDueDateSetEvents) {
+        const { id, payload } = event
+
+        // Remove one day
+        payload.completionDueOn = event.payload.completionDueOn - 24 * 3600 * 1000
+
+        await queryInterface.sequelize.query('UPDATE "eventStores" SET payload = ? WHERE id = ?', {
+          type: queryInterface.sequelize.UPDATE,
+          replacements: [JSON.stringify(payload), id],
+          transaction,
+        })
+      }
+
+      await queryInterface.sequelize.query(
+        'UPDATE "projects" SET "completionDueOn"="completionDueOn"-24*3600*1000 WHERE "completionDueOn" != 0',
+        {
+          type: queryInterface.sequelize.UPDATE,
+          transaction,
+        }
+      )
+
+      await transaction.commit()
+    } catch (err) {
+      await transaction.rollback()
+      throw err
+    }
+  },
+
+  down: async (queryInterface, Sequelize) => {},
+}

--- a/src/modules/project/Project.notify.spec.ts
+++ b/src/modules/project/Project.notify.spec.ts
@@ -105,6 +105,7 @@ describe('Project.notify()', () => {
       expect(targetEvent.payload.completionDueOn).toEqual(
         moment(notifiedOn)
           .add(appelsOffres[fakeProjectData.appelOffreId].delaiRealisationEnMois, 'months')
+          .subtract(1, 'day')
           .toDate()
           .getTime()
       )

--- a/src/modules/project/Project.setNotificationDate.spec.ts
+++ b/src/modules/project/Project.setNotificationDate.spec.ts
@@ -141,6 +141,7 @@ describe('Project.setNotificationDate()', () => {
         expect(targetEvent.payload.completionDueOn).toEqual(
           moment(newNotifiedOn)
             .add(appelsOffres[appelOffreId].delaiRealisationEnMois, 'months')
+            .subtract(1, 'day')
             .toDate()
             .getTime()
         )

--- a/src/modules/project/Project.ts
+++ b/src/modules/project/Project.ts
@@ -858,6 +858,7 @@ export const makeProject = (args: {
             completionDueOn ||
             moment(props.notifiedOn)
               .add(props.appelOffre.delaiRealisationEnMois, 'months')
+              .subtract(1, 'day')
               .toDate()
               .getTime(),
           setBy,


### PR DESCRIPTION
Le bon calcul est date de notification + délai de réalisation - 1 jour.

Cette PR corrige cette règle + corrige les dates d'achèvement de tous les projets existants.