### PR TITLE
:bug: fix delay request form

### DIFF
--- a/src/views/pages/newModificationRequestPage/components/delai/DemandeDelai.tsx
+++ b/src/views/pages/newModificationRequestPage/components/delai/DemandeDelai.tsx
@@ -19,15 +19,7 @@ export const DemandeDelai = ({ project, delayInMonths, justification }: DemandeD
     <input
       type="text"
       disabled
-      defaultValue={formatDate(
-        +moment(project.notifiedOn)
-          .add(
-            project.appelOffre && getDelaiDeRealisation(project.appelOffre, project.technologie),
-            'months'
-          )
-          .subtract(1, 'day'),
-        'DD/MM/YYYY'
-      )}
+      defaultValue={formatDate(project.completionDueOn)}
       {...dataId('modificationRequest-presentServiceDateField')}
     />
     <label style={{ marginTop: 5 }} className="required" htmlFor="delayedServiceDate">


### PR DESCRIPTION
La date théorique de mise en service dans le formulaire de demande de délai était la date initiale de mise en service. Or on veut la date de mise en service à jour (avec les précédentes demandes de délai accordées), qui est la date "completionDueOn". 