### PR TITLE
DX: Add VSCode task to run test on current file

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,13 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Test - Run test on this file",
+      "type": "shell",
+      "command": "if [[ ${file} == *\".spec.ts\" ]]; then npm run test:watch -- ${file} ; else if [[ ${file} == *\".integration.ts\" ]]; then npm run test-int:watch -- ${file} ; fi ; fi",
+      "problemMatcher": []
+    }
+  ]
+}


### PR DESCRIPTION
J'ai créé un petit script pour lancer les tests (unitaires ou integration suivant le fichier de test) en mode watch sur le fichier en cours.

C'est un raccourci pour éviter de devoir taper à la main `npm run test:watch --` puis le nom du test. 

Pour lancer, deux possibilités:
- Ouvrir la palette de commande, puis "Run Task" puis "Test - Run test on this file"
- Ajouter un raccourci clavier associé à cette tâche:
  - Palette de commande,  "Open Keyboard Shortcuts (JSON)", puis rajouter 
```json
  {
    "key": "ctrl+alt+t",
    "command": "workbench.action.tasks.runTask",
    "args": "Test - Run test on this file",
    "when": "editorTextFocus && resourceFilename =~ /.spec.ts$|.integration.ts$/"
  }
```
Ça lancera les tests lorsqu'on a un fichier de test ouvert et qu'on fait CTRL+ALT+T.

<a href="https://gitpod.io/#https://github.com/MTES-MCT/potentiel/pull/337"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

