### PR TITLE
775 Add eventPublishedAt column and fill with event occuredAt date in project_events projection

### DIFF
--- a/src/core/utils/Projection.ts
+++ b/src/core/utils/Projection.ts
@@ -13,6 +13,7 @@ export interface Projector {
   ) => EventHandler<Event>
 
   handleEvent: <Event extends DomainEvent>(event: Event) => Promise<void>
+  getListenedEvents: () => DomainEvent['type'][]
 }
 export interface HasSubscribe {
   subscribe: (cb: (event: DomainEvent) => Promise<void>, consumerName: string) => void

--- a/src/infra/sequelize/helpers/makeSequelizeProjector.spec.ts
+++ b/src/infra/sequelize/helpers/makeSequelizeProjector.spec.ts
@@ -119,4 +119,23 @@ describe('makeSequelizeProjector', () => {
       expect(handler2).not.toHaveBeenCalled()
     })
   })
+
+  describe('getListenedEvents()', () => {
+    const handler = jest.fn((event: DummyEvent) => Promise.resolve())
+    const handler2 = jest.fn((event: OtherDummyEvent) => Promise.resolve())
+
+    const projector = makeSequelizeProjector(fakeModel)
+    projector.on(DummyEvent, handler)
+    projector.on(OtherDummyEvent, handler2)
+
+    it(`should return all listened events type`, async () => {
+      const fakeDummyEvent = new DummyEvent({ payload: {} })
+
+      const actualListenedEvents = projector.getListenedEvents()
+
+      expect(actualListenedEvents).toHaveLength(2)
+      expect(actualListenedEvents).toContain(DummyEvent.type)
+      expect(actualListenedEvents).toContain(OtherDummyEvent.type)
+    })
+  })
 })

--- a/src/infra/sequelize/helpers/makeSequelizeProjector.ts
+++ b/src/infra/sequelize/helpers/makeSequelizeProjector.ts
@@ -35,5 +35,6 @@ export const makeSequelizeProjector = <ProjectionModel extends SequelizeModel>(
       }, model.name)
     },
     handleEvent,
+    getListenedEvents: () => Object.keys(handlersByType),
   }
 }

--- a/src/infra/sequelize/migrations/20211130153044-add-project-events.js
+++ b/src/infra/sequelize/migrations/20211130153044-add-project-events.js
@@ -23,6 +23,11 @@ module.exports = {
         type: Sequelize.DataTypes.INTEGER,
         allowNull: true,
       },
+      eventPublishedAt: {
+        type: Sequelize.DataTypes.BIGINT,
+        allowNull: false,
+        default: 0,
+      },
       createdAt: Sequelize.DATE,
       updatedAt: Sequelize.DATE,
     })

--- a/src/infra/sequelize/migrations/20220104135530-add-eventPublishedAt-column-to-project-events-table.js
+++ b/src/infra/sequelize/migrations/20220104135530-add-eventPublishedAt-column-to-project-events-table.js
@@ -14,7 +14,7 @@ module.exports = {
 
     const transaction = await queryInterface.sequelize.transaction()
     try {
-      await queryInterface.truncate(`TRUNCATE TABLE "project_events"`, {
+      await queryInterface.sequelize.query(`TRUNCATE TABLE "project_events"`, {
         type: queryInterface.sequelize.QueryTypes.DELETE,
       })
 

--- a/src/infra/sequelize/migrations/20220104135530-add-eventPublishedAt-column-to-project-events-table.js
+++ b/src/infra/sequelize/migrations/20220104135530-add-eventPublishedAt-column-to-project-events-table.js
@@ -1,0 +1,20 @@
+'use strict'
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn('project_events', 'eventPublishedAt', {
+      type: Sequelize.DataTypes.BIGINT,
+      allowNull: false,
+      default: 0,
+    })
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    /**
+     * Add reverting commands here.
+     *
+     * Example:
+     * await queryInterface.dropTable('users');
+     */
+  },
+}

--- a/src/infra/sequelize/migrations/20220104135530-add-eventPublishedAt-column-to-project-events-table.js
+++ b/src/infra/sequelize/migrations/20220104135530-add-eventPublishedAt-column-to-project-events-table.js
@@ -2,11 +2,45 @@
 
 module.exports = {
   up: async (queryInterface, Sequelize) => {
-    await queryInterface.addColumn('project_events', 'eventPublishedAt', {
-      type: Sequelize.DataTypes.BIGINT,
-      allowNull: false,
-      default: 0,
-    })
+    const tableDefinition = await queryInterface.describeTable('project_events')
+
+    if (!tableDefinition.eventPublishedAt) {
+      await queryInterface.addColumn('project_events', 'eventPublishedAt', {
+        type: Sequelize.DataTypes.BIGINT,
+        allowNull: false,
+        default: 0,
+      })
+    }
+
+    const transaction = await queryInterface.sequelize.transaction()
+    try {
+      await queryInterface.sequelize.query(`DELETE FROM "project_events"`, {
+        type: queryInterface.sequelize.QueryTypes.DELETE,
+      })
+
+      const projectEvents = await queryInterface.sequelize.query(
+        `SELECT * FROM "eventStores" 
+         WHERE type in ('ProjectClaimed', 
+                        'ProjectNotified', 
+                        'ProjectImported', 
+                        'ProjectCertificateGenerated', 
+                        'ProjectCertificateRegenerated', 
+                        'ProjectCertificateUpdated',
+                        'ProjectGFSubmitted') 
+          ORDER BY "occurredAt" ASC`,
+        {
+          type: queryInterface.sequelize.QueryTypes.SELECT,
+          transaction,
+        }
+      )
+
+      await Promise.all(projectEvents.map((event) => ProjectEvent.projector.handleEvent(event)))
+
+      await transaction.commit()
+    } catch (error) {
+      await transaction.rollback()
+      throw error
+    }
   },
 
   down: async (queryInterface, Sequelize) => {

--- a/src/infra/sequelize/migrations/20220104135530-add-eventPublishedAt-column-to-project-events-table.js
+++ b/src/infra/sequelize/migrations/20220104135530-add-eventPublishedAt-column-to-project-events-table.js
@@ -14,7 +14,7 @@ module.exports = {
 
     const transaction = await queryInterface.sequelize.transaction()
     try {
-      await queryInterface.sequelize.query(`DELETE FROM "project_events"`, {
+      await queryInterface.truncate(`TRUNCATE TABLE "project_events"`, {
         type: queryInterface.sequelize.QueryTypes.DELETE,
       })
 

--- a/src/infra/sequelize/projectionsNext/projectEvents/projectEvent.model.ts
+++ b/src/infra/sequelize/projectionsNext/projectEvents/projectEvent.model.ts
@@ -27,7 +27,7 @@ export const ProjectEvent = withSequelizeProjector(() => {
       },
       eventPublishedAt: {
         type: DataTypes.BIGINT,
-        allowNull: true,
+        allowNull: false,
       },
     },
     {

--- a/src/infra/sequelize/projectionsNext/projectEvents/projectEvent.model.ts
+++ b/src/infra/sequelize/projectionsNext/projectEvents/projectEvent.model.ts
@@ -25,6 +25,10 @@ export const ProjectEvent = withSequelizeProjector(() => {
         type: DataTypes.BIGINT,
         allowNull: true,
       },
+      eventPublishedAt: {
+        type: DataTypes.BIGINT,
+        allowNull: true,
+      },
     },
     {
       timestamps: true,

--- a/src/infra/sequelize/projectionsNext/projectEvents/updates/onProjectCertificateGenerated.integration.ts
+++ b/src/infra/sequelize/projectionsNext/projectEvents/updates/onProjectCertificateGenerated.integration.ts
@@ -15,12 +15,18 @@ describe('onProjectCertificateGenerated', () => {
   })
 
   it('should create a new project event of type ProjectCertificateGenerated', async () => {
+    const occurredAt = new Date('2021-12-15')
+
     await onProjectCertificateGenerated(
       new ProjectCertificateGenerated({
         payload: {
           projectId,
           certificateFileId: 'file-id',
         } as ProjectCertificateGeneratedPayload,
+        original: {
+          version: 1,
+          occurredAt,
+        },
       })
     )
 
@@ -29,19 +35,22 @@ describe('onProjectCertificateGenerated', () => {
     expect(projectEvent).not.toBeNull()
     expect(projectEvent).toMatchObject({
       type: 'ProjectCertificateGenerated',
+      valueDate: occurredAt.getTime(),
+      eventPublishedAt: occurredAt.getTime(),
       payload: { certificateFileId: 'file-id' },
     })
   })
 
   describe(`when the event already exists in the projection`, () => {
     it('should not create a new project event of type ProjectCertificateGenerated', async () => {
-      const eventDate = new Date('2021-12-15')
+      const occurredAt = new Date('2021-12-15')
 
       await ProjectEvent.create({
         id: new UniqueEntityID().toString(),
         projectId,
         type: 'ProjectCertificateGenerated',
-        valueDate: eventDate.getTime(),
+        valueDate: occurredAt.getTime(),
+        eventPublishedAt: occurredAt.getTime(),
       })
 
       await onProjectCertificateGenerated(
@@ -50,14 +59,19 @@ describe('onProjectCertificateGenerated', () => {
             projectId,
           } as ProjectCertificateGeneratedPayload,
           original: {
-            occurredAt: eventDate,
+            occurredAt,
             version: 1,
           },
         })
       )
 
       const projectEvents = await ProjectEvent.findAll({
-        where: { projectId, type: 'ProjectCertificateGenerated', valueDate: eventDate.getTime() },
+        where: {
+          projectId,
+          type: 'ProjectCertificateGenerated',
+          valueDate: occurredAt.getTime(),
+          eventPublishedAt: occurredAt.getTime(),
+        },
       })
 
       expect(projectEvents).toHaveLength(1)

--- a/src/infra/sequelize/projectionsNext/projectEvents/updates/onProjectCertificateGenerated.ts
+++ b/src/infra/sequelize/projectionsNext/projectEvents/updates/onProjectCertificateGenerated.ts
@@ -10,6 +10,7 @@ export default ProjectEvent.projector.on(
         projectId,
         type: ProjectCertificateGenerated.type,
         valueDate: occurredAt.getTime(),
+        eventPublishedAt: occurredAt.getTime(),
       },
       defaults: {
         id: new UniqueEntityID().toString(),

--- a/src/infra/sequelize/projectionsNext/projectEvents/updates/onProjectCertificateRegenerated.integration.ts
+++ b/src/infra/sequelize/projectionsNext/projectEvents/updates/onProjectCertificateRegenerated.integration.ts
@@ -15,12 +15,18 @@ describe('onProjectCertificateRegenerated', () => {
   })
 
   it('should create a new project event of type ProjectCertificateRegenerated', async () => {
+    const occurredAt = new Date('2021-12-15')
+
     await onProjectCertificateRegenerated(
       new ProjectCertificateRegenerated({
         payload: {
           projectId,
           certificateFileId: 'file-id',
         } as ProjectCertificateRegeneratedPayload,
+        original: {
+          version: 1,
+          occurredAt,
+        },
       })
     )
 
@@ -30,19 +36,22 @@ describe('onProjectCertificateRegenerated', () => {
 
     expect(projectEvent).toMatchObject({
       type: 'ProjectCertificateRegenerated',
+      valueDate: occurredAt.getTime(),
+      eventPublishedAt: occurredAt.getTime(),
       payload: { certificateFileId: 'file-id' },
     })
   })
 
   describe(`when the event already exists in the projection`, () => {
     it('should not create a new project event of type ProjectCertificateRegenerated', async () => {
-      const eventDate = new Date('2021-12-15')
+      const occurredAt = new Date('2021-12-15')
 
       await ProjectEvent.create({
         id: new UniqueEntityID().toString(),
         projectId,
         type: 'ProjectCertificateRegenerated',
-        valueDate: eventDate.getTime(),
+        valueDate: occurredAt.getTime(),
+        eventPublishedAt: occurredAt.getTime(),
       })
 
       await onProjectCertificateRegenerated(
@@ -51,14 +60,19 @@ describe('onProjectCertificateRegenerated', () => {
             projectId,
           } as ProjectCertificateRegeneratedPayload,
           original: {
-            occurredAt: eventDate,
+            occurredAt,
             version: 1,
           },
         })
       )
 
       const projectEvents = await ProjectEvent.findAll({
-        where: { projectId, type: 'ProjectCertificateRegenerated', valueDate: eventDate.getTime() },
+        where: {
+          projectId,
+          type: 'ProjectCertificateRegenerated',
+          valueDate: occurredAt.getTime(),
+          eventPublishedAt: occurredAt.getTime(),
+        },
       })
 
       expect(projectEvents).toHaveLength(1)

--- a/src/infra/sequelize/projectionsNext/projectEvents/updates/onProjectCertificateRegenerated.ts
+++ b/src/infra/sequelize/projectionsNext/projectEvents/updates/onProjectCertificateRegenerated.ts
@@ -10,6 +10,7 @@ export default ProjectEvent.projector.on(
         projectId,
         type: ProjectCertificateRegenerated.type,
         valueDate: occurredAt.getTime(),
+        eventPublishedAt: occurredAt.getTime(),
       },
       defaults: {
         id: new UniqueEntityID().toString(),

--- a/src/infra/sequelize/projectionsNext/projectEvents/updates/onProjectCertificateUpdated.integration.ts
+++ b/src/infra/sequelize/projectionsNext/projectEvents/updates/onProjectCertificateUpdated.integration.ts
@@ -15,7 +15,7 @@ describe('onProjectCertificateUpdated', () => {
   })
 
   it('should create a new project event of type ProjectCertificateUpdated', async () => {
-    const occurredAt = new Date('04-01-2022')
+    const occurredAt = new Date('2022-01-04')
 
     await onProjectCertificateUpdated(
       new ProjectCertificateUpdated({

--- a/src/infra/sequelize/projectionsNext/projectEvents/updates/onProjectCertificateUpdated.integration.ts
+++ b/src/infra/sequelize/projectionsNext/projectEvents/updates/onProjectCertificateUpdated.integration.ts
@@ -15,12 +15,18 @@ describe('onProjectCertificateUpdated', () => {
   })
 
   it('should create a new project event of type ProjectCertificateUpdated', async () => {
+    const occurredAt = new Date('04-01-2022')
+
     await onProjectCertificateUpdated(
       new ProjectCertificateUpdated({
         payload: {
           projectId,
           certificateFileId: 'file-id',
         } as ProjectCertificateUpdatedPayload,
+        original: {
+          version: 1,
+          occurredAt,
+        },
       })
     )
 
@@ -29,19 +35,22 @@ describe('onProjectCertificateUpdated', () => {
     expect(projectEvent).not.toBeNull()
     expect(projectEvent).toMatchObject({
       type: 'ProjectCertificateUpdated',
+      valueDate: occurredAt.getTime(),
+      eventPublishedAt: occurredAt.getTime(),
       payload: { certificateFileId: 'file-id' },
     })
   })
 
   describe(`when the event already exists in the projection`, () => {
     it('should not create a new project event of type ProjectCertificateUpdated', async () => {
-      const eventDate = new Date('2021-12-15')
+      const occurredAt = new Date('2021-12-15')
 
       await ProjectEvent.create({
         id: new UniqueEntityID().toString(),
         projectId,
         type: 'ProjectCertificateUpdated',
-        valueDate: eventDate.getTime(),
+        valueDate: occurredAt.getTime(),
+        eventPublishedAt: occurredAt.getTime(),
       })
 
       await onProjectCertificateUpdated(
@@ -50,14 +59,19 @@ describe('onProjectCertificateUpdated', () => {
             projectId,
           } as ProjectCertificateUpdatedPayload,
           original: {
-            occurredAt: eventDate,
+            occurredAt,
             version: 1,
           },
         })
       )
 
       const projectEvents = await ProjectEvent.findAll({
-        where: { projectId, type: 'ProjectCertificateUpdated', valueDate: eventDate.getTime() },
+        where: {
+          projectId,
+          type: 'ProjectCertificateUpdated',
+          valueDate: occurredAt.getTime(),
+          eventPublishedAt: occurredAt.getTime(),
+        },
       })
 
       expect(projectEvents).toHaveLength(1)

--- a/src/infra/sequelize/projectionsNext/projectEvents/updates/onProjectCertificateUpdated.ts
+++ b/src/infra/sequelize/projectionsNext/projectEvents/updates/onProjectCertificateUpdated.ts
@@ -10,6 +10,7 @@ export default ProjectEvent.projector.on(
         projectId,
         type: ProjectCertificateUpdated.type,
         valueDate: occurredAt.getTime(),
+        eventPublishedAt: occurredAt.getTime(),
       },
       defaults: { id: new UniqueEntityID().toString(), payload: { certificateFileId } },
     })

--- a/src/infra/sequelize/projectionsNext/projectEvents/updates/onProjectClaimed.integration.ts
+++ b/src/infra/sequelize/projectionsNext/projectEvents/updates/onProjectClaimed.integration.ts
@@ -14,6 +14,8 @@ describe('onProjectClaimed', () => {
   })
 
   it('should create a new project event of type ProjectClaimed', async () => {
+    const occurredAt = new Date('04-01-2022')
+
     await onProjectClaimed(
       new ProjectClaimed({
         payload: {
@@ -24,7 +26,7 @@ describe('onProjectClaimed', () => {
         },
         original: {
           version: 1,
-          occurredAt: new Date(1234),
+          occurredAt,
         },
       })
     )
@@ -35,18 +37,22 @@ describe('onProjectClaimed', () => {
 
     expect(projectEvent).toMatchObject({
       type: 'ProjectClaimed',
-      valueDate: 1234,
+      valueDate: occurredAt.getTime(),
+      eventPublishedAt: occurredAt.getTime(),
       payload: { claimedBy, attestationDesignationFileId },
     })
   })
 
   describe(`when the event already exists in the projection`, () => {
     it('should not create a new project event of type ProjectClaimed', async () => {
+      const occurredAt = new Date('04-01-2022')
+
       await ProjectEvent.create({
         id: new UniqueEntityID().toString(),
         projectId,
         type: 'ProjectClaimed',
-        valueDate: 1234,
+        valueDate: occurredAt.getTime(),
+        eventPublishedAt: occurredAt.getTime(),
         payload: { claimedBy, attestationDesignationFileId },
       })
 
@@ -60,13 +66,18 @@ describe('onProjectClaimed', () => {
           },
           original: {
             version: 1,
-            occurredAt: new Date(1234),
+            occurredAt,
           },
         })
       )
 
       const projectEvents = await ProjectEvent.findAll({
-        where: { projectId, type: 'ProjectClaimed', valueDate: 1234 },
+        where: {
+          projectId,
+          type: 'ProjectClaimed',
+          valueDate: occurredAt.getTime(),
+          eventPublishedAt: occurredAt.getTime(),
+        },
       })
 
       expect(projectEvents).toHaveLength(1)

--- a/src/infra/sequelize/projectionsNext/projectEvents/updates/onProjectClaimed.integration.ts
+++ b/src/infra/sequelize/projectionsNext/projectEvents/updates/onProjectClaimed.integration.ts
@@ -14,7 +14,7 @@ describe('onProjectClaimed', () => {
   })
 
   it('should create a new project event of type ProjectClaimed', async () => {
-    const occurredAt = new Date('04-01-2022')
+    const occurredAt = new Date('2022-01-04')
 
     await onProjectClaimed(
       new ProjectClaimed({
@@ -45,7 +45,7 @@ describe('onProjectClaimed', () => {
 
   describe(`when the event already exists in the projection`, () => {
     it('should not create a new project event of type ProjectClaimed', async () => {
-      const occurredAt = new Date('04-01-2022')
+      const occurredAt = new Date('2022-01-04')
 
       await ProjectEvent.create({
         id: new UniqueEntityID().toString(),

--- a/src/infra/sequelize/projectionsNext/projectEvents/updates/onProjectClaimed.ts
+++ b/src/infra/sequelize/projectionsNext/projectEvents/updates/onProjectClaimed.ts
@@ -10,6 +10,7 @@ export default ProjectEvent.projector.on(
         projectId,
         type: ProjectClaimed.type,
         valueDate: occurredAt.getTime(),
+        eventPublishedAt: occurredAt.getTime(),
       },
       defaults: {
         id: new UniqueEntityID().toString(),

--- a/src/infra/sequelize/projectionsNext/projectEvents/updates/onProjectGFSubmitted.integration.ts
+++ b/src/infra/sequelize/projectionsNext/projectEvents/updates/onProjectGFSubmitted.integration.ts
@@ -14,7 +14,7 @@ describe('onProjectGFSubmitted', () => {
   })
 
   it('should create a new project event of type ProjectGFSubmitted', async () => {
-    const occurredAt = new Date('04-01-2022')
+    const occurredAt = new Date('2022-01-04')
 
     await onProjectGFSubmitted(
       new ProjectGFSubmitted({
@@ -42,7 +42,7 @@ describe('onProjectGFSubmitted', () => {
 
   describe('when the event already exists in the projection ProjectEvent', () => {
     it('should not create a new project event of type ProjectGFSubmitted', async () => {
-      const occurredAt = new Date('04-01-2022')
+      const occurredAt = new Date('2022-01-04')
 
       await ProjectEvent.create({
         id: new UniqueEntityID().toString(),

--- a/src/infra/sequelize/projectionsNext/projectEvents/updates/onProjectGFSubmitted.integration.ts
+++ b/src/infra/sequelize/projectionsNext/projectEvents/updates/onProjectGFSubmitted.integration.ts
@@ -14,6 +14,8 @@ describe('onProjectGFSubmitted', () => {
   })
 
   it('should create a new project event of type ProjectGFSubmitted', async () => {
+    const occurredAt = new Date('04-01-2022')
+
     await onProjectGFSubmitted(
       new ProjectGFSubmitted({
         payload: {
@@ -21,6 +23,10 @@ describe('onProjectGFSubmitted', () => {
           fileId,
           submittedBy,
         } as ProjectGFSubmittedPayload,
+        original: {
+          version: 1,
+          occurredAt,
+        },
       })
     )
 
@@ -29,17 +35,22 @@ describe('onProjectGFSubmitted', () => {
     expect(projectEvent).not.toBeNull()
     expect(projectEvent).toMatchObject({
       type: 'ProjectGFSubmitted',
+      valueDate: occurredAt.getTime(),
+      eventPublishedAt: occurredAt.getTime(),
     })
   })
 
   describe('when the event already exists in the projection ProjectEvent', () => {
     it('should not create a new project event of type ProjectGFSubmitted', async () => {
+      const occurredAt = new Date('04-01-2022')
+
       await ProjectEvent.create({
         id: new UniqueEntityID().toString(),
         projectId,
         type: 'ProjectGFSubmitted',
         payload: { fileId, submittedBy },
-        valueDate: 1234,
+        valueDate: occurredAt.getTime(),
+        eventPublishedAt: occurredAt.getTime(),
       })
 
       await onProjectGFSubmitted(
@@ -51,13 +62,18 @@ describe('onProjectGFSubmitted', () => {
           } as ProjectGFSubmittedPayload,
           original: {
             version: 1,
-            occurredAt: new Date(1234),
+            occurredAt,
           },
         })
       )
 
       const projectEvents = await ProjectEvent.findAll({
-        where: { projectId, type: 'ProjectGFSubmitted', valueDate: 1234 },
+        where: {
+          projectId,
+          type: 'ProjectGFSubmitted',
+          valueDate: occurredAt.getTime(),
+          eventPublishedAt: occurredAt.getTime(),
+        },
       })
 
       expect(projectEvents).toHaveLength(1)

--- a/src/infra/sequelize/projectionsNext/projectEvents/updates/onProjectGFSubmitted.ts
+++ b/src/infra/sequelize/projectionsNext/projectEvents/updates/onProjectGFSubmitted.ts
@@ -10,6 +10,7 @@ export default ProjectEvent.projector.on(
         projectId,
         type: ProjectGFSubmitted.type,
         valueDate: occurredAt.getTime(),
+        eventPublishedAt: occurredAt.getTime(),
       },
       defaults: {
         id: new UniqueEntityID().toString(),

--- a/src/infra/sequelize/projectionsNext/projectEvents/updates/onProjectImported.integration.ts
+++ b/src/infra/sequelize/projectionsNext/projectEvents/updates/onProjectImported.integration.ts
@@ -15,19 +15,27 @@ describe('onProjectImported', () => {
   })
 
   it('should create a new project event of type ProjectImported', async () => {
+    const eventDate = new Date('04-01-2022')
+
     await onProjectImported(
       new ProjectImported({
         payload: {
           projectId,
         } as ProjectImportedPayload,
+        original: {
+          version: 1,
+          occurredAt: eventDate,
+        },
       })
     )
 
     const projectEvent = await ProjectEvent.findOne({ where: { projectId } })
 
     expect(projectEvent).not.toBeNull()
-
-    expect(projectEvent).toMatchObject({ type: 'ProjectImported' })
+    expect(projectEvent).toMatchObject({
+      type: 'ProjectImported',
+      eventPublishedAt: eventDate.getTime(),
+    })
   })
 
   describe(`when the event already exists in the projection`, () => {
@@ -39,6 +47,7 @@ describe('onProjectImported', () => {
         projectId,
         type: 'ProjectImported',
         valueDate: eventDate.getTime(),
+        eventPublishedAt: eventDate.getTime(),
       })
 
       await onProjectImported(
@@ -54,7 +63,12 @@ describe('onProjectImported', () => {
       )
 
       const projectEvents = await ProjectEvent.findAll({
-        where: { projectId, type: 'ProjectImported', valueDate: eventDate.getTime() },
+        where: {
+          projectId,
+          type: 'ProjectImported',
+          valueDate: eventDate.getTime(),
+          eventPublishedAt: eventDate.getTime(),
+        },
       })
 
       expect(projectEvents).toHaveLength(1)

--- a/src/infra/sequelize/projectionsNext/projectEvents/updates/onProjectImported.integration.ts
+++ b/src/infra/sequelize/projectionsNext/projectEvents/updates/onProjectImported.integration.ts
@@ -15,7 +15,7 @@ describe('onProjectImported', () => {
   })
 
   it('should create a new project event of type ProjectImported', async () => {
-    const eventDate = new Date('04-01-2022')
+    const eventDate = new Date('2022-01-04')
 
     await onProjectImported(
       new ProjectImported({

--- a/src/infra/sequelize/projectionsNext/projectEvents/updates/onProjectImported.integration.ts
+++ b/src/infra/sequelize/projectionsNext/projectEvents/updates/onProjectImported.integration.ts
@@ -34,6 +34,7 @@ describe('onProjectImported', () => {
     expect(projectEvent).not.toBeNull()
     expect(projectEvent).toMatchObject({
       type: 'ProjectImported',
+      valueDate: eventDate.getTime(),
       eventPublishedAt: eventDate.getTime(),
     })
   })

--- a/src/infra/sequelize/projectionsNext/projectEvents/updates/onProjectImported.ts
+++ b/src/infra/sequelize/projectionsNext/projectEvents/updates/onProjectImported.ts
@@ -10,6 +10,7 @@ export default ProjectEvent.projector.on(
         projectId,
         type: ProjectImported.type,
         valueDate: occurredAt.getTime(),
+        eventPublishedAt: occurredAt.getTime(),
       },
       defaults: {
         id: new UniqueEntityID().toString(),

--- a/src/infra/sequelize/projectionsNext/projectEvents/updates/onProjectNotified.integration.ts
+++ b/src/infra/sequelize/projectionsNext/projectEvents/updates/onProjectNotified.integration.ts
@@ -12,12 +12,17 @@ describe('onProjectNotified', () => {
   })
 
   it('should create a new project event of type ProjectNotified', async () => {
+    const eventDate = new Date('2021-12-15')
     await onProjectNotified(
       new ProjectNotified({
         payload: {
           projectId,
-          notifiedOn: new Date('2021-12-15').getTime(),
+          notifiedOn: eventDate.getTime(),
         } as ProjectNotifiedPayload,
+        original: {
+          version: 1,
+          occurredAt: eventDate,
+        },
       })
     )
 
@@ -27,7 +32,8 @@ describe('onProjectNotified', () => {
 
     expect(projectEvent).toMatchObject({
       type: 'ProjectNotified',
-      valueDate: new Date('2021-12-15').getTime(),
+      valueDate: eventDate.getTime(),
+      eventPublishedAt: eventDate.getTime(),
     })
   })
 
@@ -40,6 +46,7 @@ describe('onProjectNotified', () => {
         projectId,
         type: 'ProjectNotified',
         valueDate: eventDate.getTime(),
+        eventPublishedAt: eventDate.getTime(),
       })
 
       await onProjectNotified(
@@ -48,11 +55,20 @@ describe('onProjectNotified', () => {
             projectId,
             notifiedOn: eventDate.getTime(),
           } as ProjectNotifiedPayload,
+          original: {
+            occurredAt: eventDate,
+            version: 1,
+          },
         })
       )
 
       const projectEvents = await ProjectEvent.findAll({
-        where: { projectId, type: 'ProjectNotified', valueDate: eventDate.getTime() },
+        where: {
+          projectId,
+          type: 'ProjectNotified',
+          valueDate: eventDate.getTime(),
+          eventPublishedAt: eventDate.getTime(),
+        },
       })
 
       expect(projectEvents).toHaveLength(1)

--- a/src/infra/sequelize/projectionsNext/projectEvents/updates/onProjectNotified.integration.ts
+++ b/src/infra/sequelize/projectionsNext/projectEvents/updates/onProjectNotified.integration.ts
@@ -12,12 +12,13 @@ describe('onProjectNotified', () => {
   })
 
   it('should create a new project event of type ProjectNotified', async () => {
+    const notifiedOnTimestamp = new Date('2022-01-06').getTime()
     const eventDate = new Date('2021-12-15')
     await onProjectNotified(
       new ProjectNotified({
         payload: {
           projectId,
-          notifiedOn: eventDate.getTime(),
+          notifiedOn: notifiedOnTimestamp,
         } as ProjectNotifiedPayload,
         original: {
           version: 1,
@@ -32,7 +33,7 @@ describe('onProjectNotified', () => {
 
     expect(projectEvent).toMatchObject({
       type: 'ProjectNotified',
-      valueDate: eventDate.getTime(),
+      valueDate: notifiedOnTimestamp,
       eventPublishedAt: eventDate.getTime(),
     })
   })

--- a/src/infra/sequelize/projectionsNext/projectEvents/updates/onProjectNotified.ts
+++ b/src/infra/sequelize/projectionsNext/projectEvents/updates/onProjectNotified.ts
@@ -4,9 +4,14 @@ import { ProjectEvent } from '../projectEvent.model'
 
 export default ProjectEvent.projector.on(
   ProjectNotified,
-  async ({ payload: { projectId, notifiedOn } }) => {
+  async ({ payload: { projectId, notifiedOn }, occurredAt }) => {
     await ProjectEvent.findOrCreate({
-      where: { projectId, type: ProjectNotified.type, valueDate: notifiedOn },
+      where: {
+        projectId,
+        type: ProjectNotified.type,
+        valueDate: notifiedOn,
+        eventPublishedAt: occurredAt.getTime(),
+      },
       defaults: {
         id: new UniqueEntityID().toString(),
       },

--- a/src/infra/sequelize/queries/frise/getProjectEvents.integration.ts
+++ b/src/infra/sequelize/queries/frise/getProjectEvents.integration.ts
@@ -71,11 +71,12 @@ describe('frise.getProjectEvents', () => {
     describe(`when the user is ${role}`, () => {
       const fakeUser = { role } as User
       it('should return the ProjectNotified event', async () => {
+        const notifiedOnTimestamp = new Date('2022-01-05').getTime()
         await ProjectEvent.create({
           id: new UniqueEntityID().toString(),
           projectId,
           type: 'ProjectNotified',
-          valueDate: eventTimestamp,
+          valueDate: notifiedOnTimestamp,
           eventPublishedAt: eventTimestamp,
         })
 
@@ -85,7 +86,7 @@ describe('frise.getProjectEvents', () => {
           events: [
             {
               type: 'ProjectNotified',
-              date: eventTimestamp,
+              date: notifiedOnTimestamp,
               variant: role,
             },
           ],

--- a/src/infra/sequelize/queries/frise/getProjectEvents.integration.ts
+++ b/src/infra/sequelize/queries/frise/getProjectEvents.integration.ts
@@ -293,4 +293,66 @@ describe('frise.getProjectEvents', () => {
       })
     })
   }
+
+  it('should return events sorted by eventPublishedAt date', async () => {
+    const fakeUser = { role: 'porteur-projet' } as User
+
+    await ProjectEvent.create({
+      id: new UniqueEntityID().toString(),
+      projectId,
+      type: 'ProjectCertificateGenerated',
+      valueDate: eventTimestamp,
+      eventPublishedAt: new Date('2022-01-01').getTime(),
+      payload: { certificateFileId: 'fileId' },
+    })
+
+    await ProjectEvent.create({
+      id: new UniqueEntityID().toString(),
+      projectId,
+      type: 'ProjectCertificateRegenerated',
+      valueDate: eventTimestamp,
+      eventPublishedAt: new Date('2022-01-03').getTime(),
+      payload: { certificateFileId: 'fileId' },
+    })
+
+    await ProjectEvent.create({
+      id: new UniqueEntityID().toString(),
+      projectId,
+      type: 'ProjectCertificateUpdated',
+      valueDate: eventTimestamp,
+      eventPublishedAt: new Date('2022-01-04').getTime(),
+      payload: { certificateFileId: 'fileId' },
+    })
+
+    await ProjectEvent.create({
+      id: new UniqueEntityID().toString(),
+      projectId,
+      type: 'ProjectClaimed',
+      valueDate: eventTimestamp,
+      eventPublishedAt: new Date('2022-01-02').getTime(),
+      payload: {
+        attestationDesignationFileId: 'file-id',
+        claimedBy: 'someone',
+      },
+    })
+
+    const res = await getProjectEvents({ projectId, user: fakeUser })
+
+    expect(res._unsafeUnwrap()).toMatchObject({
+      events: [
+        {
+          type: 'ProjectCertificateGenerated',
+        },
+        {
+          type: 'ProjectClaimed',
+        },
+        {
+          type: 'ProjectCertificateRegenerated',
+        },
+        {
+          type: 'ProjectCertificateUpdated',
+        },
+      ],
+    })
+  })
 })

--- a/src/infra/sequelize/queries/frise/getProjectEvents.integration.ts
+++ b/src/infra/sequelize/queries/frise/getProjectEvents.integration.ts
@@ -261,12 +261,14 @@ describe('frise.getProjectEvents', () => {
     const fakeUser = { role } as User
     describe(`when user is ${role}`, () => {
       it('should return ProjectGFSubmitted events', async () => {
+        const gfTimestamp = new Date('2022-01-06').getTime()
+
         const fileId = new UniqueEntityID().toString()
         await ProjectEvent.create({
           id: new UniqueEntityID().toString(),
           projectId,
           type: 'ProjectGFSubmitted',
-          valueDate: eventTimestamp,
+          valueDate: gfTimestamp,
           eventPublishedAt: eventTimestamp,
           payload: {
             fileId: fileId,
@@ -283,7 +285,7 @@ describe('frise.getProjectEvents', () => {
           events: [
             {
               type: 'ProjectGFSubmitted',
-              date: eventTimestamp,
+              date: gfTimestamp,
               variant: role,
               fileId: fileId,
               submittedBy: 'someone',

--- a/src/infra/sequelize/queries/frise/getProjectEvents.integration.ts
+++ b/src/infra/sequelize/queries/frise/getProjectEvents.integration.ts
@@ -8,6 +8,8 @@ import { models } from '../../models'
 import makeFakeProject from '../../../../__tests__/fixtures/project'
 
 describe('frise.getProjectEvents', () => {
+  const eventTimestamp = new Date('2022-01-04').getTime()
+
   const { Project, File } = models
   const projectId = new UniqueEntityID().toString()
   const fakeProject = makeFakeProject({ id: projectId, potentielIdentifier: 'pot-id' })
@@ -25,7 +27,8 @@ describe('frise.getProjectEvents', () => {
           id: new UniqueEntityID().toString(),
           projectId,
           type: 'ProjectImported',
-          valueDate: 1234,
+          valueDate: eventTimestamp,
+          eventPublishedAt: eventTimestamp,
         })
 
         const res = await getProjectEvents({ projectId, user: fakeUser })
@@ -34,7 +37,7 @@ describe('frise.getProjectEvents', () => {
           events: [
             {
               type: 'ProjectImported',
-              date: 1234,
+              date: eventTimestamp,
               variant: role,
             },
           ],
@@ -51,7 +54,8 @@ describe('frise.getProjectEvents', () => {
           id: new UniqueEntityID().toString(),
           projectId,
           type: 'ProjectImported',
-          valueDate: 1234,
+          valueDate: eventTimestamp,
+          eventPublishedAt: eventTimestamp,
         })
 
         const res = await getProjectEvents({ projectId, user: fakeUser })
@@ -71,7 +75,8 @@ describe('frise.getProjectEvents', () => {
           id: new UniqueEntityID().toString(),
           projectId,
           type: 'ProjectNotified',
-          valueDate: 1234,
+          valueDate: eventTimestamp,
+          eventPublishedAt: eventTimestamp,
         })
 
         const res = await getProjectEvents({ projectId, user: fakeUser })
@@ -80,7 +85,7 @@ describe('frise.getProjectEvents', () => {
           events: [
             {
               type: 'ProjectNotified',
-              date: 1234,
+              date: eventTimestamp,
               variant: role,
             },
           ],
@@ -96,7 +101,8 @@ describe('frise.getProjectEvents', () => {
         id: new UniqueEntityID().toString(),
         projectId,
         type: 'ProjectNotified',
-        valueDate: 1234,
+        valueDate: eventTimestamp,
+        eventPublishedAt: eventTimestamp,
       })
 
       const res = await getProjectEvents({ projectId, user: fakeUser })
@@ -115,7 +121,8 @@ describe('frise.getProjectEvents', () => {
           id: new UniqueEntityID().toString(),
           projectId,
           type: 'ProjectCertificateGenerated',
-          valueDate: 1234,
+          valueDate: eventTimestamp,
+          eventPublishedAt: eventTimestamp,
           payload: { certificateFileId: 'fileId' },
         })
 
@@ -123,7 +130,8 @@ describe('frise.getProjectEvents', () => {
           id: new UniqueEntityID().toString(),
           projectId,
           type: 'ProjectCertificateRegenerated',
-          valueDate: 1234,
+          valueDate: eventTimestamp,
+          eventPublishedAt: eventTimestamp,
           payload: { certificateFileId: 'fileId' },
         })
 
@@ -131,7 +139,8 @@ describe('frise.getProjectEvents', () => {
           id: new UniqueEntityID().toString(),
           projectId,
           type: 'ProjectCertificateUpdated',
-          valueDate: 1234,
+          valueDate: eventTimestamp,
+          eventPublishedAt: eventTimestamp,
           payload: { certificateFileId: 'fileId' },
         })
 
@@ -139,7 +148,8 @@ describe('frise.getProjectEvents', () => {
           id: new UniqueEntityID().toString(),
           projectId,
           type: 'ProjectClaimed',
-          valueDate: 1234,
+          valueDate: eventTimestamp,
+          eventPublishedAt: eventTimestamp,
           payload: {
             attestationDesignationFileId: 'file-id',
             claimedBy: 'someone',
@@ -155,7 +165,7 @@ describe('frise.getProjectEvents', () => {
               potentielIdentifier: fakeProject.potentielIdentifier,
               email: ['admin', 'dgec'].includes(role) ? fakeProject.email : undefined,
               nomProjet: fakeProject.nomProjet,
-              date: 1234,
+              date: eventTimestamp,
               variant: role,
               certificateFileId: 'fileId',
             },
@@ -164,7 +174,7 @@ describe('frise.getProjectEvents', () => {
               potentielIdentifier: fakeProject.potentielIdentifier,
               email: ['admin', 'dgec'].includes(role) ? fakeProject.email : undefined,
               nomProjet: fakeProject.nomProjet,
-              date: 1234,
+              date: eventTimestamp,
               variant: role,
               certificateFileId: 'fileId',
             },
@@ -173,7 +183,7 @@ describe('frise.getProjectEvents', () => {
               potentielIdentifier: fakeProject.potentielIdentifier,
               email: ['admin', 'dgec'].includes(role) ? fakeProject.email : undefined,
               nomProjet: fakeProject.nomProjet,
-              date: 1234,
+              date: eventTimestamp,
               variant: role,
               certificateFileId: 'fileId',
             },
@@ -181,7 +191,7 @@ describe('frise.getProjectEvents', () => {
               type: 'ProjectClaimed',
               potentielIdentifier: fakeProject.potentielIdentifier,
               nomProjet: fakeProject.nomProjet,
-              date: 1234,
+              date: eventTimestamp,
               variant: role,
               certificateFileId: 'file-id',
               claimedBy: 'someone',
@@ -200,7 +210,8 @@ describe('frise.getProjectEvents', () => {
           id: new UniqueEntityID().toString(),
           projectId,
           type: 'ProjectCertificateGenerated',
-          valueDate: 1234,
+          valueDate: eventTimestamp,
+          eventPublishedAt: eventTimestamp,
           payload: { certificateFileId: 'fileId' },
         })
 
@@ -208,7 +219,8 @@ describe('frise.getProjectEvents', () => {
           id: new UniqueEntityID().toString(),
           projectId,
           type: 'ProjectCertificateRegenerated',
-          valueDate: 1234,
+          valueDate: eventTimestamp,
+          eventPublishedAt: eventTimestamp,
           payload: { certificateFileId: 'fileId' },
         })
 
@@ -216,7 +228,8 @@ describe('frise.getProjectEvents', () => {
           id: new UniqueEntityID().toString(),
           projectId,
           type: 'ProjectCertificateUpdated',
-          valueDate: 1234,
+          valueDate: eventTimestamp,
+          eventPublishedAt: eventTimestamp,
           payload: { certificateFileId: 'fileId' },
         })
 
@@ -224,7 +237,8 @@ describe('frise.getProjectEvents', () => {
           id: new UniqueEntityID().toString(),
           projectId,
           type: 'ProjectClaimed',
-          valueDate: 1234,
+          valueDate: eventTimestamp,
+          eventPublishedAt: eventTimestamp,
           payload: {
             attestationDesignationFileId: 'file-id',
             claimedBy: 'someone',
@@ -251,7 +265,8 @@ describe('frise.getProjectEvents', () => {
           id: new UniqueEntityID().toString(),
           projectId,
           type: 'ProjectGFSubmitted',
-          valueDate: 1234,
+          valueDate: eventTimestamp,
+          eventPublishedAt: eventTimestamp,
           payload: {
             fileId: fileId,
             submittedBy: 'someone',
@@ -267,7 +282,7 @@ describe('frise.getProjectEvents', () => {
           events: [
             {
               type: 'ProjectGFSubmitted',
-              date: 1234,
+              date: eventTimestamp,
               variant: role,
               fileId: fileId,
               submittedBy: 'someone',

--- a/src/infra/sequelize/queries/frise/getProjectEvents.ts
+++ b/src/infra/sequelize/queries/frise/getProjectEvents.ts
@@ -90,5 +90,7 @@ export const getProjectEvents: GetProjectEvents = ({ projectId, user }) => {
     })
 }
 function getEvents(projectId) {
-  return wrapInfra(ProjectEvent.findAll({ where: { projectId } }))
+  return wrapInfra(
+    ProjectEvent.findAll({ where: { projectId }, order: [['eventPublishedAt', 'ASC']] })
+  )
 }


### PR DESCRIPTION
- Le script src/infra/sequelize/migrations/20211130153044-add-project-events.js a été modifié car sinon on aurait une erreur lors de la migration depuis zéro (à cause du script éxécutant les handlers nécessitant maintenant la colonne eventPublishedAt)
- Dans le nouveau script on ajoute la colonne seulement si elle n'existe pas