### PR TITLE
:bug: Corriger redirections demandes modification

### DIFF
--- a/src/controllers/modificationRequest/producteur/getChangerProducteurPage.ts
+++ b/src/controllers/modificationRequest/producteur/getChangerProducteurPage.ts
@@ -11,7 +11,7 @@ import { v1Router } from '../../v1Router'
 import { ChangerProducteurPage } from '@views'
 
 v1Router.get(
-  routes.CHANGER_PRODUCTEUR(),
+  routes.GET_CHANGER_PRODUCTEUR(),
   ensureRole('porteur-projet'),
   asyncHandler(async (request, response) => {
     const {

--- a/src/controllers/modificationRequest/producteur/postChangerProducteur.ts
+++ b/src/controllers/modificationRequest/producteur/postChangerProducteur.ts
@@ -24,7 +24,7 @@ const schema = yup.object({
 })
 
 v1Router.post(
-  routes.CHANGEMENT_PRODUCTEUR_ACTION,
+  routes.POST_CHANGER_PRODUCTEUR,
   upload.single('file'),
   ensureRole('porteur-projet'),
   safeAsyncHandler(
@@ -32,7 +32,7 @@ v1Router.post(
       schema,
       onError: ({ request, response, error }) => {
         return response.redirect(
-          addQueryParams(routes.DEMANDER_DELAI(request.body.projetId), {
+          addQueryParams(routes.GET_CHANGER_PRODUCTEUR(request.body.projetId), {
             ...omit(request.body, 'projectId'),
             error: `${error.errors.join(' ')}`,
           })

--- a/src/controllers/modificationRequest/puissance/postDemanderChangementPuissance.ts
+++ b/src/controllers/modificationRequest/puissance/postDemanderChangementPuissance.ts
@@ -55,11 +55,11 @@ v1Router.post(
       }
 
       if (!isStrictlyPositiveNumber(puissance)) {
-        return response.redirect(
-          addQueryParams(routes.PROJECT_DETAILS(projectId), {
-            error: 'Erreur: la puissance n‘est pas valide.',
-          })
-        )
+        return errorResponse({
+          request,
+          response,
+          customMessage: `La puissance saisie n'est pa valide.`,
+        })
       }
 
       await demanderChangementDePuissance({
@@ -79,22 +79,20 @@ v1Router.post(
           ),
         (error) => {
           if (error instanceof PuissanceJustificationEtCourrierManquantError) {
-            return response.redirect(
-              addQueryParams(routes.PROJECT_DETAILS(projectId), {
-                ...omit(request.body, 'projectId'),
-                error: error.message,
-              })
-            )
+            return errorResponse({
+              request,
+              response,
+              customMessage: error.message,
+            })
           }
 
           if (error instanceof AggregateHasBeenUpdatedSinceError) {
-            return response.redirect(
-              addQueryParams(routes.PROJECT_DETAILS(projectId), {
-                ...omit(request.body, 'projectId'),
-                error:
-                  'Le projet a été modifié entre le moment où vous avez ouvert cette page et le moment où vous avez validé la demande. Merci de prendre en compte le changement et refaire votre demande si nécessaire.',
-              })
-            )
+            return errorResponse({
+              request,
+              response,
+              customMessage:
+                'Le projet a été modifié entre le moment où vous avez ouvert cette page et le moment où vous avez validé la demande. Merci de prendre en compte le changement et refaire votre demande si nécessaire.',
+            })
           }
 
           if (error instanceof EntityNotFoundError) {

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -234,7 +234,7 @@ class routes {
     return projectId ? route.replace(':projectId', projectId) : route
   }
 
-  static CHANGER_PRODUCTEUR = (projectId?: Project['id']) => {
+  static GET_CHANGER_PRODUCTEUR = (projectId?: Project['id']) => {
     const route = '/projet/:projectId/changer-producteur.html'
     if (projectId) {
       return route.replace(':projectId', projectId)
@@ -270,7 +270,7 @@ class routes {
   static POST_ANNULER_DEMANDE_ANNULATION_ABANDON = '/annuler-demande-annulation-abandon'
   static POST_REPONDRE_DEMANDE_ANNULATION_ABANDON = '/repondre-demande-annulation-abandon'
 
-  static CHANGEMENT_PRODUCTEUR_ACTION = '/soumettre-changement-producteur'
+  static POST_CHANGER_PRODUCTEUR = '/soumettre-changement-producteur'
   static CHANGEMENT_FOURNISSEUR_ACTION = '/soumettre-changement-fournisseur'
   static CHANGEMENT_PUISSANCE_ACTION = '/soumettre-changement-puissance'
 

--- a/src/views/components/actions/porteurProjet.spec.ts
+++ b/src/views/components/actions/porteurProjet.spec.ts
@@ -56,7 +56,7 @@ describe('porteurProjetActions', () => {
           },
           {
             title: 'Changer de producteur',
-            link: ROUTES.CHANGER_PRODUCTEUR(fakeProject.id),
+            link: ROUTES.GET_CHANGER_PRODUCTEUR(fakeProject.id),
           },
           {
             title: 'Changer de fournisseur',

--- a/src/views/components/actions/porteurProjet.ts
+++ b/src/views/components/actions/porteurProjet.ts
@@ -77,7 +77,7 @@ const porteurProjetActions = (project: {
         ? [
             {
               title: 'Changer de producteur',
-              link: ROUTES.CHANGER_PRODUCTEUR(project.id),
+              link: ROUTES.GET_CHANGER_PRODUCTEUR(project.id),
             },
           ]
         : []),

--- a/src/views/pages/changerProducteurPage/ChangerProducteur.tsx
+++ b/src/views/pages/changerProducteurPage/ChangerProducteur.tsx
@@ -64,17 +64,13 @@ export const ChangerProducteur = ({ request, project, appelOffre }: ChangerProdu
                   cahierDesChargesActuel: 'initial',
                   identifiantGestionnaireRéseau: project.numeroGestionnaire,
                 },
-                redirectUrl: routes.CHANGER_PRODUCTEUR(project.id),
+                redirectUrl: routes.GET_CHANGER_PRODUCTEUR(project.id),
                 type: 'producteur',
               }}
             />
           </div>
         ) : (
-          <form
-            action={routes.CHANGEMENT_PRODUCTEUR_ACTION}
-            method="post"
-            encType="multipart/form-data"
-          >
+          <form action={routes.POST_CHANGER_PRODUCTEUR} method="post" encType="multipart/form-data">
             <input type="hidden" name="projetId" value={project.id} />
             <div className="form__group">
               {success && <SuccessBox title={success} />}

--- a/src/views/pages/projectDetailsPage/components/ProjectActions.tsx
+++ b/src/views/pages/projectDetailsPage/components/ProjectActions.tsx
@@ -135,7 +135,7 @@ const PorteurProjetActions = ({ project }: PorteurProjetActionsProps) => (
             {project.appelOffre.type !== 'eolien' && (
               <Menu.Item key={`action_changer_producteur`}>
                 <Link
-                  href={routes.CHANGER_PRODUCTEUR(project.id)}
+                  href={routes.GET_CHANGER_PRODUCTEUR(project.id)}
                   className="no-underline bg-none hover:bg-none"
                 >
                   <div


### PR DESCRIPTION
- erreur de redirection : en cas d'erreur de validation pour un changement de producteur, la redirection pointait vers le formulaire de demande de délai
- harmonisation des pratiques de redirection : en cas d'erreur suite à une demande de changement de puissance, on redirigeait vers la page du projet, pour garder le même comportement que sur les autres demandes, j'ai simplement redirigé vers une page d'erreur
