### PR TITLE
:children_crossing: (1742): Accès aux données de raccordement pour les rôles CRE et AO

### DIFF
--- a/src/controllers/raccordement/getAucunRaccordementAListerPage.ts
+++ b/src/controllers/raccordement/getAucunRaccordementAListerPage.ts
@@ -1,0 +1,93 @@
+import routes from '@routes';
+import { v1Router } from '../v1Router';
+import * as yup from 'yup';
+import safeAsyncHandler from '../helpers/safeAsyncHandler';
+import { notFoundResponse, vérifierPermissionUtilisateur } from '../helpers';
+import { PermissionConsulterDossierRaccordement, RésuméProjetReadModel } from '@potentiel/domain';
+import { Project } from '@infra/sequelize/projectionsNext';
+import { AucunDossierAListerPage } from '@views';
+
+const schema = yup.object({
+  params: yup.object({ projetId: yup.string().uuid().required() }),
+});
+
+v1Router.get(
+  routes.GET_PAGE_RACCORDEMENT_SANS_DOSSIER_PAGE(),
+  vérifierPermissionUtilisateur(PermissionConsulterDossierRaccordement),
+  safeAsyncHandler(
+    {
+      schema,
+      onError: ({ request, response }) =>
+        notFoundResponse({ request, response, ressourceTitle: 'Projet' }),
+    },
+    async (request, response) => {
+      const {
+        user,
+        params: { projetId },
+        query: { success },
+      } = request;
+
+      const projet = await Project.findByPk(projetId, {
+        attributes: [
+          'id',
+          'nomProjet',
+          'nomCandidat',
+          'communeProjet',
+          'regionProjet',
+          'departementProjet',
+          'periodeId',
+          'familleId',
+          'appelOffreId',
+          'numeroCRE',
+          'notifiedOn',
+          'abandonedOn',
+          'classe',
+        ],
+      });
+
+      if (!projet) {
+        return notFoundResponse({
+          request,
+          response,
+          ressourceTitle: 'Projet',
+        });
+      }
+
+      const getStatutProjet = (): RésuméProjetReadModel['statut'] => {
+        if (!projet.notifiedOn) {
+          return 'non-notifié';
+        }
+        if (projet.abandonedOn !== 0) {
+          return 'abandonné';
+        }
+        if (projet.classe === 'Classé') {
+          return 'classé';
+        }
+
+        return 'éliminé';
+      };
+
+      response.send(
+        AucunDossierAListerPage({
+          user,
+          identifiantProjet: projetId,
+          résuméProjet: {
+            type: 'résumé-projet',
+            identifiantProjet: projet.id,
+            appelOffre: projet.appelOffreId,
+            période: projet.periodeId,
+            famille: projet.familleId,
+            numéroCRE: projet.numeroCRE,
+            statut: getStatutProjet(),
+            nom: projet.nomProjet,
+            localité: {
+              commune: projet.communeProjet,
+              département: projet.departementProjet,
+              région: projet.regionProjet,
+            },
+          },
+        }),
+      );
+    },
+  ),
+);

--- a/src/controllers/raccordement/getListeDossierRaccordementPage.ts
+++ b/src/controllers/raccordement/getListeDossierRaccordementPage.ts
@@ -14,6 +14,7 @@ import {
 import { Project } from '@infra/sequelize/projectionsNext';
 import { ListeDossiersRaccordementPage } from '@views';
 import { mediator } from 'mediateur';
+import { userIs } from '@modules/users';
 
 const schema = yup.object({
   params: yup.object({ projetId: yup.string().uuid().required() }),
@@ -141,7 +142,13 @@ v1Router.get(
         );
       }
 
-      return response.redirect(routes.GET_TRANSMETTRE_DEMANDE_COMPLETE_RACCORDEMENT_PAGE(projetId));
+      if (userIs(['porteur-projet', 'admin', 'dgec-validateur'])(user)) {
+        return response.redirect(
+          routes.GET_TRANSMETTRE_DEMANDE_COMPLETE_RACCORDEMENT_PAGE(projetId),
+        );
+      } else {
+        return response.redirect(routes.GET_PAGE_RACCORDEMENT_SANS_DOSSIER_PAGE(projetId));
+      }
     },
   ),
 );

--- a/src/controllers/raccordement/getListeDossierRaccordementPage.ts
+++ b/src/controllers/raccordement/getListeDossierRaccordementPage.ts
@@ -146,9 +146,9 @@ v1Router.get(
         return response.redirect(
           routes.GET_TRANSMETTRE_DEMANDE_COMPLETE_RACCORDEMENT_PAGE(projetId),
         );
-      } else {
-        return response.redirect(routes.GET_PAGE_RACCORDEMENT_SANS_DOSSIER_PAGE(projetId));
       }
+
+      return response.redirect(routes.GET_PAGE_RACCORDEMENT_SANS_DOSSIER_PAGE(projetId));
     },
   ),
 );

--- a/src/controllers/raccordement/index.ts
+++ b/src/controllers/raccordement/index.ts
@@ -13,3 +13,4 @@ export * from './getModifierGestionnaireRéseauProjetPage';
 export * from './postModifierGestionnaireRéseauProjet';
 export * from './getModifierPropositionTechniqueEtFinancière';
 export * from './postModifierPropositionTechniqueEtFinancière';
+export * from './getAucunRaccordementAListerPage';

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -496,5 +496,9 @@ class routes {
       reference || ':reference'
     }/modifier-proposition-technique-et-financiere`;
   };
+
+  static GET_PAGE_RACCORDEMENT_SANS_DOSSIER_PAGE = (projetId?: string) => {
+    return `/projet/${projetId || ':projetId'}/raccordements/aucun-dossier-renseigne.html`;
+  };
 }
 export default routes;

--- a/src/views/index.ts
+++ b/src/views/index.ts
@@ -53,6 +53,7 @@ import {
   ModifierDemandeComplèteRaccordement,
   ModifierGestionnaireRéseauProjet,
   ModifierPropositionTechniqueEtFinancière,
+  AucunDossierALister,
 } from './pages';
 
 export const StatistiquesPage = (props: Parameters<typeof Statistiques>[0]) =>
@@ -457,4 +458,11 @@ export const ModifierPropositionTechniqueEtFinancièrePage = (
     Component: ModifierPropositionTechniqueEtFinancière,
     props,
     title: 'Modifier une proposition technique et financière',
+  });
+
+export const AucunDossierAListerPage = (props: Parameters<typeof AucunDossierALister>[0]) =>
+  makeHtml({
+    Component: AucunDossierALister,
+    props,
+    title: 'Aucun dossier de raccordement à lister',
   });

--- a/src/views/pages/projectDetailsPage/ProjectDetails.tsx
+++ b/src/views/pages/projectDetailsPage/ProjectDetails.tsx
@@ -59,7 +59,7 @@ export const ProjectDetails = ({
           />
         )}
 
-        {!dossiersRaccordementExistant && (
+        {!dossiersRaccordementExistant && userIs(['porteur-projet'])(user) && (
           <DisplayDCRAlertInfos dcrDueOn={project.dcrDueOn} now={now}>
             <div className="p-2">
               L'accusé de réception de la demande complète de raccordement doit être transmis dans

--- a/src/views/pages/raccordement/AucunDossierAListerPage.tsx
+++ b/src/views/pages/raccordement/AucunDossierAListerPage.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+import { UtilisateurReadModel } from '@modules/utilisateur/récupérer/UtilisateurReadModel';
+import { PageProjetTemplate, PlugIcon, ListeVide, Link } from '@components';
+import { hydrateOnClient } from '../../helpers';
+import { RésuméProjetReadModel } from '@potentiel/domain';
+import routes from '@routes';
+
+type AucunDossierAListerProps = {
+  user: UtilisateurReadModel;
+  identifiantProjet: string;
+  résuméProjet: RésuméProjetReadModel;
+};
+
+export const AucunDossierALister = ({
+  user,
+  résuméProjet,
+  identifiantProjet,
+}: AucunDossierAListerProps) => (
+  <PageProjetTemplate
+    titre={
+      <>
+        <PlugIcon className="mr-1" aria-hidden />
+        Raccordement
+      </>
+    }
+    user={user}
+    résuméProjet={résuméProjet}
+  >
+    <ListeVide titre="Aucun dossier à lister" />
+
+    <div className="mt-4">
+      <Link href={routes.PROJECT_DETAILS(identifiantProjet)}>Retour vers le détail du projet</Link>
+    </div>
+  </PageProjetTemplate>
+);
+
+hydrateOnClient(AucunDossierALister);

--- a/src/views/pages/raccordement/components/Dossier.tsx
+++ b/src/views/pages/raccordement/components/Dossier.tsx
@@ -148,7 +148,7 @@ export const Dossier: FC<{
             </Link>
           )}
         </div>
-      ) : userIs(['admin'])(user) ? (
+      ) : userIs(['admin', 'dgec-validateur'])(user) ? (
         <Link
           className="mt-4 text-center"
           href={routes.GET_TRANSMETTRE_DATE_MISE_EN_SERVICE_PAGE(identifiantProjet, référence)}

--- a/src/views/pages/raccordement/components/Dossier.tsx
+++ b/src/views/pages/raccordement/components/Dossier.tsx
@@ -118,7 +118,7 @@ export const Dossier: FC<{
             </Link>
           )}
         </div>
-      ) : (
+      ) : userIs(['porteur-projet', 'admin', 'dgec-validateur'])(user) ? (
         <Link
           className="mt-4 text-center"
           href={routes.GET_TRANSMETTRE_PROPOSITION_TECHNIQUE_ET_FINANCIERE_PAGE(
@@ -128,6 +128,8 @@ export const Dossier: FC<{
         >
           Transmettre
         </Link>
+      ) : (
+        <p>La proposition technique et financière n'a pas été transmise</p>
       )}
     </Etape>
     <Separateur />

--- a/src/views/pages/raccordement/index.ts
+++ b/src/views/pages/raccordement/index.ts
@@ -5,3 +5,4 @@ export * from './TransmettrePropositionTechniqueEtFinancièrePage';
 export * from './ModifierDemandeComplèteRaccordementPage';
 export * from './ModifierGestionnaireRéseauProjetPage';
 export * from './ModifierPropositionTechniqueEtFinancièrePage';
+export * from './AucunDossierAListerPage';


### PR DESCRIPTION
La page raccordement était déjà accessible pour les rôles CRE et AO.

Cependant, si le projet n'a pas encore de dossier de raccordement dans Potentiel, alors on redirigeait vers le formulaire d'envoi de DCR. Les rôles AO et CRE n'ayant pas les droits de modification sur les données de raccordement, ces utilisateurs étaient redirigés vers une page d'erreur (accès non autorisé).

Dans cette PR j'ai ajouté une nouvelle page dédiée pour le cas d'un projet sans dossier de raccordement. La page affiche une liste vide.
J'ai pris le parti de ne pas utiliser la page existante pour éviter de passer toute une partie des props de la page optionnelles pour ce cas précis de projet sans dossier de raccordement, et éviter de complexifier le contrôleur getListeDossiersRaccordementPage.