### PR TITLE
Utiliser un typeguard plus efficace pour discriminer les types de DTO

### DIFF
--- a/src/core/utils/typeguards.ts
+++ b/src/core/utils/typeguards.ts
@@ -1,29 +1,51 @@
-// From https://gist.github.com/safareli/8e480d72f7e2665b6030b9a08fe93f40
+// From https://gist.github.com/paduc/5d1322e3a40ce5415b9477004716df9b
 
 /**
  * Type representing a guard function accepting Input and some other arguments
  * while refining type of input as `Output`
  */
-export type TypeGuard<Input, Output extends Input, Args extends unknown[] = []> = (
-  value: Input,
-  ...args: Args
-) => value is Output
+export type TypeGuard<Input, Output extends Input> = (value: Input) => value is Output
 
 /**
  * Combines multiple TypeGuards using `&&` operator
  */
-export function and<I, O extends I, O2 extends O, A extends unknown[] = []>(
-  f: TypeGuard<I, O, A>,
-  g: TypeGuard<O, O2, A>
-): TypeGuard<I, O2, A> {
-  return (value: I, ...args: A): value is O2 => f(value, ...args) && g(value, ...args)
+export function and<I, O extends I, O2 extends O>(
+  f: TypeGuard<I, O>,
+  g: TypeGuard<O, O2>
+): TypeGuard<I, O2> {
+  return (value: I): value is O2 => f(value) && g(value)
 }
+
 /**
  * Combines multiple TypeGuards using `||` operator
  */
-export function or<I, O extends I, O2 extends I, A extends unknown[] = []>(
-  f: TypeGuard<I, O, A>,
-  g: TypeGuard<I, O2, A>
-): TypeGuard<I, O | O2, A> {
-  return (value: I, ...args: A): value is O | O2 => f(value, ...args) || g(value, ...args)
+export function or<T extends readonly TypeGuard<unknown, unknown>[]>(...typeguards: T) {
+  return (value: InputType<TypeGuardOfUnion<T>>): value is GuardedType<TypeGuardOfUnion<T>> =>
+    typeguards.some((typeguard) => typeguard(value))
 }
+
+// Take an array of TypeGuards and return a union of output types
+// Ex: ExtractOutputTypesOfUnion<[TypeGuard<I, O1>, TypeGuard<I, 02>] = 01 | O2
+type ExtractOutputTypesOfUnion<T extends readonly TypeGuard<unknown, unknown>[]> = {
+  [idx in keyof T]: T[idx] extends TypeGuard<unknown, infer V> ? V : never
+}[number]
+
+// Take an array of TypeGuards and return the input type
+// it takes the input type of the first (since they are all the same)
+type ExtractInputTypeOfUnion<
+  T extends readonly TypeGuard<unknown, unknown>[]
+> = T[0] extends TypeGuard<infer U, any> ? U : never
+
+// Build a full TypeGuard type with the two previous
+// enforces the constraint that the output extends the input
+type TypeGuardOfUnion<
+  T extends readonly TypeGuard<unknown, unknown>[],
+  Input = ExtractInputTypeOfUnion<T>,
+  Output = ExtractOutputTypesOfUnion<T>
+> = Output extends Input ? TypeGuard<Input, Output> : never
+
+// Returns the return type of a TypeGuard<I, O> ("value is O")
+type GuardedType<T> = T extends (x: any) => x is infer T ? T : never
+
+// Returns the input type of a TypeGuard (type of first parameter)
+type InputType<T extends (...args: any) => any> = Parameters<T>[0]

--- a/src/modules/frise/dtos/ProjectEventListDTO.ts
+++ b/src/modules/frise/dtos/ProjectEventListDTO.ts
@@ -13,6 +13,12 @@ export type ProjectEventDTO =
   | ProjectDCRRemovedDTO
   | ProjectDCRDueDateSetDTO
 
+type NarrowDTOType<T, N> = T extends { type: N } ? T : never
+
+export const is = <T extends ProjectEventDTO, K extends T['type']>(type: K) => (
+  event: ProjectEventDTO
+): event is NarrowDTOType<T, K> => event.type === type
+
 export type ProjectNotifiedDTO = {
   type: 'ProjectNotified'
   variant: Exclude<UserRole, 'ademe'>

--- a/src/modules/frise/dtos/ProjectEventListDTO.ts
+++ b/src/modules/frise/dtos/ProjectEventListDTO.ts
@@ -1,3 +1,4 @@
+import { or } from '../../../core/utils'
 import { UserRole } from '../../users'
 
 export type ProjectEventDTO =
@@ -25,16 +26,12 @@ export type ProjectNotifiedDTO = {
   date: number
   isLegacy?: true
 }
-export const isProjectNotified = (event: ProjectEventDTO): event is ProjectNotifiedDTO =>
-  event.type === 'ProjectNotified'
 
 export type ProjectImportedDTO = {
   type: 'ProjectImported'
   variant: 'dgec' | 'admin'
   date: number
 }
-export const isProjectImported = (event: ProjectEventDTO): event is ProjectImportedDTO =>
-  event.type === 'ProjectImported'
 
 type ProjectCertificateBase = {
   date: number
@@ -69,13 +66,13 @@ export type ProjectCertificateDTO =
   | ProjectCertificateUpdatedDTO
   | ProjectClaimedDTO
 
-export const isCertificateDTO = (event: ProjectEventDTO): event is ProjectCertificateDTO =>
-  [
-    'ProjectCertificateGenerated',
-    'ProjectCertificateRegenerated',
-    'ProjectCertificateUpdated',
-    'ProjectClaimed',
-  ].includes(event.type)
+export const isCertificateDTO = or(
+  or(
+    or(is('ProjectCertificateGenerated'), is('ProjectCertificateRegenerated')),
+    is('ProjectCertificateUpdated')
+  ),
+  is('ProjectClaimed')
+)
 
 export type ProjectGFSubmittedDTO = {
   type: 'ProjectGFSubmitted'
@@ -85,16 +82,12 @@ export type ProjectGFSubmittedDTO = {
   filename: string
   submittedBy: string
 }
-export const isProjectGFSubmitted = (event: ProjectEventDTO): event is ProjectGFSubmittedDTO =>
-  event.type === 'ProjectGFSubmitted'
 
 export type ProjectGFDueDateSetDTO = {
   type: 'ProjectGFDueDateSet'
   date: number
   variant: Exclude<UserRole, 'ademe'>
 }
-export const isProjectGFDueDateSet = (event: ProjectEventDTO): event is ProjectGFDueDateSetDTO =>
-  event.type === 'ProjectGFDueDateSet'
 
 export type ProjectDCRSubmittedDTO = {
   type: 'ProjectDCRSubmitted'
@@ -104,8 +97,6 @@ export type ProjectDCRSubmittedDTO = {
   filename: string
   submittedBy: string
 }
-export const isProjectDCRSubmitted = (event: ProjectEventDTO): event is ProjectDCRSubmittedDTO =>
-  event.type === 'ProjectDCRSubmitted'
 
 export type ProjectDCRRemovedDTO = {
   type: 'ProjectDCRRemoved'
@@ -113,15 +104,11 @@ export type ProjectDCRRemovedDTO = {
   variant: 'porteur-projet' | 'admin' | 'dgec' | 'dreal'
   removedBy: string
 }
-export const isProjectDCRRemoved = (event: ProjectEventDTO): event is ProjectDCRRemovedDTO =>
-  event.type === 'ProjectDCRRemoved'
 
 export type ProjectDCRDueDateSetDTO = {
   type: 'ProjectDCRDueDateSet'
   date: number
   variant: Exclude<UserRole, 'ademe'>
 }
-export const isProjectDCRDueDateSet = (event: ProjectEventDTO): event is ProjectDCRDueDateSetDTO =>
-  event.type === 'ProjectDCRDueDateSet'
 
 export type ProjectEventListDTO = { events: ProjectEventDTO[] }

--- a/src/modules/frise/dtos/ProjectEventListDTO.ts
+++ b/src/modules/frise/dtos/ProjectEventListDTO.ts
@@ -67,10 +67,9 @@ export type ProjectCertificateDTO =
   | ProjectClaimedDTO
 
 export const isCertificateDTO = or(
-  or(
-    or(is('ProjectCertificateGenerated'), is('ProjectCertificateRegenerated')),
-    is('ProjectCertificateUpdated')
-  ),
+  is('ProjectCertificateGenerated'),
+  is('ProjectCertificateRegenerated'),
+  is('ProjectCertificateUpdated'),
   is('ProjectClaimed')
 )
 

--- a/src/views/components/timeline/helpers/extractDCRItemProps.ts
+++ b/src/views/components/timeline/helpers/extractDCRItemProps.ts
@@ -1,9 +1,4 @@
-import {
-  ProjectEventDTO,
-  isProjectDCRDueDateSet,
-  isProjectDCRRemoved,
-  isProjectDCRSubmitted,
-} from '../../../../modules/frise'
+import { ProjectEventDTO, is } from '../../../../modules/frise'
 import { or } from '../../../../core/utils'
 import { UserRole } from '../../../../modules/users'
 import { makeDocumentUrl } from './makeDocumentUrl'
@@ -35,10 +30,9 @@ export const extractDCRItemProps = (
 
   const lastProjectDCREvent = projectDCREvents.slice(-1)[0]
 
-  const projectDCRDueDateSetOrSubmitted =
-    lastProjectDCREvent.type !== 'ProjectDCRRemoved'
-      ? projectDCREvents.pop()
-      : projectDCREvents.filter(isProjectDCRDueDateSet).pop()
+  const projectDCRDueDateSetOrSubmitted = is('ProjectDCRRemoved')(lastProjectDCREvent)
+    ? projectDCREvents.filter(is('ProjectDCRDueDateSet')).pop()
+    : projectDCREvents.pop()
 
   if (!projectDCRDueDateSetOrSubmitted) {
     return null
@@ -64,4 +58,7 @@ export const extractDCRItemProps = (
     : { ...props, status: date < now ? 'past-due' : 'due', url: undefined }
 }
 
-const isProjectDCR = or(or(isProjectDCRDueDateSet, isProjectDCRSubmitted), isProjectDCRRemoved)
+const isProjectDCR = or(
+  or(is('ProjectDCRDueDateSet'), is('ProjectDCRSubmitted')),
+  is('ProjectDCRRemoved')
+)

--- a/src/views/components/timeline/helpers/extractDCRItemProps.ts
+++ b/src/views/components/timeline/helpers/extractDCRItemProps.ts
@@ -59,6 +59,7 @@ export const extractDCRItemProps = (
 }
 
 const isProjectDCR = or(
-  or(is('ProjectDCRDueDateSet'), is('ProjectDCRSubmitted')),
+  is('ProjectDCRDueDateSet'),
+  is('ProjectDCRSubmitted'),
   is('ProjectDCRRemoved')
 )

--- a/src/views/components/timeline/helpers/extractDesignationItemProps.ts
+++ b/src/views/components/timeline/helpers/extractDesignationItemProps.ts
@@ -2,7 +2,7 @@ import { Project } from '../../../../entities'
 import ROUTES from '../../../../routes'
 import {
   isCertificateDTO,
-  isProjectNotified,
+  is,
   ProjectCertificateDTO,
   ProjectEventDTO,
 } from '../../../../modules/frise'
@@ -24,7 +24,7 @@ export const extractDesignationItemProps = (
   events: ProjectEventDTO[],
   projectId: Project['id']
 ): DesignationItemProps | null => {
-  const projectNotifiedEvent = events.find(isProjectNotified)
+  const projectNotifiedEvent = events.find(is('ProjectNotified'))
   if (!projectNotifiedEvent) return null
 
   const certificateEvent = events.filter(isCertificateDTO).pop()

--- a/src/views/components/timeline/helpers/extractGFItemProps.ts
+++ b/src/views/components/timeline/helpers/extractGFItemProps.ts
@@ -1,8 +1,4 @@
-import {
-  isProjectGFDueDateSet,
-  isProjectGFSubmitted,
-  ProjectEventDTO,
-} from '../../../../modules/frise'
+import { is, ProjectEventDTO } from '../../../../modules/frise'
 import { or } from '../../../../core/utils'
 import { UserRole } from '../../../../modules/users'
 import { makeDocumentUrl } from './makeDocumentUrl'
@@ -49,4 +45,4 @@ export const extractGFItemProps = (
     : { ...props, status: date < now ? 'past-due' : 'due', url: undefined }
 }
 
-const isProjectGF = or(isProjectGFDueDateSet, isProjectGFSubmitted)
+const isProjectGF = or(is('ProjectGFDueDateSet'), is('ProjectGFSubmitted'))

--- a/src/views/components/timeline/helpers/extractImportItemProps.ts
+++ b/src/views/components/timeline/helpers/extractImportItemProps.ts
@@ -1,4 +1,4 @@
-import { isProjectImported, isProjectNotified, ProjectEventDTO } from '../../../../modules/frise'
+import { is, ProjectEventDTO } from '../../../../modules/frise'
 
 export type ImportItemProps = {
   type: 'import'
@@ -6,11 +6,11 @@ export type ImportItemProps = {
 }
 
 export const extractImportItemProps = (events: ProjectEventDTO[]): ImportItemProps | null => {
-  if (events.find(isProjectNotified)) {
+  if (events.find(is('ProjectNotified'))) {
     return null
   }
 
-  const importedEvent = events.find(isProjectImported)
+  const importedEvent = events.find(is('ProjectImported'))
 
   return importedEvent
     ? {


### PR DESCRIPTION
Je trouvais redondant cette déclaration explicite de tous les `isProjectNotified`, etc...

Je me suis dit qu'on pouvait faire mieux avec typescript et voila un résultat que je trouve élégant (mais pas forcément évident à comprendre le type). Qu'en pensez-vous ?

<a href="https://gitpod.io/#https://github.com/MTES-MCT/potentiel/pull/304"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

