### PR TITLE
Permissions sur la suppression de garanties financières selon leur statut 

### DIFF
--- a/src/infra/sequelize/queries/frise/getGarantiesFinancièresDTO.integration.ts
+++ b/src/infra/sequelize/queries/frise/getGarantiesFinancièresDTO.integration.ts
@@ -143,37 +143,88 @@ describe(`Requête getGarantiesFinancièresDTO`, () => {
     });
 
     describe(`Retourner les données de GF à traiter`, () => {
-      it(`Etant donné un projet soumis à garanties financières
-          Et dont les GF ne sont 'à traiter'
-          Alors un GarantiesFinancièresDTO devrait être retourné avec un statut 'à traiter' et les données des GF soumises`, async () => {
-        const garantiesFinancières = {
-          statut: 'à traiter',
-          soumisesALaCandidature: false,
-          dateLimiteEnvoi,
-          envoyéesPar,
-          dateConstitution,
-          dateEchéance,
-          validéesPar: null,
-          fichier: { id: fichierId, filename: 'nom-fichier' },
-          envoyéesParRef: { role: 'porteur-projet' as 'porteur-projet' },
-          type: null,
-        } as const;
+      for (const role of USER_ROLES.filter((role) =>
+        ['porteur-projet', 'caisse-des-dépôts'].includes(role),
+      )) {
+        it(`Etant donné un projet soumis à garanties financières
+            Et dont les GF ne sont 'à traiter'
+            Si l'utilisateur est ${role}
+            Alors un GarantiesFinancièresDTO devrait être retourné avec : 
+              - un statut 'à traiter' 
+              - retrait de dépôt possible
+              - et les données des GF soumises`, async () => {
+          const user = { role } as User;
+          const garantiesFinancières = {
+            statut: 'à traiter',
+            soumisesALaCandidature: false,
+            dateLimiteEnvoi,
+            envoyéesPar,
+            dateConstitution,
+            dateEchéance,
+            validéesPar: null,
+            fichier: { id: fichierId, filename: 'nom-fichier' },
+            envoyéesParRef: { role: 'porteur-projet' as 'porteur-projet' },
+            type: null,
+          } as const;
 
-        const résultat = await getGarantiesFinancièresDTO({
-          garantiesFinancières,
-          user: utilisateurAutorisé,
-        });
+          const résultat = await getGarantiesFinancièresDTO({
+            garantiesFinancières,
+            user,
+          });
 
-        expect(résultat).toEqual({
-          type: 'garanties-financières',
-          statut: 'à traiter',
-          date: dateConstitution.getTime(),
-          variant: 'admin',
-          url: expect.anything(),
-          envoyéesPar: 'porteur-projet',
-          dateEchéance: dateEchéance.getTime(),
+          expect(résultat).toEqual({
+            type: 'garanties-financières',
+            statut: 'à traiter',
+            date: dateConstitution.getTime(),
+            variant: role,
+            url: expect.anything(),
+            envoyéesPar: 'porteur-projet',
+            dateEchéance: dateEchéance.getTime(),
+            retraitDépôtPossible: true,
+          });
         });
-      });
+      }
+
+      for (const role of USER_ROLES.filter((role) =>
+        ['admin', 'dreal', 'cre', 'dgec-validateur'].includes(role),
+      )) {
+        it(`Etant donné un projet soumis à garanties financières
+            Et dont les GF ne sont 'à traiter'
+            Si l'utilisateur est ${role}
+            Alors un GarantiesFinancièresDTO devrait être retourné avec : 
+              - un statut 'à traiter' 
+              - SANS retrait de dépôt possible
+              - et les données des GF soumises`, async () => {
+          const user = { role } as User;
+          const garantiesFinancières = {
+            statut: 'à traiter',
+            soumisesALaCandidature: false,
+            dateLimiteEnvoi,
+            envoyéesPar,
+            dateConstitution,
+            dateEchéance,
+            validéesPar: null,
+            fichier: { id: fichierId, filename: 'nom-fichier' },
+            envoyéesParRef: { role: 'porteur-projet' as 'porteur-projet' },
+            type: null,
+          } as const;
+
+          const résultat = await getGarantiesFinancièresDTO({
+            garantiesFinancières,
+            user,
+          });
+
+          expect(résultat).toEqual({
+            type: 'garanties-financières',
+            statut: 'à traiter',
+            date: dateConstitution.getTime(),
+            variant: role,
+            url: expect.anything(),
+            envoyéesPar: 'porteur-projet',
+            dateEchéance: dateEchéance.getTime(),
+          });
+        });
+      }
     });
 
     describe(`Retourner les données de GF validées`, () => {

--- a/src/infra/sequelize/queries/frise/getGarantiesFinancièresDTO.integration.ts
+++ b/src/infra/sequelize/queries/frise/getGarantiesFinancièresDTO.integration.ts
@@ -84,7 +84,7 @@ describe(`Requête getGarantiesFinancièresDTO`, () => {
     describe(`Retourner les données de GF en attente`, () => {
       it(`Etant donné un projet soumis à garanties financières
           Et dont les GF sont en attente
-          Alors un GarantiesFinancièresDTO devrait être retourné avec la statut 'en attente'`, async () => {
+          Alors un GarantiesFinancièresDTO devrait être retourné avec un statut 'en attente'`, async () => {
         const garantiesFinancières = {
           statut: 'en attente',
           soumisesALaCandidature: false,

--- a/src/infra/sequelize/queries/frise/getGarantiesFinancièresDTO.ts
+++ b/src/infra/sequelize/queries/frise/getGarantiesFinancièresDTO.ts
@@ -55,6 +55,10 @@ export const getGarantiesFinancièresDTO = async ({
         ['admin', 'dreal', 'dgec-validateur', 'cre', 'caisse-des-dépôts'].includes(user.role) && {
           retraitDépôtPossible: true,
         }),
+      ...(statut === 'à traiter' &&
+        ['porteur-projet', 'caisse-des-dépôts'].includes(user.role) && {
+          retraitDépôtPossible: true,
+        }),
     };
   }
 

--- a/src/infra/sequelize/queries/frise/getGarantiesFinancièresDTO.ts
+++ b/src/infra/sequelize/queries/frise/getGarantiesFinancièresDTO.ts
@@ -51,7 +51,10 @@ export const getGarantiesFinancièresDTO = async ({
       ...(dateEchéance && { dateEchéance: dateEchéance.getTime() }),
       envoyéesPar: envoyéesParRef! && envoyéesParRef.role,
       variant: user.role,
-      ...(statut === 'validé' && validéesPar === null && { retraitDépôtPossible: true }),
+      ...(statut === 'validé' &&
+        ['admin', 'dreal', 'dgec-validateur', 'cre', 'caisse-des-dépôts'].includes(user.role) && {
+          retraitDépôtPossible: true,
+        }),
     };
   }
 

--- a/src/modules/frise/dtos/ProjectEventListDTO.ts
+++ b/src/modules/frise/dtos/ProjectEventListDTO.ts
@@ -134,12 +134,7 @@ export type GarantiesFinancièresDTO = {
 } & (
   | { statut: 'en attente' | 'en retard' }
   | {
-      statut: 'à traiter';
-      envoyéesPar: 'porteur-projet' | 'dreal' | 'admin';
-      url: string;
-    }
-  | {
-      statut: 'validé';
+      statut: 'validé' | 'à traiter';
       envoyéesPar: 'porteur-projet' | 'dreal' | 'admin';
       url: string;
       retraitDépôtPossible?: true;

--- a/src/modules/project/Project.removeGarantiesFinancieres.spec.ts
+++ b/src/modules/project/Project.removeGarantiesFinancieres.spec.ts
@@ -13,12 +13,14 @@ import { makeGetProjectAppelOffre } from '@modules/projectAppelOffre';
 import {
   NoGFCertificateToDeleteError,
   ProjectCannotBeUpdatedIfUnnotifiedError,
+  SuppressionGFATraiterImpossibleError,
   SuppressionGFValidéeImpossibleError,
 } from './errors';
 import makeFakeProject from '../../__tests__/fixtures/project';
 import { UnwrapForTest as OldUnwrapForTest } from '../../types';
 import makeFakeUser from '../../__tests__/fixtures/user';
 import { makeUser } from '@entities';
+import { USER_ROLES } from '@modules/users';
 
 const getProjectAppelOffre = makeGetProjectAppelOffre(appelsOffreStatic);
 const fakeUser = OldUnwrapForTest(makeUser(makeFakeUser()));
@@ -123,8 +125,9 @@ describe('Project.removeGarantiesFinancieres()', () => {
           expect(res.error).toBeInstanceOf(NoGFCertificateToDeleteError);
         });
       });
-      describe(`when user is 'porteur-projet' and the GF is validated`, () => {
-        it('should return a SuppressionGFValidéeImpossibleError', () => {
+      describe(`when the GF are validated`, () => {
+        it(`if the user is porteur 
+            it should return a SuppressionGFValidéeImpossibleError'`, () => {
           const porteur = OldUnwrapForTest(makeUser(makeFakeUser({ role: 'porteur-projet' })));
           const project = UnwrapForTest(
             makeProject({
@@ -164,8 +167,45 @@ describe('Project.removeGarantiesFinancieres()', () => {
           expect(res.error).toBeInstanceOf(SuppressionGFValidéeImpossibleError);
         });
       });
+      describe(`when the GF are not validated`, () => {
+        for (const role of USER_ROLES.filter((role) =>
+          ['admin', 'dreal', 'dgec-validateur', 'cre'].includes(role),
+        )) {
+          it(`if user is ${role} 
+              it should return a SuppressionGFATraiterImpossibleError`, () => {
+            const user = OldUnwrapForTest(makeUser(makeFakeUser({ role })));
+            const project = UnwrapForTest(
+              makeProject({
+                projectId,
+                history: [
+                  ...fakeHistory,
+                  new ProjectGFSubmitted({
+                    payload: {
+                      projectId: projectId.toString(),
+                      submittedBy: 'user-id',
+                      fileId: 'id',
+                      gfDate: new Date('2022-01-01'),
+                    },
+                    original: {
+                      occurredAt: new Date(123),
+                      version: 1,
+                    },
+                  }),
+                ],
+                getProjectAppelOffre,
+                buildProjectIdentifier: () => '',
+              }),
+            );
+            const res = project.removeGarantiesFinancieres(user);
+            expect(res.isErr()).toEqual(true);
+            if (res.isOk()) return;
+            expect(res.error).toBeInstanceOf(SuppressionGFATraiterImpossibleError);
+          });
+        }
+      });
       describe('when a GF has been submitted on Potentiel', () => {
         it('should emit a ProjectGFRemoved event', () => {
+          const porteur = OldUnwrapForTest(makeUser(makeFakeUser({ role: 'porteur-projet' })));
           const project = UnwrapForTest(
             makeProject({
               projectId,
@@ -188,7 +228,7 @@ describe('Project.removeGarantiesFinancieres()', () => {
               buildProjectIdentifier: () => '',
             }),
           );
-          project.removeGarantiesFinancieres(fakeUser);
+          project.removeGarantiesFinancieres(porteur);
 
           expect(project.pendingEvents).toHaveLength(1);
 
@@ -197,7 +237,7 @@ describe('Project.removeGarantiesFinancieres()', () => {
 
           expect(targetEvent.type).toEqual(ProjectGFRemoved.type);
           expect(targetEvent.payload.projectId).toEqual(projectId.toString());
-          expect(targetEvent.payload.removedBy).toEqual(fakeUser.id);
+          expect(targetEvent.payload.removedBy).toEqual(porteur.id);
         });
       });
     });

--- a/src/modules/project/Project.ts
+++ b/src/modules/project/Project.ts
@@ -882,7 +882,7 @@ export const makeProject = (args: {
       if (!props.hasCurrentGf) {
         return err(new NoGFCertificateToDeleteError());
       }
-      if (props.GFValidées) {
+      if (props.GFValidées && removedBy.role === 'porteur-projet') {
         return err(new SuppressionGFValidéeImpossibleError());
       }
       _publishEvent(
@@ -901,6 +901,9 @@ export const makeProject = (args: {
       }
       if (!props.hasCurrentGf) {
         return err(new NoGFCertificateToDeleteError());
+      }
+      if (props.GFValidées && removedBy.role === 'porteur-projet') {
+        return err(new SuppressionGFValidéeImpossibleError());
       }
       _publishEvent(
         new ProjectGFWithdrawn({
@@ -1303,12 +1306,19 @@ export const makeProject = (args: {
 
         break;
       case ProjectGFSubmitted.type:
-      case ProjectGFUploaded.type:
         props.hasCurrentGf = true;
         if (event.payload.expirationDate) {
           props.GFExpirationDate = event.payload.expirationDate;
         }
         break;
+      case ProjectGFUploaded.type:
+        props.hasCurrentGf = true;
+        if (event.payload.expirationDate) {
+          props.GFExpirationDate = event.payload.expirationDate;
+        }
+        props.GFValidées = true;
+        break;
+
       case ProjectGFRemoved.type:
       case ProjectGFWithdrawn.type:
         props.hasCurrentGf = false;

--- a/src/modules/project/Project.ts
+++ b/src/modules/project/Project.ts
@@ -42,6 +42,7 @@ import {
   ChangementProducteurImpossiblePourEolienError,
   SuppressionGFValidéeImpossibleError,
   GFImpossibleASoumettreError,
+  SuppressionGFATraiterImpossibleError,
 } from './errors';
 import {
   AppelOffreProjetModifié,
@@ -884,6 +885,9 @@ export const makeProject = (args: {
       }
       if (props.GFValidées && removedBy.role === 'porteur-projet') {
         return err(new SuppressionGFValidéeImpossibleError());
+      }
+      if (!props.GFValidées && !['porteur-projet', 'caisse-des-dépôts'].includes(removedBy.role)) {
+        return err(new SuppressionGFATraiterImpossibleError());
       }
       _publishEvent(
         new ProjectGFRemoved({

--- a/src/modules/project/errors/SuppressionGFATraiterImpossibleError.ts
+++ b/src/modules/project/errors/SuppressionGFATraiterImpossibleError.ts
@@ -1,0 +1,9 @@
+import { DomainError } from '@core/domain';
+
+export class SuppressionGFATraiterImpossibleError extends DomainError {
+  constructor() {
+    super(
+      `Vous ne pouvez pas retirer ces garanties financières en attente de traitement par l'autorité compétente.`,
+    );
+  }
+}

--- a/src/modules/project/errors/index.ts
+++ b/src/modules/project/errors/index.ts
@@ -25,3 +25,4 @@ export * from './ProjectHasBeenUpdatedSinceError';
 export * from './ProjectNotEligibileForCertificateError';
 export * from './SuppressionGFValidéeImpossibleError';
 export * from './GFImpossibleASoumettreError';
+export * from './SuppressionGFATraiterImpossibleError';

--- a/src/views/components/timeline/components/GFItem.tsx
+++ b/src/views/components/timeline/components/GFItem.tsx
@@ -362,9 +362,6 @@ const Validé = ({
   typeGarantiesFinancières,
   project,
 }: ValidéProps) => {
-  const utilisateurEstPorteur = variant === 'porteur-projet';
-  const utilisateurEstCaisseDesDépôts = variant === 'caisse-des-dépôts';
-  const utilisateurEstAdmin = variant === 'dreal' || variant === 'admin';
   const modificationAutorisée = utilisateurPeutModifierLesGF(variant);
 
   return (
@@ -398,12 +395,9 @@ const Validé = ({
             <span>Pièce-jointe introuvable</span>
           )}
         </div>
-        {retraitDépôtPossible &&
-          ((utilisateurEstPorteur && envoyéesPar === 'porteur-projet') ||
-            utilisateurEstAdmin ||
-            utilisateurEstCaisseDesDépôts) && (
-            <RetirerDocument projetId={project.id} envoyéesPar={envoyéesPar} />
-          )}
+        {retraitDépôtPossible && (
+          <RetirerDocument projetId={project.id} envoyéesPar={envoyéesPar} />
+        )}
         {envoyéesPar === 'dreal' && (
           <p className="m-0 italic">Ce document a été ajouté par la DREAL</p>
         )}

--- a/src/views/components/timeline/components/GFItem.tsx
+++ b/src/views/components/timeline/components/GFItem.tsx
@@ -221,8 +221,8 @@ const ATraiter = ({
   project,
   dateEchéance,
   typeGarantiesFinancières,
+  retraitDépôtPossible,
 }: ATraiterProps) => {
-  const utilisateurPeutAnnulerDépôt = ['porteur-projet', 'caisse-des-dépôts'].includes(variant);
   const utilisateurEstAdmin = variant === 'dreal' || variant === 'admin';
   const modificationAutorisée = utilisateurPeutModifierLesGF(variant);
 
@@ -259,7 +259,7 @@ const ATraiter = ({
             <span>Pièce-jointe introuvable</span>
           )}
         </div>
-        {utilisateurPeutAnnulerDépôt && <AnnulerDépôt projetId={project.id} />}
+        {retraitDépôtPossible && <AnnulerDépôt projetId={project.id} />}
       </ContentArea>
     </>
   );


### PR DESCRIPTION
- autorisés à retirer des GF validées : cre, caisse des dépôts, admin, dreal, dgec-validateur
- autorisés à retirer des GF à traiter : porteur et caisse des dépôts

Application de ces règles + règles déplacé côté backend (query et méthodes agrégat projet)