### PR TITLE
🗃️ (1300): Suppression (commentaire) des familles de l'AO ppe2 neutre

### DIFF
--- a/src/dataAccess/inMemory/appelsOffres/PPE2/ppe2.neutre.ts
+++ b/src/dataAccess/inMemory/appelsOffres/PPE2/ppe2.neutre.ts
@@ -75,18 +75,18 @@ En cas de dépassement de ce délai, la durée de contrat mentionnée au 7.1 est
   ],
   familles: [
     // seulement sur les installations hydrauliques
-    {
-      id: '1',
-      title:
-        'installations implantées sur de nouveaux sites, de puissance installée supérieure ou égale à 1 MW ',
-      soumisAuxGarantiesFinancieres: 'à la candidature',
-    },
-    {
-      id: '2',
-      title:
-        'installations équipant des sites existants, de puissance installée supérieure ou égale à 1 MW',
-      soumisAuxGarantiesFinancieres: 'à la candidature',
-    },
+    // {
+    //   id: '1',
+    //   title:
+    //     'installations implantées sur de nouveaux sites, de puissance installée supérieure ou égale à 1 MW ',
+    //   soumisAuxGarantiesFinancieres: 'à la candidature',
+    // },
+    // {
+    //   id: '2',
+    //   title:
+    //     'installations équipant des sites existants, de puissance installée supérieure ou égale à 1 MW',
+    //   soumisAuxGarantiesFinancieres: 'à la candidature',
+    // },
   ],
   cahiersDesChargesModifiésDisponibles: [],
 }


### PR DESCRIPTION
Afin de permettre la notification des projets de l'AO ppe2 neutre nous avons commenté les familles utilisées uniquement pour les projets hydrauliques qui ne sont pas concernés par la notification actuelle.
L'intégration de  famille pour un type de technologie dans un AO pourra être conçue/implémentée plus tard

<a href="https://gitpod.io/#https://github.com/MTES-MCT/potentiel/pull/765"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

