### PR TITLE
:sparkles: Mise à jour affichage formulaires GF + ajout règles métier

### DIFF
--- a/packages/domain/src/garantiesFinancières/actuelles/enregistrerGarantiesFinancièresComplètes.command.ts
+++ b/packages/domain/src/garantiesFinancières/actuelles/enregistrerGarantiesFinancièresComplètes.command.ts
@@ -18,6 +18,8 @@ import {
   createGarantiesFinancièresAggregateId,
   loadGarantiesFinancièresAggregateFactory,
 } from '../garantiesFinancières.aggregate';
+import { EnregistrementGarantiesFinancièresImpossibleCarDépôtAttenduErreur } from '../garantiesFinancières.error';
+import { isSome } from '@potentiel/monads';
 
 export type EnregistrerGarantiesFinancièresComplètesCommand = Message<
   'ENREGISTER_GARANTIES_FINANCIÈRES_COMPLÈTES',
@@ -50,6 +52,14 @@ export const registerEnregistrerGarantiesFinancièresComplètesCommand = ({
     utilisateur,
   }) => {
     const agrégatGarantiesFinancières = await loadGarantiesFinancières(identifiantProjet);
+
+    if (
+      utilisateur.rôle === 'porteur-projet' &&
+      isSome(agrégatGarantiesFinancières) &&
+      agrégatGarantiesFinancières.dateLimiteDépôt
+    ) {
+      throw new EnregistrementGarantiesFinancièresImpossibleCarDépôtAttenduErreur();
+    }
 
     verifyGarantiesFinancièresTypeForCommand(
       typeGarantiesFinancières,

--- a/packages/domain/src/garantiesFinancières/garantiesFinancières.error.ts
+++ b/packages/domain/src/garantiesFinancières/garantiesFinancières.error.ts
@@ -45,3 +45,11 @@ export class DépôtGarantiesFinancièresNonTrouvéErreur extends InvalidOperati
     );
   }
 }
+
+export class EnregistrementGarantiesFinancièresImpossibleCarDépôtAttenduErreur extends InvalidOperationError {
+  constructor() {
+    super(
+      'Vous ne pouvez pas enregistrer des garanties financières mais vous devez faire un dépôt pour validation de nouvelles garanties financières',
+    );
+  }
+}

--- a/packages/specifications/src/garantiesFinancières/enregistrement/enregistrerGarantiesFinancières.feature
+++ b/packages/specifications/src/garantiesFinancières/enregistrement/enregistrerGarantiesFinancières.feature
@@ -172,6 +172,17 @@ Scénario: Corriger le type de garanties financières legacy migrées sans type 
             | type                 | avec date d'échéance   |
             | date d'échéance      | 2030-12-01             |
         Alors l'utilisateur devrait être informé que "Vous ne pouvez pas modifier des données de garanties financières déjà validées" 
+ 
+     Scénario: Erreur si un porteur tente d'enregistrer des garanties financières alors qu'il devrait faire un dépôt 
+        Etant donné des garanties financières à déposer pour le projet "Centrale éolienne 20" avec :
+            | date limite de dépôt | 2023-11-01             |
+        Quand un utilisateur avec le rôle 'porteur-projet' enregistre des garanties financières complètes pour le projet "Centrale éolienne 20" avec : 
+            | type                 | avec date d'échéance   |
+            | date d'échéance      | 2027-12-01             |        
+            | format               | application/pdf        |
+            | date de constitution | 2021-12-02             |
+            | contenu fichier      | le contenu             |
+        Alors l'utilisateur devrait être informé que "Vous ne pouvez pas enregistrer des garanties financières mais vous devez faire un dépôt pour validation de nouvelles garanties financières" 
        
 
  

--- a/src/controllers/garantiesFinancieres/postDéposerGarantiesFinancières.ts
+++ b/src/controllers/garantiesFinancieres/postDéposerGarantiesFinancières.ts
@@ -101,7 +101,7 @@ v1Router.post(
             : '',
           numeroCRE: identifiantProjetValueType.numéroCRE,
         },
-        attributes: ['id', 'appelOffreId', 'periodeId', 'familleId'],
+        attributes: ['id', 'appelOffreId', 'periodeId', 'familleId', 'classe', 'abandonedOn'],
       });
 
       if (!projet) {
@@ -112,6 +112,14 @@ v1Router.post(
         });
       }
 
+      if (projet.abandonedOn > 0 || projet.classe === 'Eliminé') {
+        response.redirect(
+          addQueryParams(routes.PROJECT_DETAILS(identifiantProjet), {
+            error: `Vous ne pouvez pas déposer de garanties financières car le projet n'est pas "classé"`,
+          }),
+        );
+      }
+
       const appelOffre = getProjectAppelOffre({
         appelOffreId: projet.appelOffreId,
         periodeId: projet.periodeId,
@@ -120,7 +128,7 @@ v1Router.post(
       if (appelOffre && !appelOffre.isSoumisAuxGF) {
         response.redirect(
           addQueryParams(routes.PROJECT_DETAILS(identifiantProjet), {
-            error: `Enregistrement impossible car l'appel d'offres n'est pas soumis aux garanties financières.`,
+            error: `Vous ne pouvez pas déposer de garanties financières car l'appel d'offres n'est pas soumis à garanties financières`,
           }),
         );
       }

--- a/src/controllers/project/getProjectPage.ts
+++ b/src/controllers/project/getProjectPage.ts
@@ -111,6 +111,7 @@ v1Router.get(
         ? await getGarantiesFinancièresDataForProjetPage({
             identifiantProjet: identifiantFonctionnelProjet,
             user,
+            statutProjet: projet.isAbandoned ? 'abandonné' : projet.isClasse ? 'classé' : 'éliminé',
             garantiesFinancièresSoumisesÀLaCandidature:
               projet.appelOffre.famille?.soumisAuxGarantiesFinancieres === 'à la candidature'
                 ? true
@@ -239,10 +240,12 @@ const getGarantiesFinancièresDataForProjetPage = async ({
   identifiantProjet,
   garantiesFinancièresSoumisesÀLaCandidature,
   user,
+  statutProjet,
 }: {
   identifiantProjet: IdentifiantProjet;
   garantiesFinancièresSoumisesÀLaCandidature: boolean;
   user: UtilisateurReadModel;
+  statutProjet: 'abandonné' | 'classé' | 'éliminé';
 }): Promise<GarantiesFinancièresDataForProjetPage | undefined> => {
   let actionRequise: GarantiesFinancièresDataForProjetPage['actionRequise'];
 
@@ -267,7 +270,7 @@ const getGarantiesFinancièresDataForProjetPage = async ({
   );
 
   // TO DO : retirer les cas de changement de producteur et GF échue
-  if (garantiesFinancièresSoumisesÀLaCandidature) {
+  if (garantiesFinancièresSoumisesÀLaCandidature && statutProjet === 'classé') {
     if (isNone(garantiesFinancièresActuelles)) {
       actionRequise = 'enregistrer';
     } else {
@@ -283,8 +286,14 @@ const getGarantiesFinancièresDataForProjetPage = async ({
   }
 
   // TO DO : ajouter les cas de changement de producteur et GF échue
-  if (!garantiesFinancièresSoumisesÀLaCandidature && isNone(garantiesFinancièresActuelles)) {
+  if (
+    !garantiesFinancièresSoumisesÀLaCandidature &&
+    isNone(garantiesFinancièresActuelles) &&
+    statutProjet === 'classé'
+  ) {
     if (isNone(garantiesFinancièresDéposées)) {
+      // TODO : à terme il faudra se bases sur la projection suiviDépôtsGarantiesFinancières pour vérifier si dépôt en attente pour le projet
+      // à la place actuellement on se base sur l'AO seulement
       actionRequise = 'déposer';
     } else {
       if (

--- a/src/views/pages/projectDetailsPage/sections/GarantiesFinancières.tsx
+++ b/src/views/pages/projectDetailsPage/sections/GarantiesFinancières.tsx
@@ -38,11 +38,17 @@ export const GarantiesFinancières = ({
   garantiesFinancières,
   identifiantProjet,
   userRole,
+  statutProjet,
 }: {
   garantiesFinancières?: GarantiesFinancièresDataForProjetPage;
   identifiantProjet: RawIdentifiantProjet;
   userRole: UserRole;
+  statutProjet: 'classé' | 'abandonné' | 'éliminé';
 }) => {
+  if (statutProjet !== 'classé' && !garantiesFinancières?.actuelles) {
+    return <></>;
+  }
+
   return (
     <div className="mb-6">
       <Heading3 className="m-0 flex text-sm font-semibold tracking-wide uppercase">

--- a/src/views/pages/projectDetailsPage/sections/InfoGenerales.tsx
+++ b/src/views/pages/projectDetailsPage/sections/InfoGenerales.tsx
@@ -72,6 +72,7 @@ export const InfoGenerales = ({ project, role, garantiesFinancières }: InfoGene
       ) && (
         <GarantiesFinancières
           userRole={role}
+          statutProjet={project.isAbandoned ? 'abandonné' : project.isClasse ? 'classé' : 'éliminé'}
           garantiesFinancières={garantiesFinancières}
           identifiantProjet={convertirEnIdentifiantProjet({
             appelOffre: project.appelOffreId,


### PR DESCRIPTION
Page projet : 
- contrôleur : pour déterminer si un dépôt de GF est attendu, on de base sur la query ConsulterSuiviDépôtGarantiesFinancières (et non plus sur l'AO qui ne fournissait pas des info suffisantes)
- Afficher les liens vers les formulaires de dépôt / enregistrement de GF seulement si le projet est classé

Contrôleur post enregistrer / déposer GF : 
- vérifier le statut du projet (le projet doit être classé)

Domain / métier : 
- un porteur ne peut pas enregistrer des GF si un dépôt est attendu 