### PR TITLE
Bug: Admin reçoit "access denied" après avoir invité à des projets

### DIFF
--- a/src/controllers/project/getProjectListPage.ts
+++ b/src/controllers/project/getProjectListPage.ts
@@ -79,6 +79,6 @@ v1Router.get(routes.ADMIN_DASHBOARD, ensureRole(['admin', 'dgec', 'dreal']), get
 
 v1Router.get(
   routes.USER_DASHBOARD,
-  ensureRole(['porteur-projet', 'acheteur-obligé', 'ademe']),
+  ensureRole(['admin', 'dgec', 'dreal', 'porteur-projet', 'acheteur-obligé', 'ademe']),
   getProjectListPage
 )

--- a/src/controllers/project/postInviteUserToProject.ts
+++ b/src/controllers/project/postInviteUserToProject.ts
@@ -28,7 +28,9 @@ v1Router.post(
     }
 
     const redirectTo = Array.isArray(projectId)
-      ? routes.USER_LIST_PROJECTS
+      ? user.role === 'porteur-projet'
+        ? routes.USER_LIST_PROJECTS
+        : routes.ADMIN_LIST_PROJECTS
       : routes.PROJECT_DETAILS(projectId)
     ;(
       await inviteUserToProject({


### PR DESCRIPTION
Quand on est admin, après avoir invité quelqu'un via la page listing de project, on est redirigés vers la route qui correspond à la page listing de projets des porteurs de projets. Celle-ci ayant un `ensureRole` qui ne contient pas le role admin, cela fait une erreur "access denied".

Cette PR corrige ce comportement de deux manières:
- Rediriger vers la route admin après l'invitation
- Autoriser les admins à accéder au listing de projets via la route des porteurs de projet
  - ça peut servir si on PP nous copie son URL pour qu'on teste 
  - c'est branché sur le même contrôler donc aucun risque


<a href="https://gitpod.io/#https://github.com/MTES-MCT/potentiel/pull/391"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

