### PR TITLE
:bug: 655 fix Impossible de modifier les données d'un projet historique

### DIFF
--- a/src/__tests__/fixtures/aggregates/makeFakeProject.ts
+++ b/src/__tests__/fixtures/aggregates/makeFakeProject.ts
@@ -58,6 +58,7 @@ export const makeFakeProject = (data: Partial<ProjectDataProps> = {}) => ({
   pendingEvents: [] as DomainEvent[],
   appelOffre: {} as ProjectAppelOffre,
   isClasse: true,
+  isLegacy: false,
   puissanceInitiale: 0,
   lastUpdatedOn: new Date(0),
   lastCertificateUpdate: undefined,

--- a/src/controllers/project/postCorrectProjectData.ts
+++ b/src/controllers/project/postCorrectProjectData.ts
@@ -10,7 +10,7 @@ import { ensureRole } from '../../config'
 import { upload } from '../upload'
 import { v1Router } from '../v1Router'
 import asyncHandler from 'express-async-handler'
-import { CertificateFileIsMissingError } from '../../modules/project/errors/CertificateFileIsMissingError';
+import { CertificateFileIsMissingError } from '../../modules/project/errors/CertificateFileIsMissingError'
 
 const FORMAT_DATE = 'DD/MM/YYYY'
 
@@ -56,7 +56,7 @@ v1Router.post(
         : { isFinancementParticipatif: false, isInvestissementParticipatif: false }
 
     if (
-      !notificationDate ||
+      notificationDate &&
       moment(notificationDate, FORMAT_DATE).format(FORMAT_DATE) !== notificationDate
     ) {
       return response.redirect(
@@ -90,19 +90,22 @@ v1Router.post(
       motifsElimination,
     }
 
-    const certificateFile = request.file && attestation === 'custom'
-      ? {
-          contents: fs.createReadStream(request.file.path),
-          filename: sanitize(`${Date.now()}-${request.file.originalname}`),
-        }
-      : undefined
+    const certificateFile =
+      request.file && attestation === 'custom'
+        ? {
+            contents: fs.createReadStream(request.file.path),
+            filename: sanitize(`${Date.now()}-${request.file.originalname}`),
+          }
+        : undefined
 
     const result = await correctProjectData({
       projectId,
       projectVersionDate: new Date(Number(projectVersionDate)),
       correctedData,
       certificateFile,
-      newNotifiedOn: moment(notificationDate, FORMAT_DATE).tz('Europe/London').toDate().getTime(),
+      newNotifiedOn:
+        notificationDate &&
+        moment(notificationDate, FORMAT_DATE).tz('Europe/London').toDate().getTime(),
       user: request.user,
       shouldGrantClasse: Number(isClasse) === 1,
       reason,

--- a/src/modules/project/Project.ts
+++ b/src/modules/project/Project.ts
@@ -111,6 +111,7 @@ export interface Project extends EventStoreAggregate {
   readonly shouldCertificateBeGenerated: boolean
   readonly appelOffre?: ProjectAppelOffre
   readonly isClasse?: boolean
+  readonly isLegacy?: boolean
   readonly puissanceInitiale: number
   readonly certificateData: Result<
     {
@@ -550,6 +551,9 @@ export const makeProject = (args: {
     },
     get isClasse() {
       return props.isClasse
+    },
+    get isLegacy() {
+      return props.appelOffre && !props.appelOffre.periode.isNotifiedOnPotentiel
     },
     get puissanceInitiale() {
       return props.puissanceInitiale

--- a/src/modules/project/useCases/correctProjectData.spec.ts
+++ b/src/modules/project/useCases/correctProjectData.spec.ts
@@ -398,6 +398,41 @@ describe('correctProjectData', () => {
           })
         })
       })
+
+      describe('when project is legacy and newNotifiedOn is defined', () => {
+        const fakeProject = { ...makeFakeProject(), isLegacy: true }
+
+        const projectRepo = fakeTransactionalRepo(fakeProject as Project)
+
+        const fileRepo: Repository<FileObject> = {
+          save: jest.fn(),
+          load: jest.fn(),
+        }
+
+        const correctProjectData = makeCorrectProjectData({
+          generateCertificate: fakeGenerateCertificate,
+          projectRepo,
+          fileRepo,
+        })
+
+        it('should return an UnauthorizedError', async () => {
+          const res = await correctProjectData({
+            projectId,
+            projectVersionDate: new Date(),
+            newNotifiedOn: 123,
+            user,
+            shouldGrantClasse: false,
+            correctedData: {
+              numeroCRE: '1',
+            },
+            attestation: 'regenerate',
+          })
+
+          expect(res.isErr()).toEqual(true)
+          if (res.isOk()) return
+          expect(res.error).toBeInstanceOf(UnauthorizedError)
+        })
+      })
     })
   })
 })

--- a/src/modules/project/useCases/correctProjectData.ts
+++ b/src/modules/project/useCases/correctProjectData.ts
@@ -105,10 +105,16 @@ export const makeCorrectProjectData = (deps: CorrectProjectDataDeps): CorrectPro
           return err(new ProjectHasBeenUpdatedSinceError())
         }
 
+        if (newNotifiedOn && project.isLegacy) {
+          return err(new UnauthorizedError())
+        }
+
         return _addCertificateToProjectIfExists(certificateFileId, project)
           .andThen(() => _grantClasseIfNecessary(project))
           .andThen(() => project.correctData(user, correctedData))
-          .andThen(() => project.setNotificationDate(user, newNotifiedOn))
+          .andThen(() =>
+            newNotifiedOn ? project.setNotificationDate(user, newNotifiedOn) : ok<null, never>(null)
+          )
           .map((): boolean => project.shouldCertificateBeGenerated)
       }
     )


### PR DESCRIPTION
Il y avait une vérification coté controlleur sur `notificationDate` qui est un champ qui n'existe pas quand le projet est historique. Il était donc impossible de modifier un projet historique.

J'ai relaxé cette vérification dans `postCorrectProjectData` et j'ai renforcé également le comportement de `correctProjectData` pour s'assurer qu'on ne peut pas modifier la date de notification d'un projet historique (on ne peut pas dépendre uniquement du masquage du champ coté front).