### PR TITLE
617 Les comptes keycloak ne sont pas associés avec l'email

### DIFF
--- a/keycloak/themes/potentiel/login/login-update-profile.ftl
+++ b/keycloak/themes/potentiel/login/login-update-profile.ftl
@@ -4,6 +4,12 @@
         ${msg("loginProfileTitle")}
     <#elseif section = "form">
         <form id="kc-update-profile-form" class="${properties.kcFormClass!}" action="${url.loginAction}" method="post">
+
+            <input type="hidden" id="email" name="email" value="${(user.email!'')}"
+                class="${properties.kcInputClass!}"
+                aria-invalid="<#if messagesPerField.existsError('email')>true</#if>"
+            />
+
             <h3>Merci de saisir votre nom</h3>
             <#if messagesPerField.existsError('firstName')>
                 <div class="notification error">${kcSanitize(messagesPerField.get('firstName'))?no_esc}</div>
@@ -14,18 +20,6 @@
             <#if message?has_content && message.type == 'error'>
                 <div class="notification error">${kcSanitize(message.summary)?no_esc}</div>
             </#if>
-
-            <#--  <div class="${properties.kcFormGroupClass!}">
-                <div class="${properties.kcLabelWrapperClass!}">
-                    <label for="firstName" class="${properties.kcLabelClass!}">${msg("firstName")}</label>
-                </div>
-                <div class="${properties.kcInputWrapperClass!}">
-                    <input type="text" id="firstName" name="firstName" value="${(user.firstName!'')}"
-                           class="${properties.kcInputClass!}"
-                           aria-invalid="<#if messagesPerField.existsError('firstName')>true</#if>"
-                    />
-                </div>
-            </div>  -->
 
             <div class="${properties.kcFormGroupClass!}">
                 <div class="${properties.kcLabelWrapperClass!}">


### PR DESCRIPTION
Il y avait un problème avec la page de mise à jour des noms. J'avais retiré le champ email, puisqu'on ne veut pas que l'utilisateur puisse choisir son email, et ça avait pour effet de mettre à zéro l'email qui avait été associé. Les utilisateurs invités qui avaient accepté l'invitation se retrouvaient sans adresse email et donc avec un compte non fonctionnel.