### PR TITLE
738 Nettoyer historique suite à erreur de notification Bat 13 famille 2

### DIFF
--- a/src/infra/sequelize/migrations/20220128094158-add-UserRightsToProjectRevoked-in-history.js
+++ b/src/infra/sequelize/migrations/20220128094158-add-UserRightsToProjectRevoked-in-history.js
@@ -3,7 +3,7 @@
 const {
   UserRightsToProjectRevoked,
 } = require('../../../modules/authZ/events/UserRightsToProjectRevoked')
-const { toPersistance } = require('../helpers')
+const { toPersistance } = require('../helpers/toPersistance')
 
 module.exports = {
   async up(queryInterface, Sequelize) {

--- a/src/infra/sequelize/migrations/20220128094158-add-UserRightsToProjectRevoked-in-history.js
+++ b/src/infra/sequelize/migrations/20220128094158-add-UserRightsToProjectRevoked-in-history.js
@@ -1,0 +1,84 @@
+'use strict'
+
+const {
+  UserRightsToProjectRevoked,
+} = require('../../../modules/authZ/events/UserRightsToProjectRevoked')
+const { toPersistance } = require('../helpers')
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    /**
+     * Le 01/12/21, suite à un import de données erronnées pour la période Batiment 13,
+     * des utilisateurs ont reçu des droits sur les mauvais projets.
+     * Dans l'urgence, les droits erronnés ont été retirés en faisant une requête
+     * directement dans la projection `UserProjects`.
+     * Ce script ajoute des événements de type UserRightsToProjectRevoked
+     * pour que l'historique corresponde bien aux droits.
+     */
+
+    const wrongUserRightsToProjectGranted = await queryInterface.sequelize.query(
+      `SELECT * FROM "eventStores" WHERE type = 'UserRightsToProjectGranted' AND "occurredAt" >= '2021-12-01' and "occurredAt" < '2021-12-02'`,
+      {
+        type: queryInterface.sequelize.QueryTypes.SELECT,
+      }
+    )
+
+    const rightsToRevokeFromUserRightsToProjectGranted = wrongUserRightsToProjectGranted.map(
+      ({ payload: { projectId, userId } }) => ({
+        projectId,
+        userId,
+        origin: 'UserRightsToProjectGranted',
+      })
+    )
+
+    const wrongUserProjectsLinkedByContactEmail = await queryInterface.sequelize.query(
+      `SELECT * FROM "eventStores" WHERE type = 'UserProjectsLinkedByContactEmail' AND "occurredAt" >= '2021-12-01' and "occurredAt" < '2021-12-02'`,
+      {
+        type: queryInterface.sequelize.QueryTypes.SELECT,
+      }
+    )
+
+    const rightsToRevokeFromUserProjectsLinkedByContactEmail =
+      wrongUserProjectsLinkedByContactEmail.reduce(
+        (arr, { payload }) => [
+          ...arr,
+          ...payload.projectIds.map((projectId) => ({
+            projectId,
+            userId: payload.userId,
+            origin: 'UserProjectsLinkedByContactEmail',
+          })),
+        ],
+        []
+      )
+
+    const rightsToRevoke = [
+      ...rightsToRevokeFromUserRightsToProjectGranted,
+      ...rightsToRevokeFromUserProjectsLinkedByContactEmail,
+    ]
+
+    console.log('Inserting ' + rightsToRevoke.length + ' UserRightsToProjectRevoked events')
+
+    await queryInterface.bulkInsert(
+      'eventStores',
+      rightsToRevoke
+        .map(
+          ({ projectId, userId }) =>
+            new UserRightsToProjectRevoked({
+              payload: { projectId, userId, revokedBy: '' },
+              original: { version: 1, occurredAt: new Date('2021-12-02 17:35') },
+            })
+        )
+        .map(toPersistance)
+        .map((item) => ({ ...item, payload: JSON.stringify(item.payload) }))
+    )
+  },
+
+  async down(queryInterface, Sequelize) {
+    /**
+     * Add reverting commands here.
+     *
+     * Example:
+     * await queryInterface.dropTable('users');
+     */
+  },
+}

--- a/src/infra/sequelize/migrations/20220128094158-add-UserRightsToProjectRevoked-in-history.js
+++ b/src/infra/sequelize/migrations/20220128094158-add-UserRightsToProjectRevoked-in-history.js
@@ -56,6 +56,8 @@ module.exports = {
       ...rightsToRevokeFromUserProjectsLinkedByContactEmail,
     ]
 
+    if (!rightsToRevoke.length) return
+
     console.log('Inserting ' + rightsToRevoke.length + ' UserRightsToProjectRevoked events')
 
     await queryInterface.bulkInsert(

--- a/src/infra/sequelize/migrations/20220128103139-add-UserRightsToProjectGranted-in-history.js
+++ b/src/infra/sequelize/migrations/20220128103139-add-UserRightsToProjectGranted-in-history.js
@@ -1,0 +1,50 @@
+'use strict'
+
+const {
+  UserRightsToProjectGranted,
+} = require('../../../modules/authZ/events/UserRightsToProjectGranted')
+const { toPersistance } = require('../helpers')
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    /**
+     * Le 02/12/21, suite à un import de données erronnées pour la période Batiment 13,
+     * suite au retrait des droits de tous les utilisateurs de la période,
+     * un ajout manuel de droits pour tous les PP de cette période a été fait
+     * manuellement avec une requête sur UserProjects.
+     * Ce script crée des événements UserRightsToProjectGranted pour rétablir l'historique
+     */
+
+    const rightFullProjectOwners = await queryInterface.sequelize.query(
+      `SELECT projects.id as "projectId", users.id as "userId" from projects join users on projects.email = users.email where "projects"."appelOffreId"='CRE4 - Bâtiment' and "projects"."periodeId"='13' and "projects"."familleId"='2';`,
+      {
+        type: queryInterface.sequelize.QueryTypes.SELECT,
+      }
+    )
+
+    console.log('Inserting ' + rightFullProjectOwners.length + ' UserRightsToProjectGranted events')
+
+    await queryInterface.bulkInsert(
+      'eventStores',
+      rightFullProjectOwners
+        .map(
+          ({ projectId, userId }) =>
+            new UserRightsToProjectGranted({
+              payload: { projectId, userId, grantedBy: '' },
+              original: { version: 1, occurredAt: new Date('2021-12-02 11:00') },
+            })
+        )
+        .map(toPersistance)
+        .map((item) => ({ ...item, payload: JSON.stringify(item.payload) }))
+    )
+  },
+
+  async down(queryInterface, Sequelize) {
+    /**
+     * Add reverting commands here.
+     *
+     * Example:
+     * await queryInterface.dropTable('users');
+     */
+  },
+}

--- a/src/infra/sequelize/migrations/20220128103139-add-UserRightsToProjectGranted-in-history.js
+++ b/src/infra/sequelize/migrations/20220128103139-add-UserRightsToProjectGranted-in-history.js
@@ -3,7 +3,7 @@
 const {
   UserRightsToProjectGranted,
 } = require('../../../modules/authZ/events/UserRightsToProjectGranted')
-const { toPersistance } = require('../helpers')
+const { toPersistance } = require('../helpers/toPersistance')
 
 module.exports = {
   async up(queryInterface, Sequelize) {

--- a/src/infra/sequelize/migrations/20220128103139-add-UserRightsToProjectGranted-in-history.js
+++ b/src/infra/sequelize/migrations/20220128103139-add-UserRightsToProjectGranted-in-history.js
@@ -22,6 +22,8 @@ module.exports = {
       }
     )
 
+    if (!rightFullProjectOwners.length) return
+
     console.log('Inserting ' + rightFullProjectOwners.length + ' UserRightsToProjectGranted events')
 
     await queryInterface.bulkInsert(

--- a/src/modules/authZ/eventHandlers/handleUserCreated.ts
+++ b/src/modules/authZ/eventHandlers/handleUserCreated.ts
@@ -1,5 +1,5 @@
 import { EventBus } from '@core/domain'
-import { logger } from '@core/utils'
+import { logger, okAsync } from '@core/utils'
 import { GetNonLegacyProjectsByContactEmail } from '../../project'
 import { UserCreated } from '../../users'
 import { UserProjectsLinkedByContactEmail } from '../events'
@@ -15,11 +15,13 @@ export const handleUserCreated = (deps: HandleUserCreatedDeps) => async (event: 
 
   try {
     const res = await getNonLegacyProjectsByContactEmail(email).andThen((projectIds) =>
-      eventBus.publish(
-        new UserProjectsLinkedByContactEmail({
-          payload: { userId, projectIds },
-        })
-      )
+      projectIds.length
+        ? eventBus.publish(
+            new UserProjectsLinkedByContactEmail({
+              payload: { userId, projectIds },
+            })
+          )
+        : okAsync(null)
     )
     if (res.isErr()) {
       throw res.error


### PR DESCRIPTION
J'insère dans l'historique une série d'événements `UserRightsToProjectRevoked` et `UserRightsToProjectGranted` pour correspondre avec les requêtes sql brutes que j'ai fait en live lors de la crise.

<a href="https://gitpod.io/#https://github.com/MTES-MCT/potentiel/pull/335"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

