### PR TITLE
:fire: (1173): retirer champs formulaire id gestionnaire non nécessaires

### DIFF
--- a/src/controllers/modificationRequest/délai/getDemanderDélaiPage.ts
+++ b/src/controllers/modificationRequest/délai/getDemanderDélaiPage.ts
@@ -22,7 +22,7 @@ v1Router.get(
       return notFoundResponse({ request, response, ressourceTitle: 'Projet' });
     }
 
-    // TODO: lecture faite directement sur la table Project sans passé par une query...
+    // TODO: lecture faite directement sur la table Project sans passer par une query...
     const project = await Project.findByPk(projectId);
 
     if (!project) {

--- a/src/controllers/modificationRequest/délai/postDemanderDélai.ts
+++ b/src/controllers/modificationRequest/délai/postDemanderDélai.ts
@@ -29,7 +29,6 @@ const schema = yup.object({
       .transform(iso8601DateToDateYupTransformation)
       .typeError(`La date d'achèvement souhaitée saisie n'est pas valide`),
     justification: yup.string().optional(),
-    numeroGestionnaire: yup.string().optional(),
   }),
 });
 
@@ -53,7 +52,6 @@ v1Router.post(
       const {
         projectId,
         justification,
-        numeroGestionnaire,
         dateAchevementDemandee: dateAchèvementDemandée,
       } = request.body;
       const { user } = request;
@@ -68,7 +66,6 @@ v1Router.post(
         projectId,
         file,
         justification,
-        numeroGestionnaire,
         dateAchèvementDemandée,
       }).match(
         () => {

--- a/src/controllers/steps/postSubmitStep.ts
+++ b/src/controllers/steps/postSubmitStep.ts
@@ -36,14 +36,6 @@ const requestBodySchema = yup.object({
     .required('Vous devez renseigner une date.')
     .typeError(`La date n'est pas valide.`),
   type: yup.mixed().oneOf(['ptf', 'dcr']).required('Ce champ est obligatoire.'),
-  numeroDossier: yup.string().when('type', {
-    is: (type) => type === 'dcr',
-    then: yup
-      .string()
-      .required('Vous devez renseigner le numéro de dossier.')
-      .typeError("Le numéro de dossier saisi n'est pas valide"),
-    otherwise: yup.string().optional().typeError("Le numéro de dossier saisi n'est pas valide"),
-  }),
 });
 
 v1Router.post(
@@ -59,7 +51,7 @@ v1Router.post(
         return ok(body);
       })
       .asyncAndThen((body) => {
-        const { projectId, stepDate, numeroDossier, type } = body;
+        const { projectId, stepDate, type } = body;
         const { user: submittedBy } = request;
         const file = {
           contents: fs.createReadStream(request.file!.path),
@@ -73,7 +65,6 @@ v1Router.post(
             stepDate,
             file,
             submittedBy,
-            numeroDossier: numeroDossier as string,
           }).map(() => ({
             projectId,
           }));

--- a/src/infra/sequelize/projectionsNext/projectEvents/updates/onProjectDCRSubmitted.integration.ts
+++ b/src/infra/sequelize/projectionsNext/projectEvents/updates/onProjectDCRSubmitted.integration.ts
@@ -12,7 +12,6 @@ describe('onProjectDCRSubmitted', () => {
   const submittedBy = 'user-id';
   const dcrDate = new Date('2021-12-26');
   const filename = 'my-file';
-  const numeroDossier = 'DOSSIER-1';
 
   beforeEach(async () => {
     await resetDatabase();
@@ -33,7 +32,6 @@ describe('onProjectDCRSubmitted', () => {
             fileId,
             submittedBy,
             dcrDate,
-            numeroDossier,
           } as ProjectDCRSubmittedPayload,
           original: {
             version: 1,
@@ -63,7 +61,6 @@ describe('onProjectDCRSubmitted', () => {
               fileId,
               submittedBy,
               dcrDate,
-              numeroDossier,
             } as ProjectDCRSubmittedPayload,
             original: {
               version: 1,

--- a/src/infra/sequelize/projectionsNext/raccordements/updates/onProjectDCRSubmitted.ts
+++ b/src/infra/sequelize/projectionsNext/raccordements/updates/onProjectDCRSubmitted.ts
@@ -9,6 +9,10 @@ export default RaccordementsProjector.on(ProjectDCRSubmitted, async (évènement
     payload: { projectId, numeroDossier },
   } = évènement;
 
+  if (!numeroDossier) {
+    return;
+  }
+
   try {
     await Raccordements.update(
       {

--- a/src/modules/demandeModification/demandeDélai/demander/demanderDelai.ts
+++ b/src/modules/demandeModification/demandeDélai/demander/demanderDelai.ts
@@ -7,7 +7,7 @@ import { DélaiDemandé } from '@modules/demandeModification';
 import { GetProjectAppelOffreId } from '@modules/modificationRequest';
 import { AppelOffreRepo } from '@dataAccess';
 import { InfraNotAvailableError, UnauthorizedError } from '@modules/shared';
-import { NumeroGestionnaireSubmitted, Project } from '@modules/project';
+import { Project } from '@modules/project';
 
 import { DemanderDateAchèvementAntérieureDateThéoriqueError } from '.';
 import { NouveauCahierDesChargesNonChoisiError } from './NouveauCahierDesChargesNonChoisiError';
@@ -21,7 +21,6 @@ type DemanderDélai = (commande: {
   projectId: string;
   justification?: string;
   dateAchèvementDemandée: Date;
-  numeroGestionnaire?: string;
 }) => ResultAsync<
   null,
   InfraNotAvailableError | UnauthorizedError | DemanderDateAchèvementAntérieureDateThéoriqueError
@@ -45,7 +44,7 @@ export const makeDemanderDélai: MakeDemanderDélai =
     getProjectAppelOffreId,
     projectRepo,
   }) =>
-  ({ user, projectId, file, justification, dateAchèvementDemandée, numeroGestionnaire }) => {
+  ({ user, projectId, file, justification, dateAchèvementDemandée }) => {
     return wrapInfra(
       shouldUserAccessProject({
         user,
@@ -119,15 +118,6 @@ export const makeDemanderDélai: MakeDemanderDélai =
               cahierDesCharges: formatCahierDesChargesRéférence(project.cahierDesCharges),
             },
           }),
-        ).andThen(() => {
-          if (numeroGestionnaire) {
-            return publishToEventStore(
-              new NumeroGestionnaireSubmitted({
-                payload: { projectId, submittedBy: user.id, numeroGestionnaire },
-              }),
-            );
-          }
-          return okAsync(null);
-        });
+        );
       });
   };

--- a/src/modules/demandeModification/demandeDélai/demander/demanderDélai.spec.ts
+++ b/src/modules/demandeModification/demandeDélai/demander/demanderDélai.spec.ts
@@ -203,40 +203,6 @@ describe('Commande demanderDélai', () => {
         });
       });
 
-      describe(`Enregistrer le numéro de gestionnaire`, () => {
-        describe(`Lorsque le porteur saisit numéro de gestionnaire`, () => {
-          it(`Alors un événement NumeroGestionnaireSubmitted doit être émis`, async () => {
-            const demandeDelai = makeDemanderDélai({
-              fileRepo: fileRepo as Repository<FileObject>,
-              findAppelOffreById,
-              publishToEventStore,
-              shouldUserAccessProject,
-              getProjectAppelOffreId,
-              projectRepo,
-            });
-            await demandeDelai({
-              justification: 'justification',
-              dateAchèvementDemandée,
-              user,
-              projectId: fakeProject.id.toString(),
-              numeroGestionnaire: 'IdGestionnaire',
-            });
-
-            expect(publishToEventStore).toHaveBeenNthCalledWith(
-              2,
-              expect.objectContaining({
-                type: 'NumeroGestionnaireSubmitted',
-                payload: expect.objectContaining({
-                  numeroGestionnaire: 'IdGestionnaire',
-                  submittedBy: user.id,
-                  projectId: fakeProject.id.toString(),
-                }),
-              }),
-            );
-          });
-        });
-      });
-
       describe(`Erreur si le porteur n'a pas souscri à un CDC modifié alors que l'AO le requiert`, () => {
         describe(`Étant donné un projet avec un AO requérant le choix d'un CDC modifié pour pouvoir effectuer des modifications sur Potentiel,
                   Lorsque le porteur fait une demande de délai,

--- a/src/modules/project/Project.submitDemandeComplèteRaccordement.spec.ts
+++ b/src/modules/project/Project.submitDemandeComplèteRaccordement.spec.ts
@@ -48,7 +48,6 @@ describe('Project.submitDemandeComplèteRaccordement()', () => {
         projectId: projectId.toString(),
         dcrDate: new Date('2022-01-01'),
         fileId: 'identifiant-fichier',
-        numeroDossier: 'numero-dossier',
         submittedBy: 'user-id',
       });
       expect(res.isErr()).toBe(true);
@@ -121,7 +120,6 @@ describe('Project.submitDemandeComplèteRaccordement()', () => {
         projectId: projectId.toString(),
         dcrDate: new Date('2022-01-01'),
         fileId: 'identifiant-fichier',
-        numeroDossier: 'numero-dossier',
         submittedBy: 'user-id',
       });
       expect(res.isErr()).toBe(true);
@@ -179,7 +177,6 @@ describe('Project.submitDemandeComplèteRaccordement()', () => {
         projectId: projectId.toString(),
         dcrDate: new Date('2022-01-01'),
         fileId: 'identifiant-fichier',
-        numeroDossier: 'numero-dossier',
         submittedBy: 'user-id',
       });
 
@@ -192,7 +189,6 @@ describe('Project.submitDemandeComplèteRaccordement()', () => {
       expect(targetEvent.payload.projectId).toEqual(projectId.toString());
       expect(targetEvent.payload.fileId).toEqual('identifiant-fichier');
       expect(targetEvent.payload.submittedBy).toEqual('user-id');
-      expect(targetEvent.payload.numeroDossier).toEqual('numero-dossier');
     });
   });
 });

--- a/src/modules/project/Project.submitPropositionTechniqueFinancière.spec.ts
+++ b/src/modules/project/Project.submitPropositionTechniqueFinancière.spec.ts
@@ -48,7 +48,6 @@ describe('Project.submitPropositionTechniqueFinancière()', () => {
         projectId: projectId.toString(),
         dcrDate: new Date('2022-01-01'),
         fileId: 'identifiant-fichier',
-        numeroDossier: 'numero-dossier',
         submittedBy: 'user-id',
       });
       expect(res.isErr()).toBe(true);

--- a/src/modules/project/Project.ts
+++ b/src/modules/project/Project.ts
@@ -154,7 +154,6 @@ export interface Project extends EventStoreAggregate {
     dcrDate: Date;
     fileId: string;
     submittedBy: string;
-    numeroDossier: string;
   }) => Result<null, ProjectCannotBeUpdatedIfUnnotifiedError | DCRCertificatDéjàEnvoyéError>;
   submitPropositionTechniqueFinancière: (args: {
     projectId: string;
@@ -825,13 +824,7 @@ export const makeProject = (args: {
 
       return ok(null);
     },
-    submitDemandeComplèteRaccordement: function ({
-      projectId,
-      dcrDate,
-      fileId,
-      numeroDossier,
-      submittedBy,
-    }) {
+    submitDemandeComplèteRaccordement: function ({ projectId, dcrDate, fileId, submittedBy }) {
       if (!_isNotified()) {
         return err(new ProjectCannotBeUpdatedIfUnnotifiedError());
       }
@@ -842,7 +835,7 @@ export const makeProject = (args: {
 
       _publishEvent(
         new ProjectDCRSubmitted({
-          payload: { projectId, dcrDate, fileId, submittedBy, numeroDossier },
+          payload: { projectId, dcrDate, fileId, submittedBy },
         }),
       );
 

--- a/src/modules/project/events/ProjectDCRSubmitted.ts
+++ b/src/modules/project/events/ProjectDCRSubmitted.ts
@@ -4,7 +4,7 @@ export interface ProjectDCRSubmittedPayload {
   projectId: string;
   dcrDate: Date;
   fileId: string;
-  numeroDossier: string;
+  numeroDossier?: string;
   submittedBy: string;
 }
 export class ProjectDCRSubmitted

--- a/src/modules/project/useCases/submitDCR.spec.ts
+++ b/src/modules/project/useCases/submitDCR.spec.ts
@@ -31,8 +31,6 @@ const fileRepo = {
 
 const user = UnwrapForTest(makeUser(makeFakeUser({ role: 'porteur-projet', id: userId })));
 
-const numeroDossier = 'dossier123';
-
 describe('submitDCR use-case', () => {
   describe(`Lorsque l'utilisateur n'a pas les droits sur le projet`, () => {
     it('Alors une erreur de type UnauthorizedError doit être retournée', async () => {
@@ -52,7 +50,6 @@ describe('submitDCR use-case', () => {
         stepDate: new Date(123),
         projectId,
         submittedBy: user,
-        numeroDossier,
       });
 
       expect(res._unsafeUnwrapErr()).toBeInstanceOf(UnauthorizedError);
@@ -77,7 +74,6 @@ describe('submitDCR use-case', () => {
         type: 'dcr',
         file: fakeFileContents,
         stepDate: dcrDate,
-        numeroDossier,
         projectId,
         submittedBy: user,
       });
@@ -101,7 +97,6 @@ describe('submitDCR use-case', () => {
           type: 'dcr',
           file: fakeFileContents,
           stepDate: dcrDate,
-          numeroDossier,
           projectId,
           submittedBy: user,
         });
@@ -114,7 +109,6 @@ describe('submitDCR use-case', () => {
           projectId,
           dcrDate,
           fileId: fakeFile.id.toString(),
-          numeroDossier,
           submittedBy: user.id.toString(),
         });
       });

--- a/src/modules/project/useCases/submitDCR.ts
+++ b/src/modules/project/useCases/submitDCR.ts
@@ -15,7 +15,6 @@ type SubmitDCRArgs = {
   type: 'dcr';
   projectId: string;
   stepDate: Date;
-  numeroDossier: string;
   file: {
     contents: FileContents;
     filename: string;
@@ -29,7 +28,6 @@ export const makeSubmitDCR =
     type,
     projectId,
     stepDate,
-    numeroDossier,
     file,
     submittedBy,
   }: SubmitDCRArgs): ResultAsync<null, InfraNotAvailableError | UnauthorizedError> => {
@@ -77,7 +75,6 @@ export const makeSubmitDCR =
                   projectId,
                   dcrDate: stepDate,
                   fileId,
-                  numeroDossier,
                   submittedBy: submittedBy.id.toString(),
                 })
                 .asyncMap(async () => null);

--- a/src/views/components/timeline/components/DCRItem.tsx
+++ b/src/views/components/timeline/components/DCRItem.tsx
@@ -144,12 +144,6 @@ const UploadForm = ({ projectId }: UploadFormProps) => {
           />
         </div>
         <div className="mt-2">
-          <Label htmlFor="numero-dossier" required>
-            Identifiant gestionnaire de réseau (ex : GEFAR-P)
-          </Label>
-          <Input type="text" name="numeroDossier" id="numero-dossier" required />
-        </div>
-        <div className="mt-2">
           <Label htmlFor="file" required>
             Accusé de réception
           </Label>

--- a/src/views/pages/demanderDelaiPage/DemanderDelai.tsx
+++ b/src/views/pages/demanderDelaiPage/DemanderDelai.tsx
@@ -12,7 +12,6 @@ import {
   PageTemplate,
   SuccessBox,
   ErrorBox,
-  ExternalLink,
   Heading1,
   ProjectProps,
   Label,
@@ -129,23 +128,6 @@ export const DemanderDelai = ({ request, project, appelOffre }: DemanderDelaiPro
                       {...dataId('modificationRequest-justificationField')}
                     />
                   </div>
-                  {!project.identifiantGestionnaire ? (
-                    <div>
-                      <Label htmlFor="numeroGestionnaire">Identifiant gestionnaire de réseau</Label>
-                      <div className="italic">
-                        Cette indication permettra un traitement plus rapide de votre demande.{' '}
-                        <ExternalLink href="https://docs.potentiel.beta.gouv.fr/info/guide-dutilisation-potentiel/comment-transmettre-ma-demande-complete-de-raccordement-dcr">
-                          Où trouver mon numéro ?
-                        </ExternalLink>
-                      </div>
-                      <Input
-                        type="text"
-                        name="numeroGestionnaire"
-                        {...dataId('modificationRequest-numeroGestionnaireField')}
-                        id="numeroGestionnaire"
-                      />
-                    </div>
-                  ) : null}
                   <div>
                     <Label htmlFor="file">Pièce justificative (si nécessaire)</Label>
                     <Input


### PR DESCRIPTION
Suppression du champ "identifiant gestionnaire réseau" des formulaires de demande de délai et d'envoi de DCR. 