### PR TITLE
💄 (Erreur signup): si email déjà utilisé afficher erreur et ne pas logger

### DIFF
--- a/src/controllers/userAccount/postSignup.ts
+++ b/src/controllers/userAccount/postSignup.ts
@@ -5,6 +5,7 @@ import { addQueryParams } from '../../helpers/addQueryParams'
 import * as yup from 'yup'
 import safeAsyncHandler from '../helpers/safeAsyncHandler'
 import { logger } from '@core/utils'
+import { ProfilDéjàExistantError } from '@modules/utilisateur'
 
 const schema = yup.object({
   body: yup.object({
@@ -43,12 +44,18 @@ v1Router.post(
             })
           ),
         (e) => {
+          if (e instanceof ProfilDéjàExistantError) {
+            return response.redirect(
+              addQueryParams(routes.SIGNUP, {
+                error: e.message,
+                ...request.body,
+              })
+            )
+          }
           logger.error(e)
           response.redirect(
             addQueryParams(routes.SIGNUP, {
-              error:
-                e.message ||
-                `Une erreur est survenue lors de la création du compte. N'hésitez pas à nous contacter si le problème persiste.`,
+              error: `Une erreur est survenue lors de la création du compte. N'hésitez pas à nous contacter si le problème persiste.`,
               ...request.body,
             })
           )


### PR DESCRIPTION
On a des erreurs remontées sur sentry lorsque des utilisateurs tentent de créer un compte avec un email déjà utilisé. 
Dans cette PR on affiche le message d'erreur à l'utlisateur mais on ne log pas l'erreur. 

<a href="https://gitpod.io/#https://github.com/MTES-MCT/potentiel/pull/834"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

