### PR TITLE
527 Afficher la puissance lors de la demande sur la page de la demande

### DIFF
--- a/src/config/useCases.config.ts
+++ b/src/config/useCases.config.ts
@@ -38,6 +38,7 @@ import {
   hasProjectGarantieFinanciere,
   getProjectDataForProjectClaim,
   isProjectParticipatif,
+  getPuissanceProjet,
 } from './queries.config'
 import { makeClaimProject } from '@modules/projectClaim'
 import {
@@ -125,6 +126,7 @@ export const requestPuissanceModification = makeRequestPuissanceModification({
   exceedsPuissanceMaxDuVolumeReserve,
   projectRepo,
   fileRepo,
+  getPuissanceProjet,
 })
 
 export const requestActionnaireModification = makeRequestActionnaireModification({

--- a/src/infra/sequelize/migrations/20220301152345-add-modificationRequest-puissanceAuMomentDuDepot-column.js
+++ b/src/infra/sequelize/migrations/20220301152345-add-modificationRequest-puissanceAuMomentDuDepot-column.js
@@ -1,0 +1,14 @@
+'use strict'
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn('modificationRequests', 'puissanceAuMomentDuDepot', {
+      type: Sequelize.DataTypes.DOUBLE,
+      allowNull: true,
+    })
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    queryInterface.removeColumn('modificationRequests', 'puissanceAuMomentDuDepot')
+  },
+}

--- a/src/infra/sequelize/projections/modificationRequest/modificationRequest.model.ts
+++ b/src/infra/sequelize/projections/modificationRequest/modificationRequest.model.ts
@@ -85,6 +85,10 @@ export const MakeModificationRequestModel = (sequelize) => {
         type: DataTypes.DOUBLE,
         allowNull: true,
       },
+      puissanceAuMomentDuDepot: {
+        type: DataTypes.DOUBLE,
+        allowNull: true,
+      },
       evaluationCarbone: {
         type: DataTypes.DOUBLE,
         allowNull: true,

--- a/src/infra/sequelize/projections/modificationRequest/updates/onModificationReceived.ts
+++ b/src/infra/sequelize/projections/modificationRequest/updates/onModificationReceived.ts
@@ -1,43 +1,40 @@
 import { logger } from '@core/utils'
 import { ModificationReceived } from '@modules/modificationRequest'
 
-export const onModificationReceived = (models) => async (event: ModificationReceived) => {
-  const ModificationRequestModel = models.ModificationRequest
-  const {
-    modificationRequestId,
-    projectId,
-    requestedBy,
-    puissance,
-    justification,
-    fileId,
-    type,
-    actionnaire,
-    producteur,
-    fournisseurs,
-    evaluationCarbone,
-    authority,
-  } = event.payload
-
-  try {
-    await ModificationRequestModel.create({
-      id: modificationRequestId,
+export const onModificationReceived =
+  (models) =>
+  async ({ payload, occurredAt }: ModificationReceived) => {
+    const ModificationRequestModel = models.ModificationRequest
+    const {
+      modificationRequestId,
       projectId,
-      requestedOn: event.occurredAt.getTime(),
-      versionDate: event.occurredAt,
-      status: 'information validée',
-      type,
-      userId: requestedBy,
-      producteur,
-      puissance,
+      requestedBy,
       justification,
       fileId,
-      actionnaire,
-      fournisseurs,
-      evaluationCarbone,
+      type,
       authority,
-    })
-  } catch (e) {
-    logger.error(e)
-    logger.info('Error: onModificationReceived projection failed to update project :', event)
+    } = payload
+
+    try {
+      await ModificationRequestModel.create({
+        id: modificationRequestId,
+        projectId,
+        requestedOn: occurredAt.getTime(),
+        versionDate: occurredAt,
+        status: 'information validée',
+        type,
+        userId: requestedBy,
+        producteur: type === 'producteur' && payload.producteur,
+        puissance: type === 'puissance' && payload.puissance,
+        justification,
+        fileId,
+        actionnaire: type === 'actionnaire' && payload.actionnaire,
+        fournisseurs: type === 'fournisseur' && payload.fournisseurs,
+        evaluationCarbone: type === 'fournisseur' && payload.evaluationCarbone,
+        authority,
+      })
+    } catch (e) {
+      logger.error(e)
+      logger.info('Error: onModificationReceived projection failed to update project :', event)
+    }
   }
-}

--- a/src/infra/sequelize/projections/modificationRequest/updates/onModificationReceived.ts
+++ b/src/infra/sequelize/projections/modificationRequest/updates/onModificationReceived.ts
@@ -24,13 +24,15 @@ export const onModificationReceived =
         status: 'information validée',
         type,
         userId: requestedBy,
-        producteur: type === 'producteur' && payload.producteur,
-        puissance: type === 'puissance' && payload.puissance,
+        producteur: type === 'producteur' ? payload.producteur : undefined,
+        puissance: type === 'puissance' ? payload.puissance : undefined,
+        puissanceAuMomentDuDepot:
+          type === 'puissance' ? payload.puissanceAuMomentDuDepot : undefined,
         justification,
         fileId,
-        actionnaire: type === 'actionnaire' && payload.actionnaire,
-        fournisseurs: type === 'fournisseur' && payload.fournisseurs,
-        evaluationCarbone: type === 'fournisseur' && payload.evaluationCarbone,
+        actionnaire: type === 'actionnaire' ? payload.actionnaire : undefined,
+        fournisseurs: type === 'fournisseur' ? payload.fournisseurs : undefined,
+        evaluationCarbone: type === 'fournisseur' ? payload.evaluationCarbone : undefined,
         authority,
       })
     } catch (e) {

--- a/src/infra/sequelize/projections/modificationRequest/updates/onModificationRequested.ts
+++ b/src/infra/sequelize/projections/modificationRequest/updates/onModificationRequested.ts
@@ -1,28 +1,39 @@
 import { logger } from '@core/utils'
 import { ModificationRequested } from '@modules/modificationRequest'
 
-export const onModificationRequested = (models) => async (event: ModificationRequested) => {
-  const ModificationRequestModel = models.ModificationRequest
+export const onModificationRequested =
+  (models) =>
+  async ({ payload, occurredAt }: ModificationRequested) => {
+    const ModificationRequestModel = models.ModificationRequest
 
-  const { modificationRequestId, type, projectId, fileId, justification, requestedBy, authority } =
-    event.payload
-  try {
-    await ModificationRequestModel.create({
-      id: modificationRequestId,
-      projectId,
+    const {
+      modificationRequestId,
       type,
-      requestedOn: event.occurredAt.getTime(),
-      versionDate: event.occurredAt,
-      status: 'envoyée',
+      projectId,
       fileId,
-      userId: requestedBy,
       justification,
-      puissance: type === 'puissance' && event.payload.puissance,
-      delayInMonths: type === 'delai' && event.payload.delayInMonths,
-      actionnaire: type === 'actionnaire' && event.payload.actionnaire,
+      requestedBy,
       authority,
-    })
-  } catch (e) {
-    logger.error(e)
+    } = payload
+    try {
+      await ModificationRequestModel.create({
+        id: modificationRequestId,
+        projectId,
+        type,
+        requestedOn: occurredAt.getTime(),
+        versionDate: occurredAt,
+        status: 'envoyée',
+        fileId,
+        userId: requestedBy,
+        justification,
+        puissance: type === 'puissance' ? payload.puissance : undefined,
+        puissanceAuMomentDuDepot:
+          type === 'puissance' ? payload.puissanceAuMomentDuDepot : undefined,
+        delayInMonths: type === 'delai' ? payload.delayInMonths : undefined,
+        actionnaire: type === 'actionnaire' ? payload.actionnaire : undefined,
+        authority,
+      })
+    } catch (e) {
+      logger.error(e)
+    }
   }
-}

--- a/src/infra/sequelize/projections/modificationRequest/updates/onModificationRequested.ts
+++ b/src/infra/sequelize/projections/modificationRequest/updates/onModificationRequested.ts
@@ -4,18 +4,8 @@ import { ModificationRequested } from '@modules/modificationRequest'
 export const onModificationRequested = (models) => async (event: ModificationRequested) => {
   const ModificationRequestModel = models.ModificationRequest
 
-  const {
-    modificationRequestId,
-    type,
-    projectId,
-    fileId,
-    justification,
-    requestedBy,
-    puissance,
-    delayInMonths,
-    actionnaire,
-    authority,
-  } = event.payload
+  const { modificationRequestId, type, projectId, fileId, justification, requestedBy, authority } =
+    event.payload
   try {
     await ModificationRequestModel.create({
       id: modificationRequestId,
@@ -27,9 +17,9 @@ export const onModificationRequested = (models) => async (event: ModificationReq
       fileId,
       userId: requestedBy,
       justification,
-      puissance,
-      delayInMonths,
-      actionnaire,
+      puissance: type === 'puissance' && event.payload.puissance,
+      delayInMonths: type === 'delai' && event.payload.delayInMonths,
+      actionnaire: type === 'actionnaire' && event.payload.actionnaire,
       authority,
     })
   } catch (e) {

--- a/src/infra/sequelize/projectionsNext/projectEvents/updates/onModificationRequested.ts
+++ b/src/infra/sequelize/projectionsNext/projectEvents/updates/onModificationRequested.ts
@@ -4,10 +4,8 @@ import { ProjectEvent } from '../projectEvent.model'
 
 export default ProjectEvent.projector.on(
   ModificationRequested,
-  async (
-    { payload: { projectId, type, delayInMonths, modificationRequestId, authority }, occurredAt },
-    transaction
-  ) => {
+  async ({ payload, occurredAt }, transaction) => {
+    const { projectId, type, modificationRequestId, authority } = payload
     if (!['delai', 'abandon', 'recours'].includes(type)) {
       return
     }
@@ -23,7 +21,7 @@ export default ProjectEvent.projector.on(
           modificationType: type,
           modificationRequestId,
           authority,
-          ...(type === 'delai' && { delayInMonths }),
+          ...(type === 'delai' && { delayInMonths: payload.delayInMonths }),
         },
       },
       { transaction }

--- a/src/infra/sequelize/queries/modificationRequest/getModificationRequestDetails.ts
+++ b/src/infra/sequelize/queries/modificationRequest/getModificationRequestDetails.ts
@@ -81,6 +81,7 @@ export const getModificationRequestDetails: GetModificationRequestDetails = (
       versionDate,
       delayInMonths,
       puissance,
+      puissanceAuMomentDuDepot,
       actionnaire,
       fournisseurs,
       evaluationCarbone,
@@ -120,6 +121,7 @@ export const getModificationRequestDetails: GetModificationRequestDetails = (
         technologie: technologie || 'N/A',
       },
       ...(type === 'puissance' && {
+        puissanceAuMomentDuDepot,
         puissance,
       }),
     })

--- a/src/infra/sequelize/queries/modificationRequest/getPuissanceProjet.integration.ts
+++ b/src/infra/sequelize/queries/modificationRequest/getPuissanceProjet.integration.ts
@@ -1,0 +1,19 @@
+import { UniqueEntityID } from '@core/domain'
+import makeFakeProject from '../../../../__tests__/fixtures/project'
+import { resetDatabase } from '../../helpers'
+import models from '../../models'
+import { getPuissanceProjet } from './getPuissanceProjet'
+
+const { Project } = models
+
+const projectId = new UniqueEntityID().toString()
+
+describe('Sequelize getPuissanceProjet', () => {
+  it('should return the puissance', async () => {
+    await resetDatabase()
+
+    await Project.create(makeFakeProject({ id: projectId, puissance: 123 }))
+
+    expect((await getPuissanceProjet(projectId))._unsafeUnwrap()).toEqual(123)
+  })
+})

--- a/src/infra/sequelize/queries/modificationRequest/getPuissanceProjet.ts
+++ b/src/infra/sequelize/queries/modificationRequest/getPuissanceProjet.ts
@@ -1,0 +1,19 @@
+import { err, ok, wrapInfra } from '@core/utils'
+import { EntityNotFoundError } from '@modules/shared'
+import models from '../../models'
+
+const { Project } = models
+
+export const getPuissanceProjet = (projectId) => {
+  return wrapInfra(
+    Project.findByPk(projectId, {
+      attributes: ['puissance'],
+    })
+  ).andThen((projectRaw: any) => {
+    if (!projectRaw) return err(new EntityNotFoundError())
+
+    const { puissance } = projectRaw.get()
+
+    return ok(puissance)
+  })
+}

--- a/src/infra/sequelize/queries/modificationRequest/index.ts
+++ b/src/infra/sequelize/queries/modificationRequest/index.ts
@@ -6,5 +6,6 @@ export * from './getModificationRequestListForUser';
 export * from './getModificationRequestRecipient';
 export * from './getModificationRequestStatus';
 export * from './getProjectAppelOffreId';
+export * from './getPuissanceProjet';
 export * from './hasProjectGarantieFinanciere';
 export * from './isProjectParticipatif';

--- a/src/modules/modificationRequest/dtos/ModificationRequestPageDTO.ts
+++ b/src/modules/modificationRequest/dtos/ModificationRequestPageDTO.ts
@@ -55,10 +55,7 @@ type Variant =
   | { type: 'actionnaire'; actionnaire: string }
   | { type: 'fournisseur'; fournisseurs: Fournisseur[]; evaluationCarbone?: number }
   | { type: 'producteur'; producteur: string }
-  | {
-      type: 'puissance'
-      puissance: number
-    }
+  | { type: 'puissance'; puissance: number; puissanceAuMomentDuDepot?: number }
   | { type: 'recours' }
   | { type: 'abandon' }
   | { type: 'delai'; delayInMonths: number; acceptanceParams?: { delayInMonths: number } }

--- a/src/modules/modificationRequest/events/ModificationReceived.ts
+++ b/src/modules/modificationRequest/events/ModificationReceived.ts
@@ -12,6 +12,7 @@ export type ModificationReceivedPayload = {
   | {
       type: 'puissance'
       puissance: number
+      puissanceAuMomentDuDepot?: number // added later, so not always present
     }
   | { type: 'actionnaire'; actionnaire: string }
   | { type: 'producteur'; producteur: string }

--- a/src/modules/modificationRequest/events/ModificationReceived.ts
+++ b/src/modules/modificationRequest/events/ModificationReceived.ts
@@ -1,24 +1,27 @@
 import { BaseDomainEvent, DomainEvent } from '@core/domain'
 import { Fournisseur } from '../../project/types/fournisseur'
 
-export interface ModificationReceivedPayload {
+export type ModificationReceivedPayload = {
   modificationRequestId: string
-  type: string
   projectId: string
   requestedBy: string
   authority: 'dgec' | 'dreal'
-  puissance?: number
-  actionnaire?: string
-  producteur?: string
-  fournisseurs?: Fournisseur[]
-  evaluationCarbone?: number
   justification?: string
   fileId?: string
-}
+} & (
+  | {
+      type: 'puissance'
+      puissance: number
+    }
+  | { type: 'actionnaire'; actionnaire: string }
+  | { type: 'producteur'; producteur: string }
+  | { type: 'fournisseur'; fournisseurs?: Fournisseur[]; evaluationCarbone?: number }
+)
 
 export class ModificationReceived
   extends BaseDomainEvent<ModificationReceivedPayload>
-  implements DomainEvent {
+  implements DomainEvent
+{
   public static type: 'ModificationReceived' = 'ModificationReceived'
   public type = ModificationReceived.type
   currentVersion = 1

--- a/src/modules/modificationRequest/events/ModificationRequested.ts
+++ b/src/modules/modificationRequest/events/ModificationRequested.ts
@@ -1,23 +1,28 @@
 import { BaseDomainEvent, DomainEvent } from '@core/domain'
 
-export interface ModificationRequestedPayload {
-  type: string
+export type ModificationRequestedPayload = {
   modificationRequestId: string
   projectId: string
   requestedBy: string
   authority: 'dgec' | 'dreal'
   fileId?: string
   justification?: string
-  actionnaire?: string
-  producteur?: string
-  fournisseur?: string
-  puissance?: number
-  evaluationCarbone?: number
-  delayInMonths?: number
-}
+} & (
+  | {
+      type: 'puissance'
+      puissance: number
+    }
+  | { type: 'actionnaire'; actionnaire: string }
+  | { type: 'producteur'; producteur: string }
+  | { type: 'fournisseur'; fournisseur: string; evaluationCarbone: number }
+  | { type: 'delai'; delayInMonths: number }
+  | { type: 'abandon' }
+  | { type: 'recours' }
+)
 export class ModificationRequested
   extends BaseDomainEvent<ModificationRequestedPayload>
-  implements DomainEvent {
+  implements DomainEvent
+{
   public static type: 'ModificationRequested' = 'ModificationRequested'
   public type = ModificationRequested.type
   currentVersion = 1

--- a/src/modules/modificationRequest/events/ModificationRequested.ts
+++ b/src/modules/modificationRequest/events/ModificationRequested.ts
@@ -11,6 +11,7 @@ export type ModificationRequestedPayload = {
   | {
       type: 'puissance'
       puissance: number
+      puissanceAuMomentDuDepot?: number // added later, so not always present
     }
   | { type: 'actionnaire'; actionnaire: string }
   | { type: 'producteur'; producteur: string }

--- a/src/modules/modificationRequest/useCases/requestFournisseursModification.spec.ts
+++ b/src/modules/modificationRequest/useCases/requestFournisseursModification.spec.ts
@@ -1,14 +1,14 @@
-import { Readable } from 'stream'
 import { DomainEvent, Repository } from '@core/domain'
 import { okAsync } from '@core/utils'
 import { makeUser } from '@entities'
+import { Readable } from 'stream'
 import { UnwrapForTest } from '../../../types'
 import { fakeTransactionalRepo, makeFakeProject } from '../../../__tests__/fixtures/aggregates'
 import makeFakeUser from '../../../__tests__/fixtures/user'
 import { FileObject } from '../../file'
 import { FournisseurKind, Project } from '../../project'
 import { InfraNotAvailableError, UnauthorizedError } from '../../shared'
-import { ModificationReceived, ModificationRequested } from '../events'
+import { ModificationReceived } from '../events'
 import { makeRequestFournisseursModification } from './requestFournisseursModification'
 
 describe('requestFournisseurModification use-case', () => {

--- a/src/modules/modificationRequest/useCases/requestProducteurModification.spec.ts
+++ b/src/modules/modificationRequest/useCases/requestProducteurModification.spec.ts
@@ -1,14 +1,14 @@
-import { Readable } from 'stream'
 import { DomainEvent, Repository } from '@core/domain'
 import { okAsync } from '@core/utils'
 import { makeUser } from '@entities'
+import { Readable } from 'stream'
 import { UnwrapForTest } from '../../../types'
 import { fakeTransactionalRepo, makeFakeProject } from '../../../__tests__/fixtures/aggregates'
 import makeFakeUser from '../../../__tests__/fixtures/user'
 import { FileObject } from '../../file'
 import { Project } from '../../project'
 import { InfraNotAvailableError, UnauthorizedError } from '../../shared'
-import { ModificationReceived, ModificationRequested } from '../events'
+import { ModificationReceived } from '../events'
 import { makeRequestProducteurModification } from './requestProducteurModification'
 
 describe('requestProducteurModification use-case', () => {

--- a/src/modules/modificationRequest/useCases/requestPuissanceModification.spec.ts
+++ b/src/modules/modificationRequest/useCases/requestPuissanceModification.spec.ts
@@ -26,12 +26,14 @@ describe('requestPuissanceModification use-case', () => {
     load: jest.fn(),
   }
   const file = { contents: Readable.from('test-content'), filename: 'myfilename.pdf' }
+  const getPuissanceProjet = jest.fn((projectId: string) => okAsync(123))
 
   describe('when user is not allowed', () => {
     const shouldUserAccessProject = jest.fn(async () => false)
     const requestPuissanceModification = makeRequestPuissanceModification({
       projectRepo,
       eventBus,
+      getPuissanceProjet,
       shouldUserAccessProject,
       exceedsRatiosChangementPuissance: () => false,
       exceedsPuissanceMaxDuVolumeReserve: () => false,
@@ -61,6 +63,7 @@ describe('requestPuissanceModification use-case', () => {
       const requestPuissanceModification = makeRequestPuissanceModification({
         projectRepo,
         eventBus,
+        getPuissanceProjet,
         shouldUserAccessProject,
         exceedsRatiosChangementPuissance: () => true,
         exceedsPuissanceMaxDuVolumeReserve: () => false,
@@ -113,9 +116,10 @@ describe('requestPuissanceModification use-case', () => {
           const event = eventBus.publish.mock.calls[0][0]
           expect(event).toBeInstanceOf(ModificationRequested)
 
-          const { type, puissance } = event.payload
+          const { type, puissance, puissanceAuMomentDuDepot } = event.payload
           expect(type).toEqual('puissance')
           expect(puissance).toEqual(newPuissance)
+          expect(puissanceAuMomentDuDepot).toEqual(123)
         })
 
         it('should not change the project', () => {
@@ -134,6 +138,7 @@ describe('requestPuissanceModification use-case', () => {
       const requestPuissanceModification = makeRequestPuissanceModification({
         projectRepo,
         eventBus,
+        getPuissanceProjet,
         shouldUserAccessProject,
         exceedsRatiosChangementPuissance: () => false,
         exceedsPuissanceMaxDuVolumeReserve: () => false,
@@ -165,9 +170,10 @@ describe('requestPuissanceModification use-case', () => {
         const event = eventBus.publish.mock.calls[0][0]
         expect(event).toBeInstanceOf(ModificationReceived)
 
-        const { type, puissance } = event.payload
+        const { type, puissance, puissanceAuMomentDuDepot } = event.payload
         expect(type).toEqual('puissance')
         expect(puissance).toEqual(newPuissance)
+        expect(puissanceAuMomentDuDepot).toEqual(123)
       })
 
       it('should update the puissance', () => {

--- a/src/modules/modificationRequest/useCases/requestPuissanceModification.ts
+++ b/src/modules/modificationRequest/useCases/requestPuissanceModification.ts
@@ -142,21 +142,34 @@ export const makeRequestPuissanceModification =
         }): ResultAsync<null, AggregateHasBeenUpdatedSinceError | InfraNotAvailableError> => {
           const { newPuissanceIsAutoAccepted, fileId } = args
 
-          const payload = {
-            modificationRequestId: new UniqueEntityID().toString(),
-            projectId: projectId.toString(),
-            requestedBy: requestedBy.id,
-            type: 'puissance',
-            puissance: newPuissance,
-            justification,
-            fileId,
-            authority: 'dreal' as 'dreal',
-          }
+          const modificationRequestId = new UniqueEntityID().toString()
 
           return eventBus.publish(
             newPuissanceIsAutoAccepted
-              ? new ModificationReceived({ payload })
-              : new ModificationRequested({ payload })
+              ? new ModificationReceived({
+                  payload: {
+                    modificationRequestId,
+                    projectId: projectId.toString(),
+                    requestedBy: requestedBy.id,
+                    type: 'puissance',
+                    puissance: newPuissance,
+                    justification,
+                    fileId,
+                    authority: 'dreal',
+                  },
+                })
+              : new ModificationRequested({
+                  payload: {
+                    modificationRequestId,
+                    projectId: projectId.toString(),
+                    requestedBy: requestedBy.id,
+                    type: 'puissance',
+                    puissance: newPuissance,
+                    justification,
+                    fileId,
+                    authority: 'dreal',
+                  },
+                })
           )
         }
       )

--- a/src/modules/modificationRequest/useCases/requestPuissanceModification.ts
+++ b/src/modules/modificationRequest/useCases/requestPuissanceModification.ts
@@ -4,7 +4,7 @@ import {
   PuissanceJustificationOrCourrierMissingError,
 } from '..'
 import { EventBus, Repository, TransactionalRepository, UniqueEntityID } from '@core/domain'
-import { errAsync, logger, okAsync, ResultAsync, wrapInfra } from '@core/utils'
+import { errAsync, logger, okAsync, ok, ResultAsync, wrapInfra } from '@core/utils'
 import { User } from '@entities'
 import { FileContents, FileObject, makeAndSaveFile } from '../../file'
 import { ProjectCannotBeUpdatedIfUnnotifiedError } from '../../project'
@@ -21,6 +21,9 @@ interface RequestPuissanceModificationDeps {
   eventBus: EventBus
   exceedsRatiosChangementPuissance: ExceedsRatiosChangementPuissance
   exceedsPuissanceMaxDuVolumeReserve: ExceedsPuissanceMaxDuVolumeReserve
+  getPuissanceProjet: (
+    projectId: string
+  ) => ResultAsync<number, EntityNotFoundError | InfraNotAvailableError>
   shouldUserAccessProject: (args: { user: User; projectId: string }) => Promise<boolean>
   projectRepo: TransactionalRepository<Project>
   fileRepo: Repository<FileObject>
@@ -144,33 +147,42 @@ export const makeRequestPuissanceModification =
 
           const modificationRequestId = new UniqueEntityID().toString()
 
-          return eventBus.publish(
-            newPuissanceIsAutoAccepted
-              ? new ModificationReceived({
-                  payload: {
-                    modificationRequestId,
-                    projectId: projectId.toString(),
-                    requestedBy: requestedBy.id,
-                    type: 'puissance',
-                    puissance: newPuissance,
-                    justification,
-                    fileId,
-                    authority: 'dreal',
-                  },
-                })
-              : new ModificationRequested({
-                  payload: {
-                    modificationRequestId,
-                    projectId: projectId.toString(),
-                    requestedBy: requestedBy.id,
-                    type: 'puissance',
-                    puissance: newPuissance,
-                    justification,
-                    fileId,
-                    authority: 'dreal',
-                  },
-                })
-          )
+          return deps
+            .getPuissanceProjet(projectId.toString())
+            .orElse(() => ok(-1))
+            .andThen((puissanceActuelle) => {
+              const puissanceAuMomentDuDepot =
+                puissanceActuelle !== -1 ? puissanceActuelle : undefined
+              return eventBus.publish(
+                newPuissanceIsAutoAccepted
+                  ? new ModificationReceived({
+                      payload: {
+                        modificationRequestId,
+                        projectId: projectId.toString(),
+                        requestedBy: requestedBy.id,
+                        type: 'puissance',
+                        puissance: newPuissance,
+                        puissanceAuMomentDuDepot,
+                        justification,
+                        fileId,
+                        authority: 'dreal',
+                      },
+                    })
+                  : new ModificationRequested({
+                      payload: {
+                        modificationRequestId,
+                        projectId: projectId.toString(),
+                        requestedBy: requestedBy.id,
+                        type: 'puissance',
+                        puissance: newPuissance,
+                        puissanceAuMomentDuDepot,
+                        justification,
+                        fileId,
+                        authority: 'dreal',
+                      },
+                    })
+              )
+            })
         }
       )
   }

--- a/src/modules/notification/eventHandlers/handleModificationReceived.ts
+++ b/src/modules/notification/eventHandlers/handleModificationReceived.ts
@@ -4,94 +4,96 @@ import { ProjectRepo, UserRepo } from '@dataAccess'
 import routes from '../../../routes'
 import { ModificationReceived } from '../../modificationRequest'
 
-export const handleModificationReceived = (deps: {
-  sendNotification: NotificationService['sendNotification']
-  findUsersForDreal: UserRepo['findUsersForDreal']
-  findProjectById: ProjectRepo['findById']
-  findUserById: UserRepo['findById']
-}) => async (event: ModificationReceived) => {
-  const { modificationRequestId, projectId, type, requestedBy, evaluationCarbone } = event.payload
+export const handleModificationReceived =
+  (deps: {
+    sendNotification: NotificationService['sendNotification']
+    findUsersForDreal: UserRepo['findUsersForDreal']
+    findProjectById: ProjectRepo['findById']
+    findUserById: UserRepo['findById']
+  }) =>
+  async (event: ModificationReceived) => {
+    const { modificationRequestId, projectId, type, requestedBy } = event.payload
 
-  const project = await deps.findProjectById(projectId)
+    const project = await deps.findProjectById(projectId)
 
-  if (!project) {
-    logger.error(new Error('handleModificationReceived failed because project is not found'))
-    return
-  }
+    if (!project) {
+      logger.error(new Error('handleModificationReceived failed because project is not found'))
+      return
+    }
 
-  // Send user email
-  ;(await deps.findUserById(requestedBy)).match({
-    some: async ({ email, fullName }) => {
-      const payload: any = {
-        type: 'pp-modification-received',
-        message: {
-          email: email,
-          name: fullName,
-          subject: `Potentiel - Nouvelle information de type ${type} enregistrée pour votre projet ${project.nomProjet}`,
-        },
-        context: {
-          modificationRequestId,
-          projectId: project.id,
-          userId: requestedBy,
-        },
-        variables: {
-          nom_projet: project.nomProjet,
-          type_demande: type,
-          modification_request_url: routes.USER_LIST_REQUESTS,
-        },
-      }
+    // Send user email
+    ;(await deps.findUserById(requestedBy)).match({
+      some: async ({ email, fullName }) => {
+        const payload: any = {
+          type: 'pp-modification-received',
+          message: {
+            email: email,
+            name: fullName,
+            subject: `Potentiel - Nouvelle information de type ${type} enregistrée pour votre projet ${project.nomProjet}`,
+          },
+          context: {
+            modificationRequestId,
+            projectId: project.id,
+            userId: requestedBy,
+          },
+          variables: {
+            nom_projet: project.nomProjet,
+            type_demande: type,
+            modification_request_url: routes.USER_LIST_REQUESTS,
+          },
+        }
 
-      if (type === 'producteur')
-        payload.variables.demande_action_pp = `Suite à votre signalement de changement de ${type}, vous devez déposer de nouvelles garanties financières dans un délai d'un mois maximum.`
+        if (type === 'producteur')
+          payload.variables.demande_action_pp = `Suite à votre signalement de changement de ${type}, vous devez déposer de nouvelles garanties financières dans un délai d'un mois maximum.`
 
-      if (type === 'fournisseur' && evaluationCarbone) {
-        const currentEvaluationCarbone = project.evaluationCarbone
-        const newEvaluationCarbone = Number(evaluationCarbone)
-        const switchBracket =
-          Math.round(newEvaluationCarbone / 50) !== Math.round(currentEvaluationCarbone / 50)
+        if (type === 'fournisseur' && payload.evaluationCarbone) {
+          const currentEvaluationCarbone = project.evaluationCarbone
+          const newEvaluationCarbone = Number(payload.evaluationCarbone)
+          const switchBracket =
+            Math.round(newEvaluationCarbone / 50) !== Math.round(currentEvaluationCarbone / 50)
 
-        const evaluationCarboneIsOutOfBounds =
-          newEvaluationCarbone > currentEvaluationCarbone && switchBracket
+          const evaluationCarboneIsOutOfBounds =
+            newEvaluationCarbone > currentEvaluationCarbone && switchBracket
 
-        if (evaluationCarboneIsOutOfBounds)
-          payload.variables.demande_action_pp = `Vous venez de signaler une augmentation de l'évaluation carbone de votre projet. Cette nouvelle valeur entraîne une dégradation de la note du projet. Celui-ci ne recevra pas d'attestation de conformité.`
-      }
+          if (evaluationCarboneIsOutOfBounds)
+            payload.variables.demande_action_pp = `Vous venez de signaler une augmentation de l'évaluation carbone de votre projet. Cette nouvelle valeur entraîne une dégradation de la note du projet. Celui-ci ne recevra pas d'attestation de conformité.`
+        }
 
-      await deps.sendNotification(payload)
-    },
-    none: () => {},
-  })
-
-  // Send dreal email for each dreal of each region
-  const regions = project.regionProjet.split(' / ')
-  await Promise.all(
-    regions.map(async (region) => {
-      const drealUsers = await deps.findUsersForDreal(region)
-
-      await Promise.all(
-        drealUsers.map((drealUser) =>
-          deps.sendNotification({
-            type: 'dreal-modification-received',
-            message: {
-              email: drealUser.email,
-              name: drealUser.fullName,
-              subject: `Potentiel - Nouvelle information de type ${type} enregistrée dans votre département ${project.departementProjet}`,
-            },
-            context: {
-              modificationRequestId,
-              projectId: project.id,
-              dreal: region,
-              userId: drealUser.id,
-            },
-            variables: {
-              nom_projet: project.nomProjet,
-              departement_projet: project.departementProjet,
-              type_demande: type,
-              modification_request_url: routes.DEMANDE_PAGE_DETAILS(modificationRequestId),
-            },
-          })
-        )
-      )
+        await deps.sendNotification(payload)
+      },
+      none: () => {},
     })
-  )
-}
+
+    // Send dreal email for each dreal of each region
+    const regions = project.regionProjet.split(' / ')
+    await Promise.all(
+      regions.map(async (region) => {
+        const drealUsers = await deps.findUsersForDreal(region)
+
+        await Promise.all(
+          drealUsers.map((drealUser) =>
+            deps.sendNotification({
+              type: 'dreal-modification-received',
+              message: {
+                email: drealUser.email,
+                name: drealUser.fullName,
+                subject: `Potentiel - Nouvelle information de type ${type} enregistrée dans votre département ${project.departementProjet}`,
+              },
+              context: {
+                modificationRequestId,
+                projectId: project.id,
+                dreal: region,
+                userId: drealUser.id,
+              },
+              variables: {
+                nom_projet: project.nomProjet,
+                departement_projet: project.departementProjet,
+                type_demande: type,
+                modification_request_url: routes.DEMANDE_PAGE_DETAILS(modificationRequestId),
+              },
+            })
+          )
+        )
+      })
+    )
+  }

--- a/src/views/pages/modificationRequestPage/components/DemandeDetails.tsx
+++ b/src/views/pages/modificationRequestPage/components/DemandeDetails.tsx
@@ -1,19 +1,18 @@
-import React from 'react'
-import moment from 'moment'
-
-import { formatDate } from '../../../../helpers/formatDate'
 import { ModificationRequestPageDTO } from '@modules/modificationRequest'
-import { DownloadIcon } from '../../../components'
-import ROUTES from '../../../../routes'
+import moment from 'moment'
+import React from 'react'
+import { formatDate } from '../../../../helpers/formatDate'
 import { dataId } from '../../../../helpers/testId'
+import ROUTES from '../../../../routes'
+import { DownloadIcon } from '../../../components'
 
 interface DemandeDetailsProps {
   modificationRequest: ModificationRequestPageDTO
 }
 
 export const DemandeDetails = ({ modificationRequest }: DemandeDetailsProps) => {
-  const { requestedBy, requestedOn, justification, project, attachmentFile, status } =
-    modificationRequest
+  const { requestedBy, requestedOn, justification, attachmentFile } = modificationRequest
+
   return (
     <div className="panel__header">
       <div>
@@ -26,77 +25,7 @@ export const DemandeDetails = ({ modificationRequest }: DemandeDetailsProps) => 
           {'"'}
         </div>
       )}
-      {modificationRequest.type === 'delai' ? (
-        status === 'envoyée' || status === 'en instruction' ? (
-          <div style={{ marginTop: 5 }}>
-            La date de mise en service théorique est au <b>{formatDate(project.completionDueOn)}</b>
-            .
-            <br />
-            Le porteur demande un délai de <b>{modificationRequest.delayInMonths} mois</b>, ce qui
-            reporterait la mise en service au{' '}
-            <b>
-              {formatDate(
-                +moment(project.completionDueOn).add(modificationRequest.delayInMonths, 'month')
-              )}
-            </b>
-            .
-          </div>
-        ) : (
-          <div style={{ marginTop: 5 }}>
-            Le porteur a demandé un délai de <b>{modificationRequest.delayInMonths} mois</b>.{' '}
-          </div>
-        )
-      ) : null}
-      {modificationRequest.type === 'puissance' && (
-        <div className="flex flex-col" style={{ marginTop: 5 }}>
-          <span>
-            Puissance à la notification : {modificationRequest.project.puissanceInitiale}{' '}
-            {modificationRequest.project.unitePuissance}
-          </span>
-          <span>
-            Puissance actuelle : {modificationRequest.project.puissance}{' '}
-            {modificationRequest.project.unitePuissance}
-          </span>
-          <span>
-            Nouvelle puissance demandée : {modificationRequest.puissance}{' '}
-            {modificationRequest.project.unitePuissance}
-          </span>
-        </div>
-      )}
-      {modificationRequest.type === 'actionnaire' && (
-        <div style={{ marginTop: 5 }}>
-          <span>Nouvel actionnaire : {modificationRequest.actionnaire}</span>
-        </div>
-      )}
-      {modificationRequest.type === 'producteur' && (
-        <div style={{ marginTop: 5 }}>
-          <span>Nouveau producteur : {modificationRequest.producteur}</span>
-        </div>
-      )}
-      {modificationRequest.type === 'fournisseur' && (
-        <div style={{ marginTop: 5 }}>
-          {modificationRequest.fournisseurs?.length > 0 && (
-            <>
-              <span>Nouveau(x) fournisseur(s) : </span>
-              <ul>
-                {modificationRequest.fournisseurs?.map((fournisseur, index) => (
-                  <li key={index}>
-                    {fournisseur.kind} : {fournisseur.name}
-                  </li>
-                ))}
-              </ul>
-            </>
-          )}
-          {modificationRequest.evaluationCarbone && (
-            <>
-              <br />
-              <span>
-                Nouvelle évaluation carbone : {modificationRequest.evaluationCarbone} kg eq CO2/kWc
-              </span>
-            </>
-          )}
-        </div>
-      )}
+      <DetailsByType modificationRequest={modificationRequest} />
       {attachmentFile && (
         <div style={{ marginTop: 10 }}>
           <DownloadIcon />
@@ -108,6 +37,133 @@ export const DemandeDetails = ({ modificationRequest }: DemandeDetailsProps) => 
             Télécharger la pièce-jointe
           </a>
         </div>
+      )}
+    </div>
+  )
+}
+
+interface DetailsByTypeProps {
+  modificationRequest: ModificationRequestPageDTO
+}
+const DetailsByType = ({ modificationRequest }: DetailsByTypeProps) => {
+  switch (modificationRequest.type) {
+    case 'delai':
+      return <DelaiDetails modificationRequest={modificationRequest} />
+    case 'puissance':
+      return <PuissanceDetails modificationRequest={modificationRequest} />
+    case 'actionnaire':
+      return <ActionnaireDetails modificationRequest={modificationRequest} />
+    case 'producteur':
+      return <ProducteurDetails modificationRequest={modificationRequest} />
+    case 'fournisseur':
+      return <FournisseurDetails modificationRequest={modificationRequest} />
+    default:
+      return null
+  }
+}
+
+interface DelaiDetailsProps {
+  modificationRequest: ModificationRequestPageDTO & { type: 'delai' }
+}
+const DelaiDetails = ({ modificationRequest }: DelaiDetailsProps) => {
+  const { project, status } = modificationRequest
+
+  return status === 'envoyée' || status === 'en instruction' ? (
+    <div style={{ marginTop: 5 }}>
+      La date de mise en service théorique est au <b>{formatDate(project.completionDueOn)}</b>
+      .
+      <br />
+      Le porteur demande un délai de <b>{modificationRequest.delayInMonths} mois</b>, ce qui
+      reporterait la mise en service au{' '}
+      <b>
+        {formatDate(
+          +moment(project.completionDueOn).add(modificationRequest.delayInMonths, 'month')
+        )}
+      </b>
+      .
+    </div>
+  ) : (
+    <div style={{ marginTop: 5 }}>
+      Le porteur a demandé un délai de <b>{modificationRequest.delayInMonths} mois</b>.{' '}
+    </div>
+  )
+}
+
+interface PuissanceDetailsProps {
+  modificationRequest: ModificationRequestPageDTO & { type: 'puissance' }
+}
+const PuissanceDetails = ({ modificationRequest }: PuissanceDetailsProps) => {
+  return (
+    <div style={{ marginTop: 5 }}>
+      <span>
+        Puissance à la notification : {modificationRequest.project.puissanceInitiale}{' '}
+        {modificationRequest.project.unitePuissance}
+      </span>
+
+      <br />
+
+      <span>
+        Puissance actuelle : {modificationRequest.project.puissance}{' '}
+        {modificationRequest.project.unitePuissance}
+      </span>
+
+      <br />
+
+      <span>
+        Nouvelle puissance demandée : {modificationRequest.puissance}{' '}
+        {modificationRequest.project.unitePuissance}
+      </span>
+    </div>
+  )
+}
+
+interface ActionnaireDetailsProps {
+  modificationRequest: ModificationRequestPageDTO & { type: 'actionnaire' }
+}
+const ActionnaireDetails = ({ modificationRequest }: ActionnaireDetailsProps) => {
+  return (
+    <div style={{ marginTop: 5 }}>
+      <span>Nouvel actionnaire : {modificationRequest.actionnaire}</span>
+    </div>
+  )
+}
+
+interface ProducteurDetailsProps {
+  modificationRequest: ModificationRequestPageDTO & { type: 'producteur' }
+}
+const ProducteurDetails = ({ modificationRequest }: ProducteurDetailsProps) => {
+  return (
+    <div style={{ marginTop: 5 }}>
+      <span>Nouveau producteur : {modificationRequest.producteur}</span>
+    </div>
+  )
+}
+
+interface FournisseurDetailsProps {
+  modificationRequest: ModificationRequestPageDTO & { type: 'fournisseur' }
+}
+const FournisseurDetails = ({ modificationRequest }: FournisseurDetailsProps) => {
+  return (
+    <div style={{ marginTop: 5 }}>
+      {modificationRequest.fournisseurs?.length > 0 && (
+        <>
+          <span>Nouveau(x) fournisseur(s) : </span>
+          <ul>
+            {modificationRequest.fournisseurs?.map((fournisseur, index) => (
+              <li key={index}>
+                {fournisseur.kind} : {fournisseur.name}
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
+      {modificationRequest.evaluationCarbone && (
+        <>
+          <br />
+          <span>
+            Nouvelle évaluation carbone : {modificationRequest.evaluationCarbone} kg eq CO2/kWc
+          </span>
+        </>
       )}
     </div>
   )

--- a/src/views/pages/modificationRequestPage/components/DemandeDetails.tsx
+++ b/src/views/pages/modificationRequestPage/components/DemandeDetails.tsx
@@ -93,26 +93,37 @@ interface PuissanceDetailsProps {
   modificationRequest: ModificationRequestPageDTO & { type: 'puissance' }
 }
 const PuissanceDetails = ({ modificationRequest }: PuissanceDetailsProps) => {
+  const { project, status, puissanceAuMomentDuDepot } = modificationRequest
+  const { puissance, puissanceInitiale, unitePuissance } = project
+
+  const hasPuissanceChangedSinceDepot =
+    puissance !== (puissanceAuMomentDuDepot || puissanceInitiale)
+
   return (
     <div style={{ marginTop: 5 }}>
-      <span>
-        Puissance à la notification : {modificationRequest.project.puissanceInitiale}{' '}
-        {modificationRequest.project.unitePuissance}
-      </span>
+      <div>
+        Puissance à la notification : {puissanceInitiale} {unitePuissance}
+      </div>
 
-      <br />
+      {puissanceAuMomentDuDepot && puissanceInitiale !== puissanceAuMomentDuDepot && (
+        <div>
+          Puissance au moment du dépôt : {puissanceAuMomentDuDepot} {unitePuissance}
+        </div>
+      )}
 
-      <span>
-        Puissance actuelle : {modificationRequest.project.puissance}{' '}
-        {modificationRequest.project.unitePuissance}
-      </span>
+      {(status === 'en instruction' || status === 'envoyée') && (
+        <>
+          {hasPuissanceChangedSinceDepot && (
+            <div>
+              Puissance actuelle : {project.puissance} {unitePuissance}
+            </div>
+          )}
+        </>
+      )}
 
-      <br />
-
-      <span>
-        Nouvelle puissance demandée : {modificationRequest.puissance}{' '}
-        {modificationRequest.project.unitePuissance}
-      </span>
+      <div>
+        Nouvelle puissance demandée : {modificationRequest.puissance} {unitePuissance}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
Parfois la puissance a changé entre le moment où le PP a déposé sa demande et le moment où on ouvre cette demande.

Cette PR permet d'afficher la puissance au moment où la demande a été déposée.

Pour cela, j'ai du rajouter cette valeur dans le payload des événements `ModificationRequested` et `ModificationReceived` (non rétroactif) et aussi, une colonne `puissanceAuMomentDuDepot` sur la projection `modificationRequest`.


<a href="https://gitpod.io/#https://github.com/MTES-MCT/potentiel/pull/362"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

