### PR TITLE
:bug: Correction de la gestion des periodes d'un AO apres suppression

### DIFF
--- a/src/infra/sequelize/projections/appelOffre/updates/onPeriodeUpdated.ts
+++ b/src/infra/sequelize/projections/appelOffre/updates/onPeriodeUpdated.ts
@@ -1,5 +1,6 @@
 import { logger } from '@core/utils'
 import { PeriodeUpdated } from '@modules/appelOffre'
+import { ProjectionEnEchec } from '@modules/shared'
 
 export const onPeriodeUpdated = (models) => async (event: PeriodeUpdated) => {
   const { Periode } = models
@@ -11,10 +12,10 @@ export const onPeriodeUpdated = (models) => async (event: PeriodeUpdated) => {
 
   if (!instance) {
     logger.error(
-      `Error: onPeriodeUpdated projection failed to retrieve project from db ${{
-        appelOffreId,
-        periodeId,
-      }}`
+      new ProjectionEnEchec(`La période à mettre à jour n'existe pas`, {
+        nomProjection: 'onPeriodeUpdated',
+        evennement: event,
+      })
     )
     return
   }

--- a/src/modules/appelOffre/AppelOffre.ts
+++ b/src/modules/appelOffre/AppelOffre.ts
@@ -165,11 +165,11 @@ export const makeAppelOffre = (args: {
         break
       case AppelOffreRemoved.type:
         props.removed = true
+        props.periodes = []
         break
       case PeriodeUpdated.type:
         existingPeriode = props.periodes.find((periode) => periode.periodeId === periodeId)
         if (!existingPeriode) {
-          _isError = true
           break
         }
         existingPeriode.data = { ...existingPeriode.data, ...delta }


### PR DESCRIPTION
Actuellement lorsque un AO est supprimé à l'issue d'un import, les donnèes projetées `AppelOffre` et `Periodes` sont supprimées pour cet AO. Cependant après réimport de ce même AO (et donc sa (re)création) les périodes ne sont pas (re)créées. 
Ceci est dû à l'aggrégat qui ne réinitialise pas ses périodes lors du traitement de l'evenement `AppelOffreRemoved`. Lors de la mise à jour des périodes des évenements `PeriodeUpdated` sont émis et une erreur survient dans le handler `onPeriodeUpdated` car ces pe'riodes avaient été supprimées précédemment.

PS : Les évenements `AppelOffreCreated` et `PeriodeUpdated` ayant la même date il est impossible d'en insérer entre de type `PeriodeCreated` pour corriger l'historique. D'où cette solution temporaire pour débloquer la situation et permettre la prochaine notification.  

<a href="https://gitpod.io/#https://github.com/MTES-MCT/potentiel/pull/469"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

