### PR TITLE
1006 as eolien pp i cannot change project producteur

### DIFF
--- a/src/controllers/modificationRequest/postRequestModification.ts
+++ b/src/controllers/modificationRequest/postRequestModification.ts
@@ -212,6 +212,12 @@ v1Router.post(
       if (res.isErr()) return handleError(res.error)
     }
 
+    if (data.type === 'producteur' && project?.appelOffre?.type === 'eolien') {
+      const customTitle = 'Action non autorisée'
+      const customMessage = 'Vous ne pouvez pas changer le producteur pour ce projet'
+      return unauthorizedResponse({ request, response, customTitle, customMessage })
+    }
+
     switch (data.type) {
       case 'puissance':
         await requestPuissanceModification({

--- a/src/views/components/actions/porteurProjet.spec.ts
+++ b/src/views/components/actions/porteurProjet.spec.ts
@@ -1,98 +1,139 @@
-import { porteurProjetActions } from "."
-import makeFakeProject from "../../../__tests__/fixtures/project"
-import ROUTES from "../../../routes"
-
+import { porteurProjetActions } from '.'
+import makeFakeProject from '../../../__tests__/fixtures/project'
+import ROUTES from '../../../routes'
 
 describe('porteurProjetActions', () => {
-    describe('when project is abandoned', () => {
-        it('should return an empty action array', () => {
-            const fakeProject = makeFakeProject({isAbandoned: true})
-            const result = porteurProjetActions(fakeProject)
-            expect(result).toEqual([])
-        })
+  describe('when project is abandoned', () => {
+    it('should return an empty action array', () => {
+      const fakeProject = makeFakeProject({ isAbandoned: true, appelOffre: { type: 'batiment' } })
+      const result = porteurProjetActions(fakeProject)
+      expect(result).toEqual([])
     })
-    describe('when project is not "classé"', () => {
-        describe('when project has a certificate file', () => {
-            it('should return certificate link and "recours" link', () => {
-                const fakeProject = makeFakeProject({isClasse: false, certificateFile: {
-                    id: '1',
-                    filename: 'file-name'
-                  }})
-                const result = porteurProjetActions(fakeProject)   
-                expect(result).toHaveLength(2)
-                expect(result[0]).toMatchObject({
-                    title: 'Télécharger mon attestation',
-                    link: ROUTES.CANDIDATE_CERTIFICATE_FOR_CANDIDATES({
-                      id: fakeProject.id,
-                      certificateFileId: fakeProject.certificateFile.id,
-                      nomProjet: fakeProject.nomProjet,
-                      potentielIdentifier: fakeProject.potentielIdentifier,
-                    }),
-                    isDownload: true,
-                })
-                expect(result[1]).toMatchObject({
-                    title: 'Faire une demande de recours',
-                    link: ROUTES.DEPOSER_RECOURS(fakeProject.id),
-                  })
-            })         
+  })
+  describe('when project is not "classé"', () => {
+    describe('when project has a certificate file', () => {
+      it('should return certificate link and "recours" link', () => {
+        const fakeProject = makeFakeProject({
+          isClasse: false,
+          appelOffre: { type: 'batiment' },
+          certificateFile: {
+            id: '1',
+            filename: 'file-name',
+          },
         })
-        describe('when project is "classé"', () => {
-            it('should return an action array with the following actions: "Télécharger le récapitulatif", "Demander un délai", "Changer de producteur", "Changer de fournisseur", "Changer d\'actionnaire", "Changer de puissance", "Demander un abandon"', () => {
-                const fakeProject = makeFakeProject({isClasse: true})
-                const result = porteurProjetActions(fakeProject)   
-                expect(result).toHaveLength(7)
-                expect(result).toEqual([
-                    {
-                      title: 'Télécharger le récapitulatif',
-                      link: '#',
-                      disabled: true,
-                    },
-                    {
-                      title: 'Demander un délai',
-                      link: ROUTES.DEMANDE_DELAIS(fakeProject.id),
-                    },
-                    {
-                      title: 'Changer de producteur',
-                      link: ROUTES.CHANGER_PRODUCTEUR(fakeProject.id),
-                    },
-                    {
-                      title: 'Changer de fournisseur',
-                      link: ROUTES.CHANGER_FOURNISSEUR(fakeProject.id),
-                    },
-                    {
-                      title: "Changer d'actionnaire",
-                      link: ROUTES.CHANGER_ACTIONNAIRE(fakeProject.id),
-                    },
-                    {
-                      title: 'Changer de puissance',
-                      link: ROUTES.CHANGER_PUISSANCE(fakeProject.id),
-                    },
-                    {
-                      title: 'Demander un abandon',
-                      link: ROUTES.DEMANDER_ABANDON(fakeProject.id),
-                    },
-                  ])
-            })
-            describe('when project has a certificate file', () => {
-                it('should return also a link to get this file', () => {
-                    const fakeProject = makeFakeProject({isClasse: true, certificateFile: {
-                        id: '1',
-                        filename: 'file-name'
-                      }})
-                    const result = porteurProjetActions(fakeProject)   
-                    expect(result).toHaveLength(8)
-                    expect(result[0]).toMatchObject({
-                        title: 'Télécharger mon attestation',
-                        link: ROUTES.CANDIDATE_CERTIFICATE_FOR_CANDIDATES({
-                          id: fakeProject.id,
-                          certificateFileId: fakeProject.certificateFile.id,
-                          nomProjet: fakeProject.nomProjet,
-                          potentielIdentifier: fakeProject.potentielIdentifier,
-                        }),
-                        isDownload: true,
-                      })
-                })
-            })
+        const result = porteurProjetActions(fakeProject)
+        expect(result).toHaveLength(2)
+        expect(result[0]).toMatchObject({
+          title: 'Télécharger mon attestation',
+          link: ROUTES.CANDIDATE_CERTIFICATE_FOR_CANDIDATES({
+            id: fakeProject.id,
+            certificateFileId: fakeProject.certificateFile.id,
+            nomProjet: fakeProject.nomProjet,
+            potentielIdentifier: fakeProject.potentielIdentifier,
+          }),
+          isDownload: true,
         })
+        expect(result[1]).toMatchObject({
+          title: 'Faire une demande de recours',
+          link: ROUTES.DEPOSER_RECOURS(fakeProject.id),
+        })
+      })
     })
+    describe('when project is "classé"', () => {
+      it('should return an action array with the following actions: "Télécharger le récapitulatif", "Demander un délai", "Changer de producteur", "Changer de fournisseur", "Changer d\'actionnaire", "Changer de puissance", "Demander un abandon"', () => {
+        const fakeProject = makeFakeProject({ isClasse: true, appelOffre: { type: 'batiment' } })
+        const result = porteurProjetActions(fakeProject)
+        expect(result).toHaveLength(7)
+        expect(result).toEqual([
+          {
+            title: 'Télécharger le récapitulatif',
+            link: '#',
+            disabled: true,
+          },
+          {
+            title: 'Demander un délai',
+            link: ROUTES.DEMANDE_DELAIS(fakeProject.id),
+          },
+          {
+            title: 'Changer de producteur',
+            link: ROUTES.CHANGER_PRODUCTEUR(fakeProject.id),
+          },
+          {
+            title: 'Changer de fournisseur',
+            link: ROUTES.CHANGER_FOURNISSEUR(fakeProject.id),
+          },
+          {
+            title: "Changer d'actionnaire",
+            link: ROUTES.CHANGER_ACTIONNAIRE(fakeProject.id),
+          },
+          {
+            title: 'Changer de puissance',
+            link: ROUTES.CHANGER_PUISSANCE(fakeProject.id),
+          },
+          {
+            title: 'Demander un abandon',
+            link: ROUTES.DEMANDER_ABANDON(fakeProject.id),
+          },
+        ])
+      })
+      describe('when project has a certificate file', () => {
+        it('should return also a link to get this file', () => {
+          const fakeProject = makeFakeProject({
+            isClasse: true,
+            appelOffre: { type: 'batiment' },
+            certificateFile: {
+              id: '1',
+              filename: 'file-name',
+            },
+          })
+          const result = porteurProjetActions(fakeProject)
+          expect(result).toHaveLength(8)
+          expect(result[0]).toMatchObject({
+            title: 'Télécharger mon attestation',
+            link: ROUTES.CANDIDATE_CERTIFICATE_FOR_CANDIDATES({
+              id: fakeProject.id,
+              certificateFileId: fakeProject.certificateFile.id,
+              nomProjet: fakeProject.nomProjet,
+              potentielIdentifier: fakeProject.potentielIdentifier,
+            }),
+            isDownload: true,
+          })
+        })
+      })
+      describe('when the AO is eolien', () => {
+        it('should not retourn "changement de producteur" action', () => {
+          const fakeProject = makeFakeProject({ isClasse: true, appelOffre: { type: 'eolien' } })
+          const result = porteurProjetActions(fakeProject)
+          expect(result).toHaveLength(6)
+          expect(result).toEqual([
+            {
+              title: 'Télécharger le récapitulatif',
+              link: '#',
+              disabled: true,
+            },
+            {
+              title: 'Demander un délai',
+              link: ROUTES.DEMANDE_DELAIS(fakeProject.id),
+            },
+            {
+              title: 'Changer de fournisseur',
+              link: ROUTES.CHANGER_FOURNISSEUR(fakeProject.id),
+            },
+            {
+              title: "Changer d'actionnaire",
+              link: ROUTES.CHANGER_ACTIONNAIRE(fakeProject.id),
+            },
+            {
+              title: 'Changer de puissance',
+              link: ROUTES.CHANGER_PUISSANCE(fakeProject.id),
+            },
+            {
+              title: 'Demander un abandon',
+              link: ROUTES.DEMANDER_ABANDON(fakeProject.id),
+            },
+          ])
+        })
+      })
+    })
+  })
 })

--- a/src/views/components/actions/porteurProjet.spec.ts
+++ b/src/views/components/actions/porteurProjet.spec.ts
@@ -101,7 +101,7 @@ describe('porteurProjetActions', () => {
         })
       })
       describe('when the AO is eolien', () => {
-        it('should not retourn "changement de producteur" action', () => {
+        it('should not return "changement de producteur" action', () => {
           const fakeProject = makeFakeProject({ isClasse: true, appelOffre: { type: 'eolien' } })
           const result = porteurProjetActions(fakeProject)
           expect(result).toHaveLength(6)

--- a/src/views/components/actions/porteurProjet.ts
+++ b/src/views/components/actions/porteurProjet.ts
@@ -1,7 +1,9 @@
+import { ProjectAppelOffre } from '@entities/appelOffre'
 import ROUTES from '../../../routes'
 
 const porteurProjetActions = (project: {
   id: string
+  appelOffre: ProjectAppelOffre
   isClasse: boolean
   isAbandoned: boolean
   certificateFile?: {
@@ -18,6 +20,7 @@ const porteurProjetActions = (project: {
   potentielIdentifier: string
 }) => {
   const canDownloadCertificate = !!project.certificateFile
+  const isEolien = project.appelOffre.type === 'eolien'
 
   if (project.isAbandoned) return []
 
@@ -73,10 +76,6 @@ const porteurProjetActions = (project: {
         link: ROUTES.DEMANDE_DELAIS(project.id),
       },
       {
-        title: 'Changer de producteur',
-        link: ROUTES.CHANGER_PRODUCTEUR(project.id),
-      },
-      {
         title: 'Changer de fournisseur',
         link: ROUTES.CHANGER_FOURNISSEUR(project.id),
       },
@@ -94,6 +93,13 @@ const porteurProjetActions = (project: {
       },
     ]
   )
+
+  if (!isEolien) {
+    actions.splice(2, 0, {
+      title: 'Changer de producteur',
+      link: ROUTES.CHANGER_PRODUCTEUR(project.id),
+    })
+  }
 
   return actions
 }

--- a/src/views/components/actions/porteurProjet.ts
+++ b/src/views/components/actions/porteurProjet.ts
@@ -75,6 +75,14 @@ const porteurProjetActions = (project: {
         title: 'Demander un délai',
         link: ROUTES.DEMANDE_DELAIS(project.id),
       },
+      ...(!isEolien
+        ? [
+            {
+              title: 'Changer de producteur',
+              link: ROUTES.CHANGER_PRODUCTEUR(project.id),
+            },
+          ]
+        : []),
       {
         title: 'Changer de fournisseur',
         link: ROUTES.CHANGER_FOURNISSEUR(project.id),
@@ -93,13 +101,6 @@ const porteurProjetActions = (project: {
       },
     ]
   )
-
-  if (!isEolien) {
-    actions.splice(2, 0, {
-      title: 'Changer de producteur',
-      link: ROUTES.CHANGER_PRODUCTEUR(project.id),
-    })
-  }
 
   return actions
 }

--- a/src/views/pages/newModificationRequestPage/NewModificationRequest.tsx
+++ b/src/views/pages/newModificationRequestPage/NewModificationRequest.tsx
@@ -151,7 +151,7 @@ export const NewModificationRequest = PageLayout(
                     name="submit"
                     id="submit"
                     {...dataId('submit-button')}
-                    disabled={isEolien || isSubmitButtonDisabled}
+                    disabled={(isEolien && action === 'producteur') || isSubmitButtonDisabled}
                   >
                     Envoyer
                   </button>

--- a/src/views/pages/newModificationRequestPage/NewModificationRequest.tsx
+++ b/src/views/pages/newModificationRequestPage/NewModificationRequest.tsx
@@ -32,6 +32,7 @@ export const NewModificationRequest = PageLayout(
 
     const [displayForm, setDisplayForm] = useState(project.newRulesOptIn)
     const [isSubmitButtonDisabled, setDisableSubmitButton] = useState(false)
+    const isEolien = project.appelOffre?.type === 'eolien'
 
     return (
       <UserDashboard currentPage={'list-requests'}>
@@ -150,7 +151,7 @@ export const NewModificationRequest = PageLayout(
                     name="submit"
                     id="submit"
                     {...dataId('submit-button')}
-                    disabled={isSubmitButtonDisabled}
+                    disabled={isEolien || isSubmitButtonDisabled}
                   >
                     Envoyer
                   </button>

--- a/src/views/pages/newModificationRequestPage/components/producteur/ChangementProducteur.tsx
+++ b/src/views/pages/newModificationRequestPage/components/producteur/ChangementProducteur.tsx
@@ -9,12 +9,20 @@ type ChangementProducteurProps = {
 
 export const ChangementProducteur = ({ project, justification }: ChangementProducteurProps) => {
   const { appelOffre } = project
+  const isEolien = appelOffre?.type === 'eolien'
 
   return (
     <>
+      {isEolien && (
+        <div className="notification error" style={{ marginTop: 10, marginBottom: 10 }}>
+          <span>
+            Vous ne pouvez pas changer de producteur avant la date d'achèvement de ce projet.
+          </span>
+        </div>
+      )}
       <label>Ancien producteur</label>
       <input type="text" disabled defaultValue={project.nomCandidat} />
-      {appelOffre?.isSoumisAuxGFs && (
+      {!isEolien && appelOffre?.isSoumisAuxGFs && (
         <div className="notification warning" style={{ marginTop: 10, marginBottom: 10 }}>
           <span>
             Attention : de nouvelles garanties financières devront être déposées d'ici un mois
@@ -29,6 +37,8 @@ export const ChangementProducteur = ({ project, justification }: ChangementProdu
         name="producteur"
         id="producteur"
         {...dataId('modificationRequest-producteurField')}
+        disabled={isEolien}
+        required
       />
       <label htmlFor="candidats">Statuts mis à jour</label>
       <input type="file" name="file" {...dataId('modificationRequest-fileField')} id="file" />

--- a/src/views/pages/projectDetailsPage/components/ProjectActions.tsx
+++ b/src/views/pages/projectDetailsPage/components/ProjectActions.tsx
@@ -5,10 +5,12 @@ import { ChevronDownIcon, PaperClipIcon } from '@heroicons/react/solid'
 import { UserRole } from '../../../../modules/users'
 import { ACTION_BY_ROLE } from '../../../components'
 import { dataId } from '../../../../helpers/testId'
+import { ProjectAppelOffre } from '@entities/appelOffre'
 
 interface Props {
   project: {
     id: string
+    appelOffre: ProjectAppelOffre
     isClasse: boolean
     isAbandoned: boolean
     notifiedOn?: Date


### PR DESCRIPTION
La règle est que le PP éolien ne peut pas changer de producteur avant la date d'achèvement. 
Or aujourd'hui nous n'avons pas cette date dans Potentiel.
Pour le moment le PP éolien ne doit donc jamais pouvoir changer de producteur sur Potentiel.
Ce que j'ai fait  pour le PP éolien : 
- Lien "changer de producteur" retiré de la liste des actions
- Formulaire de changement de producteur désactivé
- Controlleur posrRequestModification : erreur si changement de producteur

<a href="https://gitpod.io/#https://github.com/MTES-MCT/potentiel/pull/396"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

