### PR TITLE
:white_check_mark:  Add test about inconsistency and use jest fake ti…

### DIFF
--- a/src/config/eventHandlers/modificationRequest.eventHandlers.ts
+++ b/src/config/eventHandlers/modificationRequest.eventHandlers.ts
@@ -1,3 +1,4 @@
+import { withDelay } from '../../core/utils'
 import {
   LegacyModificationRawDataImported,
   ResponseTemplateDownloaded,
@@ -20,6 +21,7 @@ eventStore.subscribe(
   handleLegacyModificationRawDataImported({
     eventBus: eventStore,
     findProjectByIdentifiers,
+    withDelay,
   })
 )
 

--- a/src/core/utils/index.ts
+++ b/src/core/utils/index.ts
@@ -3,4 +3,5 @@ export * from './Result';
 export * from './logger';
 export * from './stableStringify';
 export * from './validators';
+export * from './withDelay';
 export * from './wrapInfra';

--- a/src/core/utils/withDelay.ts
+++ b/src/core/utils/withDelay.ts
@@ -1,6 +1,11 @@
 import { Result, ResultAsync } from './Result'
 
-export const withDelay = <T, E>(
+export type WithDelay = <T, E>(
+  delayInMs: number,
+  callback: () => Result<T, E> | ResultAsync<T, E>
+) => ResultAsync<T, E>
+
+export const withDelay: WithDelay = <T, E>(
   delayInMs: number,
   callback: () => Result<T, E> | ResultAsync<T, E>
 ): ResultAsync<T, E> => {

--- a/src/modules/modificationRequest/eventHandlers/handleLegacyModificationRawDataImported.spec.ts
+++ b/src/modules/modificationRequest/eventHandlers/handleLegacyModificationRawDataImported.spec.ts
@@ -25,12 +25,8 @@ const modifications = [
 
 describe('handleLegacyModificationRawDataImported', () => {
   const fakeWithDelay: WithDelay = <T, E>(delayInMs, callback) => {
-    return ResultAsync.fromPromise(
-      new Promise(async (resolve, reject) => {
-        await callback().match(resolve, reject)
-      }),
-      (e) => e as E
-    )
+    const result = callback()
+    return result instanceof ResultAsync ? result : result.asyncMap(async (value) => value)
   }
 
   describe('when the project exists', () => {

--- a/src/modules/modificationRequest/eventHandlers/handleLegacyModificationRawDataImported.spec.ts
+++ b/src/modules/modificationRequest/eventHandlers/handleLegacyModificationRawDataImported.spec.ts
@@ -1,15 +1,8 @@
 import { LegacyModificationDTO } from '..'
 import { DomainEvent, UniqueEntityID } from '../../../core/domain'
 import { okAsync } from '../../../core/utils'
-import { FindProjectByIdentifiers } from '../../project'
 import { InfraNotAvailableError } from '../../shared'
-import {
-  LegacyModificationImported,
-  LegacyModificationRawDataImported,
-  ModificationRequestInstructionStarted,
-  ResponseTemplateDownloaded,
-} from '../events'
-import { GetModificationRequestStatus } from '../queries/GetModificationRequestStatus'
+import { LegacyModificationImported, LegacyModificationRawDataImported } from '../events'
 import { handleLegacyModificationRawDataImported } from './handleLegacyModificationRawDataImported'
 
 const eventBus = {
@@ -32,9 +25,7 @@ const modifications = [
 
 describe('handleLegacyModificationRawDataImported', () => {
   describe('when the project exists', () => {
-    const findProjectByIdentifiers = jest.fn(() =>
-      okAsync(projectId)
-    ) as unknown as FindProjectByIdentifiers
+    const findProjectByIdentifiers = jest.fn().mockReturnValue(okAsync(projectId))
 
     beforeAll(async () => {
       eventBus.publish.mockClear()
@@ -68,13 +59,15 @@ describe('handleLegacyModificationRawDataImported', () => {
     })
   })
 
-  describe('when the project does not exist', () => {
-    const findProjectByIdentifiers = jest.fn(() =>
-      okAsync(null)
-    ) as unknown as FindProjectByIdentifiers
+  describe('when the project exists but first call return null because of inconsistency', () => {
+    const findProjectByIdentifiers = jest
+      .fn()
+      .mockReturnValue(okAsync(projectId))
+      .mockReturnValueOnce(okAsync(null))
 
     beforeAll(async () => {
       eventBus.publish.mockClear()
+      jest.useFakeTimers()
 
       await handleLegacyModificationRawDataImported({
         eventBus,
@@ -84,6 +77,45 @@ describe('handleLegacyModificationRawDataImported', () => {
           payload: { importId, appelOffreId, periodeId, familleId, numeroCRE, modifications },
         })
       )
+
+      jest.runAllTimers()
+    })
+
+    it('should trigger LegacyModificationImported with the projectId', () => {
+      const targetEvent = eventBus.publish.mock.calls
+        .map((call) => call[0])
+        .find(
+          (event): event is LegacyModificationImported =>
+            event.type === LegacyModificationImported.type
+        )
+
+      expect(targetEvent).toBeDefined()
+      if (!targetEvent) return
+
+      expect(targetEvent.payload).toEqual({
+        importId,
+        modifications,
+        projectId,
+      })
+    })
+  })
+
+  describe('when the project does not exist', () => {
+    const findProjectByIdentifiers = jest.fn().mockReturnValue(okAsync(null))
+
+    beforeAll(async () => {
+      eventBus.publish.mockClear()
+      jest.useFakeTimers()
+
+      await handleLegacyModificationRawDataImported({
+        eventBus,
+        findProjectByIdentifiers,
+      })(
+        new LegacyModificationRawDataImported({
+          payload: { importId, appelOffreId, periodeId, familleId, numeroCRE, modifications },
+        })
+      )
+      jest.runAllTimers()
     })
     it('should not trigger', () => {
       expect(eventBus.publish).not.toHaveBeenCalled()

--- a/src/modules/modificationRequest/eventHandlers/handleLegacyModificationRawDataImported.ts
+++ b/src/modules/modificationRequest/eventHandlers/handleLegacyModificationRawDataImported.ts
@@ -1,5 +1,4 @@
-import { logger, errAsync, okAsync } from '../../../core/utils'
-import { withDelay } from '../../../core/utils/withDelay'
+import { logger, errAsync, okAsync, WithDelay } from '../../../core/utils'
 import { EventBus } from '../../eventStore'
 import { FindProjectByIdentifiers } from '../../project'
 import { EntityNotFoundError } from '../../shared'
@@ -8,19 +7,22 @@ import { LegacyModificationImported, LegacyModificationRawDataImported } from '.
 export const handleLegacyModificationRawDataImported = (deps: {
   findProjectByIdentifiers: FindProjectByIdentifiers
   eventBus: EventBus
+  withDelay: WithDelay
 }) => async (event: LegacyModificationRawDataImported) => {
   const {
     payload: { appelOffreId, periodeId, familleId, numeroCRE, importId, modifications },
   } = event
 
+  const { eventBus, findProjectByIdentifiers, withDelay } = deps
+
   const findProject = () =>
-    deps.findProjectByIdentifiers({ appelOffreId, periodeId, familleId, numeroCRE })
+    findProjectByIdentifiers({ appelOffreId, periodeId, familleId, numeroCRE })
 
   findProject()
     .andThen(
       (projectIdOrNull): ReturnType<typeof findProject> => {
         if (projectIdOrNull !== null) return okAsync(projectIdOrNull)
-        
+
         // findProject is a query on an eventually consistent database
         // the project id might not be available at the moment
         // try again later
@@ -29,7 +31,7 @@ export const handleLegacyModificationRawDataImported = (deps: {
     )
     .andThen((projectIdOrNull) => {
       if (projectIdOrNull !== null) {
-        return deps.eventBus.publish(
+        return eventBus.publish(
           new LegacyModificationImported({
             payload: {
               projectId: projectIdOrNull,


### PR DESCRIPTION
J'ai remarqué que nous avions cette erreur à chaque éxecution des tests : 

`(node:2387) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'match' of undefined
(Use 'node --trace-warnings ...' to show where the warning was created)
(node:2387) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag '--unhandled-rejections=strict' (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:2387) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.`

Après investigation il s'avère que celle-ci n'est apparu que depuis l'introduction du `withDelay` dans la fonction `handleLegacyModificationRawDataImported`.

Ici j'ai rajouté un test à propos du problème initial (l'inconsistance des données) en simulant un premier appel qui ne nous retourne aucun projet grâce à `mockReturnValueOnce` :

`
const findProjectByIdentifiers = jest
      .fn()
      .mockReturnValue(okAsync(projectId))
      .mockReturnValueOnce(okAsync(null))
`

Et j'ai utilisé pour l'instant les fake timers de jest afin de terminer l'éxecution des timers introduit avec l'utilisation de `withDelay` qui était la cause de l'erreur jest.
Je pense qu'il faudrait déclarer withDelay comme étant une dépendance et créer une fake implem dans les tests histoire de ne plus être dépendant des timers.
Mais avant d'aller dans cette direction je souhaiterai avoir votre avis 
