### PR TITLE
1093 durées gf cre4 éolien p1 et p3

### DIFF
--- a/src/dataAccess/inMemory/appelsOffres/CRE4/eolien.ts
+++ b/src/dataAccess/inMemory/appelsOffres/CRE4/eolien.ts
@@ -87,6 +87,7 @@ En   cas   de dépassement de ce délai, la durée de contrat mentionnée au 7.1
         url: 'https://www.cre.fr/media/fichiers/publications/appelsoffres/ancienne-version-du-cahier-des-charges-dans-sa-version-applicable-a-la-1ere-periode-ao-eolien-08112017',
       },
       delaiDcrEnMois: { valeur: 2, texte: 'deux' },
+      garantieFinanciereEnMoisSansAutorisationEnvironnementale: 57,
     },
     {
       id: '2',
@@ -107,6 +108,7 @@ En   cas   de dépassement de ce délai, la durée de contrat mentionnée au 7.1
         url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/cahier-des-charges_3eperioTelecharger-le-cahier-des-charges-en-vigueur-dans-sa-version-modifiee-le-04-mars-2019',
       },
       delaiDcrEnMois: { valeur: 2, texte: 'deux' },
+      garantieFinanciereEnMoisSansAutorisationEnvironnementale: 57,
     },
     {
       id: '4',

--- a/src/entities/periode.ts
+++ b/src/entities/periode.ts
@@ -62,6 +62,7 @@ export type Periode = {
     texte: string
   }
   dossierSuiviPar?: string
+  garantieFinanciereEnMoisSansAutorisationEnvironnementale?: number
 } & (NotifiedPeriode | NotYetNotifiedPeriode | LegacyPeriode)
 
 export const isNotifiedPeriode = (periode: Periode): periode is Periode & NotifiedPeriode => {


### PR DESCRIPTION
Les projets des périodes 1 et 3 de l'appel d'offres CRE4 Eolien ont une durée limite de GF de 57 mois si les projets ont postulé sans avoir d'autorisation environnementale. Dans les autres cas la durée est de 51 mois. 
On ajoute ici une propriété optionnelle dans les périodes pour cette particularité.
Et on met à jour la fonction qui permet de récupérer la durée de GF en mois passée à la page ProjectDetails. 
Pour appliquer cette règle il faudra réimporter le fichier des périodes concernées : cela permettra d'avoir l'info dans la propriété "details" de project. 

<a href="https://gitpod.io/#https://github.com/MTES-MCT/potentiel/pull/713"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

