### PR TITLE
🐛 (changement puissance): récupérer l'AO pour vérifier les ratios d'auto-validation

### DIFF
--- a/src/config/useCases.config.ts
+++ b/src/config/useCases.config.ts
@@ -194,6 +194,7 @@ export const demanderChangementDePuissance = makeDemanderChangementDePuissance({
   projectRepo,
   fileRepo,
   getPuissanceProjet,
+  getProjectAppelOffre,
 });
 
 export const requestActionnaireModification = makeRequestActionnaireModification({


### PR DESCRIPTION
Dans le use-case demanderChangementPuissance, on ne passait jamais l'AO du projet (n'existe pas dans l'agrégat passé) à la fonction exceedsRatiosChangementPuissance. On appliquait donc toujours les ratios par défaut, soit 0.9 et 1.1. 
Dans le use-case j'ai ajouté une dépendance au use-case qui permet de récupérer l'AO pour le passer à la fonction. 