### PR TITLE
♻️  Utilisation d'un dropdown pour les actions possible par projet depuis la liste des projets

### DIFF
--- a/src/public/scripts.js
+++ b/src/public/scripts.js
@@ -2,7 +2,6 @@
 
 window.initHandlers = function () {
   addStatusOnlyHandler();
-  addActionMenuHandlers();
   addInvitationHandlers();
   addDelayEstimator();
   addSelectorHandlers();
@@ -19,41 +18,8 @@ window.initHandlers = function () {
 document.addEventListener('DOMContentLoaded', () => window.initHandlers());
 
 //
-// Action menu
-//
-
-function addActionMenuHandlers() {
-  const actionMenuTriggers = document.querySelectorAll('[data-testid=action-menu-trigger]');
-
-  const actionMenus = document.querySelectorAll('[data-testid=action-menu]');
-
-  function hideAllMenus() {
-    actionMenus.forEach((item) => item.classList.remove('open'));
-  }
-
-  actionMenuTriggers.forEach((item) =>
-    item.addEventListener('click', function (event) {
-      event.preventDefault();
-      event.stopPropagation();
-
-      const menu = item.parentElement.querySelector('[data-testid=action-menu]');
-      const wasVisible = menu && menu.classList.contains('open');
-
-      hideAllMenus();
-
-      if (menu && !wasVisible) {
-        menu.classList.add('open');
-      }
-    }),
-  );
-
-  document.addEventListener('click', hideAllMenus);
-}
-
-//
 // Project page
 //
-
 function addInvitationHandlers() {
   const invitationFormShowButton = document.querySelector(
     '[data-testid=invitation-form-show-button]',

--- a/src/views/components/PageTemplate.tsx
+++ b/src/views/components/PageTemplate.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import routes from '@routes';
 import { Footer } from './Footer';
 import { Header } from './Header';
-import { DropdownMenu } from './UI/molecules/DropdownMenu';
+import { DropdownMenu } from './UI/molecules/dropdowns/DropdownMenu';
 import { UtilisateurReadModel } from '@modules/utilisateur/récupérer/UtilisateurReadModel';
 
 type CurrentPage =

--- a/src/views/components/ProjectActions.tsx
+++ b/src/views/components/ProjectActions.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { UserRole } from '@modules/users';
 import { ACTION_BY_ROLE } from './actions';
-import { DropdownMenu } from './UI';
+import { DropdownSecondary } from './UI';
 import { ProjectAppelOffre } from '@entities';
 
 type Props = {
@@ -36,20 +36,20 @@ export const ProjectActions = ({ project, role }: Props) => {
   return (
     <div className="relative">
       <ul>
-        <DropdownMenu buttonChildren="Actions">
+        <DropdownSecondary titre="Actions">
           {actions.map(({ title, link, isDownload, disabled }, index) => {
             return (
-              <DropdownMenu.DropdownItem
+              <DropdownSecondary.DropdownItem
                 href={link}
                 download={isDownload ? true : undefined}
                 disabled={disabled ? true : undefined}
                 key={`${title}#${index}`}
               >
                 {title}
-              </DropdownMenu.DropdownItem>
+              </DropdownSecondary.DropdownItem>
             );
           })}
-        </DropdownMenu>
+        </DropdownSecondary>
       </ul>
     </div>
   );

--- a/src/views/components/ProjectActions.tsx
+++ b/src/views/components/ProjectActions.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
-import { dataId } from '../../helpers/testId';
 import { UserRole } from '@modules/users';
 import { ACTION_BY_ROLE } from './actions';
-import { ChevronDownIcon, SecondaryButton } from './UI';
-import { Link } from '@components';
+import { DropdownMenu } from './UI';
 import { ProjectAppelOffre } from '@entities';
 
 type Props = {
@@ -33,33 +31,25 @@ type Props = {
 };
 
 export const ProjectActions = ({ project, role }: Props) => {
-  if (!project || !role) return <></>;
-  const actions = ACTION_BY_ROLE[role]?.call(null, project);
-  if (!actions || !actions.length) return <></>;
-
+  const actions = ACTION_BY_ROLE[role].call(null, project);
+  if (!actions || !actions.length) return null;
   return (
-    <div style={{ position: 'relative' }} {...dataId('project-actions')}>
-      <SecondaryButton className="ml-4" {...dataId('action-menu-trigger')}>
-        Actions <ChevronDownIcon className="ml-2" title="(menu)" />
-      </SecondaryButton>
-      <ul className="list--action-menu" {...dataId('action-menu')}>
-        {actions.map(({ title, actionId, projectId, link, disabled, isDownload }, actionIndex) => (
-          <li key={'notif_' + projectId + '_' + actionIndex}>
-            {disabled ? (
-              <i>{title}</i>
-            ) : (
-              <Link
+    <div className="relative">
+      <ul>
+        <DropdownMenu buttonChildren="Actions">
+          {actions.map(({ title, link, isDownload, disabled }, index) => {
+            return (
+              <DropdownMenu.DropdownItem
                 href={link}
-                download={isDownload}
-                data-actionid={actionId}
-                data-projectid={projectId}
-                {...dataId('item-action')}
+                download={isDownload ? true : undefined}
+                disabled={disabled ? true : undefined}
+                key={`${title}#${index}`}
               >
                 {title}
-              </Link>
-            )}
-          </li>
-        ))}
+              </DropdownMenu.DropdownItem>
+            );
+          })}
+        </DropdownMenu>
       </ul>
     </div>
   );

--- a/src/views/components/UI/molecules/DropdownMenu.tsx
+++ b/src/views/components/UI/molecules/DropdownMenu.tsx
@@ -65,9 +65,11 @@ type DropdownItemProps = {
   href: string;
   isCurrent?: true;
   children: React.ReactNode;
+  download?: true;
+  disabled?: true;
 };
 
-const DropdownItem = ({ children, href, isCurrent }: DropdownItemProps) => (
+const DropdownItem = ({ children, href, isCurrent, download, disabled }: DropdownItemProps) => (
   <li
     style={{ borderBottomWidth: 1 }}
     className={`flex items-center hover:bg-grey-1000-hover border-0 border-b-1 last:border-b-0 border-grey-925-base border-solid ${
@@ -78,6 +80,8 @@ const DropdownItem = ({ children, href, isCurrent }: DropdownItemProps) => (
     <a
       className="flex-1 px-4 py-3 block no-underline whitespace-nowrap"
       href={href}
+      {...(download && { download: true })}
+      {...(disabled && { disabled: true })}
       {...(isCurrent
         ? { 'aria-current': 'page', style: { color: '#000091' } }
         : { style: { color: 'black' } })}

--- a/src/views/components/UI/molecules/dropdowns/DropdownMenu.stories.tsx
+++ b/src/views/components/UI/molecules/dropdowns/DropdownMenu.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { DropdownMenu } from './DropdownMenu';
 
 export default {
-  title: 'Components/Molecules/DropdownMenu',
+  title: 'Components/Molecules/dropdowns/DropdownMenu',
   component: DropdownMenu,
   argTypes: {
     children: { control: 'text', defaultValue: 'Menu' },

--- a/src/views/components/UI/molecules/dropdowns/DropdownMenu.tsx
+++ b/src/views/components/UI/molecules/dropdowns/DropdownMenu.tsx
@@ -1,19 +1,21 @@
 import React, { ComponentProps, ReactElement, useEffect, useRef, useState } from 'react';
-import { ArrowDownIcon } from '../atoms/icons';
+import { ArrowDownIcon } from '../../atoms/icons';
 
 type DropdownMenuProps = ComponentProps<'li'> & {
   buttonChildren: React.ReactNode;
-  children: (ReactElement | false)[];
+  children?: (ReactElement | false)[];
 };
 
-const DropdownMenu: React.FC<DropdownMenuProps> & { DropdownItem: typeof DropdownItem } = ({
+export const DropdownMenu: React.FC<DropdownMenuProps> & { DropdownItem: typeof DropdownItem } = ({
   buttonChildren,
   children,
   className,
   ...props
 }: DropdownMenuProps) => {
   const [visible, setVisible] = useState(false);
-  const isCurrent = children.some((subMenu) => subMenu && subMenu.props.isCurrent);
+  const isCurrent = children
+    ? children.some((subMenu) => subMenu && subMenu.props.isCurrent)
+    : undefined;
   const ref = useRef<HTMLLIElement>(null);
 
   useEffect(() => {
@@ -92,5 +94,3 @@ const DropdownItem = ({ children, href, isCurrent, download, disabled }: Dropdow
 );
 
 DropdownMenu.DropdownItem = DropdownItem;
-
-export { DropdownMenu };

--- a/src/views/components/UI/molecules/dropdowns/DropdownSecondary.stories.tsx
+++ b/src/views/components/UI/molecules/dropdowns/DropdownSecondary.stories.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { DropdownSecondary } from './DropdownSecondary';
+
+export default {
+  title: 'Components/Molecules/dropdowns/DropdownSecondary',
+  component: DropdownSecondary,
+  argTypes: {
+    children: { control: 'text', defaultValue: 'DropdownSecondary' },
+  },
+};
+
+const Template = (args: Parameters<typeof DropdownSecondary>[0]) => (
+  <DropdownSecondary className="inline-flex" {...args} />
+);
+
+export const Default = Template.bind({});
+Default.args = {
+  titre: `Exemple de DropdownSecondary`,
+  children: (
+    <>
+      <DropdownSecondary.DropdownItem href="#">Lien 1</DropdownSecondary.DropdownItem>
+      <DropdownSecondary.DropdownItem href="#">Lien 2</DropdownSecondary.DropdownItem>
+    </>
+  ),
+} as Parameters<typeof DropdownSecondary>[0];

--- a/src/views/components/UI/molecules/dropdowns/DropdownSecondary.tsx
+++ b/src/views/components/UI/molecules/dropdowns/DropdownSecondary.tsx
@@ -43,7 +43,7 @@ export const DropdownSecondary: React.FC<DropdownSecondaryProps> & {
         />
       </div>
       <ul
-        className={`list-none p-3 lg:p-0 lg:mt-4 z-10 lg:absolute lg:top-full lg:left-0 w-full lg:w-auto lg:shadow-[0_2px_6px_1px_rgba(0,0,0,0.2)] lg:min-w-[300px] ${
+        className={`bg-white list-none p-0 mt-4 z-10 absolute top-full left-0 shadow-[0_2px_6px_1px_rgba(0,0,0,0.2)] min-w-[300px] ${
           visible ? 'block' : 'hidden'
         }`}
       >
@@ -61,13 +61,13 @@ type DropdownItemProps = {
   disabled?: true;
 };
 
-const DropdownItem = ({ children, href, isCurrent, download, disabled }: DropdownItemProps) => (
+const DropdownItem = ({ children, href, download, disabled }: DropdownItemProps) => (
   <li
     style={{ borderBottomWidth: 1 }}
-    className={`flex items-center hover:bg-grey-1000-hover border-0 border-b-1 last:border-b-0 border-grey-925-base border-solid`}
+    className={`bg-white flex items-center hover:bg-grey-1000-hover border-0 border-b-1 last:border-b-0 border-grey-925-base border-solid`}
   >
     <Link
-      className="flex-1 px-4 py-3 block bg-white no-underline whitespace-nowrap"
+      className="flex-1 px-4 py-3 block no-underline whitespace-nowrap"
       href={href}
       {...(download && { download: true })}
       {...(disabled && { disabled: true })}

--- a/src/views/components/UI/molecules/dropdowns/DropdownSecondary.tsx
+++ b/src/views/components/UI/molecules/dropdowns/DropdownSecondary.tsx
@@ -1,0 +1,80 @@
+import React, { ComponentProps, ReactElement, useEffect, useRef, useState } from 'react';
+import { Link } from '../../atoms';
+import { ArrowDownIcon } from '../../atoms/icons';
+
+type DropdownSecondaryProps = ComponentProps<'div'> & {
+  titre: string;
+  children: (ReactElement | false)[];
+};
+
+export const DropdownSecondary: React.FC<DropdownSecondaryProps> & {
+  DropdownItem: typeof DropdownItem;
+} = ({ titre, children, className, ...props }: DropdownSecondaryProps) => {
+  const [visible, setVisible] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const onClickOut = (e: MouseEvent) => {
+      const element = e.target as HTMLElement;
+      if (ref.current !== element && !ref.current?.contains(element)) {
+        setVisible(false);
+      }
+    };
+    document.addEventListener('click', onClickOut);
+    return () => document.removeEventListener('click', onClickOut);
+  }, [setVisible]);
+
+  return (
+    <div
+      ref={ref}
+      className={`flex flex-col relative cursor-pointer  border border-solid outline-offset-4 outline-2 outline-solid outline-outline-base border-blue-france-sun-base text-blue-france-sun-base bg-white hover:bg-blue-france-975-base focus:bg-blue-france-975-base ${className}`}
+      aria-expanded={visible}
+      {...props}
+    >
+      <div
+        onClick={() => setVisible(!visible)}
+        className={`px-6 py-2 flex items-center flex-1 no-underline `}
+      >
+        <span className="whitespace-nowrap"> {titre}</span>
+        <ArrowDownIcon
+          style={{ transform: visible ? 'rotate(180deg)' : '' }}
+          className={`ml-auto lg:ml-2 mr-2 lg:mr-0 transition`}
+          title={`${visible ? 'Fermer' : 'Ouvrir'} le sous-menu`}
+        />
+      </div>
+      <ul
+        className={`list-none p-3 lg:p-0 lg:mt-4 z-10 lg:absolute lg:top-full lg:left-0 w-full lg:w-auto lg:shadow-[0_2px_6px_1px_rgba(0,0,0,0.2)] lg:min-w-[300px] ${
+          visible ? 'block' : 'hidden'
+        }`}
+      >
+        {children}
+      </ul>
+    </div>
+  );
+};
+
+type DropdownItemProps = {
+  href: string;
+  isCurrent?: true;
+  children: React.ReactNode;
+  download?: true;
+  disabled?: true;
+};
+
+const DropdownItem = ({ children, href, isCurrent, download, disabled }: DropdownItemProps) => (
+  <li
+    style={{ borderBottomWidth: 1 }}
+    className={`flex items-center hover:bg-grey-1000-hover border-0 border-b-1 last:border-b-0 border-grey-925-base border-solid`}
+  >
+    <Link
+      className="flex-1 px-4 py-3 block bg-white no-underline whitespace-nowrap"
+      href={href}
+      {...(download && { download: true })}
+      {...(disabled && { disabled: true })}
+    >
+      {children}
+    </Link>
+  </li>
+);
+
+DropdownSecondary.DropdownItem = DropdownItem;

--- a/src/views/components/UI/molecules/dropdowns/index.ts
+++ b/src/views/components/UI/molecules/dropdowns/index.ts
@@ -1,0 +1,2 @@
+export * from './DropdownMenu';
+export * from './DropdownSecondary';

--- a/src/views/components/UI/molecules/index.ts
+++ b/src/views/components/UI/molecules/index.ts
@@ -2,7 +2,7 @@ export * from './Alertes';
 export * from './BarreDeRecherche';
 export * from './DownloadLink';
 export * from './DownloadLinkButton';
-export * from './DropdownMenu';
+export * from './dropdowns';
 export * from './ExternalLink';
 export * from './Pagination';
 export * from './RésultatSoumissionFormulaire';

--- a/src/views/components/UI/organisms/ProjectList.tsx
+++ b/src/views/components/UI/organisms/ProjectList.tsx
@@ -234,16 +234,18 @@ export const ProjectList = ({
                 </div>
 
                 <div className="flex md:absolute md:top-4 md:right-5 gap-2">
-                  <ProjectActions
-                    role={role}
-                    project={{
-                      ...project,
-                      isClasse: project.classe === 'Classé',
-                      isAbandoned: project.abandonedOn !== 0,
-                      isLegacy: project.appelOffre?.periode.type === 'legacy',
-                      notifiedOn: project.notifiedOn ? new Date(project.notifiedOn) : undefined,
-                    }}
-                  />
+                  {project && role && (
+                    <ProjectActions
+                      role={role}
+                      project={{
+                        ...project,
+                        isClasse: project.classe === 'Classé',
+                        isAbandoned: project.abandonedOn !== 0,
+                        isLegacy: project.appelOffre?.periode.type === 'legacy',
+                        notifiedOn: project.notifiedOn ? new Date(project.notifiedOn) : undefined,
+                      }}
+                    />
+                  )}
                   <LinkButton href={routes.PROJECT_DETAILS(project.id)}>Voir</LinkButton>
                 </div>
               </div>


### PR DESCRIPTION
Dans cette PR j'ai retravaillé le composant `ProjectActions` pour remplacer le dropdown legacy par un nouveau composant `DropdownSecondary`. Son comportement est assez similaire à `DropdownMenu` mais il gère mieux le responsive et est plus adapté à ce genre de cas d'usage.

Au passage ça dégage la méthode legacy du script/public.js `addActionMenuHandlers()`