### PR TITLE
:bug: La page projet ne s'affiche plus après la validation d'un changement de puissance

### DIFF
--- a/src/views/components/timeline/helpers/extractModificationRequestsItemProps.spec.ts
+++ b/src/views/components/timeline/helpers/extractModificationRequestsItemProps.spec.ts
@@ -23,6 +23,50 @@ describe('extractModificationRequestItemProps', () => {
       expect(result).toHaveLength(0)
     })
   })
+  describe('when there are some ModificationRequestXxxed events without a ModificationRequested', () => {
+    it('should return an empty array', () => {
+      const projectEventList: ProjectEventDTO[] = [
+        {
+          type: 'ModificationRequestRejected',
+          date: new Date('2022-02-10').getTime(),
+          variant: 'porteur-projet',
+          modificationRequestId: new UniqueEntityID().toString(),
+        },
+        {
+          type: 'ModificationRequestAccepted',
+          date: new Date('2022-02-09').getTime(),
+          variant: 'porteur-projet',
+          modificationRequestId: new UniqueEntityID().toString(),
+        },
+        {
+          type: 'ModificationRequestCancelled',
+          date: new Date('2022-02-09').getTime(),
+          variant: 'porteur-projet',
+          modificationRequestId: new UniqueEntityID().toString(),
+        },
+        {
+          type: 'ModificationRequestConfirmed',
+          date: new Date('2022-02-09').getTime(),
+          variant: 'porteur-projet',
+          modificationRequestId: new UniqueEntityID().toString(),
+        },
+        {
+          type: 'ModificationRequestInstructionStarted',
+          date: new Date('2022-02-09').getTime(),
+          variant: 'porteur-projet',
+          modificationRequestId: new UniqueEntityID().toString(),
+        },
+        {
+          type: 'ModificationRequestRejected',
+          date: new Date('2022-02-09').getTime(),
+          variant: 'porteur-projet',
+          modificationRequestId: new UniqueEntityID().toString(),
+        },
+      ]
+      const result = extractModificationRequestsItemProps(projectEventList)
+      expect(result).toHaveLength(0)
+    })
+  })
   describe('when there are several ModificationRequested events with different modificationRequestId', () => {
     it('should return an array with props for each modification request id', () => {
       const firstModificationRequestId = new UniqueEntityID().toString()

--- a/src/views/components/timeline/helpers/extractModificationRequestsItemProps.ts
+++ b/src/views/components/timeline/helpers/extractModificationRequestsItemProps.ts
@@ -35,8 +35,9 @@ export const extractModificationRequestsItemProps = (
   const modificationRequestGroups =
     getEventsGroupedByModificationRequestId(modificationRequestEvents)
 
-  const propsArray: ModificationRequestItemProps[] = Object.entries(modificationRequestGroups).map(
-    ([, events]) => {
+  const propsArray: ModificationRequestItemProps[] = Object.entries(modificationRequestGroups)
+    .filter(([, events]) => events.find(is('ModificationRequested')))
+    .map(([, events]) => {
       const latestEvent = getLatestEvent(events)
       const requestEvent = getRequestEvent(events)
 
@@ -65,8 +66,7 @@ export const extractModificationRequestsItemProps = (
             role,
             url,
           }
-    }
-  )
+    })
   return propsArray
 }
 


### PR DESCRIPTION
Dans le cas où une demande de modification autre que délai, abandon ou recours est instruite alors on a une erreur lors de l'extraction des props car dans ces cas nous n'avons pas l'évennement `ModificationRequested`.
Cette erreur empêche pour les projets concerné l'affichage de la page projet.

Ici je filtre donc les groupes dans lesquels ne figure pas d'évennements de type `ModificationRequested` pour l'extract.

<a href="https://gitpod.io/#https://github.com/MTES-MCT/potentiel/pull/367"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

