### PR TITLE
🐛 Correction d'un problème d'affichage de certains projets en double/triple

### DIFF
--- a/src/dataAccess/db/project.ts
+++ b/src/dataAccess/db/project.ts
@@ -333,14 +333,6 @@ export const makeProjectRepo: MakeProjectRepo = ({ sequelizeInstance, getProject
   })
 
   ProjectModel.hasOne(ProjectStep, {
-    as: 'dcr',
-    foreignKey: 'projectId',
-    scope: {
-      [Op.and]: where(col('dcr.type'), Op.eq, 'dcr'),
-    },
-  })
-
-  ProjectModel.hasOne(ProjectStep, {
     as: 'ptf',
     foreignKey: 'projectId',
     scope: {
@@ -403,11 +395,6 @@ export const makeProjectRepo: MakeProjectRepo = ({ sequelizeInstance, getProject
           },
           {
             model: ProjectStep,
-            as: 'dcr',
-            include: [{ model: FileModel, as: 'file' }],
-          },
-          {
-            model: ProjectStep,
             as: 'ptf',
             include: [{ model: FileModel, as: 'file' }],
           },
@@ -458,11 +445,6 @@ export const makeProjectRepo: MakeProjectRepo = ({ sequelizeInstance, getProject
           { model: FileModel, as: 'file' },
           { model: UserModel, as: 'user' },
         ],
-      },
-      {
-        model: ProjectStep,
-        as: 'dcr',
-        include: [{ model: FileModel, as: 'file' }],
       },
       {
         model: ProjectStep,

--- a/src/infra/sequelize/projections/project/project.model.ts
+++ b/src/infra/sequelize/projections/project/project.model.ts
@@ -217,14 +217,6 @@ export const MakeProjectModel = (sequelize) => {
     })
 
     Project.hasOne(ProjectStep, {
-      as: 'dcr',
-      foreignKey: 'projectId',
-      scope: {
-        [Op.and]: where(col('dcr.type'), Op.eq, 'dcr'),
-      },
-    })
-
-    Project.hasOne(ProjectStep, {
       as: 'ptf',
       foreignKey: 'projectId',
       scope: {

--- a/src/infra/sequelize/projections/projectStep/updates/index.ts
+++ b/src/infra/sequelize/projections/projectStep/updates/index.ts
@@ -1,7 +1,5 @@
 import { logger } from '@core/utils'
 import {
-  ProjectDCRRemoved,
-  ProjectDCRSubmitted,
   ProjectGFRemoved,
   ProjectStepStatusUpdated,
   ProjectGFSubmitted,
@@ -15,12 +13,10 @@ import { EventBus } from '@core/domain'
 
 export const initProjectPTFProjections = (eventBus: EventBus, models) => {
   eventBus.subscribe(ProjectPTFSubmitted.type, onProjectStepSubmitted(models))
-  eventBus.subscribe(ProjectDCRSubmitted.type, onProjectStepSubmitted(models))
   eventBus.subscribe(ProjectGFSubmitted.type, onProjectStepSubmitted(models))
   eventBus.subscribe(ProjectStepStatusUpdated.type, onProjectStepStatusUpdated(models))
 
   eventBus.subscribe(ProjectPTFRemoved.type, onProjectStepRemoved(models))
-  eventBus.subscribe(ProjectDCRRemoved.type, onProjectStepRemoved(models))
   eventBus.subscribe(ProjectGFRemoved.type, onProjectStepRemoved(models))
 
   logger.info('Initialized Project PTF projections')

--- a/src/infra/sequelize/projections/projectStep/updates/onProjectStepRemoved.integration.ts
+++ b/src/infra/sequelize/projections/projectStep/updates/onProjectStepRemoved.integration.ts
@@ -47,37 +47,6 @@ describe('projectStep.onProjectStepRemoved', () => {
     })
   })
 
-  describe('when event is ProjectDCRRemoved', () => {
-    beforeAll(async () => {
-      await resetDatabase()
-
-      await ProjectStep.create({
-        id: new UniqueEntityID().toString(),
-        projectId,
-        type: 'dcr',
-        stepDate: new Date(123),
-        fileId: new UniqueEntityID().toString(),
-        submittedBy: new UniqueEntityID().toString(),
-        submittedOn: new Date(1234),
-        status: 'à traiter',
-      })
-
-      expect(await ProjectStep.count({ where: { projectId, type: 'dcr' } })).toEqual(1)
-    })
-
-    it('should remove the project dcr step', async () => {
-      const event = new ProjectDCRRemoved({
-        payload: {
-          projectId,
-          removedBy: new UniqueEntityID().toString(),
-        },
-      })
-      await onProjectStepRemoved(models)(event)
-
-      expect(await ProjectStep.count({ where: { projectId, type: 'dcr' } })).toEqual(0)
-    })
-  })
-
   describe('when event is ProjectGFRemoved', () => {
     beforeAll(async () => {
       await resetDatabase()

--- a/src/infra/sequelize/projections/projectStep/updates/onProjectStepRemoved.ts
+++ b/src/infra/sequelize/projections/projectStep/updates/onProjectStepRemoved.ts
@@ -1,21 +1,11 @@
 import { Op } from 'sequelize'
 import { logger } from '@core/utils'
-import {
-  ProjectDCRRemoved,
-  ProjectGFRemoved,
-  ProjectGFWithdrawn,
-  ProjectPTFRemoved,
-} from '@modules/project'
+import { ProjectGFRemoved, ProjectGFWithdrawn, ProjectPTFRemoved } from '@modules/project'
 
-type StepRemovedEvent =
-  | ProjectPTFRemoved
-  | ProjectDCRRemoved
-  | ProjectGFRemoved
-  | ProjectGFWithdrawn
+type StepRemovedEvent = ProjectPTFRemoved | ProjectGFRemoved | ProjectGFWithdrawn
 
 const StepTypeByEventType: Record<StepRemovedEvent['type'], string> = {
   [ProjectPTFRemoved.type]: 'ptf',
-  [ProjectDCRRemoved.type]: 'dcr',
   [ProjectGFRemoved.type]: 'garantie-financiere',
   [ProjectGFWithdrawn.type]: 'garantie-financiere',
 }

--- a/src/infra/sequelize/projections/projectStep/updates/onProjectStepSubmitted.integration.ts
+++ b/src/infra/sequelize/projections/projectStep/updates/onProjectStepSubmitted.integration.ts
@@ -55,43 +55,6 @@ describe('projectStep.onProjectStepSubmitted', () => {
     })
   })
 
-  describe('when event is ProjectDCRSubmitted', () => {
-    it('should create a new dcr step with a "à traiter" status', async () => {
-      const event = new ProjectDCRSubmitted({
-        payload: {
-          projectId,
-          dcrDate: new Date(123),
-          fileId,
-          numeroDossier: 'numeroDossier',
-          submittedBy: userId,
-        },
-        original: {
-          version: 1,
-          occurredAt: new Date(456),
-        },
-      })
-      await onProjectStepSubmitted(models)(event)
-
-      const projection = await ProjectStep.findOne({ where: { projectId } })
-
-      expect(projection).toBeTruthy()
-      if (!projection) return
-
-      expect(projection.get()).toMatchObject({
-        type: 'dcr',
-        projectId,
-        stepDate: new Date(123),
-        fileId,
-        submittedBy: userId,
-        submittedOn: new Date(456),
-        details: {
-          numeroDossier: 'numeroDossier',
-        },
-        status: 'à traiter',
-      })
-    })
-  })
-
   describe('when event is ProjectGFSubmitted', () => {
     it('should create a new garantie-financiere step with a "à traiter" status', async () => {
       const event = new ProjectGFSubmitted({

--- a/src/infra/sequelize/projections/projectStep/updates/onProjectStepSubmitted.ts
+++ b/src/infra/sequelize/projections/projectStep/updates/onProjectStepSubmitted.ts
@@ -1,21 +1,11 @@
 import { UniqueEntityID } from '@core/domain'
 import { logger } from '@core/utils'
-import {
-  ProjectDCRSubmitted,
-  ProjectGFSubmitted,
-  ProjectGFUploaded,
-  ProjectPTFSubmitted,
-} from '@modules/project'
+import { ProjectGFSubmitted, ProjectGFUploaded, ProjectPTFSubmitted } from '@modules/project'
 
-type StepSubmittedEvent =
-  | ProjectPTFSubmitted
-  | ProjectDCRSubmitted
-  | ProjectGFSubmitted
-  | ProjectGFUploaded
+type StepSubmittedEvent = ProjectPTFSubmitted | ProjectGFSubmitted | ProjectGFUploaded
 
 const StepTypeByEventType: Record<StepSubmittedEvent['type'], string> = {
   [ProjectPTFSubmitted.type]: 'ptf',
-  [ProjectDCRSubmitted.type]: 'dcr',
   [ProjectGFSubmitted.type]: 'garantie-financiere',
   [ProjectGFUploaded.type]: 'garantie-financiere',
 }
@@ -24,17 +14,9 @@ const StepDateByEvent = (event: StepSubmittedEvent): Date => {
   switch (event.type) {
     case ProjectPTFSubmitted.type:
       return event.payload.ptfDate
-    case ProjectDCRSubmitted.type:
-      return event.payload.dcrDate
     case ProjectGFSubmitted.type:
     case ProjectGFUploaded.type:
       return event.payload.gfDate
-  }
-}
-
-const StepDetailsByEvent = (event: StepSubmittedEvent): Record<string, any> | undefined => {
-  if (event.type === ProjectDCRSubmitted.type) {
-    return { numeroDossier: event.payload.numeroDossier }
   }
 }
 
@@ -46,6 +28,7 @@ export const onProjectStepSubmitted = (models) => async (event: StepSubmittedEve
   const { ProjectStep } = models
 
   const { projectId, fileId, submittedBy } = event.payload
+
   try {
     await ProjectStep.create({
       id: new UniqueEntityID().toString(),
@@ -55,7 +38,6 @@ export const onProjectStepSubmitted = (models) => async (event: StepSubmittedEve
       fileId,
       submittedBy,
       submittedOn: event.occurredAt,
-      details: StepDetailsByEvent(event),
       status: getStatus(event),
     })
   } catch (e) {

--- a/src/infra/sequelize/queries/project/getProjectDataForProjectPage.integration.ts
+++ b/src/infra/sequelize/queries/project/getProjectDataForProjectPage.integration.ts
@@ -220,54 +220,6 @@ describe('Sequelize getProjectDataForProjectPage', () => {
     })
   })
 
-  describe('when dcr has been submitted', () => {
-    const dcrFileId = new UniqueEntityID().toString()
-
-    it('should include dcr info', async () => {
-      await resetDatabase()
-
-      await Project.create(
-        makeFakeProject({
-          ...projectInfo,
-          dcrSubmittedOn: 345,
-          dcrDueOn: 34,
-          dcrDate: 45,
-          dcrFileId: dcrFileId,
-          dcrNumeroDossier: 'numeroDossier',
-        })
-      )
-      await ProjectStep.create({
-        id: new UniqueEntityID().toString(),
-        projectId,
-        type: 'dcr',
-        submittedOn: new Date(345),
-        submittedBy: new UniqueEntityID().toString(),
-        stepDate: new Date(45),
-        details: {
-          numeroDossier: 'numeroDossier',
-        },
-        fileId: dcrFileId,
-      })
-      await File.create(makeFakeFile({ id: certificateFileId, filename: 'filename' }))
-      await File.create(makeFakeFile({ id: dcrFileId, filename: 'filename' }))
-
-      const res = await getProjectDataForProjectPage({ projectId, user })
-
-      expect(res._unsafeUnwrap()).toMatchObject({
-        dcr: {
-          submittedOn: new Date(345),
-          dueOn: new Date(34),
-          dcrDate: new Date(45),
-          file: {
-            id: dcrFileId,
-            filename: 'filename',
-          },
-          numeroDossier: 'numeroDossier',
-        },
-      })
-    })
-  })
-
   describe('when ptf has been submitted', () => {
     const ptfFileId = new UniqueEntityID().toString()
 

--- a/src/infra/sequelize/queries/project/getProjectDataForProjectPage.ts
+++ b/src/infra/sequelize/queries/project/getProjectDataForProjectPage.ts
@@ -41,18 +41,6 @@ export const getProjectDataForProjectPage: GetProjectDataForProjectPage = ({ pro
         },
         {
           model: ProjectStep,
-          as: 'dcr',
-          required: false,
-          include: [
-            {
-              model: File,
-              as: 'file',
-              attributes: ['id', 'filename'],
-            },
-          ],
-        },
-        {
-          model: ProjectStep,
           as: 'ptf',
           required: false,
           include: [
@@ -106,7 +94,6 @@ export const getProjectDataForProjectPage: GetProjectDataForProjectPage = ({ pro
           dcrDueOn,
           users,
           gf,
-          dcr,
           ptf,
           completionDueOn,
           updatedAt,
@@ -179,10 +166,6 @@ export const getProjectDataForProjectPage: GetProjectDataForProjectPage = ({ pro
           result.garantiesFinancieres = { dueOn: new Date(garantiesFinancieresDueOn) }
         }
 
-        if (dcrDueOn) {
-          result.dcr = { dueOn: new Date(dcrDueOn) }
-        }
-
         if (gf) {
           const { submittedOn, status, file, stepDate } = gf
 
@@ -205,21 +188,6 @@ export const getProjectDataForProjectPage: GetProjectDataForProjectPage = ({ pro
           }
         }
 
-        if (dcr) {
-          const {
-            submittedOn,
-            file,
-            stepDate,
-            details: { numeroDossier },
-          } = dcr
-          result.dcr = {
-            ...result.dcr,
-            submittedOn,
-            file: file?.get(),
-            dcrDate: stepDate,
-            numeroDossier,
-          }
-        }
         return ok(result)
       }
     )

--- a/src/modules/project/dtos/ProjectDataForProjectPage.ts
+++ b/src/modules/project/dtos/ProjectDataForProjectPage.ts
@@ -73,7 +73,6 @@ type IsClasse = {
   isAbandoned: false
   completionDueOn: Date
 } & GarantieFinanciere &
-  DCR &
   PTF
 
 type IsElimine = {
@@ -85,22 +84,6 @@ type IsElimine = {
 type IsAbandoned = {
   isAbandoned: true
   isClasse: false
-}
-
-type DCR = { dcr: { dueOn: Date } & (DCRSubmitted | DCRPending) }
-
-type DCRSubmitted = {
-  submittedOn: Date
-  dcrDate: Date
-  file: {
-    id: string
-    filename: string
-  }
-  numeroDossier: string
-}
-
-type DCRPending = {
-  submittedOn: undefined
 }
 
 type PTF = PTFSubmitted | PTFPending

--- a/src/views/pages/projectDetailsPage/ProjectDetails.stories.tsx
+++ b/src/views/pages/projectDetailsPage/ProjectDetails.stories.tsx
@@ -206,7 +206,6 @@ export const forPorteurProjet = () => (
       {
         ...fakeProjectData,
         isClasse: true,
-        dcr: { dueOn: new Date(Date.now() + 2 * MONTHS) },
         garantiesFinancieres: { dueOn: new Date(Date.now() + 2 * MONTHS) },
       } as ProjectDataForProjectPage
     }
@@ -240,7 +239,6 @@ export const forPorteurProjetWithGarantiesFinancieres = () => (
       {
         ...fakeProjectData,
         isClasse: true,
-        dcr: { dueOn: new Date(Date.now() + 2 * MONTHS) },
         garantiesFinancieres: {
           dueOn: new Date(Date.now() + 2 * MONTHS),
           submittedOn: new Date(),


### PR DESCRIPTION
Le problème des projets en double/triple résulte de plusieurs entrées dans la projection `project_steps`. Celle-ci était utilisé afin d'afficher les étapes du projet avant que nous ne refassions totalement cette partie. Donc les éléments pour les dcr dans la projection ne sont plus du tout utilisés.
Comme nous avons encore des dépendances sur cette projection pour quelques queries on ne peut pas pas la supprimer directement. 
J'ai donc désactiver le rapatriement de cette info dans toutes les queries pour l'affichage de la liste et du détail des projets ainsi que des gestionnaire d'événement qui remplissait cette projection