### PR TITLE
646 Fix email case for imported candidates

### DIFF
--- a/src/infra/sequelize/migrations/20211105173514-fix-user-created-email-case.js
+++ b/src/infra/sequelize/migrations/20211105173514-fix-user-created-email-case.js
@@ -1,0 +1,116 @@
+'use strict'
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    const transaction = await queryInterface.sequelize.transaction()
+    try {
+      /**
+       * Fix Users
+       */
+
+      await queryInterface.sequelize.query(
+        'UPDATE "users" SET email = lower(email) WHERE email != lower(email)',
+        {
+          type: queryInterface.sequelize.UPDATE,
+          replacements: [],
+          transaction,
+        }
+      )
+
+      /**
+       * Fix UserCreated events
+       */
+
+      const UserCreatedWithWrongCaseEvents = await queryInterface.sequelize.query(
+        `SELECT * FROM "eventStores" WHERE type = 'UserCreated' AND payload->>'email' != lower(payload->>'email')`,
+        {
+          type: queryInterface.sequelize.QueryTypes.SELECT,
+          transaction,
+        }
+      )
+
+      for (const event of UserCreatedWithWrongCaseEvents) {
+        const { id, payload } = event
+
+        // fix case
+        payload.email = event.payload.email.toLowerCase()
+
+        await queryInterface.sequelize.query('UPDATE "eventStores" SET payload = ? WHERE id = ?', {
+          type: queryInterface.sequelize.UPDATE,
+          replacements: [JSON.stringify(payload), id],
+          transaction,
+        })
+      }
+
+      /**
+       * Fix projects
+       */
+
+      await queryInterface.sequelize.query(
+        'UPDATE "projects" SET email = lower(email) WHERE email != lower(email)',
+        {
+          type: queryInterface.sequelize.UPDATE,
+          replacements: [],
+          transaction,
+        }
+      )
+
+      /**
+       * Fix ProjectImported events
+       */
+
+      const ProjectImportedWithWrongCaseEvents = await queryInterface.sequelize.query(
+        `SELECT * FROM "eventStores" WHERE type = 'ProjectImported' AND cast(payload->'data'->'email' as text) != lower(cast(payload->'data'->'email' as text));`,
+        {
+          type: queryInterface.sequelize.QueryTypes.SELECT,
+          transaction,
+        }
+      )
+
+      for (const event of ProjectImportedWithWrongCaseEvents) {
+        const { id, payload } = event
+
+        // fix case
+        payload.data.email = event.payload.data.email.toLowerCase()
+
+        await queryInterface.sequelize.query('UPDATE "eventStores" SET payload = ? WHERE id = ?', {
+          type: queryInterface.sequelize.UPDATE,
+          replacements: [JSON.stringify(payload), id],
+          transaction,
+        })
+      }
+
+      /**
+       * Fix ProjectReimported events
+       */
+
+      const ProjectReimportedWithWrongCaseEvents = await queryInterface.sequelize.query(
+        `SELECT * FROM "eventStores" WHERE type = 'ProjectReimported' AND cast(payload->'data'->'email' as text) != lower(cast(payload->'data'->'email' as text));`,
+        {
+          type: queryInterface.sequelize.QueryTypes.SELECT,
+          transaction,
+        }
+      )
+
+      for (const event of ProjectReimportedWithWrongCaseEvents) {
+        const { id, payload } = event
+
+        // fix case
+        payload.data.email = event.payload.data.email.toLowerCase()
+
+        await queryInterface.sequelize.query('UPDATE "eventStores" SET payload = ? WHERE id = ?', {
+          type: queryInterface.sequelize.UPDATE,
+          replacements: [JSON.stringify(payload), id],
+          transaction,
+        })
+      }
+
+      await transaction.commit()
+    } catch (err) {
+      await transaction.rollback()
+      throw err
+    }
+  },
+
+  down: async (queryInterface, Sequelize) => {},
+}

--- a/src/modules/project/utils/parseProjectLine.spec.ts
+++ b/src/modules/project/utils/parseProjectLine.spec.ts
@@ -278,6 +278,17 @@ describe('parseProjectLine', () => {
     })
   })
 
+  describe('when the email is not lowercase', () => {
+    it('should lowercase it', () => {
+      expect(
+        parseProjectLine({
+          ...fakeLine,
+          'Adresse électronique du contact': 'Test@Test.test',
+        })
+      ).toMatchObject({ email: 'test@test.test' })
+    })
+  })
+
   describe('when the Code Postal is missing', () => {
     it('should throw an error', () => {
       expect(() =>

--- a/src/modules/project/utils/parseProjectLine.ts
+++ b/src/modules/project/utils/parseProjectLine.ts
@@ -68,7 +68,7 @@ const columnMapper = {
   },
   note: (line: any) => prepareNumber(line['Note totale']),
   nomRepresentantLegal: (line: any) => line['Nom et prénom du représentant légal'],
-  email: (line: any) => line['Adresse électronique du contact'],
+  email: (line: any) => line['Adresse électronique du contact'].toLowerCase(),
   adresseProjet: (line: any) => line['N°, voie, lieu-dit'],
   codePostalProjet: (line: any) =>
     line['CP'].split('/').map((item) => padCodePostalWithleft0(item.trim())),


### PR DESCRIPTION
Lors de l'import d'un projet, l'adresse du candidat est gardée telle quelle (avec majuscules et minuscules), or quand nous créons le compte sur keycloak, nous passons l'email en minuscules.

Ainsi lors de la prochaine connexion, nous cherchons un utilisateur avec cet email et ne le trouvons pas (coté keycloak en minuscules et coté Potentiel avec majuscules). La connexion échoue.

Pour remédier à celà, `parseProjectLine` est corrigé pour passer l'email du candidat en minuscules dès l'entrée.

J'ai aussi rajouté un script de migration pour corriger l'état de la base de données.