### PR TITLE
🌟 594 update project certificate on project claimed

### DIFF
--- a/src/infra/sequelize/migrations/20211216153606-catchup-on-project-claimed-project-certificateFileId.js
+++ b/src/infra/sequelize/migrations/20211216153606-catchup-on-project-claimed-project-certificateFileId.js
@@ -1,0 +1,55 @@
+'use strict'
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    const transaction = await queryInterface.sequelize.transaction()
+    try {
+      const projectClaimedEvents = await queryInterface.sequelize.query(
+        `SELECT * FROM "eventStores" WHERE type = 'ProjectClaimed'`,
+        {
+          type: queryInterface.sequelize.QueryTypes.SELECT,
+          transaction,
+        }
+      )
+
+      for (const event of projectClaimedEvents) {
+        const { id, payload } = event
+
+        const { projectId, attestationDesignationFileId } = payload
+
+        const project = await queryInterface.sequelize.query(
+          `SELECT "certificateFileId" FROM "projects" WHERE id = ?`,
+          {
+            type: queryInterface.sequelize.QueryTypes.SELECT,
+            replacements: [projectId],
+            transaction,
+          }
+        )
+
+        if (project && !project.certificateFileId) {
+          await queryInterface.sequelize.query(
+            'UPDATE "projects" SET "certificateFileId" = ? WHERE id = ?',
+            {
+              type: queryInterface.sequelize.UPDATE,
+              replacements: [attestationDesignationFileId, projectId],
+              transaction,
+            }
+          )
+        }
+      }
+      await transaction.commit()
+    } catch (error) {
+      await transaction.rollback()
+      throw error
+    }
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    /**
+     * Add reverting commands here.
+     *
+     * Example:
+     * await queryInterface.dropTable('users');
+     */
+  },
+}

--- a/src/infra/sequelize/migrations/20211216153606-catchup-on-project-claimed-project-certificateFileId.js
+++ b/src/infra/sequelize/migrations/20211216153606-catchup-on-project-claimed-project-certificateFileId.js
@@ -13,9 +13,9 @@ module.exports = {
       )
 
       for (const event of projectClaimedEvents) {
-        const { id, payload } = event
-
-        const { projectId, attestationDesignationFileId } = payload
+        const {
+          payload: { projectId, attestationDesignationFileId },
+        } = event
 
         const project = await queryInterface.sequelize.query(
           `SELECT "certificateFileId" FROM "projects" WHERE id = ?`,

--- a/src/infra/sequelize/projections/project/updates/onProjectClaimed.integration.ts
+++ b/src/infra/sequelize/projections/project/updates/onProjectClaimed.integration.ts
@@ -20,7 +20,7 @@ describe('project.onProjectClaimed', () => {
 
     beforeAll(async () => {
       await resetDatabase()
-      await Project.bulkCreate([fakeProject])
+      await Project.create(fakeProject)
 
       const originalProject = await Project.findByPk(projectId)
       expect(originalProject.email).toEqual('old@test.test')
@@ -52,7 +52,7 @@ describe('project.onProjectClaimed', () => {
       const attestationDesignationFileId = new UniqueEntityID().toString()
       beforeAll(async () => {
         await resetDatabase()
-        await Project.bulkCreate([{ ...fakeProject, certificateFileId: originalCertificateFileId }])
+        await Project.create({ ...fakeProject, certificateFileId: originalCertificateFileId })
 
         const originalProject = await Project.findByPk(projectId)
         expect(originalProject.certificateFileId).toEqual(originalCertificateFileId)
@@ -79,7 +79,7 @@ describe('project.onProjectClaimed', () => {
   describe('on ProjectClaimedByOwner', () => {
     beforeAll(async () => {
       await resetDatabase()
-      await Project.bulkCreate([fakeProject])
+      await Project.create(fakeProject)
 
       const originalProject = await Project.findByPk(projectId)
       expect(originalProject.email).toEqual('old@test.test')

--- a/src/infra/sequelize/projections/project/updates/onProjectClaimed.integration.ts
+++ b/src/infra/sequelize/projections/project/updates/onProjectClaimed.integration.ts
@@ -8,19 +8,19 @@ import { ProjectClaimed, ProjectClaimedByOwner } from '../../../../../modules/pr
 describe('project.onProjectClaimed', () => {
   const projectId = new UniqueEntityID().toString()
 
-  const fakeProjects = [
-    {
-      id: projectId,
-      email: 'old@test.test',
-    },
-  ].map(makeFakeProject)
+  const fakeProject = makeFakeProject({
+    id: projectId,
+    email: 'old@test.test',
+  })
 
   const { Project } = models
 
   describe('on ProjectClaimed', () => {
+    const attestationDesignationFileId = new UniqueEntityID().toString()
+
     beforeAll(async () => {
       await resetDatabase()
-      await Project.bulkCreate(fakeProjects)
+      await Project.bulkCreate([fakeProject])
 
       const originalProject = await Project.findByPk(projectId)
       expect(originalProject.email).toEqual('old@test.test')
@@ -31,7 +31,7 @@ describe('project.onProjectClaimed', () => {
             projectId: projectId,
             claimedBy: new UniqueEntityID().toString(),
             claimerEmail: 'new@test.test',
-            attestationDesignationFileId: new UniqueEntityID().toString(),
+            attestationDesignationFileId,
           },
         })
       )
@@ -41,12 +41,45 @@ describe('project.onProjectClaimed', () => {
       const updatedProject = await Project.findByPk(projectId)
       expect(updatedProject.email).toEqual('new@test.test')
     })
+
+    it('should udpdate the project certificateFile', async () => {
+      const updatedProject = await Project.findByPk(projectId)
+      expect(updatedProject.certificateFileId).toEqual(attestationDesignationFileId)
+    })
+
+    describe('when the project already has a certificate', () => {
+      const originalCertificateFileId = new UniqueEntityID().toString()
+      const attestationDesignationFileId = new UniqueEntityID().toString()
+      beforeAll(async () => {
+        await resetDatabase()
+        await Project.bulkCreate([{ ...fakeProject, certificateFileId: originalCertificateFileId }])
+
+        const originalProject = await Project.findByPk(projectId)
+        expect(originalProject.certificateFileId).toEqual(originalCertificateFileId)
+
+        await onProjectClaimed(models)(
+          new ProjectClaimed({
+            payload: {
+              projectId: projectId,
+              claimedBy: new UniqueEntityID().toString(),
+              claimerEmail: 'new@test.test',
+              attestationDesignationFileId,
+            },
+          })
+        )
+      })
+
+      it('should not udpdate the project certificateFile', async () => {
+        const updatedProject = await Project.findByPk(projectId)
+        expect(updatedProject.certificateFileId).toEqual(originalCertificateFileId)
+      })
+    })
   })
 
   describe('on ProjectClaimedByOwner', () => {
     beforeAll(async () => {
       await resetDatabase()
-      await Project.bulkCreate(fakeProjects)
+      await Project.bulkCreate([fakeProject])
 
       const originalProject = await Project.findByPk(projectId)
       expect(originalProject.email).toEqual('old@test.test')

--- a/src/infra/sequelize/projections/project/updates/onProjectClaimed.ts
+++ b/src/infra/sequelize/projections/project/updates/onProjectClaimed.ts
@@ -1,5 +1,6 @@
 import { logger } from '../../../../../core/utils'
 import { ProjectClaimed, ProjectClaimedByOwner } from '../../../../../modules/projectClaim/events'
+import { EntityNotFoundError } from '../../../../../modules/shared'
 
 export const onProjectClaimed = (models) => async (
   event: ProjectClaimed | ProjectClaimedByOwner
@@ -8,7 +9,20 @@ export const onProjectClaimed = (models) => async (
   const { Project } = models
 
   try {
-    await Project.update({ email: claimerEmail }, { where: { id: projectId } })
+    const project = await Project.findByPk(projectId)
+
+    if (project === null) {
+      throw new EntityNotFoundError()
+    }
+
+    project.email = claimerEmail
+
+    if (!project.certificateFileId && event.type === ProjectClaimed.type) {
+      const { attestationDesignationFileId } = event.payload
+      project.certificateFileId = attestationDesignationFileId
+    }
+
+    await project.save()
   } catch (e) {
     logger.error(e)
   }

--- a/src/infra/sequelize/projectionsNext/projectEvents/updates/index.ts
+++ b/src/infra/sequelize/projectionsNext/projectEvents/updates/index.ts
@@ -1,1 +1,2 @@
+export * from './onProjectClaimed';
 export * from './onProjectNotified';

--- a/src/infra/sequelize/projectionsNext/projectEvents/updates/onProjectClaimed.integration.ts
+++ b/src/infra/sequelize/projectionsNext/projectEvents/updates/onProjectClaimed.integration.ts
@@ -1,0 +1,42 @@
+import { UniqueEntityID } from '../../../../../core/domain'
+import { ProjectClaimed } from '../../../../../modules/projectClaim'
+import { resetDatabase } from '../../../helpers'
+import { ProjectEvent } from '../projectEvent.model'
+import onProjectClaimed from './onProjectClaimed'
+
+describe('onProjectClaimed', () => {
+  const projectId = new UniqueEntityID().toString()
+  const claimedBy = new UniqueEntityID().toString()
+  const attestationDesignationFileId = new UniqueEntityID().toString()
+
+  beforeAll(async () => {
+    await resetDatabase()
+
+    await onProjectClaimed(
+      new ProjectClaimed({
+        payload: {
+          projectId,
+          claimedBy,
+          attestationDesignationFileId,
+          claimerEmail: '',
+        },
+        original: {
+          version: 1,
+          occurredAt: new Date(1234),
+        },
+      })
+    )
+  })
+
+  it('should create a new project event of type ProjectClaimed', async () => {
+    const projectEvent = await ProjectEvent.findOne({ where: { projectId } })
+
+    expect(projectEvent).not.toBeNull()
+
+    expect(projectEvent).toMatchObject({
+      type: 'ProjectClaimed',
+      valueDate: 1234,
+      payload: { claimedBy, attestationDesignationFileId },
+    })
+  })
+})

--- a/src/infra/sequelize/projectionsNext/projectEvents/updates/onProjectClaimed.ts
+++ b/src/infra/sequelize/projectionsNext/projectEvents/updates/onProjectClaimed.ts
@@ -1,0 +1,19 @@
+import { UniqueEntityID } from '../../../../../core/domain'
+import { ProjectClaimed } from '../../../../../modules/projectClaim'
+import { ProjectEvent } from '../projectEvent.model'
+
+export default ProjectEvent.projector.on(
+  ProjectClaimed,
+  async ({ payload: { projectId, attestationDesignationFileId, claimedBy }, occurredAt }) => {
+    await ProjectEvent.create({
+      id: new UniqueEntityID().toString(),
+      projectId,
+      type: ProjectClaimed.type,
+      valueDate: occurredAt.getTime(),
+      payload: {
+        attestationDesignationFileId,
+        claimedBy,
+      },
+    })
+  }
+)


### PR DESCRIPTION
Lorsque le porteur de projet réclame un projet, il upload une attestation.  Jusqu'ici cette attestation n'était pas accessible.

Cette PR mets à jour `project.certificateFileId` avec l'attestation uploadée par le porteur si celle-ci n'existe pas encore.

J'en profite pour créer une ligne sur la projection `projectEvents`.