### PR TITLE
:bug: 663 Lorsqu'un projet historique a été abandonné, son statut doit être "abandonné" lors de son import

### DIFF
--- a/src/__tests__/fixtures/aggregates/makeFakeProject.ts
+++ b/src/__tests__/fixtures/aggregates/makeFakeProject.ts
@@ -19,6 +19,7 @@ export const makeFakeProject = (data: Partial<ProjectDataProps> = {}) => ({
   reimport: jest.fn((args) => ok<null, never>(null)),
   import: jest.fn((args) => ok<null, never>(null)),
   abandon: jest.fn((user: User) => ok<null, EliminatedProjectCannotBeAbandonnedError>(null)),
+  abandonLegacy: jest.fn((abandonnedOn: number) => ok<null, never>(null)),
   correctData: jest.fn((user: User, data: ProjectDataCorrectedPayload['correctedData']) =>
     ok<null, ProjectCannotBeUpdatedIfUnnotifiedError | IllegalProjectDataError>(null)
   ),

--- a/src/modules/project/Project.abandonLegacy.spec.ts
+++ b/src/modules/project/Project.abandonLegacy.spec.ts
@@ -1,0 +1,87 @@
+import { UniqueEntityID } from '../../core/domain'
+import { UnwrapForTest } from '../../core/utils'
+import { appelsOffreStatic } from '../../dataAccess/inMemory/appelOffre'
+import { makeUser } from '../../entities'
+import { UnwrapForTest as OldUnwrapForTest } from '../../types'
+import makeFakeProject from '../../__tests__/fixtures/project'
+import makeFakeUser from '../../__tests__/fixtures/user'
+import { EliminatedProjectCannotBeAbandonnedError } from './errors'
+import { LegacyProjectSourced, ProjectAbandoned } from './events'
+import { makeProject } from './Project'
+
+const projectId = new UniqueEntityID('project1')
+const appelOffreId = 'Fessenheim'
+const periodeId = '2'
+const fakeProject = makeFakeProject({ appelOffreId, periodeId, classe: 'Classé' })
+const { familleId, numeroCRE } = fakeProject
+const originallyAbandonnedOn = 1234
+
+const fakeUser = OldUnwrapForTest(makeUser(makeFakeUser()))
+
+const appelsOffres = appelsOffreStatic.reduce((map, appelOffre) => {
+  map[appelOffre.id] = appelOffre
+  return map
+}, {})
+
+describe('Project.abandonLegacy()', () => {
+  describe('when project is Classé', () => {
+    const project = UnwrapForTest(
+      makeProject({
+        projectId,
+        history: [
+          new LegacyProjectSourced({
+            payload: {
+              projectId: projectId.toString(),
+              periodeId,
+              appelOffreId,
+              familleId,
+              numeroCRE,
+              content: { ...fakeProject, classe: 'Classé' },
+            },
+          }),
+        ],
+        appelsOffres,
+      })
+    )
+
+    it('should emit ProjectAbandoned event', () => {
+      project.abandonLegacy(originallyAbandonnedOn)
+
+      const targetEvent = project.pendingEvents.find(
+        (item) => item.type === ProjectAbandoned.type
+      ) as ProjectAbandoned | undefined
+      expect(targetEvent).toBeDefined()
+      if (!targetEvent) return
+
+      expect(targetEvent.payload.projectId).toEqual(projectId.toString())
+      expect(targetEvent.occurredAt).toEqual(new Date(originallyAbandonnedOn))
+    })
+  })
+
+  describe('when project is Eliminé', () => {
+    const project = UnwrapForTest(
+      makeProject({
+        projectId,
+        history: [
+          new LegacyProjectSourced({
+            payload: {
+              projectId: projectId.toString(),
+              periodeId,
+              appelOffreId,
+              familleId,
+              numeroCRE,
+              content: { ...fakeProject, classe: 'Eliminé' },
+            },
+          }),
+        ],
+        appelsOffres,
+      })
+    )
+
+    it('should not emit', () => {
+      project.abandonLegacy(originallyAbandonnedOn)
+
+      expect(project.pendingEvents.length).toEqual(0)
+    })
+  })
+})

--- a/src/modules/project/Project.ts
+++ b/src/modules/project/Project.ts
@@ -63,6 +63,7 @@ export interface Project extends EventStoreAggregate {
     notifiedOn: number
   ) => Result<null, IllegalProjectStateError | ProjectAlreadyNotifiedError>
   abandon: (user: User) => Result<null, EliminatedProjectCannotBeAbandonnedError>
+  abandonLegacy: (abandonnedOn: number) => Result<null, never>
   reimport: (args: {
     data: ProjectReimportedPayload['data']
     importId: string
@@ -260,6 +261,24 @@ export const makeProject = (args: {
           },
         })
       )
+
+      return ok(null)
+    },
+    abandonLegacy: function (abandonnedOn) {
+      if (props.isClasse) {
+        _publishEvent(
+          new ProjectAbandoned({
+            payload: {
+              projectId: projectId.toString(),
+              abandonAcceptedBy: '',
+            },
+            original: {
+              version: 1,
+              occurredAt: new Date(abandonnedOn),
+            },
+          })
+        )
+      }
 
       return ok(null)
     },

--- a/src/modules/project/eventHandlers/handleLegacyModificationImported.spec.ts
+++ b/src/modules/project/eventHandlers/handleLegacyModificationImported.spec.ts
@@ -101,4 +101,41 @@ describe('handleLegacyModificationImported', () => {
       expect(fakeProject.abandonLegacy).toHaveBeenCalledWith(modifiedOn)
     })
   })
+
+  describe('when several of the modifications are of type abandon', () => {
+    const fakeProject = makeFakeProject()
+    const projectRepo = fakeTransactionalRepo<Project>(fakeProject as Project)
+    const earlierModifiedOn = 1
+    const latterModifiedOn = 2
+
+    beforeAll(async () => {
+      await handleLegacyModificationImported({
+        projectRepo,
+      })(
+        new LegacyModificationImported({
+          payload: {
+            projectId,
+            importId,
+            modifications: [
+              {
+                type: 'abandon',
+                modifiedOn: latterModifiedOn,
+                modificationId,
+              },
+              {
+                type: 'abandon',
+                modifiedOn: earlierModifiedOn,
+                modificationId,
+              },
+            ],
+          },
+        })
+      )
+    })
+
+    it('should call Project.abandonLegacy() on the latter of the modifications of type abandon', () => {
+      expect(fakeProject.abandonLegacy).toHaveBeenCalledTimes(1)
+      expect(fakeProject.abandonLegacy).toHaveBeenCalledWith(latterModifiedOn)
+    })
+  })
 })

--- a/src/modules/project/eventHandlers/handleLegacyModificationImported.spec.ts
+++ b/src/modules/project/eventHandlers/handleLegacyModificationImported.spec.ts
@@ -10,7 +10,7 @@ describe('handleLegacyModificationImported', () => {
   const modificationId = new UniqueEntityID().toString()
   const modifiedOn = 123
 
-  describe('when none of the modifications are of type delai', () => {
+  describe('when none of the modifications are of type delai or abandon', () => {
     const fakeProject = makeFakeProject()
     const projectRepo = fakeTransactionalRepo<Project>(fakeProject as Project)
 
@@ -24,7 +24,9 @@ describe('handleLegacyModificationImported', () => {
             importId,
             modifications: [
               {
-                type: 'abandon',
+                type: 'autre',
+                column: 'a',
+                value: 'b',
                 modifiedOn,
                 modificationId,
               },
@@ -36,6 +38,7 @@ describe('handleLegacyModificationImported', () => {
 
     it('should ignore the event', () => {
       expect(fakeProject.setCompletionDueDate).not.toHaveBeenCalled()
+      expect(fakeProject.abandonLegacy).not.toHaveBeenCalled()
     })
   })
 
@@ -67,6 +70,35 @@ describe('handleLegacyModificationImported', () => {
 
     it('should call Project.setCompletionDueDate()', () => {
       expect(fakeProject.setCompletionDueDate).toHaveBeenCalledWith(123456)
+    })
+  })
+
+  describe('when one of the modifications is of type abandon', () => {
+    const fakeProject = makeFakeProject()
+    const projectRepo = fakeTransactionalRepo<Project>(fakeProject as Project)
+
+    beforeAll(async () => {
+      await handleLegacyModificationImported({
+        projectRepo,
+      })(
+        new LegacyModificationImported({
+          payload: {
+            projectId,
+            importId,
+            modifications: [
+              {
+                type: 'abandon',
+                modifiedOn,
+                modificationId,
+              },
+            ],
+          },
+        })
+      )
+    })
+
+    it('should call Project.abandonLegacy()', () => {
+      expect(fakeProject.abandonLegacy).toHaveBeenCalledWith(modifiedOn)
     })
   })
 })

--- a/src/modules/project/eventHandlers/handleLegacyModificationImported.ts
+++ b/src/modules/project/eventHandlers/handleLegacyModificationImported.ts
@@ -1,10 +1,6 @@
 import { Project } from '..'
 import { TransactionalRepository, UniqueEntityID } from '../../../core/domain'
-import {
-  LegacyDelai,
-  LegacyModificationDTO,
-  LegacyModificationImported,
-} from '../../modificationRequest'
+import { LegacyModificationImported } from '../../modificationRequest'
 
 export const handleLegacyModificationImported = (deps: {
   projectRepo: TransactionalRepository<Project>


### PR DESCRIPTION
Je corrige un comportement erroné. Lorsqu'un projet a une demande historique de type abandon, cela doit se refléter sur son statut actuel (qui doit être "abandonné"). Actuellement, ce n'est pas le cas.

J'ai fait:
- Rajout d'une méthode `abandonLegacy` dans l'agrégat `Project` (il y a déjà un `abandon` mais j'ai préféré séparer les cas de figure).
- `handleLegacyModificationImported` appelle `abandonLegacy` sur le projet s'il y a une modification de type `abandon`.