### PR TITLE
:bug: 794 FakeAuth retire cookie erroné

### DIFF
--- a/src/infra/fakeAuth/index.ts
+++ b/src/infra/fakeAuth/index.ts
@@ -43,7 +43,8 @@ export const makeFakeAuth = (deps) => {
                 `FakeAuth session open but could not find user in db with email ${userEmail}`
               )
             )
-            response.redirect(routes.LOGOUT_ACTION)
+
+            logOut(response)
             return
           }
           next()
@@ -87,8 +88,7 @@ export const makeFakeAuth = (deps) => {
     })
 
     router.get(routes.LOGOUT_ACTION, (request, response) => {
-      response.clearCookie(FAKE_AUTH_COOKIE)
-      response.redirect(routes.LOGIN)
+      logOut(response)
     })
 
     router.get(routes.REDIRECT_BASED_ON_ROLE, async (req, res) => {
@@ -138,4 +138,9 @@ export const makeFakeAuth = (deps) => {
   }
 
   return { registerAuth, ensureRole }
+}
+
+function logOut(response) {
+  response.clearCookie(FAKE_AUTH_COOKIE)
+  response.redirect(routes.LOGIN)
 }


### PR DESCRIPTION
Quand on relance un serveur de dev et qu'on a un cookie de fausse authentification avec un email qui n'est pas présent en base, le fakeAuth part en boucle: il essaye de rediriger vers /logout mais sans succès parce qu'il est intercepté par le middleware d'authentification.

Au lieu de rediriger vers /logout, maintenant ça retire tout de suite le cookie et redirige vers /login

<a href="https://gitpod.io/#https://github.com/MTES-MCT/potentiel/pull/307"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

