### PR TITLE
644 Fix bug: impossible de voir un aperçu d'attestation

### DIFF
--- a/src/controllers/candidateNotification/getCandidateCertificatePreview.ts
+++ b/src/controllers/candidateNotification/getCandidateCertificatePreview.ts
@@ -40,7 +40,7 @@ v1Router.get(
     await toProjectDataForCertificate({
       appelOffre: project.appelOffre,
       isClasse: project.classe === 'Classé',
-      notifiedOn: project.notifiedOn,
+      notifiedOn: Date.now(),
       projectId: new UniqueEntityID(project.id),
       data: project as unknown,
     } as ProjectProps)


### PR DESCRIPTION
`toProjectDataForCertificate` requires a `notifiedOn` date, which is obviously not available for unnotified projects for which we want to preview the certificate. 

Replace `project.notifiedOn` by `Date.now()` in this case.