### PR TITLE
🐛 (Suppression de GF): Définir la date de validation et l'id du validateur à null

### DIFF
--- a/src/infra/sequelize/projectionsNext/garantiesFinancières/handlers/onProjectGFRemoved.integration.ts
+++ b/src/infra/sequelize/projectionsNext/garantiesFinancières/handlers/onProjectGFRemoved.integration.ts
@@ -29,19 +29,21 @@ describe(`handler onProjectGFRemoved pour la projection garantiesFinancières`, 
     },
   });
 
-  it(`Etant donné un projet existant dans la projection garantiesFinancières,
-    Lorsqu'un événement ProjectGFRemoved est émis pour ce projet,
-    alors la ligne devrait être mise à jour avec le statut 'en attente' 
-    et les données du fichier envoyé devraient être retirées`, async () => {
+  it(`Etant donné un projet avec des garanties financières validées
+    Lorsqu'un événement ProjectGFRemoved est émis pour ce projet
+    Alors les garanties financières devraient être "en attente" 
+    Et les données des anciennes garanties financières devraient être retirées`, async () => {
     await GarantiesFinancières.create({
       id,
       projetId,
-      statut: 'à traiter',
+      statut: 'validé',
       soumisesALaCandidature: false,
       envoyéesPar,
       dateEchéance: dateExpiration,
       dateEnvoi: occurredAt,
       dateConstitution: gfDate,
+      validéesLe: occurredAt,
+      validéesPar: new UniqueEntityID().toString(),
       fichierId,
       dateLimiteEnvoi,
     });
@@ -59,6 +61,8 @@ describe(`handler onProjectGFRemoved pour la projection garantiesFinancières`, 
       envoyéesPar: null,
       dateEnvoi: null,
       dateConstitution: null,
+      validéesLe: null,
+      validéesPar: null,
     });
   });
 });

--- a/src/infra/sequelize/projectionsNext/garantiesFinancières/handlers/onProjectGFRemoved.ts
+++ b/src/infra/sequelize/projectionsNext/garantiesFinancières/handlers/onProjectGFRemoved.ts
@@ -37,6 +37,8 @@ export const onProjectGFRemoved: EventHandler<ProjectGFRemoved> = async (
         dateEnvoi: null,
         envoyéesPar: null,
         dateConstitution: null,
+        validéesLe: null,
+        validéesPar: null,
         statut: 'en attente',
       },
       { where: { projetId, id: entréeExistante.id }, transaction },

--- a/src/infra/sequelize/projectionsNext/garantiesFinancières/handlers/onProjectGFWithdrawn.integration.ts
+++ b/src/infra/sequelize/projectionsNext/garantiesFinancières/handlers/onProjectGFWithdrawn.integration.ts
@@ -29,10 +29,10 @@ describe(`handler onProjectGFWithdrawn pour la projection garantiesFinancières`
     },
   });
 
-  it(`Etant donné un projet existant dans la projection garantiesFinancières,
-    Lorsqu'un événement ProjectGFWithdrawn est émis pour ce projet,
-    alors la ligne devrait être mise à jour avec le statut 'en attente' 
-    et les données du fichier envoyé devraient être retirées`, async () => {
+  it(`Etant donné un projet avec des garanties financières validées
+    Lorsqu'un événement ProjectGFWithdrawn est émis pour ce projet
+    Alors les garanties financières devraient être "en attente" 
+    Et les données des anciennes garanties financières devraient être retirées`, async () => {
     await GarantiesFinancières.create({
       id,
       projetId,
@@ -42,6 +42,8 @@ describe(`handler onProjectGFWithdrawn pour la projection garantiesFinancières`
       dateEchéance: dateExpiration,
       dateEnvoi: occurredAt,
       dateConstitution: gfDate,
+      validéesLe: occurredAt,
+      validéesPar: new UniqueEntityID().toString(),
       fichierId,
       dateLimiteEnvoi,
     });
@@ -60,6 +62,8 @@ describe(`handler onProjectGFWithdrawn pour la projection garantiesFinancières`
       dateEnvoi: null,
       dateConstitution: null,
       fichierId: null,
+      validéesLe: null,
+      validéesPar: null,
       dateLimiteEnvoi,
     });
   });

--- a/src/infra/sequelize/projectionsNext/garantiesFinancières/handlers/onProjectGFWithdrawn.ts
+++ b/src/infra/sequelize/projectionsNext/garantiesFinancières/handlers/onProjectGFWithdrawn.ts
@@ -37,6 +37,8 @@ export const onProjectGFWithdrawn: EventHandler<ProjectGFWithdrawn> = async (
         dateConstitution: null,
         fichierId: null,
         envoyéesPar: null,
+        validéesLe: null,
+        validéesPar: null,
         statut: 'en attente',
       },
       { where: { projetId, id: entréeExistante.id }, transaction },


### PR DESCRIPTION
Lorsqu'on supprime des GF, il faut retirer la date de validation et l'identifiant du validateur de la projection garantiesFinancières. 