### PR TITLE
:bug: remove legacy modification events without status

### DIFF
--- a/src/infra/sequelize/migrations/20220412094942-remove-legacy-modification-events-without-status.js
+++ b/src/infra/sequelize/migrations/20220412094942-remove-legacy-modification-events-without-status.js
@@ -1,0 +1,32 @@
+'use strict'
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    const transaction = await queryInterface.sequelize.transaction()
+    try {
+      await queryInterface.sequelize.query(
+        `DELETE FROM "eventStores" 
+        WHERE type='LegacyModificationImported' 
+        AND "occurredAt" < '2022-01-01T00:00:00.000Z'`,
+        {
+          type: queryInterface.sequelize.QueryTypes.DELETE,
+          transaction,
+        }
+      )
+
+      await transaction.commit()
+    } catch (err) {
+      await transaction.rollback()
+      throw err
+    }
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    /**
+     * Add reverting commands here.
+     *
+     * Example:
+     * await queryInterface.dropTable('users');
+     */
+  },
+}


### PR DESCRIPTION
Les modifications historiques importée en 2021 sont toutes des modifications acceptées à l'exception de certains abandons pour lesquels le payload comporte une propriété "accepted". 
Le réimport qui va être fait de toutes ces modifications va aussi inclure en plus les modifications "Acceptées" et en "Accord de principe". Toutes les modifications historiques auront maintenant un statut obligatoire. 
Le problème est qu'avec les anciens imports, nous avons dans l'event store des événement concernant des modifications historiques avec un statut undefined, ce qui entraine un affichage erroné dans la frise. 
Dans cette PR, nous supprimons tous ces événement.
Ils seront ensuite réimportés avec un statut. 

<a href="https://gitpod.io/#https://github.com/MTES-MCT/potentiel/pull/437"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

