### PR TITLE
🐛 (1295): Liste projets - empecher la de prévisualiser une attestation si projet a une période legacy

### DIFF
--- a/src/views/components/ProjectActions.tsx
+++ b/src/views/components/ProjectActions.tsx
@@ -9,6 +9,7 @@ interface Props {
     id: string
     isClasse: boolean
     isAbandoned: boolean
+    isLegacy: boolean
     notifiedOn?: Date
     certificateFile?: {
       id: string
@@ -30,7 +31,6 @@ interface Props {
 
 export const ProjectActions = ({ project, role }: Props) => {
   if (!project || !role) return <></>
-
   const actions = ACTION_BY_ROLE[role]?.call(null, project)
   if (!actions || !actions.length) return <></>
 

--- a/src/views/components/ProjectList.tsx
+++ b/src/views/components/ProjectList.tsx
@@ -129,6 +129,12 @@ export const ProjectList = ({
       </legend>
 
       {items.map((project) => {
+        const isLegacy =
+          project.appelOffre?.periodes.find((p) => p.id === project.periodeId)?.type === 'legacy'
+        console.log(
+          'it happens here',
+          project.appelOffre?.periodes.find((p) => p.id === project.periodeId)?.type
+        )
         return (
           <Tile className="mb-4 flex md:relative flex-col" key={'project_' + project.id}>
             <div className="flex flex-col gap-2 mb-4">
@@ -219,6 +225,7 @@ export const ProjectList = ({
                     ...project,
                     isClasse: project.classe === 'Classé',
                     isAbandoned: project.abandonedOn !== 0,
+                    isLegacy,
                     notifiedOn: project.notifiedOn ? new Date(project.notifiedOn) : undefined,
                   }}
                 />

--- a/src/views/components/ProjectList.tsx
+++ b/src/views/components/ProjectList.tsx
@@ -128,108 +128,105 @@ export const ProjectList = ({
         )}
       </legend>
 
-      {items.map((project) => {
-        const isLegacy = project.appelOffre?.periode.type === 'legacy'
-        return (
-          <Tile className="mb-4 flex md:relative flex-col" key={'project_' + project.id}>
-            <div className="flex flex-col gap-2 mb-4">
-              <div className="flex flex-col md:flex-row gap-2">
-                {displaySelection && (
-                  <input
-                    onChange={(e) => toggleSelected(project.id, e.target.checked)}
-                    type="checkbox"
-                    value={project.id}
-                  />
-                )}
-                <Link href={routes.PROJECT_DETAILS(project.id)}>{project.nomProjet}</Link>
-                <StatutBadge project={project} />
-              </div>
-              <div className="italic text-xs text-grey-425-base">{project.potentielIdentifier}</div>
-            </div>
-
-            <div className="flex flex-col md:flex-row gap-4 md:items-center">
-              <div className="flex md:flex-1 flex-col gap-1 text-sm">
-                <div className="flex items-center">
-                  <MapPinIcon className="mr-2 shrink-0" />
-                  <span className="italic">
-                    {project.communeProjet}, {project.departementProjet}, {project.regionProjet}
-                  </span>
-                </div>
-
-                <div className="flex  items-center">
-                  <BuildingHouseIcon className="mr-2 shrink-0" />
-                  {project.nomCandidat}
-                </div>
-                <div className="flex items-center">
-                  <UserIcon className="mr-2 shrink-0" />
-                  <div className="flex flex-col overflow-hidden">
-                    <div>{project.nomRepresentantLegal}</div>
-                    <div className="truncate" title={project.email}>
-                      {project.email}
-                    </div>
-                  </div>
-                </div>
-              </div>
-
-              <div className="flex md:flex-1 lg:flex flex-col lg:flex-row lg:gap-4">
-                <div className="flex lg:flex-1 lg:flex-col items-center gap-2" title="Puissance">
-                  <PowerIcon className="text-yellow-moutarde-850-base" aria-label="Puissance" />
-                  <div className="lg:flex lg:flex-col items-center">
-                    {project.puissance} <Unit>{project.appelOffre?.unitePuissance}</Unit>
-                  </div>
-                </div>
-                <div
-                  className="flex lg:flex-1 lg:flex-col items-center gap-2"
-                  title="Prix de référence"
-                >
-                  <EuroIcon
-                    className="text-orange-terre-battue-main-645-base"
-                    aria-label="Prix de référence"
-                  />
-                  <div className="lg:flex lg:flex-col items-center">
-                    {project.prixReference} <Unit>€/MWh</Unit>
-                  </div>
-                </div>
-
-                {displayGF ? (
-                  <GF project={project} GFPastDue={GFPastDue} />
-                ) : (
-                  <div
-                    className="flex lg:flex-1 lg:flex-col items-center gap-2 lg:grow"
-                    title="Évaluation carbone"
-                  >
-                    <CloudIcon className="text-grey-425-active" aria-label="Évaluation carbone" />
-                    <div>
-                      {project.evaluationCarbone > 0 ? (
-                        <div className="lg:flex lg:flex-col items-center text-center">
-                          {project.evaluationCarbone}
-                          <Unit> kg eq CO2/kWc</Unit>
-                        </div>
-                      ) : (
-                        '- - -'
-                      )}
-                    </div>
-                  </div>
-                )}
-              </div>
-
-              <div className="flex md:absolute md:top-4 md:right-5 gap-2">
-                <ProjectActions
-                  role={role}
-                  project={{
-                    ...project,
-                    isClasse: project.classe === 'Classé',
-                    isAbandoned: project.abandonedOn !== 0,
-                    isLegacy,
-                    notifiedOn: project.notifiedOn ? new Date(project.notifiedOn) : undefined,
-                  }}
+      {items.map((project) => (
+        <Tile className="mb-4 flex md:relative flex-col" key={'project_' + project.id}>
+          <div className="flex flex-col gap-2 mb-4">
+            <div className="flex flex-col md:flex-row gap-2">
+              {displaySelection && (
+                <input
+                  onChange={(e) => toggleSelected(project.id, e.target.checked)}
+                  type="checkbox"
+                  value={project.id}
                 />
-                <LinkButton href={routes.PROJECT_DETAILS(project.id)}>Voir</LinkButton>
+              )}
+              <Link href={routes.PROJECT_DETAILS(project.id)}>{project.nomProjet}</Link>
+              <StatutBadge project={project} />
+            </div>
+            <div className="italic text-xs text-grey-425-base">{project.potentielIdentifier}</div>
+          </div>
+
+          <div className="flex flex-col md:flex-row gap-4 md:items-center">
+            <div className="flex md:flex-1 flex-col gap-1 text-sm">
+              <div className="flex items-center">
+                <MapPinIcon className="mr-2 shrink-0" />
+                <span className="italic">
+                  {project.communeProjet}, {project.departementProjet}, {project.regionProjet}
+                </span>
+              </div>
+
+              <div className="flex  items-center">
+                <BuildingHouseIcon className="mr-2 shrink-0" />
+                {project.nomCandidat}
+              </div>
+              <div className="flex items-center">
+                <UserIcon className="mr-2 shrink-0" />
+                <div className="flex flex-col overflow-hidden">
+                  <div>{project.nomRepresentantLegal}</div>
+                  <div className="truncate" title={project.email}>
+                    {project.email}
+                  </div>
+                </div>
               </div>
             </div>
-          </Tile>
-        )
-      })}
+
+            <div className="flex md:flex-1 lg:flex flex-col lg:flex-row lg:gap-4">
+              <div className="flex lg:flex-1 lg:flex-col items-center gap-2" title="Puissance">
+                <PowerIcon className="text-yellow-moutarde-850-base" aria-label="Puissance" />
+                <div className="lg:flex lg:flex-col items-center">
+                  {project.puissance} <Unit>{project.appelOffre?.unitePuissance}</Unit>
+                </div>
+              </div>
+              <div
+                className="flex lg:flex-1 lg:flex-col items-center gap-2"
+                title="Prix de référence"
+              >
+                <EuroIcon
+                  className="text-orange-terre-battue-main-645-base"
+                  aria-label="Prix de référence"
+                />
+                <div className="lg:flex lg:flex-col items-center">
+                  {project.prixReference} <Unit>€/MWh</Unit>
+                </div>
+              </div>
+
+              {displayGF ? (
+                <GF project={project} GFPastDue={GFPastDue} />
+              ) : (
+                <div
+                  className="flex lg:flex-1 lg:flex-col items-center gap-2 lg:grow"
+                  title="Évaluation carbone"
+                >
+                  <CloudIcon className="text-grey-425-active" aria-label="Évaluation carbone" />
+                  <div>
+                    {project.evaluationCarbone > 0 ? (
+                      <div className="lg:flex lg:flex-col items-center text-center">
+                        {project.evaluationCarbone}
+                        <Unit> kg eq CO2/kWc</Unit>
+                      </div>
+                    ) : (
+                      '- - -'
+                    )}
+                  </div>
+                </div>
+              )}
+            </div>
+
+            <div className="flex md:absolute md:top-4 md:right-5 gap-2">
+              <ProjectActions
+                role={role}
+                project={{
+                  ...project,
+                  isClasse: project.classe === 'Classé',
+                  isAbandoned: project.abandonedOn !== 0,
+                  isLegacy: project.appelOffre?.periode.type === 'legacy',
+                  notifiedOn: project.notifiedOn ? new Date(project.notifiedOn) : undefined,
+                }}
+              />
+              <LinkButton href={routes.PROJECT_DETAILS(project.id)}>Voir</LinkButton>
+            </div>
+          </div>
+        </Tile>
+      ))}
       {!Array.isArray(projects) && (
         <PaginationPanel
           pagination={projects.pagination}

--- a/src/views/components/ProjectList.tsx
+++ b/src/views/components/ProjectList.tsx
@@ -129,12 +129,7 @@ export const ProjectList = ({
       </legend>
 
       {items.map((project) => {
-        const isLegacy =
-          project.appelOffre?.periodes.find((p) => p.id === project.periodeId)?.type === 'legacy'
-        console.log(
-          'it happens here',
-          project.appelOffre?.periodes.find((p) => p.id === project.periodeId)?.type
-        )
+        const isLegacy = project.appelOffre?.periode.type === 'legacy'
         return (
           <Tile className="mb-4 flex md:relative flex-col" key={'project_' + project.id}>
             <div className="flex flex-col gap-2 mb-4">

--- a/src/views/components/actions/admin.ts
+++ b/src/views/components/actions/admin.ts
@@ -15,6 +15,7 @@ const adminActions = (project: {
   nomProjet: string
   potentielIdentifier: string
   attestationDesignationProof: { file: { id: string; filename: string } }
+  isLegacy: boolean
 }) => {
   const canDownloadCertificate = !!project.certificateFile
 
@@ -32,7 +33,7 @@ const adminActions = (project: {
       isDownload: true,
       disabled: !canDownloadCertificate,
     })
-  } else {
+  } else if (!project.isLegacy) {
     actions.push({
       title: 'Aperçu attestation',
       link: ROUTES.PREVIEW_CANDIDATE_CERTIFICATE(project),


### PR DESCRIPTION
Problème : La prévisualisation de certains documents depuis la liste des projets retournait des pdfs en échec car la période du projet (situé dans l'AO) était legacy, donc sans certificat.

Solution : Cibler si le projet a une période legacy et empêcher de soumettre l'action de visualisation

<a href="https://gitpod.io/#https://github.com/MTES-MCT/potentiel/pull/744"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

