### PR TITLE
🔥 (1345): supprimer 'delai' des params disponible pour modificationRequest

### DIFF
--- a/src/controllers/modificationRequest/postReplyToModificationRequest.ts
+++ b/src/controllers/modificationRequest/postReplyToModificationRequest.ts
@@ -145,9 +145,6 @@ v1Router.post(
             .toDate(),
         }
         break
-      case 'delai':
-        acceptanceParams = { type, delayInMonths }
-        break
       case 'puissance':
         acceptanceParams = { type, newPuissance: puissance, isDecisionJustice }
         break

--- a/src/controllers/modificationRequest/postReplyToModificationRequest.ts
+++ b/src/controllers/modificationRequest/postReplyToModificationRequest.ts
@@ -46,7 +46,6 @@ v1Router.post(
         submitConfirm,
         statusUpdateOnly,
         newNotificationDate,
-        delayInMonths,
         puissance,
         isDecisionJustice,
         actionnaire,

--- a/src/controllers/modificationRequest/postReplyToModificationRequest.ts
+++ b/src/controllers/modificationRequest/postReplyToModificationRequest.ts
@@ -101,15 +101,6 @@ v1Router.post(
       )
     }
 
-    if (type === 'delai' && !isStrictlyPositiveNumber(delayInMonths)) {
-      return response.redirect(
-        addQueryParams(routes.DEMANDE_PAGE_DETAILS(modificationRequestId), {
-          error:
-            "La réponse n'a pas pu être envoyée: le délai accordé doit être un nombre supérieur à 0.",
-        })
-      )
-    }
-
     if (type === 'puissance' && !isStrictlyPositiveNumber(puissance)) {
       return response.redirect(
         addQueryParams(routes.DEMANDE_PAGE_DETAILS(modificationRequestId), {

--- a/src/controllers/project/postChoisirCahierDesCharges.ts
+++ b/src/controllers/project/postChoisirCahierDesCharges.ts
@@ -25,14 +25,14 @@ import {
   parseCahierDesChargesRéférence,
 } from '@entities'
 
-export type TypeDeModificationCDC = ModificationRequestType | 'delai'
+export type TypeDeModification = ModificationRequestType | 'delai'
 
 const schema = yup.object({
   body: yup.object({
     projectId: yup.string().uuid().required(),
     redirectUrl: yup.string().required(),
     type: yup
-      .mixed<TypeDeModificationCDC>()
+      .mixed<TypeDeModification>()
       .oneOf([
         'actionnaire',
         'fournisseur',
@@ -51,7 +51,7 @@ const schema = yup.object({
   }),
 })
 
-const getRedirectTitle = (type: TypeDeModificationCDC) => {
+const getRedirectTitle = (type: TypeDeModification) => {
   switch (type) {
     case 'delai':
     case 'recours':

--- a/src/controllers/project/postChoisirCahierDesCharges.ts
+++ b/src/controllers/project/postChoisirCahierDesCharges.ts
@@ -25,12 +25,14 @@ import {
   parseCahierDesChargesRéférence,
 } from '@entities'
 
+export type TypeDeModificationCDC = ModificationRequestType | 'delai'
+
 const schema = yup.object({
   body: yup.object({
     projectId: yup.string().uuid().required(),
     redirectUrl: yup.string().required(),
     type: yup
-      .mixed<ModificationRequestType>()
+      .mixed<TypeDeModificationCDC>()
       .oneOf([
         'actionnaire',
         'fournisseur',
@@ -49,11 +51,11 @@ const schema = yup.object({
   }),
 })
 
-const getRedirectTitle = (type: ModificationRequestType) => {
+const getRedirectTitle = (type: TypeDeModificationCDC) => {
   switch (type) {
     case 'delai':
     case 'recours':
-      return `Retourner sur la demande de ${type === 'delai' ? 'délai' : type}`
+      return `Retourner sur la demande de ${type}`
     case 'abandon':
       return `Retourner sur la demande d'${type}`
     case 'puissance':

--- a/src/infra/sequelize/projectionsNext/projectEvents/updates/onModificationRequestAccepted.integration.ts
+++ b/src/infra/sequelize/projectionsNext/projectEvents/updates/onModificationRequestAccepted.integration.ts
@@ -78,62 +78,6 @@ describe('Handler onModificationRequestAccepted', () => {
     })
   })
 
-  describe('Cas des demandes de délai', () => {
-    describe(`Etant donné un événement de type ModificationRequestAccepted pour un délai`, () => {
-      const nouvelEvénement = new ModificationRequestAccepted({
-        payload: {
-          modificationRequestId,
-          acceptedBy: adminId,
-          responseFileId: fileId,
-          params: { type: 'delai', delayInMonths: 5 },
-        } as ModificationRequestAcceptedPayload,
-        original: {
-          version: 1,
-          occurredAt: new Date('2022-02-09'),
-        },
-      })
-      describe(`S'il y a déjà un événement de type DemandeDélai correspondant au même id dans ProjectEvent`, () => {
-        it(`Alors le statut de l'événement devrait être mis à jour`, async () => {
-          await ProjectEvent.create({
-            id: modificationRequestId,
-            projectId,
-            type: 'DemandeDélai',
-            valueDate: new Date('2022-08-08').getTime(),
-            eventPublishedAt: new Date('2022-08-08').getTime(),
-            payload: {
-              statut: 'envoyée',
-              autorité: 'dreal',
-              délaiEnMoisDemandé: 10,
-              demandeur: 'id-porteur',
-            },
-          })
-
-          await onModificationRequestAccepted(nouvelEvénement)
-
-          const projectEvent = await ProjectEvent.findOne({ where: { id: modificationRequestId } })
-          expect(projectEvent).toMatchObject({
-            id: modificationRequestId,
-            type: 'DemandeDélai',
-            projectId,
-            payload: {
-              statut: 'accordée',
-              délaiEnMoisAccordé: 5, // délai accordé différent du délai demandé
-            },
-          })
-        })
-      })
-
-      describe(`S'il n'y a pas d'événement de type DemandeDélai correspondant au même id dans ProjectEvent`, () => {
-        it(`Alors aucun événement ne doit être ajouté`, async () => {
-          await onModificationRequestAccepted(nouvelEvénement)
-
-          const projectEvent = await ProjectEvent.findOne({ where: { id: modificationRequestId } })
-          expect(projectEvent).toBeNull()
-        })
-      })
-    })
-  })
-
   describe(`Cas d'un recours`, () => {
     it(`Etant donnée une demande de recours acceptée,
     alors un item 'DateMiseEnService' avec le statut 'non-renseignée' devrait être ajouté`, async () => {

--- a/src/infra/sequelize/projectionsNext/projectEvents/updates/onModificationRequestAccepted.ts
+++ b/src/infra/sequelize/projectionsNext/projectEvents/updates/onModificationRequestAccepted.ts
@@ -10,7 +10,7 @@ export default ProjectEventProjector.on(
   ModificationRequestAccepted,
   async (évènement, transaction) => {
     const {
-      payload: { modificationRequestId, responseFileId, acceptedBy, params },
+      payload: { modificationRequestId, responseFileId, params },
       occurredAt,
     } = évènement
 

--- a/src/infra/sequelize/projectionsNext/projectEvents/updates/onModificationRequestAccepted.ts
+++ b/src/infra/sequelize/projectionsNext/projectEvents/updates/onModificationRequestAccepted.ts
@@ -14,44 +14,6 @@ export default ProjectEventProjector.on(
       occurredAt,
     } = évènement
 
-    if (params?.type === 'delai') {
-      const demandeDélai = await ProjectEvent.findOne({
-        where: { id: modificationRequestId, type: 'DemandeDélai' },
-        transaction,
-      })
-
-      if (demandeDélai) {
-        try {
-          await ProjectEvent.update(
-            {
-              valueDate: occurredAt.getTime(),
-              eventPublishedAt: occurredAt.getTime(),
-              payload: {
-                //@ts-ignore
-                ...demandeDélai.payload,
-                statut: 'accordée',
-                accordéPar: acceptedBy,
-                délaiEnMoisAccordé: params.delayInMonths,
-              },
-            },
-            { where: { id: modificationRequestId, type: 'DemandeDélai' }, transaction }
-          )
-        } catch (e) {
-          logger.error(
-            new ProjectionEnEchec(
-              `Erreur lors du traitement de l'événement ModificationRequestAccepted`,
-              {
-                évènement,
-                nomProjection: 'ProjectEvent.onModificationRequestAccepted',
-              },
-              e
-            )
-          )
-        }
-        return
-      }
-    }
-
     const { ModificationRequest } = models
 
     const { projectId } = await ModificationRequest.findByPk(modificationRequestId, {

--- a/src/modules/modificationRequest/ModificationRequest.ts
+++ b/src/modules/modificationRequest/ModificationRequest.ts
@@ -51,7 +51,6 @@ export type ModificationRequestStatus =
 
 export type ModificationRequestAcceptanceParams =
   | { type: 'recours'; newNotificationDate: Date }
-  | { type: 'delai'; delayInMonths: number }
   | { type: 'puissance'; newPuissance: number; isDecisionJustice?: boolean }
   | { type: 'actionnaire'; newActionnaire: string }
   | { type: 'producteur'; newProducteur: string }

--- a/src/modules/modificationRequest/ModificationRequest.ts
+++ b/src/modules/modificationRequest/ModificationRequest.ts
@@ -62,7 +62,6 @@ export type ModificationRequestType =
   | 'puissance'
   | 'recours'
   | 'abandon'
-  | 'delai'
 
 interface ModificationRequestProps {
   lastUpdatedOn: Date

--- a/src/modules/modificationRequest/useCases/acceptModificationRequest.spec.ts
+++ b/src/modules/modificationRequest/useCases/acceptModificationRequest.spec.ts
@@ -144,51 +144,6 @@ describe('acceptModificationRequest use-case', () => {
       })
     })
 
-    describe('when type is delai', () => {
-      const fakeModificationRequest = {
-        ...makeFakeModificationRequest(),
-        type: 'delai',
-      }
-      const fakeProject = {
-        ...makeFakeProject(),
-        id: fakeModificationRequest.projectId,
-      }
-      const modificationRequestRepo = fakeRepo(fakeModificationRequest as ModificationRequest)
-      const projectRepo = fakeRepo(fakeProject as Project)
-      const fileRepo = {
-        save: jest.fn((file: FileObject) => okAsync(null)),
-        load: jest.fn(),
-      }
-
-      const acceptModificationRequest = makeAcceptModificationRequest({
-        modificationRequestRepo,
-        projectRepo,
-        fileRepo: fileRepo as Repository<FileObject>,
-      })
-      beforeAll(async () => {
-        const res = await acceptModificationRequest({
-          modificationRequestId: fakeModificationRequest.id,
-          versionDate: fakeModificationRequest.lastUpdatedOn,
-          acceptanceParams: { type: 'delai', delayInMonths: 2 },
-          responseFile: { contents: fakeFileContents, filename: fakeFileName },
-          submittedBy: fakeUser,
-        })
-
-        if (res.isErr()) logger.error(res.error)
-        expect(res.isOk()).toEqual(true)
-      })
-
-      it('should call moveCompletionDueDate on project', () => {
-        expect(fakeProject.moveCompletionDueDate).toHaveBeenCalledTimes(1)
-        expect(fakeProject.moveCompletionDueDate).toHaveBeenCalledWith(fakeUser, 2)
-      })
-
-      it('should save the project', () => {
-        expect(projectRepo.save).toHaveBeenCalled()
-        expect(projectRepo.save.mock.calls[0][0]).toEqual(fakeProject)
-      })
-    })
-
     describe('when type is abandon', () => {
       const fakeModificationRequest = {
         ...makeFakeModificationRequest(),

--- a/src/modules/modificationRequest/useCases/acceptModificationRequest.ts
+++ b/src/modules/modificationRequest/useCases/acceptModificationRequest.ts
@@ -128,10 +128,6 @@ export const makeAcceptModificationRequest =
                   )
                 )
             break
-          case 'delai':
-            if (acceptanceParams?.type === 'delai')
-              action = project.moveCompletionDueDate(submittedBy, acceptanceParams.delayInMonths)
-            break
           case 'puissance':
             if (acceptanceParams?.type === 'puissance')
               action = project.updatePuissance(submittedBy, acceptanceParams.newPuissance)

--- a/src/views/components/UI/organisms/choisirCahierDesCharges/ChoisirCahierDesChargesFormulaire.tsx
+++ b/src/views/components/UI/organisms/choisirCahierDesCharges/ChoisirCahierDesChargesFormulaire.tsx
@@ -7,12 +7,18 @@ import { formatCahierDesChargesRéférence } from '@entities/cahierDesCharges'
 import { CahierDesChargesInitial } from './CahierDesChargesInitial'
 import { CahierDesChargesModifiéDisponible } from './CahierDesChargesModifiéDisponible'
 import { CahierDesChargesSelectionnable } from './CahierDesChargesSélectionnable'
-import { TypeDeModification } from '../../../../../controllers/project/postChoisirCahierDesCharges'
 
 type ChoisirCahierDesChargesFormulaireProps = {
   projet: ProjectDataForChoisirCDCPage
   redirectUrl?: string
-  type?: TypeDeModification
+  type?:
+    | 'actionnaire'
+    | 'fournisseur'
+    | 'producteur'
+    | 'puissance'
+    | 'recours'
+    | 'abandon'
+    | 'delai'
 }
 
 export const ChoisirCahierDesChargesFormulaire: React.FC<

--- a/src/views/components/UI/organisms/choisirCahierDesCharges/ChoisirCahierDesChargesFormulaire.tsx
+++ b/src/views/components/UI/organisms/choisirCahierDesCharges/ChoisirCahierDesChargesFormulaire.tsx
@@ -7,12 +7,12 @@ import { formatCahierDesChargesRéférence } from '@entities/cahierDesCharges'
 import { CahierDesChargesInitial } from './CahierDesChargesInitial'
 import { CahierDesChargesModifiéDisponible } from './CahierDesChargesModifiéDisponible'
 import { CahierDesChargesSelectionnable } from './CahierDesChargesSélectionnable'
-import { TypeDeModificationCDC } from '../../../../../controllers/project/postChoisirCahierDesCharges'
+import { TypeDeModification } from '../../../../../controllers/project/postChoisirCahierDesCharges'
 
 type ChoisirCahierDesChargesFormulaireProps = {
   projet: ProjectDataForChoisirCDCPage
   redirectUrl?: string
-  type?: TypeDeModificationCDC
+  type?: TypeDeModification
 }
 
 export const ChoisirCahierDesChargesFormulaire: React.FC<

--- a/src/views/components/UI/organisms/choisirCahierDesCharges/ChoisirCahierDesChargesFormulaire.tsx
+++ b/src/views/components/UI/organisms/choisirCahierDesCharges/ChoisirCahierDesChargesFormulaire.tsx
@@ -1,18 +1,18 @@
 import React, { useState } from 'react'
 import { Button, Input, Link, SecondaryLinkButton } from '@components'
 import { ProjectDataForChoisirCDCPage } from '@modules/project'
-import { ModificationRequestType } from '@modules/modificationRequest'
 import routes from '@routes'
 import { formatCahierDesChargesRéférence } from '@entities/cahierDesCharges'
 
 import { CahierDesChargesInitial } from './CahierDesChargesInitial'
 import { CahierDesChargesModifiéDisponible } from './CahierDesChargesModifiéDisponible'
 import { CahierDesChargesSelectionnable } from './CahierDesChargesSélectionnable'
+import { TypeDeModificationCDC } from '../../../../../controllers/project/postChoisirCahierDesCharges'
 
 type ChoisirCahierDesChargesFormulaireProps = {
   projet: ProjectDataForChoisirCDCPage
   redirectUrl?: string
-  type?: ModificationRequestType
+  type?: TypeDeModificationCDC
 }
 
 export const ChoisirCahierDesChargesFormulaire: React.FC<


### PR DESCRIPTION
Suite à la refacto faite sur la partie délai (cf  demandeModification/demandeDélai), j'ai viré le code legacy car plus utilisé aujourd'hui

<a href="https://gitpod.io/#https://github.com/MTES-MCT/potentiel/pull/809"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

