### PR TITLE
671 as admin i should not be able to modify project datas part of the potentiel identifier

### DIFF
--- a/src/controllers/project/postCorrectProjectData.ts
+++ b/src/controllers/project/postCorrectProjectData.ts
@@ -20,12 +20,21 @@ v1Router.post(
   upload.single('file'),
   ensureRole(['admin', 'dgec']),
   asyncHandler(async (request, response) => {
+    if(request.body.numeroCRE || request.body.familleId || request.body.appelOffreAndPeriode) {
+      return response.redirect(
+        addQueryParams(routes.PROJECT_DETAILS(request.body.projectId), {
+          error: 'Vous tentez de changer une donnée non-modifiable, votre demande ne peut être prise en compte.',
+          ...request.body,
+        })
+      )
+    }
+    
     const {
       projectId,
       projectVersionDate,
       notificationDate,
-      numeroCRE,
-      familleId,
+      //numeroCRE,
+      //familleId,
       nomProjet,
       territoireProjet,
       puissance,
@@ -42,12 +51,12 @@ v1Router.post(
       participatif,
       isClasse,
       motifsElimination,
-      appelOffreAndPeriode,
+      //appelOffreAndPeriode,
       reason,
       attestation,
     } = request.body
 
-    const [appelOffreId, periodeId] = appelOffreAndPeriode?.split('|')
+    //const [appelOffreId, periodeId] = appelOffreAndPeriode?.split('|')
     const { isFinancementParticipatif, isInvestissementParticipatif } =
       participatif === 'investissement'
         ? { isFinancementParticipatif: false, isInvestissementParticipatif: true }
@@ -68,10 +77,10 @@ v1Router.post(
     }
 
     const correctedData = {
-      numeroCRE,
-      appelOffreId,
-      periodeId,
-      familleId: familleId.length ? familleId : undefined,
+      //numeroCRE,
+      //appelOffreId,
+      //periodeId,
+      //familleId: familleId.length ? familleId : undefined,
       territoireProjet: territoireProjet.length ? territoireProjet : undefined,
       nomProjet,
       puissance: Number(puissance),

--- a/src/controllers/project/postCorrectProjectData.ts
+++ b/src/controllers/project/postCorrectProjectData.ts
@@ -33,8 +33,6 @@ v1Router.post(
       projectId,
       projectVersionDate,
       notificationDate,
-      //numeroCRE,
-      //familleId,
       nomProjet,
       territoireProjet,
       puissance,
@@ -51,12 +49,10 @@ v1Router.post(
       participatif,
       isClasse,
       motifsElimination,
-      //appelOffreAndPeriode,
       reason,
       attestation,
     } = request.body
 
-    //const [appelOffreId, periodeId] = appelOffreAndPeriode?.split('|')
     const { isFinancementParticipatif, isInvestissementParticipatif } =
       participatif === 'investissement'
         ? { isFinancementParticipatif: false, isInvestissementParticipatif: true }
@@ -77,10 +73,6 @@ v1Router.post(
     }
 
     const correctedData = {
-      //numeroCRE,
-      //appelOffreId,
-      //periodeId,
-      //familleId: familleId.length ? familleId : undefined,
       territoireProjet: territoireProjet.length ? territoireProjet : undefined,
       nomProjet,
       puissance: Number(puissance),

--- a/src/modules/project/Project.correctData.spec.ts
+++ b/src/modules/project/Project.correctData.spec.ts
@@ -89,7 +89,7 @@ describe('Project.correctData()', () => {
     )
 
     const res = project.correctData(fakeUser, {
-      numeroCRE: '1',
+      nomProjet: 'test',
       nomCandidat: fakeProject.nomCandidat, // Unchanged, should be ignored
     })
 
@@ -105,7 +105,7 @@ describe('Project.correctData()', () => {
     if (!targetEvent) return
 
     expect(targetEvent.payload.correctedData).toEqual({
-      numeroCRE: '1',
+      nomProjet: 'test',
     })
     expect(targetEvent.payload.projectId).toEqual(projectId.toString())
     expect(targetEvent.payload.correctedBy).toEqual(fakeUser.id)
@@ -124,7 +124,7 @@ describe('Project.correctData()', () => {
       )
 
       const res = project.correctData(fakeUser, {
-        numeroCRE: '1',
+        nomProjet: 'test',
       })
 
       expect(res.isErr()).toEqual(true)
@@ -157,6 +157,7 @@ describe('Project.correctData()', () => {
     })
   })
 
+  /*
   describe('when passed a familleId that does not exist in the appelOffre', () => {
     const fakeProjectData = makeFakeProject({ notifiedOn: 123, appelOffreId: 'Fessenheim' })
     const fakeHistory = makeFakeHistory(fakeProjectData)
@@ -181,5 +182,5 @@ describe('Project.correctData()', () => {
       const error = res.error as IllegalProjectStateError
       expect(error.error).toHaveProperty('familleId')
     })
-  })
+  })*/
 })

--- a/src/modules/project/Project.correctData.spec.ts
+++ b/src/modules/project/Project.correctData.spec.ts
@@ -156,31 +156,4 @@ describe('Project.correctData()', () => {
       expect(error.error).toHaveProperty('puissance')
     })
   })
-
-  /*
-  describe('when passed a familleId that does not exist in the appelOffre', () => {
-    const fakeProjectData = makeFakeProject({ notifiedOn: 123, appelOffreId: 'Fessenheim' })
-    const fakeHistory = makeFakeHistory(fakeProjectData)
-    const project = UnwrapForTest(
-      makeProject({
-        projectId,
-        history: fakeHistory,
-        appelsOffres,
-        buildProjectIdentifier: () => '',
-      })
-    )
-
-    it('should return an IllegalProjectStateError', () => {
-      const res = project.correctData(fakeUser, {
-        familleId: 'abc',
-      })
-      expect(res.isErr()).toBe(true)
-      if (res.isOk()) return
-
-      expect(res.error).toBeInstanceOf(IllegalProjectStateError)
-
-      const error = res.error as IllegalProjectStateError
-      expect(error.error).toHaveProperty('familleId')
-    })
-  })*/
 })

--- a/src/modules/project/events/ProjectDataCorrected.ts
+++ b/src/modules/project/events/ProjectDataCorrected.ts
@@ -4,10 +4,6 @@ export interface ProjectDataCorrectedPayload {
   projectId: string
   correctedBy: string
   correctedData: Partial<{
-    //numeroCRE: string
-    //appelOffreId: string
-    //periodeId: string
-    //familleId: string
     nomProjet: string
     territoireProjet: string
     puissance: number

--- a/src/modules/project/events/ProjectDataCorrected.ts
+++ b/src/modules/project/events/ProjectDataCorrected.ts
@@ -4,10 +4,10 @@ export interface ProjectDataCorrectedPayload {
   projectId: string
   correctedBy: string
   correctedData: Partial<{
-    numeroCRE: string
-    appelOffreId: string
-    periodeId: string
-    familleId: string
+    //numeroCRE: string
+    //appelOffreId: string
+    //periodeId: string
+    //familleId: string
     nomProjet: string
     territoireProjet: string
     puissance: number

--- a/src/modules/project/useCases/correctProjectData.spec.ts
+++ b/src/modules/project/useCases/correctProjectData.spec.ts
@@ -42,7 +42,7 @@ describe('correctProjectData', () => {
         user,
         shouldGrantClasse: false,
         correctedData: {
-          numeroCRE: '1',
+          nomProjet: "test",
         },
         attestation: 'regenerate',
       })
@@ -130,7 +130,7 @@ describe('correctProjectData', () => {
               user,
               shouldGrantClasse: true,
               correctedData: {
-                numeroCRE: 'nouveauNumero',
+                nomProjet: 'test',
               },
               attestation: 'custom',
             })
@@ -153,7 +153,7 @@ describe('correctProjectData', () => {
           it('should call project.correctData()', async () => {
             expect(fakeProject.correctData).toHaveBeenCalledTimes(1)
             expect(fakeProject.correctData).toHaveBeenCalledWith(user, {
-              numeroCRE: 'nouveauNumero',
+              nomProjet: 'test',
             })
           })
 
@@ -208,7 +208,7 @@ describe('correctProjectData', () => {
               user,
               shouldGrantClasse: true,
               correctedData: {
-                numeroCRE: 'nouveauNumero',
+                nomProjet: 'test',
               },
               attestation: 'regenerate',
             })
@@ -295,7 +295,7 @@ describe('correctProjectData', () => {
                 user,
                 shouldGrantClasse: true,
                 correctedData: {
-                  numeroCRE: 'nouveauNumero',
+                  nomProjet: 'test',
                 },
                 attestation: 'regenerate',
               })
@@ -338,9 +338,7 @@ describe('correctProjectData', () => {
                 newNotifiedOn: 1234,
                 user,
                 shouldGrantClasse: true,
-                correctedData: {
-                  numeroCRE: 'nouveauNumero',
-                },
+                correctedData: {},
                 attestation: 'regenerate',
               })
 
@@ -384,7 +382,7 @@ describe('correctProjectData', () => {
               user,
               shouldGrantClasse: true,
               correctedData: {
-                numeroCRE: 'nouveauNumero',
+                nomProjet: 'test',
               },
               attestation: 'donotregenerate',
             })
@@ -423,7 +421,7 @@ describe('correctProjectData', () => {
             user,
             shouldGrantClasse: false,
             correctedData: {
-              numeroCRE: '1',
+              nomProjet: 'test',
             },
             attestation: 'regenerate',
           })

--- a/src/modules/project/useCases/correctProjectData.ts
+++ b/src/modules/project/useCases/correctProjectData.ts
@@ -36,10 +36,10 @@ interface CorrectProjectDataArgs {
   attestation: 'regenerate' | 'donotregenerate' | 'custom'
   reason?: string
   correctedData: Partial<{
-    numeroCRE: string
-    appelOffreId: string
-    periodeId: string
-    familleId: string
+    //numeroCRE: string
+    //appelOffreId: string
+    //periodeId: string
+    //familleId: string
     nomProjet: string
     territoireProjet: string
     puissance: number

--- a/src/modules/project/useCases/correctProjectData.ts
+++ b/src/modules/project/useCases/correctProjectData.ts
@@ -36,10 +36,6 @@ interface CorrectProjectDataArgs {
   attestation: 'regenerate' | 'donotregenerate' | 'custom'
   reason?: string
   correctedData: Partial<{
-    //numeroCRE: string
-    //appelOffreId: string
-    //periodeId: string
-    //familleId: string
     nomProjet: string
     territoireProjet: string
     puissance: number
@@ -89,8 +85,6 @@ export const makeCorrectProjectData = (deps: CorrectProjectDataDeps): CorrectPro
   }
 
   return _uploadFileIfExists().andThen((certificateFileId) => {
-    // open a transaction on the project to update it
-    // the transaction will return a boolean for shouldCertificateBeGenerated
     const projectTransaction = deps.projectRepo.transaction(
       new UniqueEntityID(projectId),
       (

--- a/src/views/pages/projectDetailsPage/sections/EditProjectData.tsx
+++ b/src/views/pages/projectDetailsPage/sections/EditProjectData.tsx
@@ -44,6 +44,7 @@ export const EditProjectData = ({ project, request }: EditProjectDataProps) => {
             defaultValue={
               query.appelOffreAndPeriode || `${project.appelOffreId}|${project.periodeId}`
             }
+            disabled
           >
             {appelsOffreStatic.reduce((periodes: React.ReactNode[], appelOffre) => {
               return periodes?.concat(
@@ -65,6 +66,7 @@ export const EditProjectData = ({ project, request }: EditProjectDataProps) => {
             type="text"
             name="familleId"
             defaultValue={query.familleId || project.familleId || ''}
+            disabled
           />
         </div>
         <div className="form__group">
@@ -77,7 +79,7 @@ export const EditProjectData = ({ project, request }: EditProjectDataProps) => {
         </div>
         <div className="form__group">
           <label>Numéro CRE</label>
-          <input type="text" name="numeroCRE" defaultValue={query.numeroCRE || project.numeroCRE} />
+          <input type="text" name="numeroCRE" defaultValue={query.numeroCRE || project.numeroCRE} disabled/>
         </div>
         <div className="form__group">
           <label>Nom Projet</label>


### PR DESCRIPTION
On désactive temporairement les champs numéro CRE, Famille, appel d'offres et période du formulaire de correction des projets car de tels changements ont des impacts métier qui ne sont actuellement pas traités (conception à faire). 