### PR TITLE
1105 Changement de producteur : supprimer demande GF de la confirmation PP

### DIFF
--- a/src/infra/mail/mailjet.ts
+++ b/src/infra/mail/mailjet.ts
@@ -20,7 +20,7 @@ const TEMPLATE_ID_BY_TYPE: Record<NotificationProps['type'], number> = {
   'modification-request-confirmed': 2807220,
   'modification-request-cancelled': 2060611,
   'dreal-modification-received': 2857027,
-  'pp-modification-received': 2859616,
+  'pp-modification-received': 4183039,
   'pp-new-rules-opted-in': 2982401,
   'admin-modification-requested': 2047347,
   'legacy-candidate-notification': 3075029,

--- a/src/modules/notification/Notification.ts
+++ b/src/modules/notification/Notification.ts
@@ -172,7 +172,8 @@ type PPModificationReceived = {
   variables: {
     nom_projet: string
     type_demande: string
-    modification_request_url: string
+    button_url: string
+    button_title: string
     demande_action_pp?: string
   }
 }

--- a/src/modules/notification/Notification.ts
+++ b/src/modules/notification/Notification.ts
@@ -175,6 +175,7 @@ type PPModificationReceived = {
     button_url: string
     button_title: string
     demande_action_pp?: string
+    button_instructions: string
   }
 }
 

--- a/src/modules/notification/eventHandlers/modificationRequests/handleModificationReceived.spec.ts
+++ b/src/modules/notification/eventHandlers/modificationRequests/handleModificationReceived.spec.ts
@@ -56,7 +56,8 @@ describe('notification.handleModificationReceived', () => {
           notification.message.email === 'pp@test.test' &&
           notification.variables.nom_projet === 'nomProjet' &&
           notification.variables.type_demande === 'actionnaire' &&
-          notification.variables.modification_request_url === routes.USER_LIST_REQUESTS &&
+          notification.variables.button_url === routes.USER_LIST_REQUESTS &&
+          notification.variables.button_title === 'Consulter la demande' &&
           notification.variables.demande_action_pp === undefined &&
           notification.context.modificationRequestId === modificationRequestId &&
           notification.context.userId === userId &&
@@ -282,56 +283,6 @@ describe('notification.handleModificationReceived', () => {
 
         if (notification.type !== 'pp-modification-received') return
         expect(notification.variables.demande_action_pp).not.toBeUndefined()
-      })
-    })
-  })
-  describe('when event type is "producteur', () => {
-    describe('when the project is not subject to GF', () => {
-      const sendNotification = jest.fn(async (args: NotificationArgs) => null)
-      const findProjectById = jest.fn(async (region: string) =>
-        makeProject(
-          makeFakeProject({
-            id: projectId,
-            nomProjet: 'nomProjet',
-            regionProjet: 'region',
-            evaluationCarbone: 100,
-            appelOffreId: 'PPE2 - Eolien',
-            periodeId: '1',
-            appelOffre: { isSoumisAuxGF: false },
-          })
-        ).unwrap()
-      )
-      const findUserById = jest.fn(async (userId: string) =>
-        Some(makeFakeUser({ email: 'pp@test.test', fullName: 'john doe' }))
-      )
-      const findUsersForDreal = jest.fn(async (region: string) => [])
-
-      beforeAll(async () => {
-        await handleModificationReceived({
-          sendNotification,
-          findProjectById,
-          findUserById,
-          findUsersForDreal,
-        })(
-          new ModificationReceived({
-            payload: {
-              type: 'producteur',
-              modificationRequestId,
-              projectId,
-              requestedBy: userId,
-              producteur: 'new producteur',
-              authority: 'dreal',
-            },
-          })
-        )
-      })
-
-      it('should NOT add a warning section for GF in the sent email', async () => {
-        const [notification] = sendNotification.mock.calls.map((call) => call[0])
-
-        if (notification.type !== 'pp-modification-received') return
-
-        expect(notification.variables.demande_action_pp).toBeUndefined()
       })
     })
   })

--- a/src/modules/notification/eventHandlers/modificationRequests/handleModificationReceived.spec.ts
+++ b/src/modules/notification/eventHandlers/modificationRequests/handleModificationReceived.spec.ts
@@ -58,6 +58,8 @@ describe('notification.handleModificationReceived', () => {
           notification.variables.type_demande === 'actionnaire' &&
           notification.variables.button_url === routes.USER_LIST_REQUESTS &&
           notification.variables.button_title === 'Consulter la demande' &&
+          notification.variables.button_instructions ===
+            `Pour la consulter, connectez-vous à Potentiel.` &&
           notification.variables.demande_action_pp === undefined &&
           notification.context.modificationRequestId === modificationRequestId &&
           notification.context.userId === userId &&

--- a/src/modules/notification/eventHandlers/modificationRequests/handleModificationReceived.ts
+++ b/src/modules/notification/eventHandlers/modificationRequests/handleModificationReceived.ts
@@ -39,13 +39,16 @@ export const handleModificationReceived =
           variables: {
             nom_projet: project.nomProjet,
             type_demande: type,
-            modification_request_url: routes.USER_LIST_REQUESTS,
+            button_url: routes.USER_LIST_REQUESTS,
+            button_title: 'Consulter la demande',
             demande_action_pp: undefined as string | undefined,
           },
         }
 
-        if (type === 'producteur' && project.appelOffre?.isSoumisAuxGF)
-          notificationPayload.variables.demande_action_pp = `Suite à votre signalement de changement de ${type}, vous devez déposer de nouvelles garanties financières dans un délai d'un mois maximum.`
+        if (type === 'producteur') {
+          ;(notificationPayload.variables.button_url = routes.USER_LIST_PROJECTS),
+            (notificationPayload.variables.button_title = 'Voir mes projets')
+        }
 
         if (type === 'fournisseur' && event.payload.evaluationCarbone) {
           const currentEvaluationCarbone = project.evaluationCarbone

--- a/src/modules/notification/eventHandlers/modificationRequests/handleModificationReceived.ts
+++ b/src/modules/notification/eventHandlers/modificationRequests/handleModificationReceived.ts
@@ -41,13 +41,15 @@ export const handleModificationReceived =
             type_demande: type,
             button_url: routes.USER_LIST_REQUESTS,
             button_title: 'Consulter la demande',
+            button_instructions: `Pour la consulter, connectez-vous à Potentiel.`,
             demande_action_pp: undefined as string | undefined,
           },
         }
 
         if (type === 'producteur') {
-          ;(notificationPayload.variables.button_url = routes.USER_LIST_PROJECTS),
-            (notificationPayload.variables.button_title = 'Voir mes projets')
+          notificationPayload.variables.button_url = routes.USER_LIST_PROJECTS
+          notificationPayload.variables.button_title = 'Voir mes projets'
+          notificationPayload.variables.button_instructions = `Pour vos projets, connectez-vous à Potentiel.`
         }
 
         if (type === 'fournisseur' && event.payload.evaluationCarbone) {

--- a/src/views/components/UI/atoms/icons.ts
+++ b/src/views/components/UI/atoms/icons.ts
@@ -1,8 +1,5 @@
 export { RiFileDownloadLine as FileDownloadIcon } from '@react-icons/all-files/ri/RiFileDownloadLine'
 export { RiFileExcelLine as ExcelFileIcon } from '@react-icons/all-files/ri/RiFileExcelLine'
-<<<<<<< HEAD
 export { FiExternalLink as ExternalLinkIcon } from '@react-icons/all-files/fi/FiExternalLink'
 export { FiChevronLeft as ChevronLeftIcon } from '@react-icons/all-files/fi/FiChevronLeft'
-=======
 export { IoIosWarning as WarningIcon } from '@react-icons/all-files/io/IoIosWarning'
->>>>>>> 💄 (Molecules): Ajout d'une AlertBox

--- a/src/views/components/UI/atoms/icons.ts
+++ b/src/views/components/UI/atoms/icons.ts
@@ -1,4 +1,8 @@
 export { RiFileDownloadLine as FileDownloadIcon } from '@react-icons/all-files/ri/RiFileDownloadLine'
 export { RiFileExcelLine as ExcelFileIcon } from '@react-icons/all-files/ri/RiFileExcelLine'
+<<<<<<< HEAD
 export { FiExternalLink as ExternalLinkIcon } from '@react-icons/all-files/fi/FiExternalLink'
 export { FiChevronLeft as ChevronLeftIcon } from '@react-icons/all-files/fi/FiChevronLeft'
+=======
+export { IoIosWarning as WarningIcon } from '@react-icons/all-files/io/IoIosWarning'
+>>>>>>> 💄 (Molecules): Ajout d'une AlertBox

--- a/src/views/components/UI/molecules/AlertBox.tsx
+++ b/src/views/components/UI/molecules/AlertBox.tsx
@@ -1,0 +1,23 @@
+import React, { ComponentProps } from 'react'
+import { WarningIcon } from '../atoms'
+
+export type AlertBoxProps = ComponentProps<'div'> & { title?: string }
+
+export const AlertBox = ({ title, children, className = '', ...props }: AlertBoxProps) => {
+  return (
+    <div className={`flex ${className}`} {...props}>
+      <div className="bg-warning-425-base">
+        <WarningIcon className="text-white text-3xl mx-2 mt-4" />
+      </div>
+      <div className="pl-5 pr-8 py-4 border-solid border-1 border-warning-425-base">
+        {title && (
+          <>
+            <span className="text-base font-semibold mb-2 inline-block">{title}</span>
+            <br />
+          </>
+        )}
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/src/views/components/UI/molecules/index.ts
+++ b/src/views/components/UI/molecules/index.ts
@@ -1,3 +1,3 @@
+export * from './AlertBox'
 export * from './DownloadLink'
 export * from './DownloadLinkButton'
-export * from '../atoms/SecondaryButton'

--- a/src/views/pages/changerProducteurPage/ChangerProducteur.tsx
+++ b/src/views/pages/changerProducteurPage/ChangerProducteur.tsx
@@ -99,14 +99,6 @@ export const ChangerProducteur = PageLayout(
                     defaultValue={project.nomCandidat}
                     style={{ backgroundColor: '#CECECE' }}
                   />
-                  {!isEolien && appelOffre?.isSoumisAuxGF && (
-                    <div className="notification warning my-4">
-                      <span>
-                        Attention : de nouvelles garanties financières devront être déposées d'ici
-                        un mois
-                      </span>
-                    </div>
-                  )}
                   <label htmlFor="producteur" className="mt-4 ">
                     Nouveau producteur <Astérisque />
                   </label>

--- a/src/views/pages/changerProducteurPage/ChangerProducteur.tsx
+++ b/src/views/pages/changerProducteurPage/ChangerProducteur.tsx
@@ -17,6 +17,7 @@ import {
   Astérisque,
   Input,
   TextArea,
+  AlertBox,
 } from '@components'
 import { hydrateOnClient } from '../../helpers'
 
@@ -72,18 +73,18 @@ export const ChangerProducteur = PageLayout(
 
               {(newRulesOptInSelectionné || !doitChoisirCahierDesCharges) && (
                 <div {...dataId('modificationRequest-demandesInputs')}>
-                  <div className="notification error my-4">
-                    <span>
-                      Attention : une fois ce formulaire de changement de producteur envoyé,{' '}
-                      <em>vous ne pourrez plus suivre ce projet sur Potentiel</em>. Tous les accès
-                      actuels seront retirés.{' '}
-                      <strong>
-                        Le nouveau producteur pourra retrouver le projet dans les "projets à
-                        réclamer"
-                      </strong>
-                      .
+                  <AlertBox
+                    title="Attention : révocation des droits sur le projet"
+                    className="my-7"
+                  >
+                    Une fois ce formulaire de changement de producteur envoyé, vous ne pourrez plus
+                    suivre ce projet sur Potentiel. Tous les accès actuels seront retirés.
+                    <br />
+                    <span className="font-medium">
+                      Le nouveau producteur pourra retrouver le projet dans les "projets à réclamer"
                     </span>
-                  </div>
+                    .
+                  </AlertBox>
                   {isEolien && (
                     <div className="notification error my-4">
                       <span>
@@ -136,7 +137,6 @@ export const ChangerProducteur = PageLayout(
                     {...dataId('modificationRequest-justificationField')}
                     {...(isEolien && { disabled: true })}
                   />
-
                   <Button
                     className="mt-3 mr-1"
                     type="submit"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -47,6 +47,11 @@ module.exports = {
           hover: '#e6b594',
           active: '#eccab6',
         },
+        'warning-425': {
+          base: '#b34000',
+          hover: '#ff6218',
+          active: '#ff7a55',
+        },
       },
     },
   },


### PR DESCRIPTION
En cas de changement de producteur, si le projet est soumis aux GF, dans le mail de confirmation de la modification on demande au PP d'envoyer de nouvelles GF. 

Dans cette PR on supprime la phrase concernant les GF du mail de confirmation de la modification. 
ET à la place du bouton "Consulter la demande" on a un bouton "Voir mes projets" (à ce stade le porteur à l'origine de la demande a perdu les droits sur le projet. 

On supprime aussi un warning du formulaire de changement de producteur (demande d'envoi de nouvelles GF sous un mois).

Création d'une AlertBox suivant le dsfr pour l'alerte qu'on garde dans le formulaire. 

<a href="https://gitpod.io/#https://github.com/MTES-MCT/potentiel/pull/611"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

