### PR TITLE
🐛 Fix the order of events when loading an aggregate from the event store

### DIFF
--- a/src/infra/sequelize/eventStore/loadAggregateEventsFromStore.ts
+++ b/src/infra/sequelize/eventStore/loadAggregateEventsFromStore.ts
@@ -14,6 +14,7 @@ export const loadAggregateEventsFromStore: MakeEventStoreDeps['loadAggregateEven
         [Op.overlap]: [aggregateId],
       },
     },
+    order: [['occurredAt', 'ASC']],
   }
 
   return wrapInfra(EventStore.findAll(query))


### PR DESCRIPTION
Lors du chargement des évènnements pour un aggregat depuis l'event store il faut préciser l'ordre dans lequel les récupérer. En effet postgre (et tout moteur de DB) ne retourne pas forcément dans l'ordre d'insertion.

Nous avions donc un bug sur plusieurs projet pour lesquels l'évènnement ProjectDataCorrected était traité avant ProojectImported et donc les données corrigées étaient à nouveau ecrasées avec les mauvaises. Ceci engendrait un bug lors de la génération d'attestation.