### PR TITLE
 🚸 (1693): Creation de compte/invitation : notification si email déjà utilisé

### DIFF
--- a/src/controllers/admin/inviterDgecValidateur/postInviterDgecValidateur.ts
+++ b/src/controllers/admin/inviterDgecValidateur/postInviterDgecValidateur.ts
@@ -9,6 +9,7 @@ import {
 import { inviterUtilisateur } from '@config';
 import {
   InvitationUniqueParUtilisateurError,
+  InvitationUtilisateurExistantError,
   PermissionInviterDgecValidateur,
 } from '@modules/utilisateur';
 import { logger } from '@core/utils';
@@ -60,7 +61,10 @@ v1Router.post(
             });
             return response.redirect(routes.ADMIN_INVITATION_DGEC_VALIDATEUR);
           }
-          if (error instanceof InvitationUniqueParUtilisateurError) {
+          if (
+            error instanceof InvitationUniqueParUtilisateurError ||
+            error instanceof InvitationUtilisateurExistantError
+          ) {
             sauvegarderRésultatFormulaire(request, routes.ADMIN_INVITATION_DGEC_VALIDATEUR_ACTION, {
               type: 'échec',
               raison: error.message,

--- a/src/controllers/admin/partnerUsers/postInvitePartnerUser.ts
+++ b/src/controllers/admin/partnerUsers/postInvitePartnerUser.ts
@@ -6,7 +6,10 @@ import { v1Router } from '../../v1Router';
 import * as yup from 'yup';
 import { errorResponse, RequestValidationError, validateRequestBody } from '../../helpers';
 import { logger } from '@core/utils';
-import { InvitationUniqueParUtilisateurError } from '@modules/utilisateur';
+import {
+  InvitationUniqueParUtilisateurError,
+  InvitationUtilisateurExistantError,
+} from '@modules/utilisateur';
 
 const requestBodySchema = yup.object({
   role: yup
@@ -46,7 +49,10 @@ v1Router.post(
               }),
             );
           }
-          if (error instanceof InvitationUniqueParUtilisateurError) {
+          if (
+            error instanceof InvitationUniqueParUtilisateurError ||
+            error instanceof InvitationUtilisateurExistantError
+          ) {
             return response.redirect(
               addQueryParams(routes.ADMIN_PARTNER_USERS, {
                 ...request.body,

--- a/src/controllers/userAccount/postSignup.ts
+++ b/src/controllers/userAccount/postSignup.ts
@@ -5,6 +5,7 @@ import { logger } from '../../core/utils';
 import { addQueryParams } from '../../helpers/addQueryParams';
 import * as yup from 'yup';
 import safeAsyncHandler from '../helpers/safeAsyncHandler';
+import { EmailAlreadyUsedError } from '@modules/shared';
 
 const schema = yup.object({
   body: yup.object({
@@ -62,7 +63,9 @@ v1Router.post(
         });
 
         if (res.isErr()) {
-          logger.error(res.error);
+          if (!(res.error instanceof EmailAlreadyUsedError)) {
+            logger.error(res.error);
+          }
 
           return response.redirect(
             addQueryParams(routes.SIGNUP, {


### PR DESCRIPTION
- ne pas logguer l'erreur dans sentry
- afficher le bon message d'erreur à l'utilisateur