### PR TITLE
:bug: 753 Do not return project page if not admin and not notified

### DIFF
--- a/src/infra/sequelize/queries/project/getProjectDataForProjectPage.integration.ts
+++ b/src/infra/sequelize/queries/project/getProjectDataForProjectPage.integration.ts
@@ -1,4 +1,5 @@
 import { UniqueEntityID } from '../../../../core/domain'
+import { EntityNotFoundError } from '../../../../modules/shared'
 import makeFakeFile from '../../../../__tests__/fixtures/file'
 import makeFakeProject from '../../../../__tests__/fixtures/project'
 import makeFakeUser from '../../../../__tests__/fixtures/user'
@@ -338,6 +339,56 @@ describe('Sequelize getProjectDataForProjectPage', () => {
       expect(res).toMatchObject({
         isLegacy: false,
       })
+    })
+  })
+
+  describe('when project is not notified', () => {
+    beforeAll(async () => {
+      await resetDatabase()
+
+      await Project.create(makeFakeProject({ ...projectInfo, notifiedOn: 0 }))
+    })
+
+    it('should return EntityNotFoundError for porteur-projet', async () => {
+      const user = makeFakeUser({ role: 'porteur-projet' })
+
+      const res = await getProjectDataForProjectPage({ projectId, user })
+      expect(res._unsafeUnwrapErr()).toBeInstanceOf(EntityNotFoundError)
+    })
+
+    it('should return EntityNotFoundError for ademe', async () => {
+      const user = makeFakeUser({ role: 'ademe' })
+
+      const res = await getProjectDataForProjectPage({ projectId, user })
+      expect(res._unsafeUnwrapErr()).toBeInstanceOf(EntityNotFoundError)
+    })
+
+    it('should return EntityNotFoundError for acheteur-obligé', async () => {
+      const user = makeFakeUser({ role: 'acheteur-obligé' })
+
+      const res = await getProjectDataForProjectPage({ projectId, user })
+      expect(res._unsafeUnwrapErr()).toBeInstanceOf(EntityNotFoundError)
+    })
+
+    it('should return EntityNotFoundError for dreal', async () => {
+      const user = makeFakeUser({ role: 'dreal' })
+
+      const res = await getProjectDataForProjectPage({ projectId, user })
+      expect(res._unsafeUnwrapErr()).toBeInstanceOf(EntityNotFoundError)
+    })
+
+    it('should return DTO for admin', async () => {
+      const user = makeFakeUser({ role: 'admin' })
+
+      const res = await getProjectDataForProjectPage({ projectId, user })
+      expect(res.isOk()).toBe(true)
+    })
+
+    it('should return DTO for dgec', async () => {
+      const user = makeFakeUser({ role: 'dgec' })
+
+      const res = await getProjectDataForProjectPage({ projectId, user })
+      expect(res.isOk()).toBe(true)
     })
   })
 })

--- a/src/infra/sequelize/queries/project/getProjectDataForProjectPage.ts
+++ b/src/infra/sequelize/queries/project/getProjectDataForProjectPage.ts
@@ -111,8 +111,12 @@ export const getProjectDataForProjectPage: GetProjectDataForProjectPage = ({ pro
           completionDueOn,
           updatedAt,
           newRulesOptIn,
-          potentielIdentifier
+          potentielIdentifier,
         } = projectRaw.get()
+
+        if (!notifiedOn && !['admin', 'dgec'].includes(user.role)) {
+          return err(new EntityNotFoundError())
+        }
 
         const result: any = {
           id,


### PR DESCRIPTION
Il est possible d'accéder à la page d'un projet non-notifié (à condition d'avoir l'url).

Cette PR ajoute une vérification pour nous assurer que ça n'arrive pas.