### PR TITLE
🐛 1146 - Quick fix : alerte puissance min/max si CDC 2022

### DIFF
--- a/src/infra/sequelize/queries/modificationRequest/getModificationRequestDetails.ts
+++ b/src/infra/sequelize/queries/modificationRequest/getModificationRequestDetails.ts
@@ -43,6 +43,7 @@ export const getModificationRequestDetails: GetModificationRequestDetails = (
             'completionDueOn',
             'potentielIdentifier',
             'technologie',
+            'cahierDesChargesActuel',
           ],
         },
         {

--- a/src/modules/modificationRequest/dtos/ModificationRequestPageDTO.ts
+++ b/src/modules/modificationRequest/dtos/ModificationRequestPageDTO.ts
@@ -49,6 +49,7 @@ export type ModificationRequestPageDTO = {
     potentielIdentifier: string
     technologie: Technologie
     appelOffre?: ProjectAppelOffre
+    cahierDesChargesActuel: string
   }
 } & Variant
 

--- a/src/views/pages/modificationRequestPage/ModificationRequest.stories.tsx
+++ b/src/views/pages/modificationRequestPage/ModificationRequest.stories.tsx
@@ -44,6 +44,7 @@ export const RecoursOuvertPourAdmin = () => (
         completionDueOn: 7376362,
         puissanceInitiale: 123,
         technologie: 'pv',
+        cahierDesChargesActuel: 'initial',
       },
     }}
   />
@@ -86,6 +87,7 @@ export const RecoursAccepté = () => (
         completionDueOn: 7376362,
         puissanceInitiale: 123,
         technologie: 'pv',
+        cahierDesChargesActuel: 'initial',
       },
     }}
   />
@@ -128,6 +130,7 @@ export const RecoursRejeté = () => (
         completionDueOn: 123,
         puissanceInitiale: 123,
         technologie: 'pv',
+        cahierDesChargesActuel: 'initial',
       },
     }}
   />
@@ -169,6 +172,7 @@ export const ChangementPuissance = () => (
         completionDueOn: 7376362,
         puissanceInitiale: 123,
         technologie: 'pv',
+        cahierDesChargesActuel: 'initial',
       },
     }}
   />
@@ -211,6 +215,7 @@ export const ChangementPuissanceNonAutoAccepteSuperieurVolumeReserve = () => (
         puissanceInitiale: 0.5,
         technologie: 'pv',
         appelOffre: { ...batimentPPE2, periode: batimentPPE2.periodes[0] } as ProjectAppelOffre,
+        cahierDesChargesActuel: 'initial',
       },
     }}
   />

--- a/src/views/pages/modificationRequestPage/components/PuissanceForm.tsx
+++ b/src/views/pages/modificationRequestPage/components/PuissanceForm.tsx
@@ -16,7 +16,9 @@ export const PuissanceForm = ({ modificationRequest }: PuissanceFormProps) => {
   const { project, puissance: nouvellePuissance } = modificationRequest
   const exceedsRatios = exceedsRatiosChangementPuissance({ project, nouvellePuissance })
   const exceedsPuissanceMax = exceedsPuissanceMaxDuVolumeReserve({ project, nouvellePuissance })
-  const ratios = getRatiosChangementPuissance(project)
+  const ratios = ['30/08/2022', '30/08/2022-alternatif'].includes(project.cahierDesChargesActuel)
+    ? { min: 0.9, max: 1.4 }
+    : getRatiosChangementPuissance(project)
   const reservedVolume = project.appelOffre && getVolumeReserve(project.appelOffre)
 
   return (

--- a/src/views/pages/newModificationRequestPage/components/puissance/AlerteNouvellePuissance.tsx
+++ b/src/views/pages/newModificationRequestPage/components/puissance/AlerteNouvellePuissance.tsx
@@ -29,10 +29,15 @@ type AlertOnPuissanceOutsideRatiosProps = {
   project: {
     appelOffre?: ProjectAppelOffre
     technologie: Technologie
+    cahierDesChargesActuel: string
   }
 }
 export const AlertePuissanceHorsRatios = ({ project }: AlertOnPuissanceOutsideRatiosProps) => {
-  const { min, max } = getRatiosChangementPuissance(project)
+  const { min, max } = ['30/08/2022', '30/08/2022-alternatif'].includes(
+    project.cahierDesChargesActuel
+  )
+    ? { min: 0.9, max: 1.4 }
+    : getRatiosChangementPuissance(project)
 
   return (
     <div className="notification warning mt-4">


### PR DESCRIPTION
Dans le formulaire de changement de puissance et sur le détail d'une demande de changement de puissance : 
si CDC 2022 choisi, afficher l'alerte si la nouvelle puissance est en dehors des seuils 90 - 140.
En attendant d'appliquer les seuils par appel d'offre. 

<a href="https://gitpod.io/#https://github.com/MTES-MCT/potentiel/pull/643"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

