### PR TITLE
:bug: (1700): ETQ porteur je ne suis pas notifié en cas de regénération des attestations d'une période

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36546,6 +36546,7 @@
       }
     },
     "packages/specifications": {
+      "name": "@potentiel/specifications",
       "version": "0.0.0",
       "dependencies": {
         "@potentiel/core-domain": "*",

--- a/src/config/eventHandlers/notification.eventHandlers.ts
+++ b/src/config/eventHandlers/notification.eventHandlers.ts
@@ -34,13 +34,14 @@ import {
   getInfoForModificationRequested,
   getModificationRequestInfoForStatusNotification,
   getModificationRequestRecipient,
+  récupérerDonnéesPorteursParProjetQueryHandler,
 } from '../queries.config';
 import { oldProjectRepo, oldUserRepo, projectRepo } from '../repos.config';
 
 const projectCertificateChangeHandler = handleProjectCertificateUpdatedOrRegenerated({
   sendNotification,
   projectRepo,
-  getUsersForProject: oldProjectRepo.getUsers,
+  getUsersForProject: récupérerDonnéesPorteursParProjetQueryHandler,
 });
 
 eventStore.subscribe(ProjectCertificateUpdated.type, projectCertificateChangeHandler);

--- a/src/infra/sequelize/queries/project/index.ts
+++ b/src/infra/sequelize/queries/project/index.ts
@@ -1,5 +1,6 @@
 export * from './consulter';
 export * from './exporter';
+export * from './helpers';
 export * from './lister';
 export * from './findProjectByIdentifiers';
 export * from './getDélaiCdc2022Applicable';
@@ -14,5 +15,6 @@ export * from './getProjectIdsForPeriode';
 export * from './getProjetsParIdentifiantGestionnaireRéseau';
 export * from './getUnnotifiedProjectsForPeriode';
 export * from './hasDemandeDeMêmeTypeOuverte';
+export * from './récupérerDonnéesPorteursParProjet.queryHandler';
 export * from './résuméProjetQueryHandler';
 export * from './trouverProjetsParIdentifiantGestionnaireRéseau';

--- a/src/infra/sequelize/queries/project/récupérerDonnéesPorteursParProjet.integration.ts
+++ b/src/infra/sequelize/queries/project/récupérerDonnéesPorteursParProjet.integration.ts
@@ -1,0 +1,57 @@
+import { User, UserProjects } from '@infra/sequelize/projectionsNext';
+import * as uuid from 'uuid';
+import { récupérerDonnéesPorteursParProjetQueryHandler } from './récupérerDonnéesPorteursParProjet.queryHandler';
+
+describe('Récupérer les données des porteurs de projet pour un projet', () => {
+  it(`Etant donné un projet rattaché à plusieurs utilisateur : deux porteur et une Dreal
+      Lorsqu'on récupère les données des porteurs pour le projet
+      Alors seulement les données des deux porteurs devtaient être retournées`, async () => {
+    const projetId = uuid.v4();
+    const porteur1Id = uuid.v4();
+    const porteur2Id = uuid.v4();
+    const drealId = uuid.v4();
+
+    await User.bulkCreate([
+      {
+        id: porteur1Id,
+        email: 'porteur1@test.test',
+        fullName: 'porteur 1',
+        role: 'porteur-projet',
+      },
+      {
+        id: porteur2Id,
+        email: 'porteur2@test.test',
+        fullName: 'porteur 2',
+        role: 'porteur-projet',
+      },
+      { id: drealId, email: 'drealtest@test.test', fullName: 'une dreal', role: 'dreal' },
+    ]);
+
+    await UserProjects.bulkCreate([
+      { userId: porteur1Id, projectId: projetId },
+      { userId: porteur2Id, projectId: projetId },
+      { userId: drealId, projectId: projetId },
+    ]);
+
+    const readModel = await récupérerDonnéesPorteursParProjetQueryHandler({ projetId });
+
+    expect(readModel).toHaveLength(2);
+
+    expect(readModel).toEqual(
+      expect.arrayContaining([
+        {
+          id: porteur1Id,
+          email: 'porteur1@test.test',
+          fullName: 'porteur 1',
+          role: 'porteur-projet',
+        },
+        {
+          id: porteur2Id,
+          email: 'porteur2@test.test',
+          fullName: 'porteur 2',
+          role: 'porteur-projet',
+        },
+      ]),
+    );
+  });
+});

--- a/src/infra/sequelize/queries/project/récupérerDonnéesPorteursParProjet.queryHandler.ts
+++ b/src/infra/sequelize/queries/project/récupérerDonnéesPorteursParProjet.queryHandler.ts
@@ -11,6 +11,7 @@ export const récupérerDonnéesPorteursParProjetQueryHandler: RécupérerDonné
           model: User,
           as: 'user',
           attributes: ['fullName', 'email', 'id', 'role'],
+          where: { role: 'porteur-projet' },
         },
       ],
     });

--- a/src/infra/sequelize/queries/project/récupérerDonnéesPorteursParProjet.queryHandler.ts
+++ b/src/infra/sequelize/queries/project/récupérerDonnéesPorteursParProjet.queryHandler.ts
@@ -1,0 +1,24 @@
+import { User, UserProjects } from '@infra/sequelize/projectionsNext';
+import { RécupérerDonnéesPorteursParProjetQueryHandler } from '@modules/project/queries';
+
+export const récupérerDonnéesPorteursParProjetQueryHandler: RécupérerDonnéesPorteursParProjetQueryHandler =
+  async ({ projetId }) => {
+    const rawData = await UserProjects.findAll({
+      attributes: ['projectId'],
+      where: { projectId: projetId },
+      include: [
+        {
+          model: User,
+          as: 'user',
+          attributes: ['fullName', 'email', 'id', 'role'],
+        },
+      ],
+    });
+
+    return rawData.map(({ user: { fullName, email, role, id } }) => ({
+      fullName,
+      email,
+      role,
+      id,
+    }));
+  };

--- a/src/modules/notification/eventHandlers/handleProjectCertificateUpdatedOrRegenerated.spec.ts
+++ b/src/modules/notification/eventHandlers/handleProjectCertificateUpdatedOrRegenerated.spec.ts
@@ -19,7 +19,7 @@ describe('candidateNotificatio.handleProjectCertificateUpdatedOrRegenerated', ()
 
   const projectRepo = fakeRepo(fakeProject as Project);
 
-  const getUsersForProject = jest.fn(async (projectId: string) => projectUsers);
+  const getUsersForProject = jest.fn(async ({ projetId: string }) => projectUsers);
 
   const sendNotification = jest.fn(async (args: NotificationArgs) => null);
 
@@ -35,7 +35,7 @@ describe('candidateNotificatio.handleProjectCertificateUpdatedOrRegenerated', ()
       }),
     );
 
-    expect(getUsersForProject).toHaveBeenCalledWith(projectId);
+    expect(getUsersForProject).toHaveBeenCalledWith({ projetId: projectId });
 
     expect(sendNotification).toHaveBeenCalledTimes(projectUsers.length);
     const notifications = sendNotification.mock.calls.map((call) => call[0]);

--- a/src/modules/notification/eventHandlers/handleProjectCertificateUpdatedOrRegenerated.ts
+++ b/src/modules/notification/eventHandlers/handleProjectCertificateUpdatedOrRegenerated.ts
@@ -1,24 +1,22 @@
 import { NotificationService } from '..';
 import { Repository, UniqueEntityID } from '@core/domain';
 import { wrapInfra } from '@core/utils';
-import { ProjectRepo } from '@dataAccess';
 import { User } from '@entities';
 import { ProjectCertificateRegenerated, ProjectCertificateUpdated } from '../../project/events';
 import { Project } from '../../project/Project';
 import routes from '@routes';
+import { RécupérerDonnéesPorteursParProjetQueryHandler } from '@modules/project/queries';
 
 export const handleProjectCertificateUpdatedOrRegenerated =
   (deps: {
     sendNotification: NotificationService['sendNotification'];
-    getUsersForProject: ProjectRepo['getUsers'];
+    getUsersForProject: RécupérerDonnéesPorteursParProjetQueryHandler;
     projectRepo: Repository<Project>;
   }) =>
   async (event: ProjectCertificateUpdated | ProjectCertificateRegenerated) => {
     const { projectId } = event.payload;
 
-    const porteursProjet = (await deps.getUsersForProject(projectId)).filter(
-      (user) => user.role === 'porteur-projet',
-    );
+    const porteursProjet = await deps.getUsersForProject({ projetId: projectId });
 
     if (!porteursProjet || !porteursProjet.length) {
       // no registered user for this projet, no one to warn

--- a/src/modules/project/queries/index.ts
+++ b/src/modules/project/queries/index.ts
@@ -15,3 +15,4 @@ export * from './GetUnnotifiedProjectsForPeriode';
 export * from './HasDemandeDeMêmeTypeOuverte';
 export * from './RésuméProjet';
 export * from './TrouverProjetsParIdentifiantGestionnaireRéseau';
+export * from './récupérerDonnéesPorteursParProjet';

--- a/src/modules/project/queries/récupérerDonnéesPorteursParProjet.ts
+++ b/src/modules/project/queries/récupérerDonnéesPorteursParProjet.ts
@@ -1,0 +1,9 @@
+import { User } from '@entities';
+
+type RécupérerDonnéesPorteursParProjetQuery = { projetId: string };
+
+type RécupérerDonnéesPorteursParProjetReadModel = Array<User>;
+
+export type RécupérerDonnéesPorteursParProjetQueryHandler = (
+  query: RécupérerDonnéesPorteursParProjetQuery,
+) => Promise<RécupérerDonnéesPorteursParProjetReadModel>;

--- a/src/views/pages/AdminRegénérerPeriodeAttestationsPage.tsx
+++ b/src/views/pages/AdminRegénérerPeriodeAttestationsPage.tsx
@@ -132,11 +132,11 @@ export const AdminRegénérerPeriodeAttestations = ({
             </div>
           </div>
           <div className="form__group">
-            <Label htmlFor="forceCertificateGeneration">
+            <Label htmlFor="reason">
               Message justificatif du changement (facultatif, sera inclus dans le mail aux porteurs
               de projet)
             </Label>
-            <TextArea name="forceCertificateGeneration" defaultValue={reason} />
+            <TextArea name="reason" id="reason" defaultValue={reason} />
           </div>
 
           <Button


### PR DESCRIPTION
Bug remonté : porteurs  non notifiés suite à la re-génération des attestations de désignation d'une période. 

Constat : les emails de notification ne sont plus envoyés pour certains événements émis (trois handlers identifiés). 
Cela concerne les handlers qui utilisent le old project repo pour récupérer les données des utilisateurs, il ne retourne plus toutes les données des utilisateurs mais seulement leur id. 

Solution : ne plus utiliser ce code legacy. Dans un premier temps pour corriger rapidement le bug et permettre la regénération des attestation d'une période + envoi de l'email de notification, on introduit une nouvelle query qui est utlisée dans le handler concerné. 
Dans une seconde PR cette query sera utilisée pour les autres cas où les emails ne partent plus. 

Bonus : autre bug identifié et corrigé : remonter le raison de la re-génération au contrôleur.