### PR TITLE
🔥1477  (Liste Projets): Suppression export lauréats

### DIFF
--- a/src/controllers/project/getProjectsLaureatsCsv.ts
+++ b/src/controllers/project/getProjectsLaureatsCsv.ts
@@ -5,7 +5,7 @@ import routes from '@routes'
 import { parseAsync } from 'json2csv'
 import { logger } from '@core/utils'
 import { v1Router } from '../v1Router'
-import { ensureRole, listProjects } from '@config'
+import { ensureRole } from '@config'
 import asyncHandler from '../helpers/asyncHandler'
 import { formatField, writeCsvOnDisk } from '../../helpers/csv'
 import { promises as fsPromises } from 'fs'
@@ -42,24 +42,14 @@ const getProjectsLaureatsCsv = asyncHandler(async (request, response) => {
     const {
       projects: { items: projects },
     }: any =
-      beforeNotification === 'true'
-        ? await listUnnotifiedProjects({
-            appelOffreId,
-            periodeId,
-            pagination,
-            recherche,
-            classement: 'classés',
-          })
-        : await listProjects({
-            user: request.user,
-            appelOffreId,
-            periodeId,
-            familleId: undefined,
-            pagination,
-            recherche: undefined,
-            classement: 'classés',
-            garantiesFinancieres: undefined,
-          })
+      beforeNotification === 'true' &&
+      (await listUnnotifiedProjects({
+        appelOffreId,
+        periodeId,
+        pagination,
+        recherche,
+        classement: 'classés',
+      }))
 
     if (!projects?.length) return response.send('Aucun projet lauréat sur cette période')
 

--- a/src/views/pages/ListeProjetsPage.tsx
+++ b/src/views/pages/ListeProjetsPage.tsx
@@ -8,7 +8,6 @@ import { PaginatedList } from '../../types'
 
 import {
   ProjectList,
-  DownloadIcon,
   ExcelFileIcon,
   SecondaryLinkButton,
   PageTemplate,
@@ -240,25 +239,6 @@ export const ListeProjets = ({
                     </select>
                   </div>
                 )}
-
-                {['admin', 'dgec-validateur'].includes(request.user.role) &&
-                  appelOffreId &&
-                  periodeId && (
-                    <div style={{ marginTop: 15 }}>
-                      <a
-                        href={`${
-                          ROUTES.ADMIN_DOWNLOAD_PROJECTS_LAUREATS_CSV
-                        }?${querystring.stringify({
-                          ...request.query,
-                          beforeNotification: false,
-                        })}`}
-                        download
-                      >
-                        Liste des lauréats
-                        <DownloadIcon color="red" />
-                      </a>
-                    </div>
-                  )}
               </div>
             </div>
             {hasFilters && (


### PR DESCRIPTION
Depuis la page de la liste des projets, un lien permet d'exporter la liste des lauréats. Le contrôleur qui est appelé `getProjectsLaureatsCsv` utilise deux queries différentes selon l'état des projets de la période (notifiée ou non).: `listProjects` ou `listUnnotifiedProjects`. 
Suite à un changement du type de retour de listProjects dans une autre PR, nous avions une erreur venant du contrôleur. 
J'ai pris le parti de retirer ce lien de la liste des projet car fait doulon avec l'export de la liste. 