### PR TITLE
:bug: 652 Fix http response Content-Type for files

### DIFF
--- a/src/controllers/candidateNotification/getCandidateCertificatePreview.ts
+++ b/src/controllers/candidateNotification/getCandidateCertificatePreview.ts
@@ -52,6 +52,7 @@ v1Router.get(
       )
       .match(
         (certificateStream) => {
+          response.type('pdf')
           certificateStream.pipe(response)
         },
         (e: Error) => {

--- a/src/controllers/candidateNotification/getProjectCertificateFile.ts
+++ b/src/controllers/candidateNotification/getProjectCertificateFile.ts
@@ -1,12 +1,11 @@
-import { eventStore, loadFileForUser } from '../../config'
+import asyncHandler from 'express-async-handler'
+import { ensureRole, eventStore, loadFileForUser } from '../../config'
 import { UniqueEntityID } from '../../core/domain'
 import { FileAccessDeniedError, FileNotFoundError } from '../../modules/file'
 import { ProjectCertificateDownloaded } from '../../modules/project/events'
 import { InfraNotAvailableError } from '../../modules/shared'
 import routes from '../../routes'
-import { ensureRole } from '../../config'
 import { v1Router } from '../v1Router'
-import asyncHandler from 'express-async-handler'
 
 v1Router.get(
   routes.DOWNLOAD_CERTIFICATE_FILE(),
@@ -32,6 +31,7 @@ v1Router.get(
           )
         }
 
+        response.type('pdf')
         fileStream.contents.pipe(response)
       },
       async (e) => {

--- a/src/controllers/project/getProjectFile.ts
+++ b/src/controllers/project/getProjectFile.ts
@@ -6,6 +6,7 @@ import routes from '../../routes'
 import { ensureRole } from '../../config'
 import { v1Router } from '../v1Router'
 import asyncHandler from 'express-async-handler'
+import path from 'path'
 
 v1Router.get(
   routes.DOWNLOAD_PROJECT_FILE(),
@@ -19,6 +20,7 @@ v1Router.get(
       user,
     }).match(
       async (fileStream) => {
+        response.type(path.extname(request.path))
         fileStream.contents.pipe(response)
       },
       async (e) => {

--- a/src/controllers/project/getProjectsLaureatsCsv.ts
+++ b/src/controllers/project/getProjectsLaureatsCsv.ts
@@ -76,7 +76,7 @@ const getProjectsLaureatsCsv = asyncHandler(async (request, response) => {
       await fsPromises.unlink(csvFilePath)
     })
 
-    return response.sendFile(csvFilePath)
+    return response.type('text/csv').sendFile(csvFilePath)
   } catch (e) {
     logger.error(e)
     response


### PR DESCRIPTION
Certains utilisateurs n'arrivent pas à ouvrir leur attestation pdf dans le navigateur parce que ce n'est pas reconnu comme du pdf. 
Je pense que ça vient du header `Content-Type` qui n'est pas affecté pour les attestations.

J'en profite pour fixer le type pour toutes les requêtes qui envoient un fichier.