### PR TITLE
728 Simplify event hydration from persistance

### DIFF
--- a/src/core/domain/DomainEvent.ts
+++ b/src/core/domain/DomainEvent.ts
@@ -9,25 +9,44 @@ export interface DomainEvent {
   payload: any
 }
 
-export interface BaseDomainEventProps<P> {
+type ValidEventPayload = any & {
+  payload: never
+  original: never
+}
+
+export interface WrappedDomainEventProps<P> {
   payload: P
-  requestId?: DomainEvent['requestId']
   original?: {
-    occurredAt: DomainEvent['occurredAt']
+    occurredAt: Date
     eventId?: string
   }
 }
-export abstract class BaseDomainEvent<P> {
+export abstract class BaseDomainEvent<P extends ValidEventPayload> {
   public readonly payload: P
   public readonly id: DomainEvent['id']
   public readonly requestId: DomainEvent['requestId']
   public readonly aggregateId: DomainEvent['aggregateId']
   public readonly occurredAt: DomainEvent['occurredAt']
 
-  constructor({ payload }: BaseDomainEventProps<P>) {
-    this.payload = payload
-    this.occurredAt = new Date()
+  constructor(args: P | WrappedDomainEventProps<P>) {
     this.id = new UniqueEntityID().toString()
+    this.occurredAt = new Date()
+
+    // @ts-ignore
+    if (args.original) {
+      // @ts-ignore
+      this.occurredAt = args.original.occurredAt
+
+      // @ts-ignore
+      if (args.original.eventId) {
+        // @ts-ignore
+        this.id = args.original.eventId
+      }
+    }
+
+    // @ts-ignore
+    const payload = args.payload || args
+
     this.aggregateId = this.aggregateIdFromPayload(payload)
   }
 

--- a/src/core/domain/DomainEvent.ts
+++ b/src/core/domain/DomainEvent.ts
@@ -4,7 +4,6 @@ export interface DomainEvent {
   id: string
   occurredAt: Date
   type: string
-  getVersion: () => number
   aggregateId: string[] | string | undefined
   requestId?: string
   payload: any
@@ -15,7 +14,6 @@ export interface BaseDomainEventProps<P> {
   requestId?: DomainEvent['requestId']
   original?: {
     occurredAt: DomainEvent['occurredAt']
-    version: ReturnType<DomainEvent['getVersion']>
     eventId?: string
   }
 }
@@ -25,25 +23,13 @@ export abstract class BaseDomainEvent<P> {
   public readonly requestId: DomainEvent['requestId']
   public readonly aggregateId: DomainEvent['aggregateId']
   public readonly occurredAt: DomainEvent['occurredAt']
-  private originalVersion: ReturnType<DomainEvent['getVersion']>
 
-  abstract readonly currentVersion: number
-
-  constructor({ payload, requestId, original }: BaseDomainEventProps<P>) {
+  constructor({ payload }: BaseDomainEventProps<P>) {
     this.payload = payload
-    this.occurredAt = original?.occurredAt || new Date()
-    this.id = original?.eventId || new UniqueEntityID().toString()
-    this.requestId = requestId
+    this.occurredAt = new Date()
+    this.id = new UniqueEntityID().toString()
     this.aggregateId = this.aggregateIdFromPayload(payload)
-
-    if (original?.version) {
-      this.originalVersion = original.version
-    }
   }
 
   abstract aggregateIdFromPayload(payload: P): DomainEvent['aggregateId']
-
-  getVersion() {
-    return this.originalVersion || this.currentVersion
-  }
 }

--- a/src/infra/sequelize/eventStore/persistEventsToStore.integration.ts
+++ b/src/infra/sequelize/eventStore/persistEventsToStore.integration.ts
@@ -20,7 +20,6 @@ describe('sequelize.persistEventsToStore', () => {
       },
       original: {
         occurredAt: new Date(1234),
-        version: 1,
       },
       requestId,
     })
@@ -34,7 +33,6 @@ describe('sequelize.persistEventsToStore', () => {
       },
       original: {
         occurredAt: new Date(3456),
-        version: 2,
       },
     })
     expect(eventWithMultipleAggregateIds.aggregateId).toHaveLength(2)

--- a/src/infra/sequelize/eventStore/rollbackEventsFromStore.integration.ts
+++ b/src/infra/sequelize/eventStore/rollbackEventsFromStore.integration.ts
@@ -31,7 +31,7 @@ describe('rollbackEventsFromStore', () => {
       (eventId) =>
         new DummyEvent({
           payload: {},
-          original: { occurredAt: new Date(123), version: 1, eventId },
+          original: { occurredAt: new Date(123), eventId },
         })
     )
 

--- a/src/infra/sequelize/helpers/fromPersistance.ts
+++ b/src/infra/sequelize/helpers/fromPersistance.ts
@@ -1,55 +1,14 @@
 import { DomainEvent } from '../../../core/domain'
-import { logger } from '../../../core/utils'
-import * as AuthorizationEvents from '../../../modules/authZ/events'
-import * as CandidateNotificationEvents from '../../../modules/candidateNotification/events'
-import * as ModificationRequestEvents from '../../../modules/modificationRequest/events'
-import * as AppelOffreEvents from '../../../modules/appelOffre/events'
-import * as ProjectEvents from '../../../modules/project/events'
-import * as ProjectClaimEvents from '../../../modules/projectClaim/events'
-import * as UserEvents from '../../../modules/users/events'
-import * as LegacyCandidateNotificationEvents from '../../../modules/legacyCandidateNotification/events'
-
-interface EventProps {
-  payload: any
-  requestId?: string
-  original?: {
-    occurredAt: Date
-    version: number
-    eventId: string
-  }
-}
-interface HasEventConstructor {
-  new (props: EventProps): DomainEvent
-}
-
-const EventClassByType: Record<string, HasEventConstructor> = {
-  ...ModificationRequestEvents,
-  ...CandidateNotificationEvents,
-  ...ProjectEvents,
-  ...AuthorizationEvents,
-  ...AppelOffreEvents,
-  ...ProjectClaimEvents,
-  ...UserEvents,
-  ...LegacyCandidateNotificationEvents,
-}
 
 export const fromPersistance = (eventRaw: any): DomainEvent | null => {
-  const EventClass = EventClassByType[eventRaw.type]
+  const { id, type, payload, context, occurredAt, aggregateId } = eventRaw
 
-  if (!EventClass) {
-    logger.error(
-      `MEGA FAIL: SequelizeEventStore does not recognize this event type (see sequelizeEventStore.fromPersistance for missing type ${eventRaw.type}`
-    )
-    return null
+  return {
+    id,
+    type,
+    payload,
+    context,
+    occurredAt: new Date(occurredAt),
+    aggregateId,
   }
-
-  return new EventClass({
-    payload: eventRaw.payload,
-    requestId: eventRaw.requestId?.toString(),
-    original: {
-      version: eventRaw.version,
-      occurredAt: new Date(eventRaw.occurredAt),
-      eventId: eventRaw.id,
-    },
-  })
 }

--- a/src/infra/sequelize/projections/modificationRequest/updates/onConfirmationRequested.integration.ts
+++ b/src/infra/sequelize/projections/modificationRequest/updates/onConfirmationRequested.integration.ts
@@ -34,7 +34,6 @@ describe('modificationRequest.onConfirmationRequested', () => {
           responseFileId: fileId,
         },
         original: {
-          version: 1,
           occurredAt: new Date(123),
         },
       })

--- a/src/infra/sequelize/projections/modificationRequest/updates/onModificationRequestCancelled.integration.ts
+++ b/src/infra/sequelize/projections/modificationRequest/updates/onModificationRequestCancelled.integration.ts
@@ -20,7 +20,6 @@ describeProjector(onModificationRequestCancelled)
         cancelledBy: userId,
       },
       original: {
-        version: 1,
         occurredAt: new Date(123),
       },
     })

--- a/src/infra/sequelize/projections/modificationRequest/updates/onModificationRequestConfirmed.integration.ts
+++ b/src/infra/sequelize/projections/modificationRequest/updates/onModificationRequestConfirmed.integration.ts
@@ -33,7 +33,6 @@ describe('modificationRequest.onModificationRequestConfirmed', () => {
           confirmedBy: userId,
         },
         original: {
-          version: 1,
           occurredAt: new Date(123),
         },
       })

--- a/src/infra/sequelize/projections/modificationRequest/updates/onModificationRequestStatusUpdated.integration.ts
+++ b/src/infra/sequelize/projections/modificationRequest/updates/onModificationRequestStatusUpdated.integration.ts
@@ -36,7 +36,6 @@ describe('modificationRequest.onModificationRequestStatusUpdated', () => {
         },
         original: {
           occurredAt: new Date(123),
-          version: 1,
         },
       })
     )

--- a/src/infra/sequelize/projections/project/updates/onProjectAbandoned.integration.ts
+++ b/src/infra/sequelize/projections/project/updates/onProjectAbandoned.integration.ts
@@ -33,7 +33,6 @@ describe('project.onProjectAbandoned', () => {
           abandonAcceptedBy: new UniqueEntityID().toString(),
         },
         original: {
-          version: 1,
           occurredAt: new Date(1234),
         },
       })

--- a/src/infra/sequelize/projections/project/updates/onProjectImported.integration.ts
+++ b/src/infra/sequelize/projections/project/updates/onProjectImported.integration.ts
@@ -32,7 +32,6 @@ describe('project.onProjectImported', () => {
           data: fakeProject,
         },
         original: {
-          version: 1,
           occurredAt: new Date(1234),
         },
       })

--- a/src/infra/sequelize/projections/project/updates/onProjectReimported.integration.ts
+++ b/src/infra/sequelize/projections/project/updates/onProjectReimported.integration.ts
@@ -38,7 +38,6 @@ describe('project.onProjectReimported', () => {
           },
         },
         original: {
-          version: 1,
           occurredAt: new Date(1234),
         },
       })

--- a/src/infra/sequelize/projections/projectStep/updates/onProjectStepSubmitted.integration.ts
+++ b/src/infra/sequelize/projections/projectStep/updates/onProjectStepSubmitted.integration.ts
@@ -30,7 +30,6 @@ describe('projectStep.onProjectStepSubmitted', () => {
           submittedBy: userId,
         },
         original: {
-          version: 1,
           occurredAt: new Date(345),
         },
       })
@@ -64,7 +63,6 @@ describe('projectStep.onProjectStepSubmitted', () => {
           submittedBy: userId,
         },
         original: {
-          version: 1,
           occurredAt: new Date(456),
         },
       })
@@ -99,7 +97,6 @@ describe('projectStep.onProjectStepSubmitted', () => {
           submittedBy: userId,
         },
         original: {
-          version: 1,
           occurredAt: new Date(456),
         },
       })

--- a/src/modules/notification/eventHandlers/handleProjectGFSubmitted.spec.ts
+++ b/src/modules/notification/eventHandlers/handleProjectGFSubmitted.spec.ts
@@ -34,7 +34,6 @@ describe('notification.handleProjectGFSubmitted', () => {
           submittedBy: userId,
         },
         original: {
-          version: 1,
           occurredAt: new Date(1),
         },
       })

--- a/src/modules/notification/eventHandlers/handleUserInvitedToProject.spec.ts
+++ b/src/modules/notification/eventHandlers/handleUserInvitedToProject.spec.ts
@@ -35,7 +35,6 @@ describe('notification.handleUserInvitedToProject', () => {
           invitedBy: userId,
         },
         original: {
-          version: 1,
           occurredAt: new Date(1),
         },
       })

--- a/src/modules/project/Project.addGeneratedCertificate.spec.ts
+++ b/src/modules/project/Project.addGeneratedCertificate.spec.ts
@@ -40,7 +40,6 @@ const fakeHistory: DomainEvent[] = [
     },
     original: {
       occurredAt: new Date(123),
-      version: 1,
     },
   }),
   new ProjectNotified({
@@ -55,7 +54,6 @@ const fakeHistory: DomainEvent[] = [
     },
     original: {
       occurredAt: new Date(456),
-      version: 1,
     },
   }),
 ]

--- a/src/modules/project/Project.correctData.spec.ts
+++ b/src/modules/project/Project.correctData.spec.ts
@@ -57,7 +57,6 @@ const fakeHistory: DomainEvent[] = [
     },
     original: {
       occurredAt: new Date(123),
-      version: 1,
     },
   }),
   new ProjectNotified({
@@ -72,7 +71,6 @@ const fakeHistory: DomainEvent[] = [
     },
     original: {
       occurredAt: new Date(456),
-      version: 1,
     },
   }),
 ]

--- a/src/modules/project/Project.lastCertificateUpdate.spec.ts
+++ b/src/modules/project/Project.lastCertificateUpdate.spec.ts
@@ -41,7 +41,6 @@ const fakeHistory: DomainEvent[] = [
     },
     original: {
       occurredAt: new Date(123),
-      version: 1,
     },
   }),
   new ProjectNotified({
@@ -56,7 +55,6 @@ const fakeHistory: DomainEvent[] = [
     },
     original: {
       occurredAt: new Date(456),
-      version: 1,
     },
   }),
 ]
@@ -124,7 +122,6 @@ describe('Project.lastCertificateUpdate', () => {
               },
               original: {
                 occurredAt: new Date(456),
-                version: 1,
               },
             }),
           ]),

--- a/src/modules/project/Project.lastUpdatedOn.spec.ts
+++ b/src/modules/project/Project.lastUpdatedOn.spec.ts
@@ -35,7 +35,6 @@ const fakeHistory: DomainEvent[] = [
     },
     original: {
       occurredAt: new Date(123),
-      version: 1,
     },
   }),
   new ProjectNotified({
@@ -50,7 +49,6 @@ const fakeHistory: DomainEvent[] = [
     },
     original: {
       occurredAt: new Date(456),
-      version: 1,
     },
   }),
 ]

--- a/src/modules/project/Project.moveCompletionDueDate.spec.ts
+++ b/src/modules/project/Project.moveCompletionDueDate.spec.ts
@@ -60,7 +60,6 @@ const fakeHistory: DomainEvent[] = [
     },
     original: {
       occurredAt: new Date(123),
-      version: 1,
     },
   }),
   new ProjectNotified({
@@ -75,7 +74,6 @@ const fakeHistory: DomainEvent[] = [
     },
     original: {
       occurredAt: new Date(456),
-      version: 1,
     },
   }),
   new ProjectCompletionDueDateSet({
@@ -85,7 +83,6 @@ const fakeHistory: DomainEvent[] = [
     },
     original: {
       occurredAt: new Date(678),
-      version: 1,
     },
   }),
 ]

--- a/src/modules/project/Project.setCompletionDueDate.spec.ts
+++ b/src/modules/project/Project.setCompletionDueDate.spec.ts
@@ -30,7 +30,6 @@ const fakeHistory: DomainEvent[] = [
     },
     original: {
       occurredAt: new Date(123),
-      version: 1,
     },
   }),
   new ProjectNotified({
@@ -45,7 +44,6 @@ const fakeHistory: DomainEvent[] = [
     },
     original: {
       occurredAt: new Date(456),
-      version: 1,
     },
   }),
 ]

--- a/src/modules/project/Project.setNotificationDate.spec.ts
+++ b/src/modules/project/Project.setNotificationDate.spec.ts
@@ -61,7 +61,6 @@ const fakeHistory: DomainEvent[] = [
     },
     original: {
       occurredAt: new Date(123),
-      version: 1,
     },
   }),
   new ProjectNotified({
@@ -76,7 +75,6 @@ const fakeHistory: DomainEvent[] = [
     },
     original: {
       occurredAt: new Date(456),
-      version: 1,
     },
   }),
 ]

--- a/src/modules/project/Project.shouldCertificateBeGenerated.spec.ts
+++ b/src/modules/project/Project.shouldCertificateBeGenerated.spec.ts
@@ -41,7 +41,6 @@ const fakeHistory: DomainEvent[] = [
     },
     original: {
       occurredAt: new Date(123),
-      version: 1,
     },
   }),
   new ProjectNotified({
@@ -56,7 +55,6 @@ const fakeHistory: DomainEvent[] = [
     },
     original: {
       occurredAt: new Date(456),
-      version: 1,
     },
   }),
 ]
@@ -169,7 +167,6 @@ describe('Project.shouldCertificateBeGenerated', () => {
               },
               original: {
                 occurredAt: new Date(1000),
-                version: 1,
               },
             }),
             new ProjectNotificationDateSet({
@@ -180,7 +177,6 @@ describe('Project.shouldCertificateBeGenerated', () => {
               },
               original: {
                 occurredAt: new Date(1001),
-                version: 1,
               },
             }),
           ]),
@@ -207,7 +203,6 @@ describe('Project.shouldCertificateBeGenerated', () => {
               },
               original: {
                 occurredAt: new Date(456),
-                version: 1,
               },
             }),
           ]),

--- a/src/modules/project/Project.ts
+++ b/src/modules/project/Project.ts
@@ -269,7 +269,6 @@ export const makeProject = (args: {
               abandonAcceptedBy: '',
             },
             original: {
-              version: 1,
               occurredAt: new Date(abandonnedOn),
             },
           })

--- a/src/modules/project/Project.updateCertificate.spec.ts
+++ b/src/modules/project/Project.updateCertificate.spec.ts
@@ -36,7 +36,6 @@ const fakeHistory: DomainEvent[] = [
     },
     original: {
       occurredAt: new Date(123),
-      version: 1,
     },
   }),
   new ProjectNotified({
@@ -51,7 +50,6 @@ const fakeHistory: DomainEvent[] = [
     },
     original: {
       occurredAt: new Date(456),
-      version: 1,
     },
   }),
 ]

--- a/src/modules/project/eventHandlers/handleModificationReceived.spec.ts
+++ b/src/modules/project/eventHandlers/handleModificationReceived.spec.ts
@@ -39,7 +39,6 @@ describe('handleModificationReceived', () => {
           requestId,
           original: {
             occurredAt: date,
-            version: 1,
           },
         })
       )
@@ -71,7 +70,6 @@ describe('handleModificationReceived', () => {
           requestId,
           original: {
             occurredAt: date,
-            version: 1,
           },
         })
       )


### PR DESCRIPTION
When an event comes from persistance (database, redis), it arrives as raw data and we try to recreate the proper event class instance. However, this is not an easy task, as we need to import the Event class constructor. 

This creates coupling between the infrastructure methods `fromPersistance` / `fromRedisMessage` and the event modules, and represents a point of failure.

Here, I propose to not call the event class constructor but simply pass a simple object, acting as the event class instance (same type, payload, etc.). 

I also try to simplify the event class constructor (remove useless properties, accept the payload directly to avoid having to write `{ payload: { ... } }` on each event. 
These may be moved to separate PRs.