### PR TITLE
🚸 Intitulé des liens explicites

### DIFF
--- a/src/views/components/RequestList.tsx
+++ b/src/views/components/RequestList.tsx
@@ -35,27 +35,27 @@ export const RequestList = ({ modificationRequests, requestActions }: Props) => 
     return <ListeVide titre="Aucune demande n’a été trouvée" />;
   }
 
-  const buttonTitleByType = (type: ModificationRequestTypes) => {
+  const intituléLien = (type: ModificationRequestTypes) => {
     switch (type) {
       case 'abandon':
-        return `Voir la demande d'abandon`;
+        return `la demande d'abandon`;
 
       case 'annulation abandon':
-        return `Voir la demande d'annulation d'abandon`;
+        return `la demande d'annulation d'abandon`;
       case 'delai':
-        return `Voir la demande de délai supplémentaire`;
+        return `la demande de délai supplémentaire`;
       case 'fournisseur':
-        return `Voir la demande de changement de fournisseur`;
+        return `la demande de changement de fournisseur`;
       case 'actionnaire':
-        return `Voir la demande de changement d'actionnaire`;
+        return `la demande de changement d'actionnaire`;
       case 'producteur':
-        return `Voir la demande de changement de producteur`;
+        return `la demande de changement de producteur`;
       case 'puissance':
-        return `Voir la demande de changement de puissance`;
+        return `la demande de changement de puissance`;
       case 'recours':
-        return `Voir la demande de recours`;
+        return `la demande de recours`;
       case 'autre':
-        return `Voir la demande`;
+        return `la demande`;
       default:
         return '';
     }
@@ -112,9 +112,14 @@ export const RequestList = ({ modificationRequests, requestActions }: Props) => 
                     <span>{project.communeProjet}</span>, <span>{project.departementProjet}</span>,{' '}
                     <span>{project.regionProjet}</span>
                     <div>
-                      Déposé par{' '}
-                      <Link href={`mailto:${requestedBy.email}`}>{requestedBy.fullName}</Link> le{' '}
-                      {afficherDate(requestedOn)}
+                      Déposé par {requestedBy.fullName}{' '}
+                      <Link
+                        href={`mailto:${requestedBy.email}`}
+                        aria-label={`Envoyer un email au porteur du projet ${project.nomProjet}`}
+                      >
+                        (envoyer un email)
+                      </Link>{' '}
+                      le {afficherDate(requestedOn)}
                     </div>
                   </div>
                 </Td>
@@ -130,6 +135,9 @@ export const RequestList = ({ modificationRequests, requestActions }: Props) => 
                           modificationRequest.attachmentFile.id,
                           modificationRequest.attachmentFile.filename,
                         )}
+                        aria-label={`Télécharger la pièce-jointe de ${intituléLien(
+                          modificationRequest.type,
+                        )} pour le projet ${project.nomProjet}`}
                         download={true}
                       >
                         Télécharger la pièce-jointe
@@ -146,9 +154,9 @@ export const RequestList = ({ modificationRequests, requestActions }: Props) => 
                 <Td>
                   <LinkButton
                     href={ROUTES.DEMANDE_PAGE_DETAILS(modificationRequest.id)}
-                    title={`${buttonTitleByType(modificationRequest.type)} pour le projet ${
-                      project.nomProjet
-                    }`}
+                    aria-label={`Voir le détail de ${intituléLien(
+                      modificationRequest.type,
+                    )} pour le projet ${project.nomProjet}`}
                   >
                     Voir
                   </LinkButton>

--- a/src/views/components/UI/molecules/DownloadLink.tsx
+++ b/src/views/components/UI/molecules/DownloadLink.tsx
@@ -1,19 +1,13 @@
-import React, { FC } from 'react';
+import React, { ComponentProps, FC } from 'react';
 import { Link, FileDownloadIcon } from '../atoms';
 
-type DownloadLinkProps = {
+type DownloadLinkProps = ComponentProps<'a'> & {
   className?: string;
   fileUrl: string;
-  intituléLien?: string;
 };
 
-export const DownloadLink: FC<DownloadLinkProps> = ({
-  children,
-  className,
-  fileUrl,
-  intituléLien = '',
-}) => (
-  <Link className={className} href={fileUrl} download aria-label={intituléLien}>
+export const DownloadLink: FC<DownloadLinkProps> = ({ children, className, fileUrl, ...props }) => (
+  <Link className={className} href={fileUrl} download {...props}>
     <FileDownloadIcon className="text-lg mr-1 -mb-1 shrink-0" aria-hidden />
     {children}
   </Link>

--- a/src/views/components/UI/molecules/DownloadLink.tsx
+++ b/src/views/components/UI/molecules/DownloadLink.tsx
@@ -4,10 +4,16 @@ import { Link, FileDownloadIcon } from '../atoms';
 type DownloadLinkProps = {
   className?: string;
   fileUrl: string;
+  intituléLien?: string;
 };
 
-export const DownloadLink: FC<DownloadLinkProps> = ({ children, className, fileUrl }) => (
-  <Link className={className} href={fileUrl} download>
+export const DownloadLink: FC<DownloadLinkProps> = ({
+  children,
+  className,
+  fileUrl,
+  intituléLien = '',
+}) => (
+  <Link className={className} href={fileUrl} download aria-label={intituléLien}>
     <FileDownloadIcon className="text-lg mr-1 -mb-1 shrink-0" aria-hidden />
     {children}
   </Link>

--- a/src/views/components/UI/organisms/Footer.tsx
+++ b/src/views/components/UI/organisms/Footer.tsx
@@ -18,6 +18,7 @@ const Footer = () => {
               <a
                 href="/"
                 title="Retour à l’accueil"
+                aria-label="Retour à l’accueil"
                 className="no-underline hover:no-underline visited:no-underline outline-0"
               >
                 <div className="lg:mb-1 logo-before" />

--- a/src/views/components/UI/organisms/Header.tsx
+++ b/src/views/components/UI/organisms/Header.tsx
@@ -27,6 +27,7 @@ const LogoAndTitle = () => (
     className="flex items-center no-underline hover:no-underline focus:no-underline visited:no-underline"
     href={routes.HOME}
     title="Retour à l'accueil"
+    aria-label="Retour à l'accueil"
   >
     <div className="flex flex-col">
       <div className="lg:mb-1 logo-before" />

--- a/src/views/components/UI/organisms/ProjectList.tsx
+++ b/src/views/components/UI/organisms/ProjectList.tsx
@@ -301,7 +301,7 @@ const GF = ({ project, GFPastDue }: { project: ProjectListItem; GFPastDue?: bool
             <DownloadLink
               className="flex text-sm items-center"
               fileUrl={routes.DOWNLOAD_PROJECT_FILE(gf.fichier.id, gf.fichier.filename)}
-              intituléLien={`Télécharger les garanties financières du projet ${
+              aria-label={`Télécharger les garanties financières du projet ${
                 project.nomProjet
               } déposées le ${afficherDate(new Date(gf.dateEnvoi))}`}
             >
@@ -319,7 +319,7 @@ const GF = ({ project, GFPastDue }: { project: ProjectListItem; GFPastDue?: bool
             id: project.id,
             nomProjet: project.nomProjet,
           })}
-          intituléLien={`Télécharger un modèle de mise en demeure pour le projet ${project.nomProjet}`}
+          aria-label={`Télécharger un modèle de mise en demeure pour le projet ${project.nomProjet}`}
         >
           Télécharger le modèle de mise de demeure
         </DownloadLink>

--- a/src/views/components/UI/organisms/ProjectList.tsx
+++ b/src/views/components/UI/organisms/ProjectList.tsx
@@ -248,7 +248,12 @@ export const ProjectList = ({
                       }}
                     />
                   )}
-                  <LinkButton href={routes.PROJECT_DETAILS(project.id)}>Voir</LinkButton>
+                  <LinkButton
+                    href={routes.PROJECT_DETAILS(project.id)}
+                    aria-label={`voir le projet ${project.nomProjet}`}
+                  >
+                    Voir
+                  </LinkButton>
                 </div>
               </div>
             </Tile>

--- a/src/views/components/UI/organisms/ProjectList.tsx
+++ b/src/views/components/UI/organisms/ProjectList.tsx
@@ -301,6 +301,9 @@ const GF = ({ project, GFPastDue }: { project: ProjectListItem; GFPastDue?: bool
             <DownloadLink
               className="flex text-sm items-center"
               fileUrl={routes.DOWNLOAD_PROJECT_FILE(gf.fichier.id, gf.fichier.filename)}
+              intituléLien={`Télécharger les garanties financières du projet ${
+                project.nomProjet
+              } déposées le ${afficherDate(new Date(gf.dateEnvoi))}`}
             >
               Déposées le <br />
               {afficherDate(new Date(gf.dateEnvoi))}
@@ -316,6 +319,7 @@ const GF = ({ project, GFPastDue }: { project: ProjectListItem; GFPastDue?: bool
             id: project.id,
             nomProjet: project.nomProjet,
           })}
+          intituléLien={`Télécharger un modèle de mise en demeure pour le projet ${project.nomProjet}`}
         >
           Télécharger le modèle de mise de demeure
         </DownloadLink>

--- a/src/views/components/timeline/components/ACItem.tsx
+++ b/src/views/components/timeline/components/ACItem.tsx
@@ -17,6 +17,8 @@ export const ACItem = ({ date, covidDelay, délaiCDC2022Appliqué }: ACItemProps
             Ce projet bénéficie d'une prolongation de délai d'achèvement ou de mise en service
             compte tenu de la crise liée au coronavirus (covid-19) (
             <Link
+              aria-label={`Voir les critères d'attribution de la prolongation de délai d'achèvement ou de mise en service
+            compte tenu de la crise liée au coronavirus (covid-19)`}
               href="https://www.ecologie.gouv.fr/sites/default/files/2004%20-%20SR%20-%20Note%20EDF%20OA%20D%C3%A9finition%20des%20d%C3%A9lais%20COVID%202019_v5.pdf"
               download
             >

--- a/src/views/components/timeline/components/DemandeAbandonItem.tsx
+++ b/src/views/components/timeline/components/DemandeAbandonItem.tsx
@@ -44,7 +44,16 @@ export const DemandeAbandonItem = (props: DemandeAbandonItemProps) => {
         </div>
         <>
           <ItemTitle title={titre} />
-          <p className="p-0 m-0">{demandeUrl && <Link href={demandeUrl}>Voir la demande</Link>}</p>
+          <p className="p-0 m-0">
+            {demandeUrl && (
+              <Link
+                href={demandeUrl}
+                aria-label={`Voir le détail de la demande d'abandon en statut "${statut}"`}
+              >
+                Voir la demande
+              </Link>
+            )}
+          </p>
         </>
       </ContentArea>
     </>

--- a/src/views/components/timeline/components/DemandeAbandonSignaledItem.tsx
+++ b/src/views/components/timeline/components/DemandeAbandonSignaledItem.tsx
@@ -26,7 +26,10 @@ export const DemandeAbandonSignaledItem = ({
           {notes && <p className="p-0 m-0 italic">Note : {notes}</p>}
         </>
         {attachment && (
-          <DownloadLink fileUrl={makeDocumentUrl(attachment.id, attachment.name)}>
+          <DownloadLink
+            fileUrl={makeDocumentUrl(attachment.id, attachment.name)}
+            aria-label={`Télécharger le courrier de réponse de la demande d'abandon en statut "${status}"`}
+          >
             Voir le courrier de réponse
           </DownloadLink>
         )}

--- a/src/views/components/timeline/components/DemandeAnnulationAbandonItem.tsx
+++ b/src/views/components/timeline/components/DemandeAnnulationAbandonItem.tsx
@@ -39,7 +39,16 @@ export const DemandeAnnulationAbandonItem = (props: DemandeAnnulationAbandonItem
         </div>
         <>
           <ItemTitle title={titre} />
-          <p className="p-0 m-0">{demandeUrl && <Link href={demandeUrl}>Voir la demande</Link>}</p>
+          <p className="p-0 m-0">
+            {demandeUrl && (
+              <Link
+                href={demandeUrl}
+                aria-label={`Voir le détail de la demande d'annulation d'abandon en statut "${statut}"`}
+              >
+                Voir la demande
+              </Link>
+            )}
+          </p>
         </>
       </ContentArea>
     </>

--- a/src/views/components/timeline/components/DemandeDelaiSignaledItem.tsx
+++ b/src/views/components/timeline/components/DemandeDelaiSignaledItem.tsx
@@ -47,7 +47,10 @@ const Rejected = ({ date, attachment, notes }: RejectedProps) => (
         {notes && <p className="p-0 m-0 italic">Note : {notes}</p>}
       </>
       {attachment && (
-        <DownloadLink fileUrl={makeDocumentUrl(attachment.id, attachment.name)}>
+        <DownloadLink
+          fileUrl={makeDocumentUrl(attachment.id, attachment.name)}
+          aria-label={`Télécharger le courrier de réponse de la demande de délai rejetée`}
+        >
           Voir le courrier de réponse
         </DownloadLink>
       )}
@@ -67,7 +70,10 @@ const AccordPrincipe = ({ date, attachment, notes }: AccordPrincipeProps) => (
         {notes && <p className="p-0 m-0 italic">Note : {notes}</p>}
       </>
       {attachment && (
-        <DownloadLink fileUrl={makeDocumentUrl(attachment.id, attachment.name)}>
+        <DownloadLink
+          fileUrl={makeDocumentUrl(attachment.id, attachment.name)}
+          aria-label={`Télécharger le courrier de réponse de la demande de délai en "accord de principe"`}
+        >
           Voir le courrier de réponse
         </DownloadLink>
       )}
@@ -101,7 +107,10 @@ const Accepted = ({
         {notes && <p className="p-0 m-0 italic">Note : {notes}</p>}
       </>
       {attachment && (
-        <DownloadLink fileUrl={makeDocumentUrl(attachment.id, attachment.name)}>
+        <DownloadLink
+          fileUrl={makeDocumentUrl(attachment.id, attachment.name)}
+          aria-label={`Télécharger le courrier de réponse de la demande de délai accordée`}
+        >
           Voir le courrier de réponse
         </DownloadLink>
       )}

--- a/src/views/components/timeline/components/DemandeDélaiItem.tsx
+++ b/src/views/components/timeline/components/DemandeDélaiItem.tsx
@@ -50,7 +50,12 @@ export const DemandeDélaiItem = (props: DemandeDélaiItemProps) => {
             {demandeUrl && (
               <>
                 <br />
-                <Link href={demandeUrl}>Voir la demande</Link>
+                <Link
+                  href={demandeUrl}
+                  aria-label={`Voir le détail de la demande de délai en statut "${statut}"`}
+                >
+                  Voir la demande
+                </Link>
               </>
             )}
           </p>

--- a/src/views/components/timeline/components/DemandeRecoursSignaledItem.tsx
+++ b/src/views/components/timeline/components/DemandeRecoursSignaledItem.tsx
@@ -25,7 +25,10 @@ export const DemandeRecoursSignaledItem = ({
         {notes && <p className="p-0 m-0 italic">Note : {notes}</p>}
       </>
       {attachment && (
-        <DownloadLink fileUrl={makeDocumentUrl(attachment.id, attachment.name)}>
+        <DownloadLink
+          fileUrl={makeDocumentUrl(attachment.id, attachment.name)}
+          aria-label={`Télécharger le courrier de réponse de la demande de recours en statut "${status}"`}
+        >
           Voir le courrier de réponse
         </DownloadLink>
       )}

--- a/src/views/components/timeline/components/LegacyModificationsItem.tsx
+++ b/src/views/components/timeline/components/LegacyModificationsItem.tsx
@@ -35,7 +35,10 @@ const LegacyModificationContainer = (
         {children}
         {courrier && (
           <div>
-            <DownloadLink fileUrl={makeDocumentUrl(courrier.id, courrier.name)}>
+            <DownloadLink
+              fileUrl={makeDocumentUrl(courrier.id, courrier.name)}
+              aria-label={`Télécharger le courrier de la demande de type "${props.modificationType}"`}
+            >
               Télécharger le courrier
             </DownloadLink>
           </div>

--- a/src/views/components/timeline/components/ModificationReceivedItem.tsx
+++ b/src/views/components/timeline/components/ModificationReceivedItem.tsx
@@ -19,10 +19,10 @@ const Details = (props: ModificationReceivedItemProps) => {
   const { modificationType, detailsUrl } = props;
   const libelleTypeDemande: { [key in ModificationReceivedItemProps['modificationType']]: string } =
     {
-      producteur: 'Changement de producteur',
-      actionnaire: 'Modification de l’actionnariat',
-      fournisseur: 'Changement de fournisseur(s) ou de produit',
-      puissance: 'Modification de la puissance installée',
+      producteur: 'changement de producteur',
+      actionnaire: 'modification de l’actionnariat',
+      fournisseur: 'changement de fournisseur(s) ou de produit',
+      puissance: 'modification de la puissance installée',
     };
 
   return (
@@ -48,7 +48,14 @@ const Details = (props: ModificationReceivedItemProps) => {
           ))}
         </ul>
       )}
-      {detailsUrl && <Link href={detailsUrl}>Voir la demande</Link>}
+      {detailsUrl && (
+        <Link
+          href={detailsUrl}
+          aria-label={`Voir le détail de la modification de type "${libelleTypeDemande[modificationType]}"`}
+        >
+          Voir la demande
+        </Link>
+      )}
     </>
   );
 };

--- a/src/views/components/timeline/components/ModificationRequestItem.tsx
+++ b/src/views/components/timeline/components/ModificationRequestItem.tsx
@@ -76,7 +76,12 @@ const Rejected = (props: RejectedProps) => {
         <ItemDate date={date} />
         <Details {...props} />
         {responseUrl && (
-          <DownloadLink fileUrl={responseUrl}>Voir le courrier de réponse</DownloadLink>
+          <DownloadLink
+            fileUrl={responseUrl}
+            aria-label={`Voir le courrier de réponse de la demande de type "${props.modificationType}" en statut "rejetée"`}
+          >
+            Voir le courrier de réponse
+          </DownloadLink>
         )}
       </ContentArea>
     </>
@@ -96,7 +101,12 @@ const Accepted = (props: AcceptedProps) => {
         <ItemDate date={date} />
         <Details {...props} />
         {responseUrl && (
-          <DownloadLink fileUrl={responseUrl}>Voir le courrier de réponse</DownloadLink>
+          <DownloadLink
+            fileUrl={responseUrl}
+            aria-label={`Voir le courrier de réponse de la demande de type "${props.modificationType}" en statut "accordée"`}
+          >
+            Voir le courrier de réponse
+          </DownloadLink>
         )}
       </ContentArea>
     </>
@@ -137,9 +147,9 @@ const Details = (
 
   const libelleTypeDemande: { [key in ModificationRequestItemProps['modificationType']]: string } =
     {
-      delai: `Délai supplémentaire`,
-      recours: `Recours`,
-      puissance: `Changement de puissance installée`,
+      delai: `délai supplémentaire`,
+      recours: `recours`,
+      puissance: `changement de puissance installée`,
     };
 
   const libelleStatus: { [key in ModificationRequestItemProps['status']]: string } = {
@@ -174,7 +184,14 @@ const Details = (
           Puissance demandée : {props.puissance} {props.unitePuissance}
         </p>
       )}
-      {showDemandeButton() && <Link href={detailsUrl}>Voir la demande</Link>}
+      {showDemandeButton() && (
+        <Link
+          href={detailsUrl}
+          aria-label={`Voir le détail de la demande de ${libelleTypeDemande[modificationType]} en statut "${libelleStatus[status]}"`}
+        >
+          Voir la demande
+        </Link>
+      )}
     </>
   );
 };

--- a/src/views/pages/gestionaireReseau/components/Liste.tsx
+++ b/src/views/pages/gestionaireReseau/components/Liste.tsx
@@ -12,7 +12,12 @@ export const Liste: FC<ListeProps> = ({ gestionnairesRéseau }) => (
       <li key={`gestionnaire-reseau-${codeEIC}`} className="m-0 mb-3 p-0">
         <Tile className="flex justify-between">
           <div className="font-bold">{raisonSociale}</div>
-          <Link href={routes.GET_DETAIL_GESTIONNAIRE_RESEAU(codeEIC)}>Voir</Link>
+          <Link
+            href={routes.GET_DETAIL_GESTIONNAIRE_RESEAU(codeEIC)}
+            aria-label={`Voir les détails pour ${raisonSociale}`}
+          >
+            Voir
+          </Link>
         </Tile>
       </li>
     ))}

--- a/src/views/pages/projectDetailsPage/sections/Contact.tsx
+++ b/src/views/pages/projectDetailsPage/sections/Contact.tsx
@@ -60,10 +60,11 @@ const ListComptesAvecAcces = ({ user, project }: ListComptesAvecAccesProps) => (
                 projectId: project.id,
                 userId: id,
               })}
+              aria-label={`Retirer les droits sur le projet à ${fullName || email}`}
               className="ml-1"
               confirmation={`Êtes-vous sur de vouloir retirer les droits à ce projet à ${fullName} ?`}
             >
-              retirer
+              retirer les droits
             </Link>
           )}
         </li>

--- a/src/views/pages/projectDetailsPage/sections/EtapesProjet.tsx
+++ b/src/views/pages/projectDetailsPage/sections/EtapesProjet.tsx
@@ -47,6 +47,7 @@ export const EtapesProjet = ({ user, projectEventList, project }: EtapesProjetPr
               numéroCRE: project.numeroCRE,
             }).formatter(),
           )}
+          aria-label="Accéder aux données de raccordement"
         >
           cette page dédiée.
         </Link>

--- a/src/views/pages/raccordement/listeDossiersRaccordement/ListeDossiersRaccordementPage.tsx
+++ b/src/views/pages/raccordement/listeDossiersRaccordement/ListeDossiersRaccordementPage.tsx
@@ -38,6 +38,7 @@ export const ListeDossiersRaccordement = ({
               <Link
                 className="ml-1"
                 href={routes.GET_MODIFIER_GESTIONNAIRE_RESEAU_PROJET_PAGE(identifiantProjet)}
+                aria-label={`Modifier le gestionnaire (actuel : ${gestionnaireRéseau.raisonSociale})`}
               >
                 (<EditIcon className="mr-1" />
                 Modifier)

--- a/src/views/pages/raccordement/listeDossiersRaccordement/components/ÉtapeDemandeComplèteRaccordement.tsx
+++ b/src/views/pages/raccordement/listeDossiersRaccordement/components/ÉtapeDemandeComplèteRaccordement.tsx
@@ -53,6 +53,7 @@ export const ÉtapeDemandeComplèteRaccordement: FC<ÉtapeDemandeComplèteRaccor
         <DownloadLink
           className="flex items-center"
           fileUrl={routes.GET_DEMANDE_COMPLETE_RACCORDEMENT_FILE(identifiantProjet, référence)}
+          aria-label={`Télécharger l'accusé de réception pour le dossier ${référence}`}
         >
           Télécharger l'accusé de réception
         </DownloadLink>
@@ -65,6 +66,7 @@ export const ÉtapeDemandeComplèteRaccordement: FC<ÉtapeDemandeComplèteRaccor
             référence,
           )}
           className="absolute top-2 right-2"
+          aria-label={`Modifier la demande de raccordement ${référence}`}
         >
           <EditIcon aria-hidden className="mr-1" />
           Modifier

--- a/src/views/pages/raccordement/listeDossiersRaccordement/components/ÉtapeMiseEnService.tsx
+++ b/src/views/pages/raccordement/listeDossiersRaccordement/components/ÉtapeMiseEnService.tsx
@@ -35,6 +35,7 @@ export const ÉtapeMiseEnService: FC<ÉtapeMiseEnServiceProps> = ({
           <Link
             href={routes.GET_TRANSMETTRE_DATE_MISE_EN_SERVICE_PAGE(identifiantProjet, référence)}
             className="absolute top-2 right-2"
+            aria-label={`Modifier la date de mise en service pour le dossier ${référence}`}
           >
             <EditIcon aria-hidden className="mr-1" />
             Modifier
@@ -45,6 +46,7 @@ export const ÉtapeMiseEnService: FC<ÉtapeMiseEnServiceProps> = ({
       <Link
         className="mt-4 text-center"
         href={routes.GET_TRANSMETTRE_DATE_MISE_EN_SERVICE_PAGE(identifiantProjet, référence)}
+        aria-label={`Transmettre la date de mise en service pour le dossier ${référence}`}
       >
         Transmettre
       </Link>

--- a/src/views/pages/raccordement/listeDossiersRaccordement/components/ÉtapePropositionTechniqueEtFinancière.tsx
+++ b/src/views/pages/raccordement/listeDossiersRaccordement/components/ÉtapePropositionTechniqueEtFinancière.tsx
@@ -47,6 +47,7 @@ export const ÉtapePropositionTechniqueEtFinancière: FC<
                 identifiantProjet,
                 référence,
               )}
+              aria-label={`Télécharger la proposition technique et financière pour le dossier ${référence}`}
             >
               Télécharger
             </DownloadLink>
@@ -59,6 +60,7 @@ export const ÉtapePropositionTechniqueEtFinancière: FC<
               référence,
             )}
             className="absolute top-2 right-2"
+            aria-label={`Modifier la proposition technique et financière pour le dossier ${référence}`}
           >
             <EditIcon aria-hidden className="mr-1" />
             Modifier
@@ -72,6 +74,7 @@ export const ÉtapePropositionTechniqueEtFinancière: FC<
           identifiantProjet,
           référence,
         )}
+        aria-label={`Transmettre la proposition technique et financière pour le dossier ${référence}`}
       >
         Transmettre
       </Link>


### PR DESCRIPTION
Objectif : les utilisateurs utilisant une technologie d'assistance peuvent vouloir afficher la liste des liens disponibles sur une page. Il faut donc que tous les liens aient un intitulé spécifique.Quand le titre du lien n'est pas assez spécifique, j'ajoute un attribue aria-label. 