### PR TITLE
Permettre teporairement d'importer un projet dont la période est notifiée dans Potentiel

### DIFF
--- a/src/modules/project/useCases/importProjects.spec.ts
+++ b/src/modules/project/useCases/importProjects.spec.ts
@@ -452,51 +452,53 @@ describe('importProjects', () => {
     });
   });
 
-  describe('when a line is from a non-legacy periode and has a notification date', () => {
-    const invalidLine = {
-      ...validLine,
-      "Appel d'offres": 'appelOffreId',
-      Période: 'periodeId',
-      Notification: '12/12/2020',
-    };
+  // TO DO
+  // Règle supprimée temporairement
+  // describe('when a line is from a non-legacy periode and has a notification date', () => {
+  //   const invalidLine = {
+  //     ...validLine,
+  //     "Appel d'offres": 'appelOffreId',
+  //     Période: 'periodeId',
+  //     Notification: '12/12/2020',
+  //   };
 
-    const appelOffreRepo = {
-      findAll: async () => [
-        {
-          id: 'appelOffreId',
-          periodes: [{ id: 'periodeId', type: 'notified' }],
-          familles: [{ id: 'familleId' }],
-        },
-      ],
-    } as unknown as AppelOffreRepo;
+  //   const appelOffreRepo = {
+  //     findAll: async () => [
+  //       {
+  //         id: 'appelOffreId',
+  //         periodes: [{ id: 'periodeId', type: 'notified' }],
+  //         familles: [{ id: 'familleId' }],
+  //       },
+  //     ],
+  //   } as unknown as AppelOffreRepo;
 
-    const lines = [invalidLine] as Record<string, string>[];
-    const importId = new UniqueEntityID().toString();
+  //   const lines = [invalidLine] as Record<string, string>[];
+  //   const importId = new UniqueEntityID().toString();
 
-    const eventBus = {
-      publish: jest.fn((event: DomainEvent) => okAsync<null, InfraNotAvailableError>(null)),
-      subscribe: jest.fn(),
-    };
+  //   const eventBus = {
+  //     publish: jest.fn((event: DomainEvent) => okAsync<null, InfraNotAvailableError>(null)),
+  //     subscribe: jest.fn(),
+  //   };
 
-    const importProjects = makeImportProjects({
-      eventBus,
-      appelOffreRepo,
-    });
+  //   const importProjects = makeImportProjects({
+  //     eventBus,
+  //     appelOffreRepo,
+  //   });
 
-    it('should throw an error', async () => {
-      expect.assertions(4);
-      try {
-        await importProjects({ lines, importId, importedBy: user });
-      } catch (error) {
-        expect(error).toBeDefined();
-        expect(error).toBeInstanceOf(IllegalProjectDataError);
-        expect(error.errors[1]).toContain(
-          'notifiée sur Potentiel. Le projet concerné ne doit pas comporter de date de notification.',
-        );
-        expect(eventBus.publish).not.toHaveBeenCalled();
-      }
-    });
-  });
+  //   it('should throw an error', async () => {
+  //     expect.assertions(4);
+  //     try {
+  //       await importProjects({ lines, importId, importedBy: user });
+  //     } catch (error) {
+  //       expect(error).toBeDefined();
+  //       expect(error).toBeInstanceOf(IllegalProjectDataError);
+  //       expect(error.errors[1]).toContain(
+  //         'notifiée sur Potentiel. Le projet concerné ne doit pas comporter de date de notification.',
+  //       );
+  //       expect(eventBus.publish).not.toHaveBeenCalled();
+  //     }
+  //   });
+  // });
 
   describe('when a line is from a non-legacy periode and has a legacy modifications', () => {
     const invalidLine = {

--- a/src/modules/project/useCases/importProjects.ts
+++ b/src/modules/project/useCases/importProjects.ts
@@ -136,11 +136,13 @@ const checkLegacyRules = (args: {
       );
     }
   } else {
-    if (projectData.notifiedOn) {
-      throw new Error(
-        `La période ${appelOffreId}-${periodeId} est notifiée sur Potentiel. Le projet concerné ne doit pas comporter de date de notification.`,
-      );
-    }
+    // TO DO
+    // Règle supprimée temporairement :
+    // if (projectData.notifiedOn) {
+    //   throw new Error(
+    //     `La période ${appelOffreId}-${periodeId} est notifiée sur Potentiel. Le projet concerné ne doit pas comporter de date de notification.`,
+    //   );
+    // }
 
     if (hasLegacyModifications) {
       throw new Error(

--- a/src/views/pages/projectDetailsPage/sections/EditProjectData.tsx
+++ b/src/views/pages/projectDetailsPage/sections/EditProjectData.tsx
@@ -340,7 +340,13 @@ export const EditProjectData = ({ project, request }: EditProjectDataProps) => {
                   onChange={handleCertificateTypeChange}
                 >
                   Uploader une attestation
-                  <Input type="file" name="file" id="file" disabled={uploadIsDisabled} />
+                  <Input
+                    type="file"
+                    name="file"
+                    id="file"
+                    disabled={uploadIsDisabled}
+                    accept="application/pdf"
+                  />
                 </Radio>
               </li>
             </ul>


### PR DESCRIPTION
Un admin souhaite importer dans Potentiel un projet dont la période à déjà été importée et notifiée dans Potentiel. 
Il s'agit d'un cas exceptionnel puisque tous les projets d'une période doivent être importés et notifiés en même temps. 
Deux projets concernés (deux AO différents). 

Le seul moyen d'importer des projets dans Potentiel sans avoir à déclencher une notification par un validateur est d'importer les projets avec une date de notification.
Or on ne peut pas importer des projets avec date de notification si l'appel d'offre n'est pas de type "legacy". 

Pour traiter le cas de ces deux projets on va : 

1. en tant que dev : supprimer la règle dans importProjects qui throw une erreur si le projet n'est pas legacy mais a une date de notification => PR actuelle 
2. en tant qu'admin : importer le fichier csv du projet 
3. en tant qu'admin : accorder les droits au candidat sur le projet 
4. en tant que dev : rétablir la règle supprimée