### PR TITLE
:sparkles: 901 Ajout d'une propriété innovation pour identifier les appels d'offre

### DIFF
--- a/src/dataAccess/inMemory/appelsOffres/CRE4/innovation.ts
+++ b/src/dataAccess/inMemory/appelsOffres/CRE4/innovation.ts
@@ -3,6 +3,7 @@ import { makeParagrapheAchevementForDelai } from '../commonDataFields'
 
 const innovation: AppelOffre = {
   id: 'CRE4 - Innovation',
+  innovation: true,
   title:
     '2017/S 051-094731 portant sur la réalisation et l’exploitation d’Installations de production d’électricité innovantes à partir de l’énergie solaire, sans dispositifs de stockage',
   shortTitle: 'CRE4 - Innovation 2017/S 051-094731',

--- a/src/dataAccess/inMemory/appelsOffres/PPE2/ppe2.innovation.ts
+++ b/src/dataAccess/inMemory/appelsOffres/PPE2/ppe2.innovation.ts
@@ -3,6 +3,7 @@ import { makeParagrapheAchevementForDelai } from '../commonDataFields'
 
 const innovationPPE2: AppelOffre = {
   id: 'PPE2 - Innovation',
+  innovation: true,
   title:
     '2021 S 203-530267 portant sur la réalisation et l’exploitation d’Installations de production d’électricité innovantes à partir de l’énergie solaire sans dispositifs de stockage',
   shortTitle: 'PPE2 - Innovation 2021 S 203-530267',

--- a/src/entities/appelOffre.ts
+++ b/src/entities/appelOffre.ts
@@ -29,6 +29,7 @@ export type AppelOffre = {
   periodes: Periode[]
   familles: Famille[]
   contenuParagrapheAchevement: string
+  innovation?: true
 } & (
   | { delaiRealisationEnMois: number; decoupageParTechnologie: false }
   | {

--- a/src/infra/sequelize/queries/modificationRequest/getModificationRequestDataForResponseTemplate.ts
+++ b/src/infra/sequelize/queries/modificationRequest/getModificationRequestDataForResponseTemplate.ts
@@ -238,7 +238,7 @@ export const getModificationRequestDataForResponseTemplate: GetModificationReque
               affichageParagrapheECS: affichageParagrapheECS ? 'yes' : '',
               unitePuissance,
               eolien: appelOffreId === 'Eolien' ? 'yes' : '',
-              AOInnovation: appelOffreId === 'CRE4 - Innovation' ? 'yes' : '',
+              AOInnovation: appelOffre.innovation ? 'yes' : '',
               soumisGF: soumisAuxGarantiesFinancieres ? 'yes' : '',
               renvoiSoumisAuxGarantiesFinancieres,
               renvoiDemandeCompleteRaccordement,

--- a/src/views/certificates/cre4.v0.tsx
+++ b/src/views/certificates/cre4.v0.tsx
@@ -166,7 +166,7 @@ const Laureat = (project: ProjectDataForCertificate) => {
       ) : (
         <Text />
       )}
-      {appelOffre.id === 'CRE4 - Innovation' ? (
+      {appelOffre.innovation ? (
         <Text
           style={{
             fontSize: 10,
@@ -257,7 +257,7 @@ const Laureat = (project: ProjectDataForCertificate) => {
             ) : (
               <Text />
             )}
-            {appelOffre.id === 'CRE4 - Innovation' ? (
+            {appelOffre.innovation ? (
               <>
                 Toute demande de modification substantielle de l’innovation sera notamment refusée
                 <Text>{addFootNote('5.4.4')}</Text>.

--- a/src/views/certificates/cre4.v1.tsx
+++ b/src/views/certificates/cre4.v1.tsx
@@ -171,7 +171,7 @@ const Laureat = (project: ProjectDataForCertificate) => {
       ) : (
         <Text />
       )}
-      {appelOffre.id === 'CRE4 - Innovation' ? (
+      {appelOffre.innovation ? (
         <Text
           style={{
             fontSize: 10,
@@ -263,7 +263,7 @@ const Laureat = (project: ProjectDataForCertificate) => {
             ) : (
               <Text />
             )}
-            {appelOffre.id === 'CRE4 - Innovation' ? (
+            {appelOffre.innovation ? (
               <>
                 Toute demande de modification substantielle de l’innovation sera notamment refusée
                 <Text>{addFootNote('5.4.4')}</Text>.

--- a/src/views/certificates/ppe2/components/Laureat.tsx
+++ b/src/views/certificates/ppe2/components/Laureat.tsx
@@ -106,7 +106,7 @@ export const makeLaureat: MakeLaureat = (project) => {
           </Text>
         )}
 
-        {appelOffre.id === 'PPE2 - Innovation' && (
+        {appelOffre.innovation && (
           <Text
             style={{
               marginTop: 10,
@@ -183,7 +183,7 @@ export const makeLaureat: MakeLaureat = (project) => {
               </Text>
             </>
           )}
-          {appelOffre.id === 'PPE2 - Innovation' && (
+          {appelOffre.innovation && (
             <>
               {'. '}
               <Text

--- a/src/views/legacy-pages/candidateCertificate.tsx
+++ b/src/views/legacy-pages/candidateCertificate.tsx
@@ -162,7 +162,7 @@ const Laureat = ({ project, appelOffre, periode }: LaureatProps) => {
       ) : (
         <Text />
       )}
-      {appelOffre.id === 'CRE4 - Innovation' ? (
+      {appelOffre.innovation ? (
         <Text
           style={{
             fontSize: 10,
@@ -254,7 +254,7 @@ const Laureat = ({ project, appelOffre, periode }: LaureatProps) => {
             ) : (
               <Text />
             )}
-            {appelOffre.id === 'CRE4 - Innovation' ? (
+            {appelOffre.innovation ? (
               <>
                 Toute demande de modification substantielle de l’innovation sera notamment refusée
                 <Text>{addFootNote('5.4.4')}</Text>.

--- a/src/views/pages/projectDetailsPage/ProjectDetails.tsx
+++ b/src/views/pages/projectDetailsPage/ProjectDetails.tsx
@@ -157,7 +157,7 @@ export const ProjectDetails = PageLayout(
             <div>Fournisseur: {project.fournisseur}</div>
             <div>Evaluation carbone simplifiée: {project.evaluationCarbone} kg eq CO2/kWc</div>
           </Section>
-          {project.appelOffre?.id === 'CRE4 - Innovation' && user.role !== 'dreal' ? (
+          {project.appelOffre?.innovation && user.role !== 'dreal' ? (
             <Section title="Résultats de l'appel d'offres" icon="clipboard-check">
               <div style={{ marginBottom: 10, fontSize: 18 }} {...dataId('project-note')}>
                 <b>Note totale</b>: {project.note || 'N/A'}


### PR DESCRIPTION
Ceci permet d'éviter de filtrer les appels d'offres sur leur id pour savoir s'il sont de type innovation et donc d'oublier certains cas d'utilisations

<a href="https://gitpod.io/#https://github.com/MTES-MCT/potentiel/pull/345"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

