### PR TITLE
:sparkles: Permission pour les DREAL et admin dgec de compléter un dépôt

### DIFF
--- a/packages/domain-views/src/garantiesFinancières/garantiesFinancièresActuelles/garantiesFinancières.projector.ts
+++ b/packages/domain-views/src/garantiesFinancières/garantiesFinancièresActuelles/garantiesFinancières.projector.ts
@@ -39,7 +39,7 @@ export const registerGarantiesFinancièresProjector = ({
           const readModel = {
             typeGarantiesFinancières:
               typeGarantiesFinancières === 'Type inconnu' ? undefined : typeGarantiesFinancières,
-            dateÉchéance: dateÉchéance === 'Date inconnue ' ? undefined : dateÉchéance,
+            dateÉchéance: dateÉchéance === 'Date inconnue' ? undefined : dateÉchéance,
             attestationConstitution:
               'attestationAbsente' in attestationConstitution ? undefined : attestationConstitution,
           };

--- a/packages/domain/src/garantiesFinancières/dépôt/déposerGarantiesFinancières.command.ts
+++ b/packages/domain/src/garantiesFinancières/dépôt/déposerGarantiesFinancières.command.ts
@@ -52,8 +52,10 @@ export const registerDéposerGarantiesFinancièresCommand = ({
     utilisateur,
   }) => {
     const agrégatGarantiesFinancières = await loadGarantiesFinancières(identifiantProjet);
-
-    if (isSome(agrégatGarantiesFinancières) && agrégatGarantiesFinancières.dépôt) {
+    if (
+      isSome(agrégatGarantiesFinancières) &&
+      agrégatGarantiesFinancières.dépôt?.attestationConstitution
+    ) {
       throw new DépôtGarantiesFinancièresDéjàExistantErreur();
     }
 

--- a/packages/domain/src/garantiesFinancières/dépôt/validerDépôtGarantiesFinancières.usecase.ts
+++ b/packages/domain/src/garantiesFinancières/dépôt/validerDépôtGarantiesFinancières.usecase.ts
@@ -35,12 +35,18 @@ export const registerValiderDépôtGarantiesFinancièresUseCase = () => {
       data: { identifiantProjet },
     });
 
-    await mediator.send<ValiderDépôtGarantiesFinancièresCommand>({
-      type: 'VALIDER_DÉPÔT_GARANTIES_FINANCIÈRES',
-      data: {
-        identifiantProjet,
-      },
-    });
+    //TODO : problème de concurrence à traiter
+
+    setTimeout(
+      async () =>
+        await mediator.send<ValiderDépôtGarantiesFinancièresCommand>({
+          type: 'VALIDER_DÉPÔT_GARANTIES_FINANCIÈRES',
+          data: {
+            identifiantProjet,
+          },
+        }),
+      100,
+    );
   };
 
   mediator.register('VALIDER_DÉPÔT_GARANTIES_FINANCIÈRES_USE_CASE', runner);

--- a/packages/domain/src/permissions/garantiesFinancières.permissions.ts
+++ b/packages/domain/src/permissions/garantiesFinancières.permissions.ts
@@ -13,6 +13,11 @@ export const PermissionDéposerGarantiesFinancières = {
   description: 'Déposer de nouvelles garanties financières',
 };
 
+export const PermissionModifierDépôtGarantiesFinancières = {
+  nom: 'modifier-dépôt-garanties-financières',
+  description: 'Modifier un dépôt de garanties financières',
+};
+
 export const PermissionValiderDépôtGarantiesFinancières = {
   nom: 'valider-dépôt-garanties-financières',
   description: 'Valider un dépôt de garanties financières',

--- a/packages/libraries/core-domain-views/src/readModel.ts
+++ b/packages/libraries/core-domain-views/src/readModel.ts
@@ -16,6 +16,7 @@ export type Find = <TReadModel extends ReadModel>(
 export type ListOptions<TReadModel extends ReadModel> = {
   type: TReadModel['type'];
   orderBy?: keyof TReadModel;
+  sort?: 'ASC' | 'DESC';
   where?: Partial<TReadModel>;
   like?: Partial<TReadModel>;
   pagination?: {

--- a/packages/libraries/pg-projections/src/listProjection.integration.ts
+++ b/packages/libraries/pg-projections/src/listProjection.integration.ts
@@ -301,8 +301,8 @@ describe(`listProjection`, () => {
   });
 
   describe(`ordering`, () => {
-    it(`Lorsqu'on liste les projections avec un ordre
-      Alors la liste devrait être ordonnée`, async () => {
+    it(`Lorsqu'on liste les projections avec un ordre et sans préciser le sens de tri
+      Alors la liste devrait être ordonnée dans un ordre croissant`, async () => {
       // Arrange
       await executeQuery(
         `insert 
@@ -346,6 +346,55 @@ describe(`listProjection`, () => {
         {
           type: 'projection',
           target: 'C',
+        },
+      ]);
+    });
+
+    it(`Lorsqu'on liste les projections avec un ordre décroissant
+      Alors la liste devrait être ordonnée dans un ordre décroissant`, async () => {
+      // Arrange
+      await executeQuery(
+        `insert 
+       into domain_views.projection
+       values ($1, $2)`,
+        'projection|another-one',
+        { type: 'projection', target: 'B' },
+      );
+      await executeQuery(
+        `insert 
+       into domain_views.projection
+       values ($1, $2)`,
+        'projection|another-one-2',
+        { type: 'projection', target: 'C' },
+      );
+      await executeQuery(
+        `insert 
+       into domain_views.projection
+       values ($1, $2)`,
+        'projection|the-expected-one',
+        { type: 'projection', target: 'A' },
+      );
+
+      // Act
+      const result = await listProjection<ProjectionReadModel>({
+        type: 'projection',
+        orderBy: 'target',
+        sort: 'DESC',
+      });
+
+      // Assert
+      expect(result.items).toEqual([
+        {
+          type: 'projection',
+          target: 'C',
+        },
+        {
+          type: 'projection',
+          target: 'B',
+        },
+        {
+          type: 'projection',
+          target: 'A',
         },
       ]);
     });

--- a/packages/libraries/pg-projections/src/listProjection.ts
+++ b/packages/libraries/pg-projections/src/listProjection.ts
@@ -9,10 +9,11 @@ export const listProjection = async <TReadModel extends ReadModel>({
   where,
   like,
   pagination,
+  sort,
 }: ListOptions<TReadModel>): Promise<ListResult<TReadModel>> => {
   const baseQuery = `select key, value from domain_views.projection where key like $1`;
 
-  const orderByClause = orderBy ? format(`order by value ->> %L`, orderBy) : '';
+  const orderByClause = orderBy ? format(`order by value ->> %L %s`, orderBy, sort || '') : '';
 
   const whereClause = where
     ? format(

--- a/packages/specifications/src/garantiesFinancières/dépôt/déposerGarantiesFinancières.feature
+++ b/packages/specifications/src/garantiesFinancières/dépôt/déposerGarantiesFinancières.feature
@@ -21,7 +21,6 @@ Fonctionnalité: Déposer des garanties financières pour validation dans Potent
             | date de constitution | <date de constitution> |
             | date de dépôt        | 2023-08-11             |
             | région               | Nouvelle-Aquitaine     |
-            | date limite de dépôt | 2023-11-01             |
         Et il devrait y avoir un dépôt de garanties financières "en cours" pour le projet "Centrale éolienne 20" avec :
             | date limite de dépôt | 2023-11-01            |
             | région               | Nouvelle-Aquitaine    |
@@ -49,6 +48,38 @@ Fonctionnalité: Déposer des garanties financières pour validation dans Potent
             | date d'échéance | format du fichier | contenu du fichier    | date de constitution |
             | 2027-12-01      | application/pdf   | le contenu du fichier | 2021-12-02           |
             |                 | application/pdf   | le contenu du fichier | 2021-12-02           |
+
+     Scénario: Déposer de nouvelle garanties financières après validation d'un premier dépôt 
+        Etant donné des garanties financières à déposer pour le projet "Centrale éolienne 20" avec :
+            | date limite de dépôt | 2023-11-01            |
+        Et un dépôt de garanties financières pour le projet "Centrale éolienne 20" avec :
+            | type                 | consignation          |
+            | format               | application/pdf       |
+            | contenu fichier      | contenu               |
+            | date de constitution | 2023-01-01            |
+            | date de dépôt        | 2023-10-01            |     
+        Et une validation du dépôt de garanties financières par la Dreal pour le projet "Centrale éolienne 20" avec :
+            | type                 | consignation          |
+            | format               | application/pdf       |
+            | contenu fichier      | contenu               |
+            | date de constitution | 2023-01-01            |
+        Quand un utilisateur avec le rôle 'porteur-projet' dépose des garanties financières pour le projet "Centrale éolienne 20" avec :
+            | type                 | avec date d'échéance  |
+            | date d'échéance      | 2025-01-01            |
+            | format               |  application/pdf      |
+            | contenu fichier      | nouveau contenu       |
+            | date de constitution | 2023-09-01            |
+            | date de dépôt        | 2023-09-20            |    
+        Alors le dépôt de garanties financières devrait être consultable pour le projet "Centrale éolienne 20" avec :
+            | type                 | avec date d'échéance  |
+            | date d'échéance      | 2025-01-01            |
+            | format               | application/pdf       |
+            | contenu fichier      | nouveau contenu       |
+            | date de constitution | 2023-09-01            |
+            | région               | Nouvelle-Aquitaine    |  
+            | date de dépôt        | 2023-09-20            |           
+         Et il devrait y avoir un dépôt de garanties financières "en cours" pour le projet "Centrale éolienne 20" avec :
+            | région               | Nouvelle-Aquitaine    |        
 
     Scénario: Erreur si date de constitution dans le futur
         Quand un utilisateur avec le rôle 'porteur-projet' dépose des garanties financières pour le projet "Centrale éolienne 20" avec :

--- a/packages/specifications/src/garantiesFinancières/dépôt/stepDefinitions/dépôtGarantiesFinancières.given.ts
+++ b/packages/specifications/src/garantiesFinancières/dépôt/stepDefinitions/dépôtGarantiesFinancières.given.ts
@@ -97,3 +97,37 @@ EtantDonné(
     await sleep(500);
   },
 );
+
+EtantDonné(
+  `une validation du dépôt de garanties financières par la Dreal pour le projet {string} avec :`,
+  async function (nomProjet: string, dataTable: DataTable) {
+    const exemple = dataTable.rowsHash();
+
+    const typeGarantiesFinancières = exemple['type'] as TypeGarantiesFinancières;
+    const dateÉchéance = exemple[`date d'échéance`];
+    const format = exemple['format'];
+    const dateConstitution = exemple[`date de constitution`];
+    const contenuFichier = convertStringToReadableStream(exemple['contenu fichier']);
+    const { identifiantProjet } = this.projetWorld.rechercherProjetFixture(nomProjet);
+
+    try {
+      await mediator.send<DomainUseCase>({
+        type: 'VALIDER_DÉPÔT_GARANTIES_FINANCIÈRES_USE_CASE',
+        data: {
+          identifiantProjet: convertirEnIdentifiantProjet(identifiantProjet),
+          typeGarantiesFinancières,
+          ...(dateÉchéance && { dateÉchéance: convertirEnDateTime(dateÉchéance) }),
+          utilisateur: { rôle: 'dreal' } as Utilisateur,
+          attestationConstitution: {
+            format,
+            content: contenuFichier,
+            date: convertirEnDateTime(dateConstitution),
+          },
+        },
+      });
+    } catch (error) {
+      console.log(error);
+    }
+    await sleep(500);
+  },
+);

--- a/packages/specifications/src/garantiesFinancières/suiviDépôts/stepDefinitions/suiviDépôts.then.ts
+++ b/packages/specifications/src/garantiesFinancières/suiviDépôts/stepDefinitions/suiviDépôts.then.ts
@@ -43,7 +43,7 @@ Alors(
 
     if (statutDépôt === 'validé') {
       expect(actualAggregate.dateLimiteDépôt).to.be.undefined;
-    } else {
+    } else if (dateLimiteDépôt) {
       expect(actualAggregate.dateLimiteDépôt).not.to.be.undefined;
       expect(actualAggregate.dateLimiteDépôt?.date).to.be.deep.equal(
         convertirEnDateTime(dateLimiteDépôt).date,
@@ -54,9 +54,10 @@ Alors(
 
     const expectedReadModel = {
       type: 'suivi-dépôt-garanties-financières',
-      ...(statutDépôt !== 'validé' && {
-        dateLimiteDépôt: convertirEnDateTime(dateLimiteDépôt).formatter(),
-      }),
+      ...(statutDépôt !== 'validé' &&
+        dateLimiteDépôt && {
+          dateLimiteDépôt: convertirEnDateTime(dateLimiteDépôt).formatter(),
+        }),
       région,
       identifiantProjet: convertirEnIdentifiantProjet(identifiantProjet).formatter(),
       statutDépôt,

--- a/src/controllers/garantiesFinancieres/getListeDépôtsGarantiesFinancièresÀValiderPage.ts
+++ b/src/controllers/garantiesFinancieres/getListeDépôtsGarantiesFinancièresÀValiderPage.ts
@@ -17,7 +17,10 @@ v1Router.get(
   routes.GET_LISTE_DEPOTS_GARANTIES_FINANCIERES_PAGE(),
   vérifierPermissionUtilisateur(PermissionConsulterListeDépôts),
   asyncHandler(async (request, response) => {
-    const { user } = request;
+    const {
+      user,
+      query: { error },
+    } = request;
 
     const userRégion = await UserDreal.findOne({ where: { userId: user.id } });
 
@@ -43,6 +46,7 @@ v1Router.get(
         user,
         listeDépôtsGarantiesFinancières: résultat.liste,
         pagination: { ...résultat.pagination, currentUrl: getCurrentUrl(request) },
+        error: error as string,
       }),
     );
   }),

--- a/src/controllers/garantiesFinancieres/getModifierDépôtGarantiesFinancièresPage.ts
+++ b/src/controllers/garantiesFinancieres/getModifierDépôtGarantiesFinancièresPage.ts
@@ -12,7 +12,7 @@ import { mediator } from 'mediateur';
 import {
   convertirEnIdentifiantProjet,
   estUnRawIdentifiantProjet,
-  PermissionDéposerGarantiesFinancières,
+  PermissionModifierDépôtGarantiesFinancières,
 } from '@potentiel/domain';
 import { isNone, isSome } from '@potentiel/monads';
 import { Project, UserProjects } from '../../infra/sequelize/projectionsNext';
@@ -27,7 +27,7 @@ const schema = yup.object({
 
 v1Router.get(
   routes.GET_MODIFIER_DEPOT_GARANTIES_FINANCIERES_PAGE(),
-  vérifierPermissionUtilisateur(PermissionDéposerGarantiesFinancières),
+  vérifierPermissionUtilisateur(PermissionModifierDépôtGarantiesFinancières),
   safeAsyncHandler(
     {
       schema,

--- a/src/controllers/garantiesFinancieres/getModifierDépôtGarantiesFinancièresPage.ts
+++ b/src/controllers/garantiesFinancieres/getModifierDépôtGarantiesFinancièresPage.ts
@@ -22,6 +22,7 @@ import { getProjectAppelOffre } from '../../config';
 const schema = yup.object({
   params: yup.object({
     identifiantProjet: yup.string().required(),
+    origine: yup.string().required(),
   }),
 });
 
@@ -37,7 +38,7 @@ v1Router.get(
     async (request, response) => {
       const {
         user,
-        params: { identifiantProjet },
+        params: { identifiantProjet, origine },
         query: { error },
       } = request;
 
@@ -119,6 +120,7 @@ v1Router.get(
           user,
           projet,
           error: error as string,
+          origine: origine === 'liste' ? 'liste' : 'projet',
           ...(isSome(dépôt) && { dépôt }),
         }),
       );

--- a/src/controllers/garantiesFinancieres/postModifierDépôtGarantiesFinancières.ts
+++ b/src/controllers/garantiesFinancieres/postModifierDépôtGarantiesFinancières.ts
@@ -16,7 +16,7 @@ import {
   convertirEnIdentifiantProjet,
   estUnRawIdentifiantProjet,
   AttestationConstitution,
-  PermissionDéposerGarantiesFinancières,
+  PermissionModifierDépôtGarantiesFinancières,
 } from '@potentiel/domain';
 import { isNone, isSome } from '@potentiel/monads';
 import { Project, UserProjects } from '../../infra/sequelize/projectionsNext';
@@ -52,7 +52,7 @@ const schema = yup.object({
 v1Router.post(
   routes.POST_MODIFIER_DEPOT_GARANTIES_FINANCIERES(),
   uploadMiddleware.single('file'),
-  vérifierPermissionUtilisateur(PermissionDéposerGarantiesFinancières),
+  vérifierPermissionUtilisateur(PermissionModifierDépôtGarantiesFinancières),
   safeAsyncHandler(
     {
       schema,

--- a/src/controllers/garantiesFinancieres/postModifierDépôtGarantiesFinancières.ts
+++ b/src/controllers/garantiesFinancieres/postModifierDépôtGarantiesFinancières.ts
@@ -46,6 +46,7 @@ const schema = yup.object({
       .required('Vous devez renseigner la date de constitution')
       .transform(iso8601DateToDateYupTransformation)
       .typeError(`La date de constitution n'est pas valide`),
+    origine: yup.mixed<`liste` | `projet`>().oneOf([`liste`, `projet`]),
   }),
 });
 
@@ -60,9 +61,15 @@ v1Router.post(
         const identifiant = request.params.identifiantProjet;
         if (estUnRawIdentifiantProjet(identifiant)) {
           return response.redirect(
-            addQueryParams(routes.GET_MODIFIER_DEPOT_GARANTIES_FINANCIERES_PAGE(identifiant), {
-              error: `Le dépôt de garanties financières n'a pas pu être modifié. ${error}`,
-            }),
+            addQueryParams(
+              routes.GET_MODIFIER_DEPOT_GARANTIES_FINANCIERES_PAGE(
+                identifiant,
+                request.params.origine === 'liste' ? 'liste' : 'projet',
+              ),
+              {
+                error: `Le dépôt de garanties financières n'a pas pu être modifié. ${error}`,
+              },
+            ),
           );
         }
         response.redirect(
@@ -76,7 +83,7 @@ v1Router.post(
       const {
         user,
         params: { identifiantProjet },
-        body: { typeGarantiesFinancieres, dateEcheance, dateConstitution },
+        body: { typeGarantiesFinancieres, dateEcheance, dateConstitution, origine },
         file,
       } = request;
 
@@ -85,6 +92,11 @@ v1Router.post(
       if (!estUnRawIdentifiantProjet(identifiantProjet)) {
         return notFoundResponse({ request, response, ressourceTitle: 'Projet' });
       }
+
+      const redirectUrl =
+        origine === 'liste'
+          ? routes.GET_LISTE_DEPOTS_GARANTIES_FINANCIERES_PAGE()
+          : routes.PROJECT_DETAILS(identifiantProjet);
 
       const identifiantProjetValueType = convertirEnIdentifiantProjet(identifiantProjet);
 
@@ -100,7 +112,10 @@ v1Router.post(
         if (isNone(fichierAttestationActuel)) {
           return response.redirect(
             addQueryParams(
-              routes.GET_MODIFIER_DEPOT_GARANTIES_FINANCIERES_PAGE(identifiantProjet),
+              routes.GET_MODIFIER_DEPOT_GARANTIES_FINANCIERES_PAGE(
+                identifiantProjet,
+                request.params.origine === 'liste' ? 'liste' : 'projet',
+              ),
               {
                 error: `Vous devez joindre l'attestation de constitution des garanties financières`,
               },
@@ -147,7 +162,7 @@ v1Router.post(
       });
       if (appelOffre && !appelOffre.isSoumisAuxGF) {
         response.redirect(
-          addQueryParams(routes.PROJECT_DETAILS(identifiantProjet), {
+          addQueryParams(redirectUrl, {
             error: `L'appel d'offres n'est pas soumis aux garanties financières.`,
           }),
         );
@@ -185,15 +200,21 @@ v1Router.post(
         return response.redirect(
           routes.SUCCESS_OR_ERROR_PAGE({
             success: 'Le dépôt de garanties financières a bien été modifié',
-            redirectUrl: routes.PROJECT_DETAILS(identifiantProjet),
-            redirectTitle: 'Retourner sur la page projet',
+            redirectUrl,
+            redirectTitle:
+              origine === 'liste'
+                ? 'Retourner sur la liste de dépôts'
+                : 'Retourner sur la page du projet',
           }),
         );
       } catch (error) {
         if (error instanceof DomainError) {
           return response.redirect(
             addQueryParams(
-              routes.GET_MODIFIER_DEPOT_GARANTIES_FINANCIERES_PAGE(identifiantProjet),
+              routes.GET_MODIFIER_DEPOT_GARANTIES_FINANCIERES_PAGE(
+                identifiantProjet,
+                request.params.origine === 'liste' ? 'liste' : 'projet',
+              ),
               {
                 error: error.message,
               },

--- a/src/controllers/project/getProjectPage.ts
+++ b/src/controllers/project/getProjectPage.ts
@@ -300,7 +300,7 @@ const getGarantiesFinancièresDataForProjetPage = async ({
         !garantiesFinancièresActuelles.dateÉchéance))
   ) {
     actionRequise = 'compléter enregistrement';
-  } else if (isNone(garantiesFinancièresActuelles)) {
+  } else if (isNone(garantiesFinancièresActuelles) && isNone(suiviDépôtsGarantiesFinancières)) {
     actionRequise = 'enregistrer';
   }
 

--- a/src/modules/authN/Permission.ts
+++ b/src/modules/authN/Permission.ts
@@ -26,6 +26,7 @@ import {
   PermissionValiderDépôtGarantiesFinancières,
   PermissionSupprimerDépôtGarantiesFinancières,
   PermissionConsulterListeDépôts,
+  PermissionModifierDépôtGarantiesFinancières,
 } from '@potentiel/domain';
 import {
   PermissionListerGestionnairesRéseau,
@@ -56,6 +57,7 @@ export const getPermissions = ({ role }: { role: UserRole }): Array<Permission> 
         PermissionEnregistrerGarantiesFinancières,
         PermissionValiderDépôtGarantiesFinancières,
         PermissionConsulterListeDépôts,
+        PermissionModifierDépôtGarantiesFinancières,
       ];
     case 'porteur-projet':
       return [
@@ -73,6 +75,7 @@ export const getPermissions = ({ role }: { role: UserRole }): Array<Permission> 
         PermissionEnregistrerGarantiesFinancières,
         PermissionDéposerGarantiesFinancières,
         PermissionSupprimerDépôtGarantiesFinancières,
+        PermissionModifierDépôtGarantiesFinancières,
       ];
     case 'caisse-des-dépôts':
       return [
@@ -108,6 +111,7 @@ export const getPermissions = ({ role }: { role: UserRole }): Array<Permission> 
         PermissionModifierGestionnaireRéseauProjet,
         PermissionConsulterGarantiesFinancières,
         PermissionEnregistrerGarantiesFinancières,
+        PermissionModifierDépôtGarantiesFinancières,
       ];
     case 'dgec-validateur':
       return [

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -593,10 +593,11 @@ class routes {
 
   static GET_MODIFIER_DEPOT_GARANTIES_FINANCIERES_PAGE = (
     identifiantProjet?: RawIdentifiantProjet,
+    origine?: 'projet' | 'liste',
   ) => {
     return `/projet/${
       identifiantProjet ? encodeURIComponent(identifiantProjet) : ':identifiantProjet'
-    }/depot-garanties-financieres/modifier.html`;
+    }/depot-garanties-financieres/modifier-depuis-${origine || ':origine'}.html`;
   };
 
   static POST_MODIFIER_DEPOT_GARANTIES_FINANCIERES = (identifiantProjet?: RawIdentifiantProjet) => {

--- a/src/views/pages/garantiesFinancières/DéposerGarantiesFinancièresPage.tsx
+++ b/src/views/pages/garantiesFinancières/DéposerGarantiesFinancièresPage.tsx
@@ -103,8 +103,8 @@ export const DéposerGarantiesFinancières = ({
 
         <InfoBox className="flex md:w-1/3 md:mx-auto">
           Une fois les garanties financières déposées dans Potentiel, la DREAL concernée recevra une
-          notification l'invitation vérifier leur conformité. Vous serez à votre tour notifié à la
-          validation des garanties financières.
+          notification par mail l'invitant à vérifier leur conformité. Vous serez à votre tour
+          notifié par mail à la validation des garanties financières.
         </InfoBox>
       </div>
     </PageProjetTemplate>

--- a/src/views/pages/garantiesFinancières/EnregistrerGarantiesFinancièresPage.tsx
+++ b/src/views/pages/garantiesFinancières/EnregistrerGarantiesFinancièresPage.tsx
@@ -164,8 +164,7 @@ export const EnregistrerGarantiesFinancières = ({
 
         <InfoBox className="flex md:w-1/3 md:mx-auto">
           En transmettant votre attestation de constitution de garanties financières sur Potentiel,
-          elle sera directement accessible par la DREAL concernée par votre projet, vous n'avez plus
-          à l'envoyer par courrier.
+          elle sera directement accessible par la DREAL concernée par votre projet.
         </InfoBox>
       </div>
     </PageProjetTemplate>

--- a/src/views/pages/garantiesFinancières/ModifierDépôtGarantiesFinancièresPage.tsx
+++ b/src/views/pages/garantiesFinancières/ModifierDépôtGarantiesFinancièresPage.tsx
@@ -24,6 +24,7 @@ type ModifierDépôtGarantiesFinancièresProps = {
   projet: ProjetReadModel;
   dépôt?: DépôtGarantiesFinancièresReadModel;
   error?: string;
+  origine: 'liste' | 'projet';
 };
 
 export const ModifierDépôtGarantiesFinancières = ({
@@ -31,6 +32,7 @@ export const ModifierDépôtGarantiesFinancières = ({
   projet,
   error,
   dépôt,
+  origine,
 }: ModifierDépôtGarantiesFinancièresProps) => {
   const { identifiantProjet } = projet;
   const [typeSélectionné, sélectionnerType] = useState(dépôt?.typeGarantiesFinancières || '');
@@ -44,11 +46,13 @@ export const ModifierDépôtGarantiesFinancières = ({
           encType="multipart/form-data"
           action={routes.POST_MODIFIER_DEPOT_GARANTIES_FINANCIERES(identifiantProjet)}
         >
-          <Heading2>Modifier des garanties financières déposées</Heading2>
+          <Heading2>Modifier des garanties financières déposées depuis</Heading2>
 
           <ChampsObligatoiresLégende />
 
           {error && <ErrorBox>{error}</ErrorBox>}
+
+          <input type="hidden" name="origine" value={origine} />
 
           <div>
             <Label htmlFor="typeGarantiesFinancieres">Type des garanties financières</Label>

--- a/src/views/pages/garantiesFinancières/ModifierDépôtGarantiesFinancièresPage.tsx
+++ b/src/views/pages/garantiesFinancières/ModifierDépôtGarantiesFinancièresPage.tsx
@@ -109,6 +109,7 @@ export const ModifierDépôtGarantiesFinancières = ({
               id="file"
               name="file"
               required={!dépôt?.attestationConstitution.format}
+              disabled={user.role !== 'porteur-projet'}
               fileUrl={routes.GET_ATTESTATION_CONSTITUTION_GARANTIES_FINANCIERES_DEPOT(
                 identifiantProjet,
               )}
@@ -124,7 +125,8 @@ export const ModifierDépôtGarantiesFinancières = ({
         </Form>
 
         <InfoBox className="flex md:w-1/3 md:mx-auto">
-          Vous pouvez modifier ce dépôt jusqu'à sa validation par la DREAL concernée.
+          Vous pouvez modifier ce dépôt jusqu'à sa validation{' '}
+          {user.role === 'porteur-projet' && <span>par la DREAL concernée</span>}.
         </InfoBox>
       </div>
     </PageProjetTemplate>

--- a/src/views/pages/garantiesFinancières/lister/ListeDépôtsGarantiesFinancièresÀValiderPage.tsx
+++ b/src/views/pages/garantiesFinancières/lister/ListeDépôtsGarantiesFinancièresÀValiderPage.tsx
@@ -5,6 +5,7 @@ import {
   DownloadLink,
   EditIcon,
   ErrorBox,
+  ErrorIcon,
   Heading1,
   Heading2,
   KeyIcon,
@@ -165,10 +166,11 @@ export const ListeDépôtsGarantiesFinancièresÀValider = ({
                         Valider le dépôt
                       </PrimaryButton>
                       {!dépôt.typeGarantiesFinancières && (
-                        <p className="text-sm italic">
+                        <div className="italic text-sm text-warning-425-base mt-2">
+                          <ErrorIcon className="mr-1 align-middle" aria-hidden />
                           La validation est désactivée car le type de garanties financières doit
-                          être précisé.
-                        </p>
+                          être précisé (lien vers le formulaire ci-contre).
+                        </div>
                       )}
                     </form>
                   </div>

--- a/src/views/pages/garantiesFinancières/lister/ListeDépôtsGarantiesFinancièresÀValiderPage.tsx
+++ b/src/views/pages/garantiesFinancières/lister/ListeDépôtsGarantiesFinancièresÀValiderPage.tsx
@@ -3,6 +3,8 @@ import {
   Badge,
   ClockIcon,
   DownloadLink,
+  EditIcon,
+  ErrorBox,
   Heading1,
   Heading2,
   KeyIcon,
@@ -21,6 +23,7 @@ import { afficherDate, formatDateForInput, hydrateOnClient } from '../../../help
 
 type ListeDépôtsGarantiesFinancièresÀValiderProps = {
   user: UtilisateurReadModel;
+  error?: string;
   listeDépôtsGarantiesFinancières?: ReadonlyArray<{
     dépôt: DépôtGarantiesFinancièresReadModel;
     projet: Omit<ProjetReadModel, 'type' | 'identifiantGestionnaire'>;
@@ -30,6 +33,7 @@ type ListeDépôtsGarantiesFinancièresÀValiderProps = {
 
 export const ListeDépôtsGarantiesFinancièresÀValider = ({
   user,
+  error,
   listeDépôtsGarantiesFinancières,
   pagination: { currentPage, pageCount, currentUrl, totalCount },
 }: ListeDépôtsGarantiesFinancièresÀValiderProps) => {
@@ -40,6 +44,7 @@ export const ListeDépôtsGarantiesFinancièresÀValider = ({
       contentHeader={<Heading1 className="text-white">Garanties financières</Heading1>}
     >
       <Heading2>Dépôts de garanties financières à valider ({totalCount})</Heading2>
+      {error && <ErrorBox className="mb-4">{error}</ErrorBox>}
       {!listeDépôtsGarantiesFinancières || !listeDépôtsGarantiesFinancières.length ? (
         <ListeVide titre="Aucun dépôt à afficher" />
       ) : (
@@ -51,28 +56,33 @@ export const ListeDépôtsGarantiesFinancièresÀValider = ({
                   className="mb-8 flex md:relative flex-col gap-2"
                   key={`depot_gf_${projet.identifiantProjet}`}
                 >
-                  <div className="flex flex-col gap-1">
-                    <Link
-                      href={routes.PROJECT_DETAILS(projet.legacyId)}
-                      aria-label={`aller sur la page du projet ${projet.nom}`}
-                    >
-                      {projet.nom}
-                    </Link>
-                    <div className="flex flex-col md:flex-row md:gap-3">
-                      <div className="text-xs italic">
-                        <KeyIcon
-                          className="mr-1"
-                          aria-label="identification du projet : appel d'offres, période, famille, numéro CRE"
-                        />
-                        {projet.appelOffre}-{projet.période}
-                        {projet.famille && `-${projet.famille}`}-{projet.numéroCRE}
-                      </div>
-                      <div className="p-0 m-0 mt-0 text-xs italic">
-                        <MapPinIcon className="mr-1" aria-label="localisation du projet" />
-                        {projet.localité.commune}, {projet.localité.département},{' '}
-                        {projet.localité.région}
+                  <div className="flex md:flex-row md:justify-between">
+                    <div className="flex flex-col gap-1">
+                      <Link
+                        href={routes.PROJECT_DETAILS(projet.legacyId)}
+                        aria-label={`aller sur la page du projet ${projet.nom}`}
+                      >
+                        {projet.nom}
+                      </Link>
+                      <div className="flex flex-col md:flex-row md:gap-3">
+                        <div className="text-xs italic">
+                          <KeyIcon
+                            className="mr-1"
+                            aria-label="identification du projet : appel d'offres, période, famille, numéro CRE"
+                          />
+                          {projet.appelOffre}-{projet.période}
+                          {projet.famille && `-${projet.famille}`}-{projet.numéroCRE}
+                        </div>
+                        <div className="p-0 m-0 mt-0 text-xs italic">
+                          <MapPinIcon className="mr-1" aria-label="localisation du projet" />
+                          {projet.localité.commune}, {projet.localité.département},{' '}
+                          {projet.localité.région}
+                        </div>
                       </div>
                     </div>
+                    <p className="text-sm italic self-start mt-1">
+                      Dernière mise à jour : {afficherDate(new Date(dépôt.dateDernièreMiseÀJour))}
+                    </p>
                   </div>
                   <div className="mt-2 flex flex-col gap-1 md:grid md:grid-cols-4 md:grid-rows-1 md:items-center">
                     <div className="col-span-1">
@@ -92,25 +102,41 @@ export const ListeDépôtsGarantiesFinancièresÀValider = ({
                         </div>
                       )}
                     </div>
-                    {dépôt.attestationConstitution && dépôt.attestationConstitution.format && (
-                      <div className="col-span-2">
-                        <DownloadLink
-                          fileUrl={routes.GET_ATTESTATION_CONSTITUTION_GARANTIES_FINANCIERES_DEPOT(
+                    <div className="col-span-2">
+                      {dépôt.attestationConstitution && dépôt.attestationConstitution.format && (
+                        <div>
+                          <DownloadLink
+                            fileUrl={routes.GET_ATTESTATION_CONSTITUTION_GARANTIES_FINANCIERES_DEPOT(
+                              projet.identifiantProjet,
+                            )}
+                            aria-label={`télécharger l'attestation de constitution des garanties financières à valider pour le projet ${projet.nom}`}
+                          >
+                            télécharger l'attestation (constituée le{' '}
+                            {afficherDate(new Date(dépôt.attestationConstitution.date))})
+                          </DownloadLink>
+                        </div>
+                      )}
+                      {!dépôt.typeGarantiesFinancières && (
+                        <Link
+                          aria-label={`Modifier le dépôt de garanties financières pour le projet ${projet.nom}`}
+                          href={routes.GET_MODIFIER_DEPOT_GARANTIES_FINANCIERES_PAGE(
                             projet.identifiantProjet,
+                            'liste',
                           )}
-                          aria-label={`télécharger l'attestation de constitution des garanties financières à valider pour le projet ${projet.nom}`}
                         >
-                          télécharger l'attestation (constituée le{' '}
-                          {afficherDate(new Date(dépôt.attestationConstitution.date))})
-                        </DownloadLink>
-                      </div>
-                    )}
+                          <EditIcon className="mr-1" aria-hidden />
+                          Préciser le type de garanties financières
+                        </Link>
+                      )}
+                    </div>
+
                     <form
                       method="post"
                       action={routes.POST_VALIDER_DEPOT_GARANTIES_FINANCIERES(
                         projet.identifiantProjet,
                       )}
                     >
+                      <input type="hidden" name="origine" value="liste" />
                       <input
                         type="hidden"
                         value={dépôt.typeGarantiesFinancières}
@@ -131,12 +157,19 @@ export const ListeDépôtsGarantiesFinancièresÀValider = ({
                       />
                       <PrimaryButton
                         type="submit"
+                        disabled={!dépôt.typeGarantiesFinancières}
                         className="mt-2"
                         confirmation="Êtes-vous sûr de vouloir valider ce dépôt de garanties financières ?"
                         aria-label={`Valider le dépôt de garanties financières pour le projet ${projet.nom}`}
                       >
                         Valider le dépôt
                       </PrimaryButton>
+                      {!dépôt.typeGarantiesFinancières && (
+                        <p className="text-sm italic">
+                          La validation est désactivée car le type de garanties financières doit
+                          être précisé.
+                        </p>
+                      )}
                     </form>
                   </div>
                 </Tile>

--- a/src/views/pages/projectDetailsPage/sections/GarantiesFinancières.tsx
+++ b/src/views/pages/projectDetailsPage/sections/GarantiesFinancières.tsx
@@ -155,25 +155,27 @@ const Dépôt = ({
               identifiantProjet,
             )}
           />
-          {userRole === 'porteur-projet' && (
+          {['porteur-projet', 'admin', 'dreal'].includes(userRole) && (
             <div className="flex items-center gap-4 mt-2">
               <Link href={routes.GET_MODIFIER_DEPOT_GARANTIES_FINANCIERES_PAGE(identifiantProjet)}>
                 <EditIcon className="mr-1" aria-hidden />
-                Modifier le dépôt en cours
+                Modifier ou compléter le dépôt en cours
               </Link>
 
-              <Form
-                action={routes.POST_SUPPRIMER_DEPOT_GARANTIES_FINANCIERES(identifiantProjet)}
-                method="post"
-              >
-                <SecondaryButton
-                  className="!p-0 shadow-none border-none bg-transparent hover:bg-transparent focus:bg-transparent text-error-425-base underline w-fit cursor-pointer"
-                  confirmation="Êtes-vous sûr de vouloir supprimer le dépôt en cours ?"
+              {userRole === 'porteur-projet' && (
+                <Form
+                  action={routes.POST_SUPPRIMER_DEPOT_GARANTIES_FINANCIERES(identifiantProjet)}
+                  method="post"
                 >
-                  <TrashIcon className="h-4 w-4 mr-2 align-middle text-error-425-base" />
-                  Supprimer le dépôt en cours
-                </SecondaryButton>
-              </Form>
+                  <SecondaryButton
+                    className="!p-0 shadow-none border-none bg-transparent hover:bg-transparent focus:bg-transparent text-error-425-base underline w-fit cursor-pointer"
+                    confirmation="Êtes-vous sûr de vouloir supprimer le dépôt en cours ?"
+                  >
+                    <TrashIcon className="h-4 w-4 mr-2 align-middle text-error-425-base" />
+                    Supprimer le dépôt en cours
+                  </SecondaryButton>
+                </Form>
+              )}
             </div>
           )}
           {userRole === 'dreal' && (

--- a/src/views/pages/projectDetailsPage/sections/GarantiesFinancières.tsx
+++ b/src/views/pages/projectDetailsPage/sections/GarantiesFinancières.tsx
@@ -222,7 +222,7 @@ const Dépôt = ({
           {garantiesFinancièresActuelles && (
             <div className="italic text-sm text-grey-425-base">
               <ErrorIcon className="mr-1 align-middle" aria-hidden />
-              Une fois validées, ces garanties financières renplaceront les garanties financières
+              Une fois validées, ces garanties financières remplaceront les garanties financières
               actuelles.
             </div>
           )}

--- a/src/views/pages/projectDetailsPage/sections/GarantiesFinancières.tsx
+++ b/src/views/pages/projectDetailsPage/sections/GarantiesFinancières.tsx
@@ -157,7 +157,12 @@ const Dépôt = ({
           />
           {['porteur-projet', 'admin', 'dreal'].includes(userRole) && (
             <div className="flex items-center gap-4 mt-2">
-              <Link href={routes.GET_MODIFIER_DEPOT_GARANTIES_FINANCIERES_PAGE(identifiantProjet)}>
+              <Link
+                href={routes.GET_MODIFIER_DEPOT_GARANTIES_FINANCIERES_PAGE(
+                  identifiantProjet,
+                  'projet',
+                )}
+              >
                 <EditIcon className="mr-1" aria-hidden />
                 Modifier ou compléter le dépôt en cours
               </Link>
@@ -183,6 +188,7 @@ const Dépôt = ({
               method="post"
               action={routes.POST_VALIDER_DEPOT_GARANTIES_FINANCIERES(identifiantProjet)}
             >
+              <input type="hidden" name="origine" value="projet" />
               <input
                 type="hidden"
                 value={garantiesFinancièresDéposées?.typeGarantiesFinancières}


### PR DESCRIPTION
Suite à la migration des GF legacy, nous aurons des dépôts de GF sans type précisé. 
Afin de faciliter la validation de ces dépôts, on permet aux utilisateurs DREAL de compléter le type des dépôt depuis la liste des dépôts à valider. 