### PR TITLE
:lipstick: 1536 - Alternatives textuelles icones

### DIFF
--- a/src/views/components/Footer.tsx
+++ b/src/views/components/Footer.tsx
@@ -21,10 +21,7 @@ const Footer = () => {
                 className="no-underline hover:no-underline visited:no-underline outline-0"
               >
                 <div className="lg:mb-1 logo-before" />
-                <div
-                  className="m-0 font-bold tracking-tighter text-black uppercase text-[17px] md:text-[21px] leading-5"
-                  title="Ministère de la transition énergétique"
-                >
+                <div className="m-0 font-bold tracking-tighter text-black uppercase text-[17px] md:text-[21px] leading-5">
                   Ministère
                   <br />
                   de la transition

--- a/src/views/components/Header.tsx
+++ b/src/views/components/Header.tsx
@@ -134,7 +134,7 @@ const QuickAccess = ({ user }: QuickAccessProps) => (
             className="no-underline hover:no-underline flex flex-row items-center px-2 md:px-3 lg:border-0 lg:border-r lg:border-slate-200 lg:border-solid"
             href={routes.SIGNUP}
           >
-            <RiAccountCircleLine className="text-blue-france-sun-base" />
+            <RiAccountCircleLine className="text-blue-france-sun-base" aria-hidden />
             <span className="hidden lg:block mx-1 text-blue-france-sun-base">M'inscrire</span>
           </Link>
         </li>
@@ -143,7 +143,7 @@ const QuickAccess = ({ user }: QuickAccessProps) => (
             className="no-underline hover:no-underline flex flex-row items-center px-2 md:px-3 lg:border-0 lg:border-r lg:border-slate-200 lg:border-solid text-blue-france-sun-base"
             href={routes.LOGIN}
           >
-            <LockIcon className="text-blue-france-sun-base" />
+            <LockIcon className="text-blue-france-sun-base" aria-hidden />
             <span className="hidden lg:block mx-1 text-blue-france-sun-base">M'identifier</span>
           </Link>
         </li>

--- a/src/views/components/Header.tsx
+++ b/src/views/components/Header.tsx
@@ -23,6 +23,7 @@ const LogoAndTitle = () => (
   <Link
     className="flex items-center no-underline hover:no-underline focus:no-underline visited:no-underline"
     href={routes.HOME}
+    title="Retour à l'accueil"
   >
     <div className="flex flex-col">
       <div className="lg:mb-1 logo-before" />

--- a/src/views/components/Header.tsx
+++ b/src/views/components/Header.tsx
@@ -159,7 +159,7 @@ const QuickAccess = ({ user }: QuickAccessProps) => (
         <QuestionIcon className="lg:hidden text-blue-france-sun-base" />
         <span className="hidden lg:flex lg:items-center mx-1 text-blue-france-sun-base">
           <span className="pt-0.5">Aide</span>
-          <ExternalLinkIcon className="w-4 h-4 ml-1" />
+          <ExternalLinkIcon className="w-4 h-4 ml-1" title="(ouvrir dans un nouvel onglet)" />
         </span>
       </Link>
     </li>

--- a/src/views/components/Header.tsx
+++ b/src/views/components/Header.tsx
@@ -92,7 +92,7 @@ const QuickAccess = ({ user }: QuickAccessProps) => (
               className="no-underline hover:no-underline flex flex-row items-center px-2 md:px-3 lg:border-0 lg:border-r lg:border-slate-200 lg:border-solid text-blue-france-sun-base"
               href={user.accountUrl}
             >
-              <UserIcon />
+              <UserIcon aria-hidden />
               <span
                 className="hidden lg:block max-w-xs truncate pt-0.5 mx-1"
                 title={user.fullName ? user.fullName : user.email}
@@ -105,7 +105,7 @@ const QuickAccess = ({ user }: QuickAccessProps) => (
               className="hidden lg:flex flex-row items-center px-2 md:px-3 lg:border-0 lg:border-r lg:border-slate-200 lg:border-solid"
               style={{ color: 'var(--text-default-grey)' }}
             >
-              <UserIcon />
+              <UserIcon aria-hidden />
               <span
                 className="max-w-xs whitespace-nowrap overflow-hidden overflow-ellipsis pt-0.5 mx-1"
                 title={user.fullName ? user.fullName : user.email}
@@ -120,7 +120,7 @@ const QuickAccess = ({ user }: QuickAccessProps) => (
             className="no-underline hover:no-underline flex flex-row items-center px-2 md:px-3 lg:border-0 lg:border-r lg:border-slate-200 lg:border-solid"
             href={routes.LOGOUT_ACTION}
           >
-            <LogoutBoxIcon className="text-blue-france-sun-base" />
+            <LogoutBoxIcon className="text-blue-france-sun-base" aria-hidden />
             <span className="hidden lg:block pt-0.5 mx-1 text-blue-france-sun-base">
               Me déconnecter
             </span>

--- a/src/views/components/ProjectActions.tsx
+++ b/src/views/components/ProjectActions.tsx
@@ -40,7 +40,7 @@ export const ProjectActions = ({ project, role }: Props) => {
   return (
     <div style={{ position: 'relative' }} {...dataId('project-actions')}>
       <SecondaryButton className="ml-4" {...dataId('action-menu-trigger')}>
-        Actions <ChevronDownIcon className="ml-2" />
+        Actions <ChevronDownIcon className="ml-2" title="(menu)" />
       </SecondaryButton>
       <ul className="list--action-menu" {...dataId('action-menu')}>
         {actions.map(({ title, actionId, projectId, link, disabled, isDownload }, actionIndex) => (

--- a/src/views/components/UI/molecules/Alertes/Alerte.tsx
+++ b/src/views/components/UI/molecules/Alertes/Alerte.tsx
@@ -15,13 +15,13 @@ type PictoAlerteProps = ComponentProps<'svg'> & {
 const PictoAlerte: FC<PictoAlerteProps> = ({ type, className = '' }) => {
   switch (type) {
     case 'Erreur':
-      return <ErrorIcon {...{ className }} />
+      return <ErrorIcon {...{ className }} title="Information erreur" />
     case 'Succès':
-      return <SuccessIcon {...{ className }} />
+      return <SuccessIcon {...{ className }} title="Information succès" />
     case 'Information':
-      return <InfoIcon {...{ className }} />
+      return <InfoIcon {...{ className }} title="Information" />
     case 'Attention':
-      return <WarningIcon {...{ className }} />
+      return <WarningIcon {...{ className }} title="Information alerte" />
   }
 }
 

--- a/src/views/components/UI/molecules/BarreDeRecherche.tsx
+++ b/src/views/components/UI/molecules/BarreDeRecherche.tsx
@@ -31,7 +31,7 @@ export const BarreDeRecherche: FC<BarreDeRechercheProps> = ({
       title={placeholder}
       className="flex items-center py-2 px-2 lg:px-6 border-0 bg-blue-france-sun-base hover:bg-blue-france-sun-hover text-white"
     >
-      <SearchIcon className="w-6 h-6 lg:mr-2" />
+      <SearchIcon className="w-6 h-6 lg:mr-2" aria-hidden />
       <span className="hidden lg:block text-lg font-medium">Rechercher</span>
     </Button>
   </div>

--- a/src/views/components/UI/molecules/DownloadLink.tsx
+++ b/src/views/components/UI/molecules/DownloadLink.tsx
@@ -9,6 +9,6 @@ type DownloadLinkProps = {
 export const DownloadLink: FC<DownloadLinkProps> = ({ children, className, fileUrl }) => (
   <Link className={className} href={fileUrl} download>
     {children}
-    <FileDownloadIcon className="text-lg ml-1 -mb-1 shrink-0" />
+    <FileDownloadIcon className="text-lg ml-1 -mb-1 shrink-0" aria-hidden />
   </Link>
 )

--- a/src/views/components/UI/molecules/DownloadLinkButton.tsx
+++ b/src/views/components/UI/molecules/DownloadLinkButton.tsx
@@ -12,7 +12,7 @@ export const DownloadLinkButton: FC<DownloadLinkButtonProps> = ({
   fileUrl,
 }) => (
   <LinkButton className={className} download href={fileUrl}>
-    <FileDownloadIcon className="mr-2" />
+    <FileDownloadIcon className="mr-2" aria-hidden />
     {children}
   </LinkButton>
 )

--- a/src/views/components/UI/molecules/DropdownMenu.tsx
+++ b/src/views/components/UI/molecules/DropdownMenu.tsx
@@ -46,6 +46,7 @@ const DropdownMenu: React.FC<DropdownMenuProps> & { DropdownItem: typeof Dropdow
           <ArrowDownIcon
             style={{ transform: visible ? 'rotate(180deg)' : '' }}
             className={`ml-auto lg:ml-2 mr-2 lg:mr-0 transition`}
+            title={`${visible ? 'Fermer' : 'Ouvrir'} le sous-menu`}
           />
         </div>
       </div>

--- a/src/views/components/UI/molecules/ExternalLink.tsx
+++ b/src/views/components/UI/molecules/ExternalLink.tsx
@@ -6,6 +6,6 @@ type ExternalLinkProps = ComponentProps<'a'>
 export const ExternalLink: FC<ExternalLinkProps> = ({ children, className = '', ...props }) => (
   <Link className={className} target="_blank" rel="noopener noreferrer" {...props}>
     {children}
-    <ExternalLinkIcon className="text-lg ml-1 -mb-1" />
+    <ExternalLinkIcon className="text-lg ml-1 -mb-1" title="(ouvrir dans un nouvel onglet)" />
   </Link>
 )

--- a/src/views/components/UI/molecules/Section.tsx
+++ b/src/views/components/UI/molecules/Section.tsx
@@ -20,7 +20,7 @@ export const Section = ({
     {...props}
   >
     <Heading2 className="flex items-center text-2xl border-solid border-x-0 border-t-0 border-b-[1px] border-b-grey-900-base">
-      {Icon && <Icon className="mr-[10px]" />}
+      {Icon && <Icon className="mr-[10px]" aria-hidden />}
       {title}
     </Heading2>
     {children}

--- a/src/views/components/UI/organisms/ProjectList.tsx
+++ b/src/views/components/UI/organisms/ProjectList.tsx
@@ -192,20 +192,17 @@ export const ProjectList = ({
             </div>
 
             <div className="flex md:flex-1 lg:flex flex-col lg:flex-row lg:gap-4">
-              <div className="flex lg:flex-1 lg:flex-col items-center gap-2" title="Puissance">
-                <PowerIcon className="text-yellow-moutarde-850-base" aria-label="Puissance" />
+              <div className="flex lg:flex-1 lg:flex-col items-center gap-2">
+                <PowerIcon className="text-yellow-moutarde-850-base" title="Puissance" />
                 <div className="lg:flex lg:flex-col items-center">
                   {project.puissance} <Unit>{project.appelOffre?.unitePuissance}</Unit>
                 </div>
               </div>
               {project.prixReference && (
-                <div
-                  className="flex lg:flex-1 lg:flex-col items-center gap-2"
-                  title="Prix de référence"
-                >
+                <div className="flex lg:flex-1 lg:flex-col items-center gap-2">
                   <EuroIcon
                     className="text-orange-terre-battue-main-645-base"
-                    aria-label="Prix de référence"
+                    title="Prix de référence"
                   />
                   <div className="lg:flex lg:flex-col items-center">
                     {project.prixReference} <Unit>€/MWh</Unit>
@@ -217,11 +214,8 @@ export const ProjectList = ({
                 <GF project={project} GFPastDue={GFPastDue} />
               ) : (
                 project.evaluationCarbone !== undefined && (
-                  <div
-                    className="flex lg:flex-1 lg:flex-col items-center gap-2 lg:grow"
-                    title="Évaluation carbone"
-                  >
-                    <CloudIcon className="text-grey-425-active" aria-label="Évaluation carbone" />
+                  <div className="flex lg:flex-1 lg:flex-col items-center gap-2 lg:grow">
+                    <CloudIcon className="text-grey-425-active" title="Évaluation carbone" />
                     <div>
                       {project.evaluationCarbone > 0 ? (
                         <div className="lg:flex lg:flex-col items-center text-center">
@@ -270,11 +264,13 @@ export const ProjectList = ({
 const GF = ({ project, GFPastDue }: { project: ProjectListItem; GFPastDue?: boolean }) => {
   const gf = project.garantiesFinancières
   return (
-    <div
-      className="flex lg:flex-1 lg:flex-col gap-1 mt-1 md:items-center"
-      title="Garanties financières"
-    >
-      <div className="flex text-grey-200-base font-bold text-sm pt-0.5">GF</div>
+    <div className="flex lg:flex-1 lg:flex-col gap-1 mt-1 md:items-center">
+      <div
+        className="flex text-grey-200-base font-bold text-sm pt-0.5"
+        title="Garanties financières"
+      >
+        GF
+      </div>
       {!gf?.dateEnvoi && !GFPastDue && <div className="flex">Non Déposées</div>}
 
       {gf?.dateEnvoi && (

--- a/src/views/components/UI/organisms/ProjectList.tsx
+++ b/src/views/components/UI/organisms/ProjectList.tsx
@@ -94,7 +94,8 @@ export const ProjectList = ({
 
   return (
     <>
-      <legend className="flex flex-col md:flex-row gap-2 mb-2 text-sm" aria-hidden>
+      <legend className="flex flex-col md:flex-row gap-2 mb-2 text-sm italic" aria-hidden>
+        Legende :
         <div className="flex items-center">
           <PowerIcon
             className="text-yellow-moutarde-850-base mr-1 shrink-0"

--- a/src/views/components/UI/organisms/ProjectList.tsx
+++ b/src/views/components/UI/organisms/ProjectList.tsx
@@ -151,7 +151,7 @@ export const ProjectList = ({
 
       <ul className="p-0 m-0">
         {projects.items.map((project) => (
-          <li className="list-none p-0 m-0">
+          <li className="list-none p-0 m-0" key={project.id}>
             <Tile className="mb-4 flex md:relative flex-col" key={'project_' + project.id}>
               <div className="flex flex-col gap-2 mb-4">
                 <div className="flex flex-col md:flex-row gap-2">

--- a/src/views/components/UI/organisms/ProjectList.tsx
+++ b/src/views/components/UI/organisms/ProjectList.tsx
@@ -95,7 +95,7 @@ export const ProjectList = ({
   return (
     <>
       <legend className="flex flex-col md:flex-row gap-2 mb-2 text-sm italic" aria-hidden>
-        Legende :
+        Légende :
         <div className="flex items-center">
           <PowerIcon
             className="text-yellow-moutarde-850-base mr-1 shrink-0"
@@ -149,104 +149,110 @@ export const ProjectList = ({
         )}
       </div>
 
-      {projects.items.map((project) => (
-        <Tile className="mb-4 flex md:relative flex-col" key={'project_' + project.id}>
-          <div className="flex flex-col gap-2 mb-4">
-            <div className="flex flex-col md:flex-row gap-2">
-              {displaySelection && (
-                <InputCheckbox
-                  onChange={(e) => toggleSelected(project.id, e.target.checked)}
-                  type="checkbox"
-                  value={project.id}
-                  checked={selectedIds.indexOf(project.id) > -1}
-                />
-              )}
-              <Link href={routes.PROJECT_DETAILS(project.id)}>{project.nomProjet}</Link>
-              <StatutBadge project={project} role={role} />
-            </div>
-            <div className="italic text-xs text-grey-425-base">{project.potentielIdentifier}</div>
-          </div>
-
-          <div className="flex flex-col md:flex-row gap-4 md:items-center">
-            <div className="flex md:flex-1 flex-col gap-1 text-sm">
-              <div className="flex items-center">
-                <MapPinIcon className="mr-2 shrink-0" title="Localisation du projet" />
-                <span className="italic">
-                  {project.communeProjet}, {project.departementProjet}, {project.regionProjet}
-                </span>
+      <ul className="p-0 m-0">
+        {projects.items.map((project) => (
+          <li className="list-none p-0 m-0">
+            <Tile className="mb-4 flex md:relative flex-col" key={'project_' + project.id}>
+              <div className="flex flex-col gap-2 mb-4">
+                <div className="flex flex-col md:flex-row gap-2">
+                  {displaySelection && (
+                    <InputCheckbox
+                      onChange={(e) => toggleSelected(project.id, e.target.checked)}
+                      type="checkbox"
+                      value={project.id}
+                      checked={selectedIds.indexOf(project.id) > -1}
+                    />
+                  )}
+                  <Link href={routes.PROJECT_DETAILS(project.id)}>{project.nomProjet}</Link>
+                  <StatutBadge project={project} role={role} />
+                </div>
+                <div className="italic text-xs text-grey-425-base">
+                  {project.potentielIdentifier}
+                </div>
               </div>
 
-              <div className="flex  items-center">
-                <BuildingHouseIcon className="mr-2 shrink-0" title="Nom du candidat" />
-                {project.nomCandidat}
-              </div>
-              <div className="flex items-center">
-                <UserIcon className="mr-2 shrink-0" title="Représentant légal" />
-                <div className="flex flex-col overflow-hidden">
-                  <div>{project.nomRepresentantLegal}</div>
-                  <div className="truncate" title={project.email}>
-                    {project.email}
+              <div className="flex flex-col md:flex-row gap-4 md:items-center">
+                <div className="flex md:flex-1 flex-col gap-1 text-sm">
+                  <div className="flex items-center">
+                    <MapPinIcon className="mr-2 shrink-0" title="Localisation du projet" />
+                    <span className="italic">
+                      {project.communeProjet}, {project.departementProjet}, {project.regionProjet}
+                    </span>
                   </div>
-                </div>
-              </div>
-            </div>
 
-            <div className="flex md:flex-1 lg:flex flex-col lg:flex-row lg:gap-4">
-              <div className="flex lg:flex-1 lg:flex-col items-center gap-2">
-                <PowerIcon className="text-yellow-moutarde-850-base" title="Puissance" />
-                <div className="lg:flex lg:flex-col items-center">
-                  {project.puissance} <Unit>{project.appelOffre?.unitePuissance}</Unit>
-                </div>
-              </div>
-              {project.prixReference && (
-                <div className="flex lg:flex-1 lg:flex-col items-center gap-2">
-                  <EuroIcon
-                    className="text-orange-terre-battue-main-645-base"
-                    title="Prix de référence"
-                  />
-                  <div className="lg:flex lg:flex-col items-center">
-                    {project.prixReference} <Unit>€/MWh</Unit>
+                  <div className="flex  items-center">
+                    <BuildingHouseIcon className="mr-2 shrink-0" title="Nom du candidat" />
+                    {project.nomCandidat}
                   </div>
-                </div>
-              )}
-
-              {displayGF ? (
-                <GF project={project} GFPastDue={GFPastDue} />
-              ) : (
-                project.evaluationCarbone !== undefined && (
-                  <div className="flex lg:flex-1 lg:flex-col items-center gap-2 lg:grow">
-                    <CloudIcon className="text-grey-425-active" title="Évaluation carbone" />
-                    <div>
-                      {project.evaluationCarbone > 0 ? (
-                        <div className="lg:flex lg:flex-col items-center text-center">
-                          {project.evaluationCarbone}
-                          <Unit> kg eq CO2/kWc</Unit>
-                        </div>
-                      ) : (
-                        '- - -'
-                      )}
+                  <div className="flex items-center">
+                    <UserIcon className="mr-2 shrink-0" title="Représentant légal" />
+                    <div className="flex flex-col overflow-hidden">
+                      <div>{project.nomRepresentantLegal}</div>
+                      <div className="truncate" title={project.email}>
+                        {project.email}
+                      </div>
                     </div>
                   </div>
-                )
-              )}
-            </div>
+                </div>
 
-            <div className="flex md:absolute md:top-4 md:right-5 gap-2">
-              <ProjectActions
-                role={role}
-                project={{
-                  ...project,
-                  isClasse: project.classe === 'Classé',
-                  isAbandoned: project.abandonedOn !== 0,
-                  isLegacy: project.appelOffre?.periode.type === 'legacy',
-                  notifiedOn: project.notifiedOn ? new Date(project.notifiedOn) : undefined,
-                }}
-              />
-              <LinkButton href={routes.PROJECT_DETAILS(project.id)}>Voir</LinkButton>
-            </div>
-          </div>
-        </Tile>
-      ))}
+                <div className="flex md:flex-1 lg:flex flex-col lg:flex-row lg:gap-4">
+                  <div className="flex lg:flex-1 lg:flex-col items-center gap-2">
+                    <PowerIcon className="text-yellow-moutarde-850-base" title="Puissance" />
+                    <div className="lg:flex lg:flex-col items-center">
+                      {project.puissance} <Unit>{project.appelOffre?.unitePuissance}</Unit>
+                    </div>
+                  </div>
+                  {project.prixReference && (
+                    <div className="flex lg:flex-1 lg:flex-col items-center gap-2">
+                      <EuroIcon
+                        className="text-orange-terre-battue-main-645-base"
+                        title="Prix de référence"
+                      />
+                      <div className="lg:flex lg:flex-col items-center">
+                        {project.prixReference} <Unit>€/MWh</Unit>
+                      </div>
+                    </div>
+                  )}
+
+                  {displayGF ? (
+                    <GF project={project} GFPastDue={GFPastDue} />
+                  ) : (
+                    project.evaluationCarbone !== undefined && (
+                      <div className="flex lg:flex-1 lg:flex-col items-center gap-2 lg:grow">
+                        <CloudIcon className="text-grey-425-active" title="Évaluation carbone" />
+                        <div>
+                          {project.evaluationCarbone > 0 ? (
+                            <div className="lg:flex lg:flex-col items-center text-center">
+                              {project.evaluationCarbone}
+                              <Unit> kg eq CO2/kWc</Unit>
+                            </div>
+                          ) : (
+                            '- - -'
+                          )}
+                        </div>
+                      </div>
+                    )
+                  )}
+                </div>
+
+                <div className="flex md:absolute md:top-4 md:right-5 gap-2">
+                  <ProjectActions
+                    role={role}
+                    project={{
+                      ...project,
+                      isClasse: project.classe === 'Classé',
+                      isAbandoned: project.abandonedOn !== 0,
+                      isLegacy: project.appelOffre?.periode.type === 'legacy',
+                      notifiedOn: project.notifiedOn ? new Date(project.notifiedOn) : undefined,
+                    }}
+                  />
+                  <LinkButton href={routes.PROJECT_DETAILS(project.id)}>Voir</LinkButton>
+                </div>
+              </div>
+            </Tile>
+          </li>
+        ))}
+      </ul>
       {!Array.isArray(projects) && (
         <PaginationPanel
           nombreDePage={projects.pageCount}

--- a/src/views/components/UI/organisms/ProjectList.tsx
+++ b/src/views/components/UI/organisms/ProjectList.tsx
@@ -170,18 +170,18 @@ export const ProjectList = ({
           <div className="flex flex-col md:flex-row gap-4 md:items-center">
             <div className="flex md:flex-1 flex-col gap-1 text-sm">
               <div className="flex items-center">
-                <MapPinIcon className="mr-2 shrink-0" />
+                <MapPinIcon className="mr-2 shrink-0" title="Localisation du projet" />
                 <span className="italic">
                   {project.communeProjet}, {project.departementProjet}, {project.regionProjet}
                 </span>
               </div>
 
               <div className="flex  items-center">
-                <BuildingHouseIcon className="mr-2 shrink-0" />
+                <BuildingHouseIcon className="mr-2 shrink-0" title="Nom du candidat" />
                 {project.nomCandidat}
               </div>
               <div className="flex items-center">
-                <UserIcon className="mr-2 shrink-0" />
+                <UserIcon className="mr-2 shrink-0" title="Représentant légal" />
                 <div className="flex flex-col overflow-hidden">
                   <div>{project.nomRepresentantLegal}</div>
                   <div className="truncate" title={project.email}>

--- a/src/views/components/dropdowns/Dropdown.tsx
+++ b/src/views/components/dropdowns/Dropdown.tsx
@@ -30,9 +30,9 @@ export const Dropdown: React.FunctionComponent<DropdownProps> = ({
       >
         {text}{' '}
         {isOpen ? (
-          <ChevronUpIcon className="w-5 h-5 ml-1 -mb-1" />
+          <ChevronUpIcon className="w-5 h-5 ml-1 -mb-1" title="Fermer le contenu" />
         ) : (
-          <ChevronDownIcon className="w-5 h-5 ml-1 -mb-1" />
+          <ChevronDownIcon className="w-5 h-5 ml-1 -mb-1" title="Ouvrir le contenu" />
         )}
       </Link>
     ) : (
@@ -42,9 +42,9 @@ export const Dropdown: React.FunctionComponent<DropdownProps> = ({
       >
         {text}{' '}
         {isOpen ? (
-          <ChevronUpIcon className="w-5 h-5 ml-1" />
+          <ChevronUpIcon className="w-5 h-5 ml-1" title="Fermer le contenu" />
         ) : (
-          <ChevronDownIcon className="w-5 h-5 ml-1" />
+          <ChevronDownIcon className="w-5 h-5 ml-1" title="Ouvrir le contenu" />
         )}
       </Button>
     )

--- a/src/views/components/timeline/components/CurrentIcon.tsx
+++ b/src/views/components/timeline/components/CurrentIcon.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 export const CurrentIcon = () => (
-  <div className="h-9 flex items-center" aria-hidden="true">
+  <div className="h-9 flex items-center" title="étape à valider">
     <span
       className={
         'relative z-2 w-8 h-8 flex items-center justify-center bg-white border-2 border-solid rounded-full border-blue-700 group-hover:border-blue-900'

--- a/src/views/components/timeline/components/NextupIcon.tsx
+++ b/src/views/components/timeline/components/NextupIcon.tsx
@@ -3,11 +3,11 @@ import React from 'react'
 import { ClockIcon } from '@components'
 
 export const NextUpIcon = () => (
-  <div className="h-9 flex items-center" aria-hidden="true">
+  <div className="h-9 flex items-center">
     <span
       className={'relative z-2 w-8 h-8 flex items-center justify-center bg-gray-300 rounded-full'}
     >
-      <ClockIcon className="h-5 w-5 text-white" aria-hidden="true" />
+      <ClockIcon className="h-5 w-5 text-white" title="étape à venir" />
     </span>
   </div>
 )

--- a/src/views/components/timeline/components/PastIcon.tsx
+++ b/src/views/components/timeline/components/PastIcon.tsx
@@ -2,9 +2,9 @@ import React from 'react'
 import { CheckIcon } from '@components'
 
 export const PastIcon = () => (
-  <div className="h-9 flex items-center" aria-hidden="true">
+  <div className="h-9 flex items-center">
     <span className="relative z-2 w-8 h-8 flex items-center justify-center bg-green-700 rounded-full group-hover:bg-green-900">
-      <CheckIcon className="w-5 h-5 text-white" />
+      <CheckIcon className="w-5 h-5 text-white" title="étape passée" />
     </span>
   </div>
 )

--- a/src/views/components/timeline/components/WarningIcon.tsx
+++ b/src/views/components/timeline/components/WarningIcon.tsx
@@ -3,13 +3,13 @@ import React from 'react'
 import { ExclamationIcon } from '@components'
 
 export const WarningIcon = () => (
-  <div className="h-9 flex items-center" aria-hidden="true">
+  <div className="h-9 flex items-center">
     <span
       className={
         'relative z-2 w-8 h-8 flex items-center justify-center bg-yellow-400 rounded-full group-hover:bg-yellow-200'
       }
     >
-      <ExclamationIcon className="h-6 w-6 text-white" aria-hidden="true" />
+      <ExclamationIcon className="h-6 w-6 text-white" title="alerte" />
     </span>
   </div>
 )

--- a/src/views/pages/ListeProjetsPage.tsx
+++ b/src/views/pages/ListeProjetsPage.tsx
@@ -73,6 +73,7 @@ export const ListeProjets = ({
 
   const [selectedProjectIds, setSelectedProjectIds] = useState<string[]>([])
   const [displaySelection, setDisplaySelection] = useState(false)
+  const [afficherFiltres, setAfficherFiltres] = useState(false)
 
   return (
     <PageTemplate user={request.user} currentPage="list-projects">
@@ -92,6 +93,7 @@ export const ListeProjets = ({
 
             <div className="mt-8">
               <div
+                onClick={() => setAfficherFiltres(!afficherFiltres)}
                 {...dataId('visibility-toggle')}
                 className={'filter-toggle' + (hasFilters ? ' open' : '')}
               >
@@ -105,6 +107,7 @@ export const ListeProjets = ({
                 </span>
                 <svg className="icon filter-icon">
                   <use xlinkHref="#expand"></use>
+                  <title>{afficherFiltres ? `Fermer` : `Ouvrir`}</title>
                 </svg>
               </div>
               <div className="filter-panel mt-8">
@@ -233,6 +236,7 @@ export const ListeProjets = ({
                   style={{ transform: displaySelection ? 'rotate(0deg)' : '' }}
                 >
                   <use xlinkHref="#expand"></use>
+                  <title>{displaySelection ? `Fermer` : `Ouvrir`} le formulaire</title>
                 </svg>
               </div>
               {displaySelection && (

--- a/src/views/pages/homePage/Home.tsx
+++ b/src/views/pages/homePage/Home.tsx
@@ -22,7 +22,7 @@ export const Home = (props: HomeProps) => {
           <Header.MenuItem href={routes.REDIRECT_BASED_ON_ROLE}>
             <div className="flex flex-row items-center">
               Voir {user.role === 'porteur-projet' ? 'mes' : 'les'} projets
-              <RiArrowRightCircleLine className="w-5 h-5 ml-2" />
+              <RiArrowRightCircleLine className="w-5 h-5 ml-2" aria-hidden />
             </div>
           </Header.MenuItem>
         )}

--- a/src/views/pages/homePage/components/Benefices.tsx
+++ b/src/views/pages/homePage/components/Benefices.tsx
@@ -13,6 +13,7 @@ export const Benefices = () => (
       <img
         className="flex-2 hidden md:block self-center w-full p-4 lg:w-3/5 object-scale-down"
         src="/images/home/enr-illustration.png"
+        aria-hidden
       />
       <div className="bg-blue-france-975-base lg:p-10 w-full lg:w-2/5">
         <ul className="flex flex-col text-lg xl:text-xl font-medium md:font-semibold w-fit md:mx-auto m-0 p-4">
@@ -33,7 +34,7 @@ type BeneficeProps = {
 }
 const Benefice = ({ title }: BeneficeProps) => (
   <li className="flex flex-row items-center leading-loose list-none">
-    <img src="/images/home/check.png" className="align-bottom mr-2"></img>
+    <img src="/images/home/check.png" className="align-bottom mr-2" aria-hidden></img>
     {title}
   </li>
 )

--- a/src/views/pages/homePage/components/InscriptionConnexion.tsx
+++ b/src/views/pages/homePage/components/InscriptionConnexion.tsx
@@ -45,14 +45,14 @@ const Bienvenue = ({ user }: BienvenueProps) => (
         className="inline-flex items-center lg:text-lg"
         href={routes.REDIRECT_BASED_ON_ROLE}
       >
-        <RiDashboardLine className="mr-4" />
+        <RiDashboardLine className="mr-4" aria-hidden />
         Voir {user.role === 'porteur-projet' ? 'mes' : 'les'} projets
       </LinkButton>
       <SecondaryLinkButton
         className="inline-flex items-center lg:text-lg"
         href={routes.LOGOUT_ACTION}
       >
-        <RiLogoutBoxLine className="mr-4" />
+        <RiLogoutBoxLine className="mr-4" aria-hidden />
         Me déconnecter
       </SecondaryLinkButton>
     </div>
@@ -86,7 +86,7 @@ const SignupBox = () => {
       </div>
       {active === 'porteur-projet' && (
         <SecondaryLinkButton href={routes.SIGNUP} className="inline-flex items-center mx-auto">
-          <RiAccountCircleLine className="mr-4" />
+          <RiAccountCircleLine className="mr-4" aria-hidden />
           M'inscrire
         </SecondaryLinkButton>
       )}
@@ -145,7 +145,7 @@ const LoginBox = () => {
         <p className="m-0 p-0">Connectez-vous pour accéder aux projets.</p>
       </div>
       <LinkButton href={routes.LOGIN} className="inline-flex items-center mx-auto">
-        <RiLockLine className="mr-4" />
+        <RiLockLine className="mr-4" aria-hidden />
         M'identifier
       </LinkButton>
     </div>

--- a/src/views/pages/homePage/components/PropositionDeValeur.tsx
+++ b/src/views/pages/homePage/components/PropositionDeValeur.tsx
@@ -17,6 +17,7 @@ export const PropositionDeValeur = () => (
         <img
           className="flex object-scale-down w-full md:w-1/2"
           src="/images/home/proposition_valeur.png"
+          aria-hidden
         />
       </div>
       <p className="text-lg md:text-base lg:text-xl font-medium md:font-semibold md:text-center md:m-0 md:mt-10 md:mb-0 lg:px-16 lg:leading-loose">

--- a/src/views/pages/modificationRequestListPage/ModificationRequestList.tsx
+++ b/src/views/pages/modificationRequestListPage/ModificationRequestList.tsx
@@ -58,6 +58,8 @@ export const ModificationRequestList = ({
     .find((ao) => ao.id === appelOffreId)
     ?.familles.sort((a, b) => a.title.localeCompare(b.title))
 
+  const [afficherFiltres, setAfficherFiltres] = useState(false)
+
   return (
     <PageTemplate user={request.user} currentPage="list-requests">
       <div className="panel">
@@ -85,6 +87,7 @@ export const ModificationRequestList = ({
               <div
                 {...dataId('visibility-toggle')}
                 className={'filter-toggle' + (hasFilters ? ' open' : '')}
+                onClick={() => setAfficherFiltres(!afficherFiltres)}
               >
                 <span
                   style={{
@@ -96,6 +99,7 @@ export const ModificationRequestList = ({
                 </span>
                 <svg className="icon filter-icon">
                   <use xlinkHref="#expand"></use>
+                  <title>{afficherFiltres ? `Fermer` : `Ouvrir`}</title>
                 </svg>
               </div>
               <div className="filter-panel">

--- a/src/views/pages/projectDetailsPage/components/ProjectActions.tsx
+++ b/src/views/pages/projectDetailsPage/components/ProjectActions.tsx
@@ -102,7 +102,7 @@ const PorteurProjetActions = ({ project }: PorteurProjetActionsProps) => (
     {project.isClasse && (
       <Menu as="div" className="m-auto self-stretch relative grow md:grow-0 text-left">
         <Menu.Button className="inline-flex items-center px-6 py-2 border border-solid text-base font-medium shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 border-blue-france-sun-base text-blue-france-sun-base bg-white hover:bg-blue-france-975-base focus:bg-blue-france-975-base">
-          <InboxInIcon className="h-5 w-5 align-middle mr-2" />
+          <InboxInIcon className="h-5 w-5 align-middle mr-2" aria-hidden />
           Faire une demande
         </Menu.Button>
         <Transition


### PR DESCRIPTION
Ajouter un `title` aux icones qui apportent du sens au contenu, et masquer ceux qui ne sont que purement décoratifs.
Idem pour les images. 