### PR TITLE
Permission enregistrer / soumettre des garanties financières

### DIFF
--- a/src/infra/sequelize/queries/frise/getGarantiesFinancièresDTO.integration.ts
+++ b/src/infra/sequelize/queries/frise/getGarantiesFinancièresDTO.integration.ts
@@ -89,7 +89,7 @@ describe(`Requête getGarantiesFinancièresDTO`, () => {
           Si le l'utilisateur a le rôle 'porteur-projet'
           Alors un GarantiesFinancièresDTO devrait être retourné avec : 
           - un statut 'en attente'
-          - la propriété 'soumissionDeNouvellesGarantiesFinancièresAutorisé'`, async () => {
+          - l'action possible 'soumettre'`, async () => {
         const user = { role: 'porteur-projet' } as User;
         const garantiesFinancières = {
           statut: 'en attente',
@@ -121,7 +121,7 @@ describe(`Requête getGarantiesFinancièresDTO`, () => {
           Si le l'utilisateur a le rôle 'porteur-projet'
           Alors un GarantiesFinancièresDTO devrait être retourné : 
           - avec un statut 'en attente'
-          - sans la propriété 'soumissionDeNouvellesGarantiesFinancièresAutorisé'`, async () => {
+          - sans d'action possible 'soumettre'`, async () => {
         const user = { role: 'porteur-projet' } as User;
         const garantiesFinancières = {
           statut: 'en attente',
@@ -159,7 +159,7 @@ describe(`Requête getGarantiesFinancièresDTO`, () => {
           Si le l'utilisateur a le rôle ${role}
           Alors un GarantiesFinancièresDTO devrait être retourné avec :
           - un statut 'en attente'
-          - la propriété 'enregistrementDeGarantiesFinancièresAutorisé'`, async () => {
+          - l'action possible 'enregistrer'`, async () => {
           const garantiesFinancières = {
             statut: 'en attente',
             soumisesALaCandidature: false,
@@ -190,7 +190,7 @@ describe(`Requête getGarantiesFinancièresDTO`, () => {
           Si le l'utilisateur a le rôle ${role}
           Alors un GarantiesFinancièresDTO devrait être retourné avec :
           - un statut 'en attente'
-          - la propriété 'enregistrementDeGarantiesFinancièresAutorisé'`, async () => {
+          - l'action possible 'enregistrer'`, async () => {
           const dateEchéance = new Date('2025-01-01');
           const garantiesFinancières = {
             statut: 'en attente',

--- a/src/infra/sequelize/queries/frise/getGarantiesFinancièresDTO.integration.ts
+++ b/src/infra/sequelize/queries/frise/getGarantiesFinancièresDTO.integration.ts
@@ -187,7 +187,7 @@ describe(`Requête getGarantiesFinancièresDTO`, () => {
 
         it(`Etant donné un projet soumis à garanties financières
           Et dont les GF non soumises à la candidature sont en attente
-          Si le l'utilisateur a le rôle ${role}
+          Si l'utilisateur a le rôle ${role}
           Alors un GarantiesFinancièresDTO devrait être retourné avec :
           - un statut 'en attente'
           - l'action possible 'enregistrer'`, async () => {

--- a/src/infra/sequelize/queries/frise/getGarantiesFinancièresDTO.integration.ts
+++ b/src/infra/sequelize/queries/frise/getGarantiesFinancièresDTO.integration.ts
@@ -118,7 +118,7 @@ describe(`Requête getGarantiesFinancièresDTO`, () => {
 
       it(`Etant donné un projet soumis à garanties financières
           Et dont les GF soumises à la candidature sont 'en attente'
-          Si le l'utilisateur a le rôle 'porteur-projet'
+          Si l'utilisateur a le rôle 'porteur-projet'
           Alors un GarantiesFinancièresDTO devrait être retourné : 
           - avec un statut 'en attente'
           - sans d'action possible 'soumettre'`, async () => {

--- a/src/infra/sequelize/queries/frise/getGarantiesFinancièresDTO.integration.ts
+++ b/src/infra/sequelize/queries/frise/getGarantiesFinancièresDTO.integration.ts
@@ -121,7 +121,7 @@ describe(`Requête getGarantiesFinancièresDTO`, () => {
           Si l'utilisateur a le rôle 'porteur-projet'
           Alors un GarantiesFinancièresDTO devrait être retourné : 
           - avec un statut 'en attente'
-          - sans d'action possible 'soumettre'`, async () => {
+          - sans action possible`, async () => {
         const user = { role: 'porteur-projet' } as User;
         const garantiesFinancières = {
           statut: 'en attente',

--- a/src/infra/sequelize/queries/frise/getGarantiesFinancièresDTO.ts
+++ b/src/infra/sequelize/queries/frise/getGarantiesFinancièresDTO.ts
@@ -10,7 +10,7 @@ type GarantiesFinancièresDonnéesPourDTO = {
   dateConstitution: Date | null;
   dateEchéance: Date | null;
   type: string | null;
-  validéesPar: string | null;
+  soumisesALaCandidature: boolean;
   fichier?: { filename: string; id: string };
   envoyéesParRef?: { role: 'admin' | 'dreal' | 'porteur-projet' };
 };
@@ -35,10 +35,10 @@ export const getGarantiesFinancièresDTO = async ({
     dateConstitution,
     dateEchéance,
     type,
-    validéesPar,
     dateLimiteEnvoi,
     fichier,
     envoyéesParRef,
+    soumisesALaCandidature,
   } = garantiesFinancières;
 
   if (statut === 'à traiter' || statut === 'validé') {
@@ -64,6 +64,19 @@ export const getGarantiesFinancièresDTO = async ({
 
   if (statut === 'en attente') {
     const dateLimiteDépassée = (dateLimiteEnvoi && dateLimiteEnvoi <= new Date()) || false;
+
+    if (user.role === 'porteur-projet') {
+      return {
+        type: 'garanties-financières',
+        ...(type && { typeGarantiesFinancières: type }),
+        ...(dateEchéance && { dateEchéance: dateEchéance.getTime() }),
+        date: dateLimiteEnvoi?.getTime() || 0,
+        statut: dateLimiteDépassée ? 'en retard' : 'en attente',
+        variant: user.role,
+        ...(!soumisesALaCandidature && { actionPossible: 'soumettre' }),
+      };
+    }
+
     return {
       type: 'garanties-financières',
       ...(type && { typeGarantiesFinancières: type }),
@@ -71,6 +84,7 @@ export const getGarantiesFinancièresDTO = async ({
       date: dateLimiteEnvoi?.getTime() || 0,
       statut: dateLimiteDépassée ? 'en retard' : 'en attente',
       variant: user.role,
+      actionPossible: 'enregistrer',
     };
   }
 };

--- a/src/infra/sequelize/queries/frise/getProjectEvents.ts
+++ b/src/infra/sequelize/queries/frise/getProjectEvents.ts
@@ -30,9 +30,9 @@ export const getProjectEvents: GetProjectEvents = ({ projectId, user }) => {
             'envoyéesPar',
             'dateConstitution',
             'dateEchéance',
-            'validéesPar',
             'dateLimiteEnvoi',
             'type',
+            'soumisesALaCandidature',
           ],
           include: [
             {

--- a/src/modules/authN/Permission.ts
+++ b/src/modules/authN/Permission.ts
@@ -53,7 +53,6 @@ export const getPermissions = ({ role }: { role: UserRole }): Array<Permission> 
         PermissionConsulterProjet,
         PermissionAnnulerGF,
         PermissionAjouterDateExpirationGF,
-        PermissionUploaderGF,
         PermissionRetirerGF,
         PermissionExporterProjets,
         PermissionTransmettreDemandeComplèteRaccordement,
@@ -113,12 +112,19 @@ export const getPermissions = ({ role }: { role: UserRole }): Array<Permission> 
         PermissionModifierGestionnaireRéseauProjet,
       ];
     case 'acheteur-obligé':
+      return [
+        PermissionListerProjets,
+        PermissionConsulterProjet,
+        PermissionExporterProjets,
+        PermissionConsulterDossierRaccordement,
+      ];
     case 'cre':
       return [
         PermissionListerProjets,
         PermissionConsulterProjet,
         PermissionExporterProjets,
         PermissionConsulterDossierRaccordement,
+        PermissionUploaderGF,
       ];
     case 'ademe':
       return [PermissionListerProjets, PermissionConsulterProjet, PermissionExporterProjets];

--- a/src/modules/frise/dtos/ProjectEventListDTO.ts
+++ b/src/modules/frise/dtos/ProjectEventListDTO.ts
@@ -132,7 +132,10 @@ export type GarantiesFinancièresDTO = {
   typeGarantiesFinancières?: string;
   dateEchéance?: number;
 } & (
-  | { statut: 'en attente' | 'en retard' }
+  | {
+      statut: 'en attente' | 'en retard';
+      actionPossible?: 'enregistrer' | 'soumettre';
+    }
   | {
       statut: 'validé' | 'à traiter';
       envoyéesPar: 'porteur-projet' | 'dreal' | 'admin';

--- a/src/views/components/timeline/components/GFItem.tsx
+++ b/src/views/components/timeline/components/GFItem.tsx
@@ -45,7 +45,14 @@ export const GFItem = (props: ComponentProps) => {
   }
 };
 
-const rolesAutorisés = ['porteur-projet', 'dreal', 'admin', 'caisse-des-dépôts'] as const;
+const rolesAutorisés = [
+  'porteur-projet',
+  'dreal',
+  'admin',
+  'caisse-des-dépôts',
+  'cre',
+  'dgec-validateur',
+] as const;
 const utilisateurPeutModifierLesGF = (role: UserRole): role is typeof rolesAutorisés[number] => {
   return (rolesAutorisés as readonly string[]).includes(role);
 };
@@ -65,12 +72,11 @@ const EnAttente = ({
   variant,
   typeGarantiesFinancières,
   dateEchéance,
+  actionPossible,
   project: { nomProjet, id: projectId, garantieFinanciereEnMois },
 }: GFEnAttenteProps) => {
-  const utilisateurEstPorteur = variant === 'porteur-projet';
-  const afficherAlerteRetard = statut === 'en retard' && utilisateurEstPorteur;
+  const afficherAlerteRetard = statut === 'en retard' && variant === 'porteur-projet';
   const utilisateurEstAdmin = variant === 'dreal' || variant === 'admin';
-  const modificationAutorisée = utilisateurPeutModifierLesGF(variant);
   return (
     <>
       {afficherAlerteRetard ? <WarningIcon /> : <CurrentIcon />}
@@ -100,11 +106,11 @@ const EnAttente = ({
               Attestation de constitution de garanties financières en attente
             </p>
           </div>
-          {modificationAutorisée && (
+          {actionPossible && (
             <Formulaire
               projetId={projectId}
               garantieFinanciereEnMois={garantieFinanciereEnMois}
-              action={utilisateurEstPorteur && dateLimiteEnvoi !== 0 ? 'soumettre' : 'enregistrer'}
+              action={actionPossible}
               role={variant}
               dateEchéance={dateEchéance}
             />
@@ -148,7 +154,11 @@ const Formulaire = ({
       design="link"
       isOpen={displayForm}
       changeOpenState={(isOpen) => showForm(isOpen)}
-      text={action === 'soumettre' ? 'Soumettre une attestation' : `Enregistrer l'attestation`}
+      text={
+        action === 'soumettre'
+          ? 'Soumettre une attestation de garanties financières'
+          : `Enregistrer une attestation de garanties financières`
+      }
     >
       <Form
         action={
@@ -161,10 +171,16 @@ const Formulaire = ({
         className="mt-2 border border-solid border-gray-300 rounded-md p-5 flex flex-col gap-3"
       >
         <FormulaireChampsObligatoireLégende className="ml-auto" />
-        {action === 'enregistrer' && role === 'porteur-projet' && (
-          <p className="m-0">
-            Il s'agit de l'attestation soumise à la candidature. Cet envoi ne fera pas l'objet d'une
-            nouvelle validation dans Potentiel.
+        {action === 'enregistrer' && (
+          <p className="m-0 italic">
+            L'attestation que vous enregistrez ne sera pas soumise à validation par la DREAL
+            concernée. Les garanties financières doivent déjà avoir été validée (soit à la
+            candidature, soit par la DREAL).
+          </p>
+        )}
+        {action === 'soumettre' && (
+          <p className="m-0 italic">
+            L'attestation que vous enregistrez sera soumise à validation par la DREAL concernée.
           </p>
         )}
         <input type="hidden" name="type" id="type" value="garanties-financieres" />

--- a/src/views/components/timeline/components/GFItem.tsx
+++ b/src/views/components/timeline/components/GFItem.tsx
@@ -439,8 +439,5 @@ const RetirerDocument = ({ projetId, envoyéesPar }: RetirerDocumentProps) => (
     >
       Retirer le document de Potentiel
     </Link>
-    {envoyéesPar === 'porteur-projet' && (
-      <span> (cela n'annule pas les garanties financières soumises à la candidature)</span>
-    )}
   </p>
 );

--- a/src/views/components/timeline/components/GFItem.tsx
+++ b/src/views/components/timeline/components/GFItem.tsx
@@ -411,9 +411,7 @@ const Validé = ({
             <span>Pièce-jointe introuvable</span>
           )}
         </div>
-        {retraitDépôtPossible && (
-          <RetirerDocument projetId={project.id} envoyéesPar={envoyéesPar} />
-        )}
+        {retraitDépôtPossible && <RetirerDocument projetId={project.id} />}
         {envoyéesPar === 'dreal' && (
           <p className="m-0 italic">Ce document a été ajouté par la DREAL</p>
         )}
@@ -427,9 +425,8 @@ const Validé = ({
 
 type RetirerDocumentProps = {
   projetId: string;
-  envoyéesPar?: 'porteur-projet' | 'dreal' | 'admin';
 };
-const RetirerDocument = ({ projetId, envoyéesPar }: RetirerDocumentProps) => (
+const RetirerDocument = ({ projetId }: RetirerDocumentProps) => (
   <p className="p-0 m-0">
     <Link
       href={ROUTES.WITHDRAW_GARANTIES_FINANCIERES({


### PR DESCRIPTION
Règle : 
Le porteur peut soumettre des GF pour les projets CRE4 (GF non soumises à la candidature), mais il ne peut pas enregistrer des GF  déjà validées.
Les autres rôles, dgec, dreal, cre, et caisse des dépôts peuvent enregistrer des GF déjà validées.  