### PR TITLE
:rotating_light: fusion des déclarations d'extensions eslint-prettier

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,9 +6,7 @@
   },
   "extends": [
     "plugin:react/recommended",
-    "prettier",
-    "prettier/@typescript-eslint",
-    "prettier/react"
+    "prettier"
   ],
   // Prevent ESLint from yelling at chai assertions (e.g : expect(undefined).to.be.undefined)
   "overrides": [


### PR DESCRIPTION
Depuis la version 8 de eslint-conffig-prettier, toutes les extensions sont mergées en une :

https://github.com/prettier/eslint-config-prettier/blob/main/CHANGELOG.md#version-800-2021-02-21

<a href="https://gitpod.io/#https://github.com/MTES-MCT/potentiel/pull/558"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

