### PR TITLE
1146 - Suppression alerte puissance hors ratio pour CDC 2022

### DIFF
--- a/src/infra/sequelize/queries/modificationRequest/getModificationRequestDetails.ts
+++ b/src/infra/sequelize/queries/modificationRequest/getModificationRequestDetails.ts
@@ -43,6 +43,7 @@ export const getModificationRequestDetails: GetModificationRequestDetails = (
             'completionDueOn',
             'potentielIdentifier',
             'technologie',
+            'cahierDesChargesActuel',
           ],
         },
         {

--- a/src/modules/modificationRequest/dtos/ModificationRequestPageDTO.ts
+++ b/src/modules/modificationRequest/dtos/ModificationRequestPageDTO.ts
@@ -1,4 +1,4 @@
-import { ProjectAppelOffre, Technologie } from '@entities'
+import { ProjectAppelOffre, Technologie, CahierDesChargesRéférence } from '@entities'
 import { Fournisseur } from '../../project'
 import { ModificationRequestStatusDTO } from './ModificationRequestListItemDTO'
 
@@ -49,7 +49,7 @@ export type ModificationRequestPageDTO = {
     potentielIdentifier: string
     technologie: Technologie
     appelOffre?: ProjectAppelOffre
-    cahierDesChargesActuel: string
+    cahierDesChargesActuel: CahierDesChargesRéférence
   }
 } & Variant
 

--- a/src/modules/modificationRequest/dtos/ModificationRequestPageDTO.ts
+++ b/src/modules/modificationRequest/dtos/ModificationRequestPageDTO.ts
@@ -49,6 +49,7 @@ export type ModificationRequestPageDTO = {
     potentielIdentifier: string
     technologie: Technologie
     appelOffre?: ProjectAppelOffre
+    cahierDesChargesActuel: string
   }
 } & Variant
 

--- a/src/modules/modificationRequest/useCases/requestPuissanceModification.ts
+++ b/src/modules/modificationRequest/useCases/requestPuissanceModification.ts
@@ -125,7 +125,11 @@ export const makeRequestPuissanceModification =
                 })
               }
 
-              if ((!fileId || fileId === '') && !justification) {
+              if (
+                project.cahierDesCharges.paruLe !== '30/08/2022' &&
+                (!fileId || fileId === '') &&
+                !justification
+              ) {
                 return errAsync(new PuissanceJustificationOrCourrierMissingError())
               }
 

--- a/src/modules/modificationRequest/useCases/requestPuissanceModification.ts
+++ b/src/modules/modificationRequest/useCases/requestPuissanceModification.ts
@@ -125,11 +125,7 @@ export const makeRequestPuissanceModification =
                 })
               }
 
-              if (
-                project.cahierDesCharges.paruLe !== '30/08/2022' &&
-                (!fileId || fileId === '') &&
-                !justification
-              ) {
+              if (project.cahierDesCharges.paruLe !== '30/08/2022' && !fileId && !justification) {
                 return errAsync(new PuissanceJustificationOrCourrierMissingError())
               }
 

--- a/src/views/pages/modificationRequestPage/ModificationRequest.stories.tsx
+++ b/src/views/pages/modificationRequestPage/ModificationRequest.stories.tsx
@@ -44,6 +44,7 @@ export const RecoursOuvertPourAdmin = () => (
         completionDueOn: 7376362,
         puissanceInitiale: 123,
         technologie: 'pv',
+        cahierDesChargesActuel: 'initial',
       },
     }}
   />
@@ -86,6 +87,7 @@ export const RecoursAccepté = () => (
         completionDueOn: 7376362,
         puissanceInitiale: 123,
         technologie: 'pv',
+        cahierDesChargesActuel: 'initial',
       },
     }}
   />
@@ -128,6 +130,7 @@ export const RecoursRejeté = () => (
         completionDueOn: 123,
         puissanceInitiale: 123,
         technologie: 'pv',
+        cahierDesChargesActuel: 'initial',
       },
     }}
   />
@@ -169,6 +172,7 @@ export const ChangementPuissance = () => (
         completionDueOn: 7376362,
         puissanceInitiale: 123,
         technologie: 'pv',
+        cahierDesChargesActuel: 'initial',
       },
     }}
   />
@@ -211,6 +215,7 @@ export const ChangementPuissanceNonAutoAccepteSuperieurVolumeReserve = () => (
         puissanceInitiale: 0.5,
         technologie: 'pv',
         appelOffre: { ...batimentPPE2, periode: batimentPPE2.periodes[0] } as ProjectAppelOffre,
+        cahierDesChargesActuel: 'initial',
       },
     }}
   />

--- a/src/views/pages/modificationRequestPage/components/PuissanceForm.tsx
+++ b/src/views/pages/modificationRequestPage/components/PuissanceForm.tsx
@@ -19,6 +19,10 @@ export const PuissanceForm = ({ modificationRequest }: PuissanceFormProps) => {
   const ratios = getRatiosChangementPuissance(project)
   const reservedVolume = project.appelOffre && getVolumeReserve(project.appelOffre)
 
+  const CDC2022choisi = ['30/08/2022', '30/08/2022-alternatif'].includes(
+    project.cahierDesChargesActuel
+  )
+
   return (
     <>
       <div className="form__group mt-4">
@@ -34,7 +38,7 @@ export const PuissanceForm = ({ modificationRequest }: PuissanceFormProps) => {
         />
       </div>
 
-      {exceedsRatios && (
+      {!CDC2022choisi && exceedsRatios && (
         <div className="notification warning mt-3">
           La nouvelle puissance demandée est inférieure à {Math.round(ratios.min * 100)}% de la
           puissance initiale ou supérieure à {Math.round(ratios.max * 100)}%.{' '}

--- a/src/views/pages/newModificationRequestPage/components/puissance/ChangementPuissance.tsx
+++ b/src/views/pages/newModificationRequestPage/components/puissance/ChangementPuissance.tsx
@@ -42,6 +42,10 @@ export const ChangementPuissance = ({
     setFileRequiredforPuissanceModification(exceedsRatios || exceedsPuissanceMax)
   }
 
+  const CDC2022choisi = ['30/08/2022', '30/08/2022-alternatif'].includes(
+    project.cahierDesChargesActuel
+  )
+
   return (
     <>
       <label>Puissance à la notification (en {appelOffre?.unitePuissance})</label>
@@ -72,7 +76,7 @@ export const ChangementPuissance = ({
         required={true}
       />
 
-      {displayAlertHorsRatios && <AlertePuissanceHorsRatios {...{ project }} />}
+      {!CDC2022choisi && displayAlertHorsRatios && <AlertePuissanceHorsRatios {...{ project }} />}
 
       {displayAlertPuissanceMaxVolumeReserve && <AlertePuissanceMaxDepassee {...{ project }} />}
 

--- a/src/views/pages/newModificationRequestPage/components/puissance/ChangementPuissance.tsx
+++ b/src/views/pages/newModificationRequestPage/components/puissance/ChangementPuissance.tsx
@@ -27,8 +27,7 @@ export const ChangementPuissance = ({
   const [displayAlertHorsRatios, setDisplayAlertHorsRatios] = useState(false)
   const [displayAlertPuissanceMaxVolumeReserve, setDisplayAlertPuissanceMaxVolumeReserve] =
     useState(false)
-  const [fileRequiredforPuissanceModification, setFileRequiredforPuissanceModification] =
-    useState(false)
+  const [fichierEtJustificationRequis, setFichierEtJustificationRequis] = useState(false)
 
   const handlePuissanceOnChange = (e) => {
     const isNewValueCorrect = isStrictlyPositiveNumber(e.target.value)
@@ -39,7 +38,7 @@ export const ChangementPuissance = ({
     setDisplayAlertOnPuissanceType(!isNewValueCorrect)
     setDisplayAlertHorsRatios(exceedsRatios)
     setDisplayAlertPuissanceMaxVolumeReserve(exceedsPuissanceMax)
-    setFileRequiredforPuissanceModification(exceedsRatios || exceedsPuissanceMax)
+    setFichierEtJustificationRequis(exceedsRatios || exceedsPuissanceMax)
   }
 
   const CDC2022choisi = ['30/08/2022', '30/08/2022-alternatif'].includes(
@@ -94,24 +93,26 @@ export const ChangementPuissance = ({
           <strong>Veuillez nous indiquer les raisons qui motivent votre demande</strong>
           <br />
           Pour faciliter le traitement de votre demande, veillez à détailler les raisons ayant
-          conduit à ce besoin de modification (contexte, facteurs extérieurs, etc)
+          conduit à ce besoin de modification (contexte, facteurs extérieurs, etc){' '}
+          {!CDC2022choisi && fichierEtJustificationRequis && <Astérisque />}
         </Label>
         <textarea
           name="justification"
           id="justification"
           defaultValue={justification || ''}
           {...dataId('modificationRequest-justificationField')}
+          required={!CDC2022choisi && fichierEtJustificationRequis}
         />
         <label htmlFor="candidats" className="mt-4">
           Courrier explicatif ou décision administrative.{' '}
-          {fileRequiredforPuissanceModification && <Astérisque />}
+          {!CDC2022choisi && fichierEtJustificationRequis && <Astérisque />}
         </label>
         <input
           type="file"
           name="file"
           {...dataId('modificationRequest-fileField')}
           id="file"
-          required={fileRequiredforPuissanceModification}
+          required={!CDC2022choisi && fichierEtJustificationRequis}
         />
       </div>
     </>


### PR DESCRIPTION
En attendant d'intégrer les seuils propres à chaque AO pour les CDC 2022

<a href="https://gitpod.io/#https://github.com/MTES-MCT/potentiel/pull/644"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

