### PR TITLE
🐛 1065 - Ajout fichiers réponse manquants dans modificationRequests

### DIFF
--- a/src/infra/sequelize/migrations/20220823151651-Correction-ModificationRequests-responseFileId-manquants.ts
+++ b/src/infra/sequelize/migrations/20220823151651-Correction-ModificationRequests-responseFileId-manquants.ts
@@ -1,0 +1,36 @@
+'use strict'
+
+import models from '../models'
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    const transaction = await queryInterface.sequelize.transaction()
+
+    try {
+      const { EventStore, ModificationRequest } = models
+      const événementsDesDemandesACorriger = await EventStore.findAll(
+        { where: { type: 'DélaiRejeté' } },
+        { transaction }
+      )
+
+      événementsDesDemandesACorriger.map(async ({ payload }) => {
+        await ModificationRequest.update(
+          {
+            responseFileId: payload.fichierRéponseId,
+          },
+          {
+            where: { id: payload.demandeDélaiId },
+          },
+          { transaction }
+        )
+      })
+
+      await transaction.commit()
+    } catch (error) {
+      await transaction.rollback()
+      throw error
+    }
+  },
+
+  async down(queryInterface, Sequelize) {},
+}


### PR DESCRIPTION
Avant [cette correction](https://github.com/MTES-MCT/potentiel/pull/578), dans le handler onDélaiRejeté, on n'enregistrait pas dans la projection modificationRequests l'id du fichier de réponse. Le porteur n'avait donc pas accès à ce fichier de réponse depuis la page de la demande de délai. 

Pour les événements "DélaiRejeté" déjà émis, j'ai créé un script de migration pour mettre modificationRequests à jour. 

<a href="https://gitpod.io/#https://github.com/MTES-MCT/potentiel/pull/579"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

