### PR TITLE
:recycle: Ajout de details pour l'erreur sur la creation d'utilisateur

### DIFF
--- a/src/config/logger.config.ts
+++ b/src/config/logger.config.ts
@@ -29,6 +29,7 @@ if (isProdEnv) {
 
   logger.on('errorLog', (exception: Error | string) => {
     console.error(exception)
+    Sentry.setExtra('exception', exception)
     Sentry.captureException(exception)
   })
 } else {

--- a/src/modules/shared/errors/EmailAlreadyUsedError.ts
+++ b/src/modules/shared/errors/EmailAlreadyUsedError.ts
@@ -1,9 +1,7 @@
 import { DomainError } from '@core/domain'
 
-type ErrorDetails = { userId: string }
-
 export class EmailAlreadyUsedError extends DomainError {
-  constructor({ userId }: ErrorDetails) {
-    super(`Cette adresse email est déjà utilisée pour le compte Potentiel ${userId}.`)
+  constructor(public userId: string) {
+    super(`Cette adresse email est déjà utilisée pour un compte Potentiel existant.`)
   }
 }

--- a/src/modules/shared/errors/EmailAlreadyUsedError.ts
+++ b/src/modules/shared/errors/EmailAlreadyUsedError.ts
@@ -1,7 +1,9 @@
 import { DomainError } from '@core/domain'
 
+type ErrorDetails = { userId: string }
+
 export class EmailAlreadyUsedError extends DomainError {
-  constructor() {
-    super('Cette adresse mail est déjà utilisée pour un compte Potentiel existant.')
+  constructor({ userId }: ErrorDetails) {
+    super(`Cette adresse email est déjà utilisée pour le compte Potentiel ${userId}.`)
   }
 }

--- a/src/modules/users/User.ts
+++ b/src/modules/users/User.ts
@@ -83,7 +83,7 @@ export const makeUser = (args: {
           })
         )
       } else {
-        return err(new EmailAlreadyUsedError({ userId }))
+        return err(new EmailAlreadyUsedError(userId))
       }
 
       return ok(null)

--- a/src/modules/users/User.ts
+++ b/src/modules/users/User.ts
@@ -68,7 +68,9 @@ export const makeUser = (args: {
       return ok(props.userId)
     },
     create: function ({ fullName, role, createdBy }) {
-      if (!props.userId) {
+      const { userId } = props
+
+      if (!userId) {
         _publishEvent(
           new UserCreated({
             payload: {
@@ -81,7 +83,7 @@ export const makeUser = (args: {
           })
         )
       } else {
-        return err(new EmailAlreadyUsedError())
+        return err(new EmailAlreadyUsedError({ userId }))
       }
 
       return ok(null)


### PR DESCRIPTION
Régulièrement nous avons des erreurs à propos de compte déjà existant dans keycloak mais qui n'existe pas dans Potentiel. L'erreur logguée dans Sentry n'a cependant aucune info concernant le compte en question. 
Ici j'ai donc rajouté l'identifiant du compte en question afin de pouvoir investiguer sur ce problème.

<a href="https://gitpod.io/#https://github.com/MTES-MCT/potentiel/pull/458"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

