### PR TITLE
:construction_worker: Change production deployment workflow

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,43 @@
+name: Deploy production on push
+
+on:
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - 'README.md'
+      - '.github/**'
+      - '.storybook/**'
+      - '.vscode/**'
+      - 'devtools/**'
+      - 'docs/**'
+      - 'legacy-features/**'
+      - 'keycloak/**'
+      - '.env.template'
+      - '.eslint**'
+      - '.prettier**'
+      - 'LICENSE'
+
+jobs:
+  bump-version:
+    if: "!contains(github.event.commits[0].message, 'ci: version bump to')"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          # SPECIAL_GH_ACTIONS_TOKEN is a personal access token for an admin user
+          # It is required to have write rights when increasing version number
+          token: ${{ secrets.SPECIAL_GH_ACTIONS_TOKEN }}
+
+      - run: git fetch --prune --unshallow
+
+      - name: Increase version number
+        uses: 'phips28/gh-action-bump-version@master'
+        env:
+          GITHUB_TOKEN: ${{ secrets.SPECIAL_GH_ACTIONS_TOKEN }}
+        with:
+          tag-prefix: ''
+          minor-wording: ':star2:,:revert:'
+          major-wording: 'BREAKING'

--- a/.github/workflows/deploy.prod.yml
+++ b/.github/workflows/deploy.prod.yml
@@ -2,23 +2,8 @@ name: Deploy production on push
 
 on:
   push:
-    branches:
-      - master
-    paths-ignore:
-      - 'package.json' #To avoid circular actions because of version bump
-      - 'package-lock.json' #To avoid circular actions because of version bump
-      - 'README.md'
-      - '.github/**'
-      - '.storybook/**'
-      - '.vscode/**'
-      - 'devtools/**'
-      - 'docs/**'
-      - 'legacy-features/**'
-      - 'keycloak/**'
-      - '.env.template'
-      - '.eslint**'
-      - '.prettier**'
-      - 'LICENSE'
+    tags:
+      - *.*.*
 
 jobs:
   deploy:
@@ -34,15 +19,6 @@ jobs:
           token: ${{ secrets.SPECIAL_GH_ACTIONS_TOKEN }}
 
       - run: git fetch --prune --unshallow
-
-      - name: Increase version number
-        uses: 'phips28/gh-action-bump-version@master'
-        env:
-          GITHUB_TOKEN: ${{ secrets.SPECIAL_GH_ACTIONS_TOKEN }}
-        with:
-          tag-prefix: ''
-          minor-wording: ':star2:,:revert:'
-          major-wording: 'BREAKING'
 
       - name: Deploy to Clever Cloud
         uses: 47ng/actions-clever-cloud@v1


### PR DESCRIPTION
Le but ici est de pouvoir déployer en production même lorsqu'un changement est fait sur un fichier package*.json 

Ma proposition est de ne déclencher le bump de la version que pour les commits poussés sur master autre qu'un commit de bump de version.
J'ai également pris le parti de séparer les workflow bump version et déploiement en production. Et désormais le déploiement en production ne se déclencherait que lorsqu'un tag au format `*.*.*` serait poussé sur le répository. (Cette dernière partie n'est pas obligatoire et on pourrait se contenter de la condition sur le message de commit)