### PR TITLE
1262  ETQ admin je ne peux pas accepter un recours si le projet est déjà "classé"

### DIFF
--- a/src/controllers/modificationRequest/postReplyToModificationRequest.ts
+++ b/src/controllers/modificationRequest/postReplyToModificationRequest.ts
@@ -13,6 +13,7 @@ import { isDateFormatValid, isStrictlyPositiveNumber } from '../../helpers/formV
 import { validateUniqueId } from '../../helpers/validateUniqueId'
 import {
   ModificationRequestAcceptanceParams,
+  ProjetDéjàClasséError,
   PuissanceVariationWithDecisionJusticeError,
 } from '@modules/modificationRequest'
 import {
@@ -225,6 +226,14 @@ function _handleErrors(request, response, modificationRequestId) {
       return response.redirect(
         addQueryParams(routes.DEMANDE_PAGE_DETAILS(modificationRequestId), {
           error: e.message,
+        })
+      )
+    }
+
+    if (e instanceof ProjetDéjàClasséError) {
+      return response.redirect(
+        addQueryParams(routes.DEMANDE_PAGE_DETAILS(modificationRequestId), {
+          error: `Vous ne pouvez pas accepter cette demande de recours car le projet est déjà "classé". Le porteur a la possibilité d'annuler sa demande, ou bien vous pouvez la rejeter.`,
         })
       )
     }

--- a/src/controllers/project/postCorrectProjectData.ts
+++ b/src/controllers/project/postCorrectProjectData.ts
@@ -147,16 +147,7 @@ v1Router.post(
           )
         }
 
-        if (e instanceof CertificateFileIsMissingError) {
-          return response.redirect(
-            addQueryParams(routes.PROJECT_DETAILS(projectId), {
-              error: e.message,
-              ...request.body,
-            })
-          )
-        }
-
-        if (e instanceof ProjetDéjàClasséError) {
+        if (e instanceof CertificateFileIsMissingError || e instanceof ProjetDéjàClasséError) {
           return response.redirect(
             addQueryParams(routes.PROJECT_DETAILS(projectId), {
               error: e.message,

--- a/src/controllers/project/postCorrectProjectData.ts
+++ b/src/controllers/project/postCorrectProjectData.ts
@@ -11,6 +11,7 @@ import routes from '@routes'
 import { errorResponse } from '../helpers'
 import { upload } from '../upload'
 import { v1Router } from '../v1Router'
+import { ProjetDéjàClasséError } from '@modules/modificationRequest'
 
 const FORMAT_DATE = 'DD/MM/YYYY'
 
@@ -145,7 +146,17 @@ v1Router.post(
             })
           )
         }
+
         if (e instanceof CertificateFileIsMissingError) {
+          return response.redirect(
+            addQueryParams(routes.PROJECT_DETAILS(projectId), {
+              error: e.message,
+              ...request.body,
+            })
+          )
+        }
+
+        if (e instanceof ProjetDéjàClasséError) {
           return response.redirect(
             addQueryParams(routes.PROJECT_DETAILS(projectId), {
               error: e.message,

--- a/src/modules/modificationRequest/errors/ProjetDéjàClasséError.ts
+++ b/src/modules/modificationRequest/errors/ProjetDéjàClasséError.ts
@@ -1,0 +1,7 @@
+import { DomainError } from '@core/domain'
+
+export class ProjetDéjàClasséError extends DomainError {
+  constructor() {
+    super(`Le projet est déjà en statut "classé".`)
+  }
+}

--- a/src/modules/modificationRequest/errors/index.ts
+++ b/src/modules/modificationRequest/errors/index.ts
@@ -1,3 +1,4 @@
+export * from './ProjetDéjàClasséError'
 export * from './PuissanceJustificationEtCourrierManquantError'
 export * from './PuissanceVariationError'
 export * from './StatusPreventsAcceptingError'

--- a/src/modules/modificationRequest/useCases/acceptModificationRequest.ts
+++ b/src/modules/modificationRequest/useCases/acceptModificationRequest.ts
@@ -1,4 +1,4 @@
-import { PuissanceVariationWithDecisionJusticeError } from '..'
+import { ProjetDéjàClasséError, PuissanceVariationWithDecisionJusticeError } from '..'
 import { Repository, UniqueEntityID } from '@core/domain'
 import { err, errAsync, logger, ok, okAsync, Result, ResultAsync } from '@core/utils'
 import { User } from '@entities'
@@ -41,6 +41,7 @@ export const makeAcceptModificationRequest =
     | EntityNotFoundError
     | UnauthorizedError
     | PuissanceVariationWithDecisionJusticeError
+    | ProjetDéjàClasséError
   > => {
     const { fileRepo, modificationRequestRepo, projectRepo } = deps
     const { modificationRequestId, versionDate, responseFile, submittedBy, acceptanceParams } = args
@@ -111,7 +112,7 @@ export const makeAcceptModificationRequest =
       .andThen(({ project, modificationRequest, responseFileId }) => {
         let action: Result<
           null,
-          ProjectCannotBeUpdatedIfUnnotifiedError | IllegalProjectDataError
+          ProjectCannotBeUpdatedIfUnnotifiedError | IllegalProjectDataError | ProjetDéjàClasséError
         > = ok(null)
 
         switch (modificationRequest.type) {

--- a/src/modules/project/Project.grantClasse.spec.ts
+++ b/src/modules/project/Project.grantClasse.spec.ts
@@ -8,6 +8,7 @@ import makeFakeUser from '../../__tests__/fixtures/user'
 import { LegacyProjectSourced, ProjectClasseGranted } from './events'
 import { makeProject } from './Project'
 import { makeGetProjectAppelOffre } from '@modules/projectAppelOffre'
+import { ProjetDéjàClasséError } from '@modules/modificationRequest'
 
 const projectId = new UniqueEntityID('project1')
 const appelOffreId = 'Fessenheim'
@@ -20,7 +21,7 @@ const fakeUser = OldUnwrapForTest(makeUser(makeFakeUser()))
 const getProjectAppelOffre = makeGetProjectAppelOffre(appelsOffreStatic)
 
 describe('Project.grantClasse()', () => {
-  describe('when project is Eliminé', () => {
+  describe('Si le projet est Eliminé', () => {
     const project = UnwrapForTest(
       makeProject({
         projectId,
@@ -42,7 +43,7 @@ describe('Project.grantClasse()', () => {
       })
     )
 
-    it('should emit ProjectClasseGranted event', () => {
+    it('Alors un événement ProjectClasseGranted devrait être émis.', () => {
       project.grantClasse(fakeUser)
 
       const targetEvent = project.pendingEvents.find(
@@ -56,7 +57,7 @@ describe('Project.grantClasse()', () => {
     })
   })
 
-  describe('when project is Classé', () => {
+  describe('Si le projet est Classé', () => {
     const project = UnwrapForTest(
       makeProject({
         projectId,
@@ -78,10 +79,14 @@ describe('Project.grantClasse()', () => {
       })
     )
 
-    it('not emit', () => {
-      project.grantClasse(fakeUser)
+    it('Alors aucun événement ne devrait être émis et une erreur devrait être retournée', () => {
+      const résultat = project.grantClasse(fakeUser)
 
       expect(project.pendingEvents).toHaveLength(0)
+
+      expect(résultat.isErr()).toBe(true)
+      if (!résultat.isErr()) return
+      expect(résultat.error).toBeInstanceOf(ProjetDéjàClasséError)
     })
   })
 })

--- a/src/modules/project/useCases/correctProjectData.ts
+++ b/src/modules/project/useCases/correctProjectData.ts
@@ -1,6 +1,7 @@
 import { Repository, TransactionalRepository, UniqueEntityID } from '@core/domain'
 import { err, errAsync, logger, ok, okAsync, Result, ResultAsync } from '@core/utils'
 import { User } from '@entities'
+import { ProjetDéjàClasséError } from '@modules/modificationRequest'
 import { FileContents, FileObject, IllegalFileDataError, makeFileObject } from '../../file'
 import {
   EntityNotFoundError,
@@ -64,6 +65,7 @@ type CorrectProjectDataError =
   | IllegalProjectDataError
   | IllegalFileDataError
   | OtherError
+  | ProjetDéjàClasséError
 
 export type CorrectProjectData = (
   args: CorrectProjectDataArgs
@@ -124,7 +126,7 @@ export const makeCorrectProjectData =
       })
     })
 
-    function _grantClasseIfNecessary(project: Project): Result<null, never> {
+    function _grantClasseIfNecessary(project: Project): Result<null, ProjetDéjàClasséError> {
       return shouldGrantClasse ? project.grantClasse(user) : ok(null)
     }
     function _addCertificateToProjectIfExists(


### PR DESCRIPTION
Ne pas permettre à un admin d'accepter un recours pour un projet déjà "classé" retourner une erreur.
Retourner une erreur également si un admin tente de corriger un projet pour passer le statut en "classé" d'un projet déjà "classé". 


<a href="https://gitpod.io/#https://github.com/MTES-MCT/potentiel/pull/719"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

