### PR TITLE
:recycle: Use direct import on @entities/periode to use isNotifiedPeriode

### DIFF
--- a/.github/workflows/ci.build.yml
+++ b/.github/workflows/ci.build.yml
@@ -19,8 +19,10 @@ on:
       - 'LICENSE'
 
 jobs:
-  test:
+  build:
     runs-on: ubuntu-latest
+    env:
+      NODE_ENV: production
 
     steps:
       - uses: actions/checkout@v2
@@ -29,8 +31,5 @@ jobs:
         with:
           node-version: 16.x
           cache: 'npm'
+      - name: 'Install dependencies, build front, css, and back for production'
       - run: npm ci
-      - name: 'Build the front, css, and back'
-        run: npm run build
-        env:
-          NODE_ENV: production

--- a/.github/workflows/ci.build.yml
+++ b/.github/workflows/ci.build.yml
@@ -31,5 +31,6 @@ jobs:
         with:
           node-version: 16.x
           cache: 'npm'
-      - name: 'Install dependencies, build front, css, and back for production'
       - run: npm ci
+        env:
+          DO_NOT_EXECUTE_MIGRATE: '1'

--- a/.github/workflows/ci.integration-tests.yml
+++ b/.github/workflows/ci.integration-tests.yml
@@ -18,7 +18,7 @@ on:
       - 'LICENSE'
 
 jobs:
-  test:
+  test-int:
     runs-on: ubuntu-latest
     env:
       NODE_ENV: test

--- a/jest.unit.config.js
+++ b/jest.unit.config.js
@@ -17,6 +17,7 @@ module.exports = {
     '^@modules/(.*)$': '<rootDir>/src/modules/$1/index.ts',
     '^@core/(.*)$': '<rootDir>/src/core/$1/index.ts',
     '^@entities$': '<rootDir>/src/entities/index.ts',
+    '^@entities/(.*)$': '<rootDir>/src/entities/$1.ts',
     '^@infra/(.*)$': '<rootDir>/src/infra/$1/index.ts',
     '^@useCases$': '<rootDir>/src/useCases/index.ts',
     '^@views$': '<rootDir>/src/views/index.ts',

--- a/scripts/postInstall.ts
+++ b/scripts/postInstall.ts
@@ -6,11 +6,14 @@ import { spawnSync } from 'child_process'
 process.env.NODE_ENV ?? dotenv.config()
 
 const NODE_ENV = process.env.NODE_ENV || ''
+const executeMigrateScript = process.env.DO_NOT_EXECUTE_MIGRATE ? false : true 
 
 if (!['', 'local', 'test'].includes(NODE_ENV)) {
   const build = spawnSync('npm', ['run', 'build'], { stdio: 'inherit' })
   build.status && build.status > 0 && process.exit(build.status)
 
-  const migrate = spawnSync('npm', ['run', 'migrate'], { stdio: 'inherit' })
-  process.exit(migrate.status ?? 0)
+  if (executeMigrateScript) {
+    const migrate = spawnSync('npm', ['run', 'migrate'], { stdio: 'inherit' })
+    process.exit(migrate.status ?? 0)
+  }
 }

--- a/src/modules/modificationRequest/helpers/isModificationPuissanceAuto.ts
+++ b/src/modules/modificationRequest/helpers/isModificationPuissanceAuto.ts
@@ -1,4 +1,4 @@
-import { isNotifiedPeriode, ProjectAppelOffre, Technologie } from '@entities'
+import { ProjectAppelOffre, Technologie } from '@entities'
 
 export const defaultAutoAcceptRatios = { min: 0.9, max: 1.1 }
 

--- a/src/modules/project/Project.ts
+++ b/src/modules/project/Project.ts
@@ -12,13 +12,12 @@ import {
   Result,
 } from '@core/utils'
 import {
-  AppelOffre,
   CertificateTemplate,
-  isNotifiedPeriode,
   ProjectAppelOffre,
   Technologie,
   User,
 } from '@entities'
+import { isNotifiedPeriode } from '@entities/periode'
 import {
   EntityNotFoundError,
   HeterogeneousHistoryError,

--- a/src/views/certificates/helpers/getNoteThreshold.ts
+++ b/src/views/certificates/helpers/getNoteThreshold.ts
@@ -1,5 +1,6 @@
 import { logger } from '@core/utils'
-import { isNotifiedPeriode, ProjectAppelOffre } from '@entities'
+import { ProjectAppelOffre } from '@entities'
+import { isNotifiedPeriode } from '@entities/periode'
 
 type GetNoteThreshold = (project: {
   appelOffre: ProjectAppelOffre

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,6 +28,9 @@
       "@entities": [
         "src/entities/index.ts"
       ],
+      "@entities/*": [
+        "src/entities/*.ts"
+      ],
       "@infra/*": [
         "src/infra/*/index.ts"
       ],


### PR DESCRIPTION
Pour les parties utilisée côté front il faut faire des imports direct sur `@entities/periode` pour utiliser `isNotifiedPeriode`. Sinon tous le module `@entities` sera chargé inutilement par webpack
Le job de build a été modifié pour construire l'application en environnement de production et afin d'avoir une erreur si le build du front, par exemple, échoue

Certaines fonctions ou objets ne devraient pas être utilisés dans les composants visuels. Des données devraient être récupérées depuis les controleurs et passée en props aux pages. À prévoir dans une prochaine PR ou pendant la refonte UX

<a href="https://gitpod.io/#https://github.com/MTES-MCT/potentiel/pull/364"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

