### PR TITLE
👷 (1061): Ajout du déploiement sur l'instance scalingo de production

### DIFF
--- a/.github/workflows/deploy.prod.yml
+++ b/.github/workflows/deploy.prod.yml
@@ -28,3 +28,11 @@ jobs:
         env:
           CLEVER_TOKEN: ${{ secrets.CLEVER_TOKEN }}
           CLEVER_SECRET: ${{ secrets.CLEVER_SECRET }}
+
+      - name: Deploy to Scalingo
+        uses: webfactory/ssh-agent@v0.5.4
+        with:
+          ssh-private-key: ${{ secrets.SCALINGO_SECRET }}
+        run: |
+          git remote add scalingo ${{secrets.SCALINGO_REPOSITORY}}
+          git push scalingo master


### PR DESCRIPTION
Ici nous préparons la bascule de l'instance de production sur scalingo. Pour l'instant nous déployons en plus de CleverCloud l'instance sur Scalingo.
Une fois la bascule faite nous n'aurons plus qu'à supprimer la partie CleverCloud du workflow

PS: impossible de tester localement donc à monitorer une fois la PR mergée