### PR TITLE
1016 Optimize js bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ La suite de ce document explique comment lancer l'application sur sa machine et 
 - [Les grandes 'recettes' pour le développeur](./docs/RECIPES.md)
 - [L'authentification avec Keycloak](./docs/KEYCLOAK.md)
 - [L'analyse de données avec Metabase](./docs/METABASE.md)
+- [Optimisation d'un bundle js front](./docs/BUNDLE_FRONT.md)
 
 ## Sommaire
 - [Développement en local](#développement-en-local)

--- a/docs/BUNDLE_FRONT.md
+++ b/docs/BUNDLE_FRONT.md
@@ -14,7 +14,7 @@ Un bundle est créé par page. Pour cela, la page doit se situer dans [src/views
 Webpack détermine ce qu'il faut inclure dans le bundle en regardant les imports. Si cette analyse n'est pas faite correctement, il est possible d'embarquer des choses inutiles et de se retrouver avec un bundle énorme.
 
 ### Analyse de bundle avec Statoscope
-[Statoscope](https://github.com/statoscope/statoscope/tree/master/packages/webpack-plugin) est un utilitaire permet de voir ce qui est inclus dans le bundle (et pourquoi)
+[Statoscope](https://github.com/statoscope/statoscope/tree/master/packages/webpack-plugin) est un utilitaire qui permet de voir ce qui est inclus dans le bundle (et pourquoi)
 
 ```bash
 npm install @statoscope/webpack-plugin

--- a/docs/BUNDLE_FRONT.md
+++ b/docs/BUNDLE_FRONT.md
@@ -1,0 +1,43 @@
+# Bundles javascript "front"
+
+Le html des pages est généré coté serveur avant d'être transmis comme réponse au front.
+
+Afin de rajouter de l'interactivité dans le navigateur, un bundle javascript est chargé sur la page. Ce bundle "hydrate" la page, c'est à dire que le code React prend le contrôle du DOM afin de lui attacher des listeners et ainsi ajouter du comportement.
+
+Ces bundles sont générés par webpack dont la configuration se situe dans [webpack.config.js](../webpack.config.js).
+
+Un bundle est créé par page. Pour cela, la page doit se situer dans [src/views/pages](../src/views/pages) et avoir un nom qui termine par `Page.tsx` si c'est un fichier, ou `Page` si c'est un dossier.  
+*NB: Il est possible de tweaker cette règle en modifiant [webpack.config.js](../webpack.config.js).*
+
+## Optimisation du bundle
+
+Webpack détermine ce qu'il faut inclure dans le bundle en regardant les imports. Si cette analyse n'est pas faite correctement, il est possible d'embarquer des choses inutiles et de se retrouver avec un bundle énorme.
+
+### Analyse de bundle avec Statoscope
+[Statoscope](https://github.com/statoscope/statoscope/tree/master/packages/webpack-plugin) est un utilitaire permet de voir ce qui est inclus dans le bundle (et pourquoi)
+
+```bash
+npm install @statoscope/webpack-plugin
+```
+
+puis ajouter dans webpack.config.js
+```js
+const StatoscopeWebpackPlugin = require('@statoscope/webpack-plugin').default;
+
+module.exports = {
+  // ...
+  plugins: [
+    //...
+    new StatoscopeWebpackPlugin()
+  ],
+  // ...
+}
+```
+
+Ensuite, il suffit de faire `npm run build:front` et une page web avec un rapport s'ouvrira.
+
+### Réglage Webpack
+
+[Cette page](https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free) parle de comment on peut améliorer les choses.
+
+Ajouter `"sideEffects": false` dans le `package.json` aide beaucoup pour la taille du bundle.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "potentiel.beta.gouv.fr",
   "version": "2.124.4",
+  "sideEffects": false,
   "description": "Suivi des Projets d'Energies Renouvelables",
   "main": "index.js",
   "scripts": {

--- a/src/__tests__/matchers/toHavePublishedWithPayload.ts
+++ b/src/__tests__/matchers/toHavePublishedWithPayload.ts
@@ -1,7 +1,7 @@
 import { DomainEvent, Constructor, HasType } from '@core/domain'
 import { ResultAsync } from '@core/utils'
 import { InfraNotAvailableError } from '@modules/shared'
-import _ from 'lodash'
+import isMatch from 'lodash/isMatch'
 import { diffLinesUnified2 } from 'jest-diff'
 import { format } from 'pretty-format'
 
@@ -31,7 +31,7 @@ Instead, the eventBus triggered ${this.utils.printReceived(emittedEventTypes.joi
       }
     }
 
-    const pass = eventsOfClass.some((event) => _.isMatch(event.payload, expectedPayload))
+    const pass = eventsOfClass.some((event) => isMatch(event.payload, expectedPayload))
 
     const message = pass
       ? () =>

--- a/src/controllers/modificationRequest/postRequestModification.ts
+++ b/src/controllers/modificationRequest/postRequestModification.ts
@@ -1,6 +1,7 @@
 import asyncHandler from '../helpers/asyncHandler'
 import fs from 'fs'
-import _ from 'lodash'
+import pick from 'lodash/pick'
+import omit from 'lodash/omit'
 import {
   requestActionnaireModification,
   requestFournisseurModification,
@@ -81,7 +82,7 @@ v1Router.post(
       return unauthorizedResponse({ request, response })
     }
 
-    const data = _.pick(request.body, [
+    const data = pick(request.body, [
       'type',
       'actionnaire',
       'producteur',
@@ -175,7 +176,7 @@ v1Router.post(
       if (error instanceof PuissanceJustificationOrCourrierMissingError) {
         return response.redirect(
           addQueryParams(redirectRoute, {
-            ..._.omit(data, 'projectId'),
+            ...omit(data, 'projectId'),
             error: error.message,
           })
         )
@@ -184,7 +185,7 @@ v1Router.post(
       if (error instanceof AggregateHasBeenUpdatedSinceError) {
         return response.redirect(
           addQueryParams(redirectRoute, {
-            ..._.omit(data, 'projectId'),
+            ...omit(data, 'projectId'),
             error:
               'Le projet a été modifié entre le moment où vous avez ouvert cette page et le moment où vous avez validé la demande. Merci de prendre en compte le changement et refaire votre demande si nécessaire.',
           })

--- a/src/dataAccess/db/helpers/truncateTables.ts
+++ b/src/dataAccess/db/helpers/truncateTables.ts
@@ -1,6 +1,5 @@
 import map from 'lodash/map'
 import { sequelizeInstance } from '../../../sequelize.legacy.config'
-
 export default async function truncateAllTables() {
   const { models } = sequelizeInstance
   return await Promise.all(

--- a/src/dataAccess/inMemory/appelOffre.ts
+++ b/src/dataAccess/inMemory/appelOffre.ts
@@ -1,5 +1,5 @@
 import { AppelOffre, Famille, Periode } from '@entities'
-import _ from 'lodash'
+import cloneDeep from 'lodash/cloneDeep'
 
 import {
   fessenheim,
@@ -49,7 +49,7 @@ const appelOffreRepo: AppelOffreRepo = {
     return appelsOffreStatic
   },
   findById: async (id: AppelOffre['id']) => {
-    return _.cloneDeep(appelsOffreStatic.find((ao) => ao.id === id))
+    return cloneDeep(appelsOffreStatic.find((ao) => ao.id === id))
   },
   getFamille: (appelOffreId: AppelOffre['id'], familleId: Famille['id']) => {
     const appelOffre = appelsOffreStatic.find((ao) => ao.id === appelOffreId)

--- a/src/entities/project.ts
+++ b/src/entities/project.ts
@@ -1,5 +1,5 @@
 import isEmail from 'isemail'
-import _ from 'lodash'
+import pick from 'lodash/pick'
 import buildMakeEntity from '../helpers/buildMakeEntity'
 import {
   Boolean,
@@ -184,8 +184,8 @@ const buildApplyProjectUpdate = (makeId: () => string) => {
                 ].filter((innerKey) => project[key][innerKey] !== update[key][innerKey])
 
                 if (changedKeys.length) {
-                  before[key] = _.pick(project[key], changedKeys)
-                  after[key] = _.pick(update[key], changedKeys)
+                  before[key] = pick(project[key], changedKeys)
+                  after[key] = pick(update[key], changedKeys)
                 }
               } else {
                 // For other types, do a shallow comparison

--- a/src/helpers/buildMakeEntity.ts
+++ b/src/helpers/buildMakeEntity.ts
@@ -1,7 +1,7 @@
 import { Result, Ok, ErrorResult } from '../types'
 import { Runtype } from '../types/schemaTypes'
 import { Optional } from 'utility-types'
-import _ from 'lodash'
+import pick from 'lodash/pick'
 
 interface HasId {
   id: string
@@ -14,7 +14,7 @@ const buildMakeEntity = <T extends HasId>(
   defaults?: Record<string, any>
 ) => {
   // Make a small utility to remove all unnecessary fields
-  const extractTypeFields = (obj: any) => _.pick(obj, typeFields)
+  const extractTypeFields = (obj: any) => pick(obj, typeFields)
 
   // The input object doesn't require an id
   return (obj: Optional<T, 'id'>): Result<T, Error> => {

--- a/src/infra/sequelize/__tests__/projections/describeProjector.ts
+++ b/src/infra/sequelize/__tests__/projections/describeProjector.ts
@@ -1,4 +1,4 @@
-import { matches } from 'lodash'
+import matches from 'lodash/matches'
 import { resetDatabase } from '../../helpers/resetDatabase'
 
 interface ShouldCreateProps {

--- a/src/infra/sequelize/helpers/projector.ts
+++ b/src/infra/sequelize/helpers/projector.ts
@@ -1,4 +1,4 @@
-import { merge } from 'lodash'
+import merge from 'lodash/merge'
 
 import { BaseDomainEvent, DomainEvent, EventBus } from '@core/domain'
 import { logger } from '@core/utils'

--- a/src/modules/appelOffre/AppelOffre.ts
+++ b/src/modules/appelOffre/AppelOffre.ts
@@ -116,7 +116,7 @@ export const makeAppelOffre = (args: {
           })
         )
       } else {
-        const delta = _.omitBy(data, (value, key) => periode.data[key] === value)
+        const delta = omitBy(data, (value, key) => periode.data[key] === value)
         if (Object.keys(delta).length) {
           _publishEvent(
             new PeriodeUpdated({

--- a/src/modules/appelOffre/AppelOffre.ts
+++ b/src/modules/appelOffre/AppelOffre.ts
@@ -1,4 +1,4 @@
-import _ from 'lodash'
+import omitBy from 'lodash/omitBy'
 
 import { DomainEvent, EventStoreAggregate, UniqueEntityID } from '@core/domain'
 import { err, ok, Result } from '@core/utils'
@@ -69,7 +69,7 @@ export const makeAppelOffre = (args: {
         return err(new UnauthorizedError())
       }
 
-      const delta = _.omitBy(data, (value, key) => props.data[key] === value)
+      const delta = omitBy(data, (value, key) => props.data[key] === value)
 
       if (Object.keys(delta).length) {
         _publishEvent(

--- a/src/modules/appelOffre/dtos/AppelOffreDTO.ts
+++ b/src/modules/appelOffre/dtos/AppelOffreDTO.ts
@@ -1,5 +1,3 @@
-import _ from 'lodash'
-
 export type AppelOffreDTO = {
   appelOffreId: string
 }

--- a/src/modules/project/Project.ts
+++ b/src/modules/project/Project.ts
@@ -1,4 +1,4 @@
-import _ from 'lodash'
+import remove from 'lodash/remove'
 import moment from 'moment-timezone'
 import sanitize from 'sanitize-filename'
 import { BuildProjectIdentifier, Fournisseur } from '.'
@@ -1014,7 +1014,7 @@ export const makeProject = (args: {
   }
 
   function _removePendingEventsOfType(type: DomainEvent['type']) {
-    _.remove(pendingEvents, (event) => event.type === type)
+    remove(pendingEvents, (event) => event.type === type)
   }
 
   function _hasPendingEventOfType(type: DomainEvent['type']) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -41,7 +41,7 @@ module.exports = {
       : 'development',
   entry: {
     ...pageEntries,
-    shared: ['react', 'react-dom'],
+    shared: ['react', 'react-dom', 'moment', 'moment-timezone'],
   },
   target: 'web',
   resolve: {


### PR DESCRIPTION
Dans l'optique de réduire la taille des bundles qui sont envoyés au front:

- `sideEffects: false` dans `package.json`
- placer `moment` dans le bundle commun
- utiliser les packages spécifiques de lodash plutot que le général
- ajouter un document pour expliquer comme faire une analyse
    

<a href="https://gitpod.io/#https://github.com/MTES-MCT/potentiel/pull/413"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

