### PR TITLE
🔀 Intégration des derniers changements de la version 3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35267,9 +35267,9 @@
       "dev": true
     },
     "node_modules/vm2": {
-      "version": "3.9.17",
-      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.17.tgz",
-      "integrity": "sha512-AqwtCnZ/ERcX+AVj9vUsphY56YANXxRuqMb7GsDtAr0m0PcQX3u0Aj3KWiXM0YAHy7i6JEeHrwOnwXbGYgRpAw==",
+      "version": "3.9.18",
+      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.18.tgz",
+      "integrity": "sha512-iM7PchOElv6Uv6Q+0Hq7dcgDtWWT6SizYqVcvol+1WQc+E9HlgTCnPozbQNSP3yDV9oXHQOEQu530w2q/BCVZg==",
       "dev": true,
       "dependencies": {
         "acorn": "^8.7.0",

--- a/src/infra/redis/helpers/fromRedisMessage.spec.ts
+++ b/src/infra/redis/helpers/fromRedisMessage.spec.ts
@@ -17,18 +17,19 @@ describe('fromRedisMessage', () => {
   });
 
   describe('when the message type does not exist', () => {
-    it('should throw an error', () => {
-      expect(() =>
-        fromRedisMessage({
-          type: 'unknownEvent',
-        } as RedisMessage),
-      ).toThrow();
+    it('should return null', () => {
+      const actual = fromRedisMessage({
+        type: 'unknownEvent',
+      } as RedisMessage);
+
+      expect(actual).toBeNull();
     });
   });
 
   describe('when the message does not have a type', () => {
-    it('should throw an error', () => {
-      expect(() => fromRedisMessage({} as RedisMessage)).toThrow();
+    it('should return null', () => {
+      const actual = fromRedisMessage({} as RedisMessage);
+      expect(actual).toBeNull();
     });
   });
 });

--- a/src/infra/redis/helpers/fromRedisMessage.ts
+++ b/src/infra/redis/helpers/fromRedisMessage.ts
@@ -19,6 +19,7 @@ import { isLegacyEvent, RedisMessage } from './RedisMessage';
 
 import { transformerISOStringEnDate } from '../../helpers';
 import { DateMiseEnServiceTransmise } from '@modules/project/events';
+import { logger } from '@core/utils';
 
 interface EventProps {
   payload: any;
@@ -55,11 +56,12 @@ const EventClassByType: Record<string, HasEventConstructor> = {
   ...compatibilityEvents,
 };
 
-export const fromRedisMessage = (message: RedisMessage): DomainEvent => {
+export const fromRedisMessage = (message: RedisMessage): DomainEvent | null => {
   const EventClass = EventClassByType[message.type];
 
   if (!EventClass) {
-    throw new Error('Event class not recognized');
+    logger.warning(`Event class not recognized`, { event: message });
+    return null;
   }
 
   const original = isLegacyEvent(message)


### PR DESCRIPTION
* 🔊 Logguer un warning si le type d'évènement n'est pas reconnu depuis Redis

* :arrow_up: Bump vm2 from 3.9.17 to 3.9.18

Bumps [vm2](https://github.com/patriksimek/vm2) from 3.9.17 to 3.9.18.
- [Release notes](https://github.com/patriksimek/vm2/releases)
- [Changelog](https://github.com/patriksimek/vm2/blob/master/CHANGELOG.md)
- [Commits](https://github.com/patriksimek/vm2/compare/3.9.17...3.9.18)

---
updated-dependencies:
- dependency-name: vm2 dependency-type: indirect ...



---------