### PR TITLE
🐛 (1703): Notifications porteurs - fix queries

### DIFF
--- a/src/config/eventHandlers/notification.eventHandlers.ts
+++ b/src/config/eventHandlers/notification.eventHandlers.ts
@@ -135,7 +135,7 @@ eventStore.subscribe(
   ProjectCompletionDueDateSet.type,
   makeOnProjectCompletionDueDateSet({
     sendNotification,
-    getProjectUsers: oldProjectRepo.getUsers,
+    getProjectUsers: récupérerDonnéesPorteursParProjetQueryHandler,
     getProjectById: oldProjectRepo.findById,
     findUsersForDreal: oldUserRepo.findUsersForDreal,
   }),

--- a/src/config/eventHandlers/notifications/révocationsAccèsPorteurs.notifications.ts
+++ b/src/config/eventHandlers/notifications/révocationsAccèsPorteurs.notifications.ts
@@ -6,12 +6,13 @@ import {
 import { notifierPorteurRévocationAccèsProjet } from '@config/useCases.config';
 import { ToutAccèsAuProjetRevoqué, UserRightsToProjectRevoked } from '@modules/authZ';
 import { projectRepo, userRepo } from '@dataAccess';
+import { récupérerDonnéesPorteursParProjetQueryHandler } from '@config/queries.config';
 
 notificationEventSubscriber(
   ToutAccèsAuProjetRevoqué,
   makeOnToutAccèsAuProjetRévoqué({
     notifierPorteurRévocationAccèsProjet,
-    getProjectUsers: projectRepo.getUsers,
+    getProjectUsers: récupérerDonnéesPorteursParProjetQueryHandler,
     getProject: projectRepo.findById,
   }),
 );

--- a/src/dataAccess/db/project.ts
+++ b/src/dataAccess/db/project.ts
@@ -81,7 +81,6 @@ export const makeProjectRepo: MakeProjectRepo = ({ sequelizeInstance, getProject
     findAll,
     save,
     remove,
-    getUsers,
     findExistingAppelsOffres,
     findExistingFamillesForAppelOffre,
     findExistingPeriodesForAppelOffre,
@@ -481,18 +480,6 @@ export const makeProjectRepo: MakeProjectRepo = ({ sequelizeInstance, getProject
       if (CONFIG.logDbErrors) logger.error(error);
       return Err(error);
     }
-  }
-
-  async function getUsers(projectId: Project['id']): Promise<Array<User>> {
-    await _isDbReady;
-
-    const projectInstance = await ProjectModel.findByPk(projectId);
-
-    if (!projectInstance) {
-      return [];
-    }
-
-    return (await (projectInstance as any).getUsers()).map((item) => item.get());
   }
 
   async function findExistingAppelsOffres(

--- a/src/dataAccess/project.ts
+++ b/src/dataAccess/project.ts
@@ -104,8 +104,4 @@ export type ProjectRepo = {
    * @deprecated
    */
   save: (project: Project) => ResultAsync<null>;
-  /**
-   * @deprecated
-   */
-  getUsers: (projectId: Project['id']) => Promise<Array<User>>;
 };

--- a/src/modules/notification/eventHandlers/onProjectCompletionDueDateSet.ts
+++ b/src/modules/notification/eventHandlers/onProjectCompletionDueDateSet.ts
@@ -1,6 +1,9 @@
 import { logger } from '@core/utils';
 import { ProjectRepo, UserRepo } from '@dataAccess';
-import { ProjectCompletionDueDateSet } from '@modules/project';
+import {
+  ProjectCompletionDueDateSet,
+  RécupérerDonnéesPorteursParProjetQueryHandler,
+} from '@modules/project';
 import routes from '@routes';
 import { NotificationService } from '../NotificationService';
 
@@ -8,7 +11,7 @@ type OnProjectCompletionDueDateSet = (évènement: ProjectCompletionDueDateSet) 
 
 type MakeOnProjectCompletionDueDateSet = (dépendances: {
   sendNotification: NotificationService['sendNotification'];
-  getProjectUsers: ProjectRepo['getUsers'];
+  getProjectUsers: RécupérerDonnéesPorteursParProjetQueryHandler;
   getProjectById: ProjectRepo['findById'];
   findUsersForDreal: UserRepo['findUsersForDreal'];
 }) => OnProjectCompletionDueDateSet;
@@ -27,7 +30,7 @@ export const makeOnProjectCompletionDueDateSet: MakeOnProjectCompletionDueDateSe
       );
       return;
     }
-    const porteursEmails = await getProjectUsers(projectId);
+    const porteursEmails = await getProjectUsers({ projetId: projectId });
 
     await Promise.all(
       porteursEmails.map(({ email, fullName, id }) =>

--- a/src/modules/notification/eventHandlers/révocationAccèsPorteurs/onToutAccèsAuProjetRevoqué.ts
+++ b/src/modules/notification/eventHandlers/révocationAccèsPorteurs/onToutAccèsAuProjetRevoqué.ts
@@ -2,12 +2,13 @@ import { logger } from '@core/utils';
 import { ProjectRepo } from '@dataAccess';
 import { ToutAccèsAuProjetRevoqué } from '@modules/authZ';
 import { NotifierPorteurRévocationAccèsProjet } from '@modules/notification/useCases';
+import { RécupérerDonnéesPorteursParProjetQueryHandler } from '@modules/project';
 
 type OnToutAccèsAuProjetRévoqué = (événement: ToutAccèsAuProjetRevoqué) => Promise<void>;
 
 type MakeOnToutAccèsAuProjetRévoqué = (dépendances: {
   notifierPorteurRévocationAccèsProjet: NotifierPorteurRévocationAccèsProjet;
-  getProjectUsers: ProjectRepo['getUsers'];
+  getProjectUsers: RécupérerDonnéesPorteursParProjetQueryHandler;
   getProject: ProjectRepo['findById'];
 }) => OnToutAccèsAuProjetRévoqué;
 
@@ -15,7 +16,11 @@ export const makeOnToutAccèsAuProjetRévoqué: MakeOnToutAccèsAuProjetRévoqu�
   ({ notifierPorteurRévocationAccèsProjet, getProjectUsers, getProject }) =>
   async ({ payload }: ToutAccèsAuProjetRevoqué) => {
     const { projetId, cause } = payload;
-    const utilisateursANotifier = await getProjectUsers(projetId);
+    const utilisateursANotifier = await getProjectUsers({ projetId });
+
+    if (utilisateursANotifier.length === 0) {
+      return;
+    }
 
     const projet = await getProject(projetId);
 


### PR DESCRIPTION
Suite de la PR qui introduisait une query sequelize pour récupérer les users d'un projet pour les notifier en cas de regénération d'une attestation. 

Utilisation de la query pour récupérer les coordonnées des destinataires de notifications en cas de : 
- révocation de tous les droits sur un projet (changement de producteur)
- ajout du délai de 18 mois (CDC 2022) à un projet 

Suppression de l'ancien code qui n'est plus utilisé et ne fonctionne plus correctement (projectRepo.getUsers)