### PR TITLE
729 Le champ adresseProjet doit accepter des chaines de plus de 255 caractères

### DIFF
--- a/src/infra/sequelize/migrations/20220125162859-projects-adresseProjet-as-text.js
+++ b/src/infra/sequelize/migrations/20220125162859-projects-adresseProjet-as-text.js
@@ -1,15 +1,4 @@
 'use strict'
-const { models } = require('../models')
-const { fromPersistance } = require('../helpers/fromPersistance')
-const { onProjectImported } = require('../projections/project/updates/onProjectImported')
-const {
-  onProjectNotificationDateSet,
-} = require('../projections/project/updates/onProjectNotificationDateSet')
-const { onProjectDCRDueDateSet } = require('../projections/project/updates/onProjectDCRDueDateSet')
-const { onProjectGFDueDateSet } = require('../projections/project/updates/onProjectGFDueDateSet')
-const {
-  onProjectCompletionDueDateSet,
-} = require('../projections/project/updates/onProjectCompletionDueDateSet')
 
 module.exports = {
   async up(queryInterface, Sequelize) {

--- a/src/infra/sequelize/migrations/20220125162859-projects-adresseProjet-as-text.js
+++ b/src/infra/sequelize/migrations/20220125162859-projects-adresseProjet-as-text.js
@@ -1,0 +1,39 @@
+'use strict'
+const { models } = require('../models')
+const { fromPersistance } = require('../helpers/fromPersistance')
+const { onProjectImported } = require('../projections/project/updates/onProjectImported')
+const {
+  onProjectNotificationDateSet,
+} = require('../projections/project/updates/onProjectNotificationDateSet')
+const { onProjectDCRDueDateSet } = require('../projections/project/updates/onProjectDCRDueDateSet')
+const { onProjectGFDueDateSet } = require('../projections/project/updates/onProjectGFDueDateSet')
+const {
+  onProjectCompletionDueDateSet,
+} = require('../projections/project/updates/onProjectCompletionDueDateSet')
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    const transaction = await queryInterface.sequelize.transaction()
+    try {
+      await queryInterface.changeColumn('projects', 'adresseProjet', {
+        type: Sequelize.DataTypes.TEXT,
+        transaction,
+      })
+
+      await transaction.commit()
+    } catch (err) {
+      console.log('err', err)
+      await transaction.rollback()
+      throw err
+    }
+  },
+
+  async down(queryInterface, Sequelize) {
+    /**
+     * Add reverting commands here.
+     *
+     * Example:
+     * await queryInterface.dropTable('users');
+     */
+  },
+}

--- a/src/infra/sequelize/migrations/20220128093007-fix-projects-with-too-long-address.js
+++ b/src/infra/sequelize/migrations/20220128093007-fix-projects-with-too-long-address.js
@@ -13,6 +13,10 @@ const {
 
 module.exports = {
   async up(queryInterface, Sequelize) {
+    if (process.env.NODE_ENV !== 'production') {
+      return
+    }
+
     try {
       const projectIds = [
         '0d78c388-b723-4485-b190-611f53d779f2',

--- a/src/infra/sequelize/migrations/20220128093007-fix-projects-with-too-long-address.js
+++ b/src/infra/sequelize/migrations/20220128093007-fix-projects-with-too-long-address.js
@@ -1,0 +1,61 @@
+'use strict'
+const { models } = require('../models')
+const { fromPersistance } = require('../helpers/fromPersistance')
+const { onProjectImported } = require('../projections/project/updates/onProjectImported')
+const {
+  onProjectNotificationDateSet,
+} = require('../projections/project/updates/onProjectNotificationDateSet')
+const { onProjectDCRDueDateSet } = require('../projections/project/updates/onProjectDCRDueDateSet')
+const { onProjectGFDueDateSet } = require('../projections/project/updates/onProjectGFDueDateSet')
+const {
+  onProjectCompletionDueDateSet,
+} = require('../projections/project/updates/onProjectCompletionDueDateSet')
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    try {
+      const projectIds = [
+        '0d78c388-b723-4485-b190-611f53d779f2',
+        '9c6b0c33-1963-4d76-a101-a3ee86c70aa8',
+        '04864102-436e-423f-8a1a-8b9be7d82b52',
+      ]
+
+      const projections = [
+        ['ProjectImported', onProjectImported],
+        ['ProjectNotificationDateSet', onProjectNotificationDateSet],
+        ['ProjectDCRDueDateSet', onProjectDCRDueDateSet],
+        ['ProjectGFDueDateSet', onProjectGFDueDateSet],
+        ['ProjectCompletionDueDateSet', onProjectCompletionDueDateSet],
+      ]
+
+      for (const projectId of projectIds) {
+        for (const [eventType, projector] of projections) {
+          const eventsFromDb = await queryInterface.sequelize.query(
+            'SELECT * FROM "eventStores" WHERE type = ? AND "aggregateId" && ?',
+            {
+              type: queryInterface.sequelize.QueryTypes.SELECT,
+              replacements: [eventType, `{${projectId}}`],
+            }
+          )
+
+          if (eventsFromDb.length === 0) {
+            throw `Impossble de trouver l'événement de type ${eventType} pour le projet ${projectId}`
+          }
+
+          await projector(models)(fromPersistance(eventsFromDb[0]))
+        }
+      }
+    } catch (err) {
+      throw err
+    }
+  },
+
+  async down(queryInterface, Sequelize) {
+    /**
+     * Add reverting commands here.
+     *
+     * Example:
+     * await queryInterface.dropTable('users');
+     */
+  },
+}


### PR DESCRIPTION
Il y a trois projets qui n'ont pas pu être importés dans l'historique parce que leur adresse dépassait 255 caractères de long (limite d'une colonne de type `VARCHAR` dans postgres). 

Les projecteurs pour les événements `ProjectImported` ont échoué à rajouter une ligne à la table `projects`. Du coup, les projecteurs suivants (`onProjectNotificationDateSet`, `onProjectGFDueDateSet`, etc.) ont également échoués, puisqu'ils essayaient de mettre à jour des lignes inexistantes dans la table `projects`. 

J'ai donc rajouté un script de migration qui rejoue les projections qui ont échoué.

<a href="https://gitpod.io/#https://github.com/MTES-MCT/potentiel/pull/333"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

