### PR TITLE
🐛 Renommage des titres courts de certains AOs pour les différencier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ src/public/css/dsfr.css
 
 # Generated js files
 src/public/js
+
+# Storybook
+storybook-static/

--- a/src/dataAccess/inMemory/appelsOffres/CRE4/autoconsommationMetropole2016.ts
+++ b/src/dataAccess/inMemory/appelsOffres/CRE4/autoconsommationMetropole2016.ts
@@ -6,7 +6,7 @@ export const autoconsommationMetropole2016: AppelOffre = {
   type: 'autoconso',
   title:
     'portant sur la réalisation et l’exploitation d’installations de production d’électricité à partir d’énergies renouvelables en autoconsommation',
-  shortTitle: 'CRE4 - Autoconsommation métropole',
+  shortTitle: 'CRE4 - Autoconsommation métropole 2016',
   launchDate: 'juillet 2016',
   unitePuissance: 'MWc',
   delaiRealisationEnMois: 30,

--- a/src/dataAccess/inMemory/appelsOffres/CRE4/autoconsommationZNI2017.ts
+++ b/src/dataAccess/inMemory/appelsOffres/CRE4/autoconsommationZNI2017.ts
@@ -6,7 +6,7 @@ export const autoconsommationZNI2017: AppelOffre = {
   type: 'autoconso',
   title:
     'portant sur la réalisation et l’exploitation d’Installations de production d’électricité à partir d’énergies renouvelables en autoconsommation et situées dans les zones non interconnectées',
-  shortTitle: 'CRE4 - Autoconsommation ZNI',
+  shortTitle: 'CRE4 - Autoconsommation ZNI 2017',
   launchDate: 'décembre 2016',
   unitePuissance: 'MWc',
   delaiRealisationEnMois: 30,

--- a/src/dataAccess/inMemory/appelsOffres/CRE4/zni2017.ts
+++ b/src/dataAccess/inMemory/appelsOffres/CRE4/zni2017.ts
@@ -6,7 +6,7 @@ export const zni2017: AppelOffre = {
   type: 'zni',
   title:
     'portant sur la réalisation et l’exploitation d’installations de production d’électricité à partir de techniques de conversion du rayonnement solaire d’une puissance supérieure à 100 kWc et situées dans les zones non interconnectées',
-  shortTitle: 'CRE4 - ZNI',
+  shortTitle: 'CRE4 - ZNI 2017',
   launchDate: 'mai 2015',
   unitePuissance: 'MWc',
   delaiRealisationEnMois: 36,


### PR DESCRIPTION
Pour les noms des AO dans les filtres nous auront donc :

- CRE4 - Autoconsommation métropole
- CRE4 - Autoconsommation métropole 2016
- CRE4 - Autoconsommation ZNI
- CRE4 - Autoconsommation ZNI 2017
- CRE4 - ZNI 
- CRE4 - ZNI 2017

<a href="https://gitpod.io/#https://github.com/MTES-MCT/potentiel/pull/509"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

