### PR TITLE
:wrench:  706 Compile migrations scripts before executing them

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "cy:run:legacy": "cypress run --config-file=cypress.legacy.json",
     "cy:open:legacy": "cypress open --config-file=cypress.legacy.json",
     "launch-test-db": "export NODE_ENV=test && export COMPOSE_PROJECT_NAME=potentiel_tests && docker-compose down --remove-orphans && docker-compose -f ./docker-compose-integration.yml up -d && until docker exec potentiel_db_tests_integration pg_isready -U testuser -d potentiel_test; do sleep 1; done",
-    "migrate": "npx sequelize-cli db:migrate",
+    "migrate": "tsc --build tsconfig.migrations.json && npx sequelize-cli db:migrate --migrations-path=dist/migrations/src/infra/sequelize/migrations",
     "seed": "npx sequelize-cli db:seed:all",
     "test-db": "export NODE_ENV=test && npm run launch-test-db && sleep 2 && npm run migrate",
     "dev-db": "docker-compose down --remove-orphans && docker-compose up -d",

--- a/tsconfig.migrations.json
+++ b/tsconfig.migrations.json
@@ -1,0 +1,22 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist/migrations",
+    "sourceMap": false,
+    "inlineSourceMap": true
+  },
+  "include": ["src/infra/sequelize/migrations/*.js", "src/infra/sequelize/migrations/*.ts"],
+  "exclude": [
+    "node_modules",
+    "features",
+    "**/*.spec.ts",
+    "**/*.integration.ts",
+    "**/*.stories.tsx",
+    "**/__tests__/**/*",
+    "e2e-legacy",
+    "e2e-legacy/**/*",
+    "e2e",
+    "e2e/**/*",
+    "scripts"
+  ]
+}


### PR DESCRIPTION
This is a necessary step before being able to build/rebuild projections during migration.