### PR TITLE
🐛 Empêcher de réinviter un porteur sur des projets

### DIFF
--- a/src/controllers/project/postInviteUserToProject.ts
+++ b/src/controllers/project/postInviteUserToProject.ts
@@ -23,13 +23,7 @@ const schema = yup.object({
   }),
 });
 
-const getRedirectTo = ({
-  projectId,
-  role,
-}: {
-  projectId: string | string[];
-  role: User['role'];
-}) => {
+const getRedirectTo = ({ projectId }: { projectId: string | string[]; role: User['role'] }) => {
   return Array.isArray(projectId) ? routes.LISTE_PROJETS : routes.PROJECT_DETAILS(projectId);
 };
 

--- a/src/infra/sequelize/queries/project/exporter/requêtes/récupérerExportProjets.ts
+++ b/src/infra/sequelize/queries/project/exporter/requêtes/récupérerExportProjets.ts
@@ -59,6 +59,7 @@ export const récupérerExportProjets = ({
       ],
       attributes: [...convertirEnAttributsSequelize(colonnesÀExporter), 'details'],
       raw: true,
+      //group: ['appelOffreId', 'periodeId', 'numeroCRE', 'familleId', 'nomProjet'],
     }),
   ).map((projects) => ({
     colonnes: récupérerIntitulés(colonnesÀExporter),

--- a/src/infra/sequelize/queries/users/rechercherDroitsDéjàExistants.integration.ts
+++ b/src/infra/sequelize/queries/users/rechercherDroitsDéjàExistants.integration.ts
@@ -1,0 +1,52 @@
+import { User } from '@infra/sequelize/projectionsNext';
+import { v4 } from 'uuid';
+import { resetDatabase } from '../../helpers';
+import { rechercherDroitsDéjàExistantsQueryHandler } from './rechercherDroitsDéjàExistants';
+
+describe('Requête RechercherDroitsDéjàExistant', () => {
+  beforeAll(async () => {
+    // Create the tables and remove all data
+    await resetDatabase();
+  });
+
+  it(`Étant donné un utilisateur non existant
+      Lorsqu'on recherche si son email a déjà des droits sur des projets
+      Alors aucun projet ne devrait être retourné
+  `, async () => {
+    const résultat = await rechercherDroitsDéjàExistantsQueryHandler({
+      email: 'utilisateurInconnu@email.com',
+      projectIds: ['projet1', 'projet2'],
+    });
+
+    expect(résultat).toEqual([]);
+  });
+
+  it(`Étant donné un utilisateur existant et n'étant pas rattaché à un projet
+      Lorsqu'on recherche si son email a déjà des droits sur des projets
+      Alors aucun projet ne devrait être retourné
+  `, async () => {
+    const email = 'email@test.test';
+    await User.create({
+      id: v4().toString(),
+      email,
+      role: 'porteur-projet',
+    });
+
+    const résultat = await rechercherDroitsDéjàExistantsQueryHandler({
+      email,
+      projectIds: [v4().toString(), v4().toString()],
+    });
+
+    expect(résultat).toEqual([]);
+  });
+
+  // it(`Étant donné un utilisateur existant et ayant des accès pour certains projets
+  //     Lorsqu'on recherche si son email a déjà des droits sur plusieurs projets
+  //     Alors on devrait retourner uniquement les projets pour lesquels l'utilisateur a déjà les droits
+  // `, () => {});
+
+  // it(`Étant donné un utilisateur existant et ayant des accès à tous les projets
+  //     Lorsqu'on recherche si son email a déjà des droits sur plusieurs projets
+  //     Alors on devrait retourner tout les projets concernés
+  // `, () => {});
+});

--- a/src/infra/sequelize/queries/users/rechercherDroitsDéjàExistants.integration.ts
+++ b/src/infra/sequelize/queries/users/rechercherDroitsDéjàExistants.integration.ts
@@ -1,11 +1,10 @@
-import { User } from '@infra/sequelize/projectionsNext';
+import { User, UserProjects } from '@infra/sequelize/projectionsNext';
 import { v4 } from 'uuid';
 import { resetDatabase } from '../../helpers';
 import { rechercherDroitsDéjàExistantsQueryHandler } from './rechercherDroitsDéjàExistants';
 
 describe('Requête RechercherDroitsDéjàExistant', () => {
-  beforeAll(async () => {
-    // Create the tables and remove all data
+  beforeEach(async () => {
     await resetDatabase();
   });
 
@@ -40,13 +39,31 @@ describe('Requête RechercherDroitsDéjàExistant', () => {
     expect(résultat).toEqual([]);
   });
 
-  // it(`Étant donné un utilisateur existant et ayant des accès pour certains projets
-  //     Lorsqu'on recherche si son email a déjà des droits sur plusieurs projets
-  //     Alors on devrait retourner uniquement les projets pour lesquels l'utilisateur a déjà les droits
-  // `, () => {});
+  it(`Étant donné un utilisateur existant et ayant des accès pour certains projets
+      Lorsqu'on recherche si son email a déjà des droits sur plusieurs projets
+      Alors on devrait retourner uniquement les projets pour lesquels l'utilisateur a déjà les droits
+  `, async () => {
+    const email = 'email@test.test';
+    const projetId1 = v4().toString();
+    const projetId2 = v4().toString();
 
-  // it(`Étant donné un utilisateur existant et ayant des accès à tous les projets
-  //     Lorsqu'on recherche si son email a déjà des droits sur plusieurs projets
-  //     Alors on devrait retourner tout les projets concernés
-  // `, () => {});
+    const userId = v4().toString();
+    await User.create({
+      id: userId,
+      email,
+      role: 'porteur-projet',
+    });
+
+    await UserProjects.bulkCreate([
+      { userId, projectId: projetId1 },
+      { userId, projectId: projetId2 },
+    ]);
+
+    const résultat = await rechercherDroitsDéjàExistantsQueryHandler({
+      email,
+      projectIds: [projetId1, projetId2, v4().toString()],
+    });
+
+    expect(résultat).toEqual([projetId1, projetId2]);
+  });
 });

--- a/src/infra/sequelize/queries/users/rechercherDroitsDéjàExistants.ts
+++ b/src/infra/sequelize/queries/users/rechercherDroitsDéjàExistants.ts
@@ -1,14 +1,28 @@
 import { User, UserProjects } from '@infra/sequelize';
+import { RechercherDroitsDéjàExistantsQueryHandler } from '@modules/utilisateur/inviterPorteurSurDesProjets/rechercherDroitsDéjàExistants';
 
-const rechercherDroitsDéjàExistants = async (email, projectId) => {
-  const utilisateurExistant = await User.findOne({ where: { email }, attributes: ['id'] });
-  if (!utilisateurExistant) {
-    return;
-  }
-  const userProjects = await UserProjects.findOne({
-    where: { userId: utilisateurExistant.id, projectId },
-  });
-  if (userProjects) {
-  }
-  return;
-};
+export const rechercherDroitsDéjàExistantsQueryHandler: RechercherDroitsDéjàExistantsQueryHandler =
+  async ({ email, projectIds }) => {
+    const utilisateurExistant = await User.findOne({ where: { email }, attributes: ['id'] });
+    const projetsDéjàRattachésUser: string[] = [];
+
+    if (!utilisateurExistant) {
+      return projetsDéjàRattachésUser;
+    }
+
+    for (const projectId of projectIds) {
+      try {
+        const userProject = await UserProjects.findOne({
+          where: { userId: utilisateurExistant.id, projectId },
+        });
+
+        if (userProject) {
+          projetsDéjàRattachésUser.push(userProject.projectId);
+        }
+      } catch (e) {
+        console.error(e);
+      }
+    }
+
+    return projetsDéjàRattachésUser;
+  };

--- a/src/infra/sequelize/queries/users/rechercherDroitsDéjàExistants.ts
+++ b/src/infra/sequelize/queries/users/rechercherDroitsDéjàExistants.ts
@@ -1,0 +1,14 @@
+import { User, UserProjects } from '@infra/sequelize';
+
+const rechercherDroitsDéjàExistants = async (email, projectId) => {
+  const utilisateurExistant = await User.findOne({ where: { email }, attributes: ['id'] });
+  if (!utilisateurExistant) {
+    return;
+  }
+  const userProjects = await UserProjects.findOne({
+    where: { userId: utilisateurExistant.id, projectId },
+  });
+  if (userProjects) {
+  }
+  return;
+};

--- a/src/infra/sequelize/queries/users/rechercherDroitsDéjàExistants.ts
+++ b/src/infra/sequelize/queries/users/rechercherDroitsDéjàExistants.ts
@@ -3,24 +3,22 @@ import { RechercherDroitsDéjàExistantsQueryHandler } from '@modules/utilisateu
 
 export const rechercherDroitsDéjàExistantsQueryHandler: RechercherDroitsDéjàExistantsQueryHandler =
   async ({ email, projectIds }) => {
-    const utilisateurExistant = await User.findOne({ where: { email }, attributes: ['id'] });
     const projetsDéjàRattachésUser: string[] = [];
+
+    const utilisateurExistant = await User.findOne({ where: { email }, attributes: ['id'] });
 
     if (!utilisateurExistant) {
       return projetsDéjàRattachésUser;
     }
 
     for (const projectId of projectIds) {
-      try {
-        const userProject = await UserProjects.findOne({
-          where: { userId: utilisateurExistant.id, projectId },
-        });
+      const userProject = await UserProjects.findOne({
+        where: { userId: utilisateurExistant.id, projectId },
+        attributes: ['projectId'],
+      });
 
-        if (userProject) {
-          projetsDéjàRattachésUser.push(userProject.projectId);
-        }
-      } catch (e) {
-        console.error(e);
+      if (userProject) {
+        projetsDéjàRattachésUser.push(userProject.projectId);
       }
     }
 

--- a/src/modules/utilisateur/inviterPorteurSurDesProjets/rechercherDroitsDéjàExistants.ts
+++ b/src/modules/utilisateur/inviterPorteurSurDesProjets/rechercherDroitsDéjàExistants.ts
@@ -1,5 +1,5 @@
 export type RechercherDroitsDéjàExistantsQuery = { email: string; projectIds: string[] };
 
-export type RechercherDroitsDéjàExistantsQueryQueryHandler = (
+export type RechercherDroitsDéjàExistantsQueryHandler = (
   query: RechercherDroitsDéjàExistantsQuery,
-) => Promise<null | string[]>;
+) => Promise<string[]>;

--- a/src/modules/utilisateur/inviterPorteurSurDesProjets/rechercherDroitsDéjàExistants.ts
+++ b/src/modules/utilisateur/inviterPorteurSurDesProjets/rechercherDroitsDéjàExistants.ts
@@ -1,0 +1,5 @@
+export type RechercherDroitsDéjàExistantsQuery = { email: string; projectIds: string[] };
+
+export type RechercherDroitsDéjàExistantsQueryQueryHandler = (
+  query: RechercherDroitsDéjàExistantsQuery,
+) => Promise<null | string[]>;


### PR DESCRIPTION
Certains projets sont en doublon dans l'export de la liste des projets pour les porteurs.
Dans la liste des projets, il y a une différence entre le compte des projets et le nombre de projets affichés. 