### PR TITLE
:bug:  721 Fix import de l'historique éolien

### DIFF
--- a/src/modules/project/utils/parseProjectLine.spec.ts
+++ b/src/modules/project/utils/parseProjectLine.spec.ts
@@ -481,6 +481,14 @@ describe('parseProjectLine', () => {
             '',
         })
       ).toThrowError('Le champ Evaluation carbone doit contenir un nombre')
+
+      expect(() =>
+        parseProjectLine({
+          ...fakeLine,
+          'Evaluation carbone simplifiée indiquée au C. du formulaire de candidature et arrondie (kg eq CO2/kWc)': undefined,
+          'Valeur de l’évaluation carbone des modules (kg eq CO2/kWc)': undefined,
+        })
+      ).toThrowError('Le champ Evaluation carbone doit contenir un nombre')
     })
   })
 })

--- a/src/modules/project/utils/parseProjectLine.ts
+++ b/src/modules/project/utils/parseProjectLine.ts
@@ -32,7 +32,7 @@ const mappedColumns = [
   'Valeur de l’évaluation carbone des modules (kg eq CO2/kWc)',
 ]
 
-const prepareNumber = (str) => str.replace(/,/g, '.')
+const prepareNumber = (str) => str && str.replace(/,/g, '.')
 
 const padCodePostalWithleft0 = (codePostalProjet) => {
   if (codePostalProjet.length === 4) {
@@ -104,7 +104,7 @@ const columnMapper = {
       ] || line['Valeur de l’évaluation carbone des modules (kg eq CO2/kWc)']
     )
 
-    if (ecs === '') return null
+    if (ecs === '' || typeof ecs === 'undefined') return null
 
     if (ecs === 'N/A') return 0
 
@@ -298,6 +298,10 @@ export const parseProjectLine = (line) => {
         .reduce((details, [key, value]) => ({ ...details, [key]: value }), {}),
     }
   } catch (e) {
-    throw new Error(e.errors.join(', '))
+    if (e.errors) {
+      throw new Error(e.errors.join(', '))
+    }
+
+    throw e
   }
 }


### PR DESCRIPTION
Cette PR rend possible l'import d'un fichier avec aucune valeur dans les colonnes evaluation carbone: l'erreur retournée en cas de valeur manquante est lisible.