### PR TITLE
:sparkles: Nouvelle date de mise en service annulant le délai CDC 2022

### DIFF
--- a/packages/domain-views/src/projet/candidature/candidature.readmodel.ts
+++ b/packages/domain-views/src/projet/candidature/candidature.readmodel.ts
@@ -26,5 +26,6 @@ export type CandidatureLegacyReadModel = ReadModel<
     email: string;
     dateDésignation: string;
     puissance: number;
+    cahierDesCharges: string;
   }
 >;

--- a/packages/libraries/infra-adapters/src/projet/récupérerCandidatureLegacy.adapter.ts
+++ b/packages/libraries/infra-adapters/src/projet/récupérerCandidatureLegacy.adapter.ts
@@ -31,7 +31,8 @@ const selectProjectQuery = `
     'nomCandidat', "nomCandidat",
     'email', "email",
     'dateDésignation', TO_CHAR(TO_TIMESTAMP("notifiedOn" / 1000), 'YYYY-MM-DD"T"HH24:MI:SS"+00:00"'),
-    'puissance', "puissance"
+    'puissance', "puissance",
+    'cahierDesCharges', "cahierDesChargesActuel"
   ) as value
   from "projects"
   where "appelOffreId" = $1 and "periodeId" = $2 and "numeroCRE" = $3 and "familleId" = $4

--- a/src/controllers/raccordement/getTransmettreDateMiseEnServicePage.ts
+++ b/src/controllers/raccordement/getTransmettreDateMiseEnServicePage.ts
@@ -18,6 +18,7 @@ import {
   ConsulterGestionnaireRéseauLauréatQuery,
   ConsulterGestionnaireRéseauQuery,
 } from '@potentiel/domain-views';
+import { ProjectEvent } from '../../infra/sequelize/projectionsNext';
 
 const schema = yup.object({
   params: yup.object({
@@ -112,11 +113,20 @@ v1Router.get(
         });
       }
 
+      const délaiCDC2022Appliqué = await ProjectEvent.findOne({
+        where: {
+          type: 'ProjectCompletionDueDateSet',
+          'payload.reason': 'délaiCdc2022',
+          projectId: projet.legacyId,
+        },
+      });
+
       return response.send(
         TransmettreDateMiseEnServicePage({
           user,
           projet,
           dossierRaccordement,
+          ...(délaiCDC2022Appliqué && { délaiCDC2022Appliqué: true }),
           error: error as string,
         }),
       );

--- a/src/controllers/raccordement/getTransmettreDateMiseEnServicePage.ts
+++ b/src/controllers/raccordement/getTransmettreDateMiseEnServicePage.ts
@@ -136,6 +136,10 @@ v1Router.get(
           familleId: projet.famille,
         });
 
+        if (!appelOffreProjet) {
+          return undefined;
+        }
+
         const détailsCDC = appelOffreProjet!.periode.cahiersDesChargesModifiésDisponibles.find(
           (CDC) =>
             CDC.type === cahierDesChargesParsé.type &&

--- a/src/controllers/raccordement/getTransmettreDateMiseEnServicePage.ts
+++ b/src/controllers/raccordement/getTransmettreDateMiseEnServicePage.ts
@@ -13,12 +13,15 @@ import { TransmettreDateMiseEnServicePage } from '../../views';
 import { mediator } from 'mediateur';
 import { isNone, isSome, none } from '@potentiel/monads';
 import {
+  CandidatureLegacyReadModel,
   ConsulterCandidatureLegacyQuery,
   ConsulterDossierRaccordementQuery,
   ConsulterGestionnaireRéseauLauréatQuery,
   ConsulterGestionnaireRéseauQuery,
 } from '@potentiel/domain-views';
 import { ProjectEvent } from '../../infra/sequelize/projectionsNext';
+import { getProjectAppelOffre } from '../../config/queryProjectAO.config';
+import { CahierDesChargesRéférenceParsed, parseCahierDesChargesRéférence } from '../../entities';
 
 const schema = yup.object({
   params: yup.object({
@@ -121,12 +124,43 @@ v1Router.get(
         },
       });
 
+      const cahierDesChargesParsé = parseCahierDesChargesRéférence(projet.cahierDesCharges);
+
+      const récupérerIntervalleDatesMeSDélaiCDC2022 = (
+        projet: CandidatureLegacyReadModel,
+        cahierDesChargesParsé: CahierDesChargesRéférenceParsed,
+      ) => {
+        const appelOffreProjet = getProjectAppelOffre({
+          appelOffreId: projet.appelOffre,
+          periodeId: projet.période,
+          familleId: projet.famille,
+        });
+
+        const détailsCDC = appelOffreProjet!.periode.cahiersDesChargesModifiésDisponibles.find(
+          (CDC) =>
+            CDC.type === cahierDesChargesParsé.type &&
+            CDC.paruLe === cahierDesChargesParsé.paruLe &&
+            CDC.alternatif === cahierDesChargesParsé.alternatif,
+        );
+
+        return détailsCDC?.délaiApplicable?.intervaleDateMiseEnService;
+      };
+
+      const intervalleDatesMeSDélaiCDC2022 =
+        cahierDesChargesParsé.type === 'modifié' &&
+        cahierDesChargesParsé.paruLe === '30/08/2022' &&
+        récupérerIntervalleDatesMeSDélaiCDC2022(projet, cahierDesChargesParsé);
+
       return response.send(
         TransmettreDateMiseEnServicePage({
           user,
           projet,
           dossierRaccordement,
           ...(délaiCDC2022Appliqué && { délaiCDC2022Appliqué: true }),
+          ...(délaiCDC2022Appliqué &&
+            intervalleDatesMeSDélaiCDC2022 && {
+              intervalleDatesMeSDélaiCDC2022,
+            }),
           error: error as string,
         }),
       );

--- a/src/infra/mail/mailjet.ts
+++ b/src/infra/mail/mailjet.ts
@@ -29,6 +29,7 @@ const TEMPLATE_ID_BY_TYPE: Record<NotificationProps['type'], number> = {
   'dreals-delai-cdc-2022-appliqué': 4326138,
   'tous-rôles-sauf-dgec-et-porteurs-nouvelle-periode-notifiée': 3849728,
   'pp-delai-cdc-2022-annulé': 5166575,
+  'dreals-delai-cdc-2022-annulé': 5169667,
 };
 
 interface SendEmailFromMailjetDeps {

--- a/src/infra/mail/mailjet.ts
+++ b/src/infra/mail/mailjet.ts
@@ -28,6 +28,7 @@ const TEMPLATE_ID_BY_TYPE: Record<NotificationProps['type'], number> = {
   'pp-delai-cdc-2022-appliqué': 4316228,
   'dreals-delai-cdc-2022-appliqué': 4326138,
   'tous-rôles-sauf-dgec-et-porteurs-nouvelle-periode-notifiée': 3849728,
+  'pp-delai-cdc-2022-annulé': 5166575,
 };
 
 interface SendEmailFromMailjetDeps {

--- a/src/infra/sequelize/projectionsNext/projectEvents/updates/onProjectCompletionDueDateSet.ts
+++ b/src/infra/sequelize/projectionsNext/projectEvents/updates/onProjectCompletionDueDateSet.ts
@@ -6,6 +6,14 @@ import { ProjectEventProjector } from '../projectEvent.projector';
 export default ProjectEventProjector.on(
   ProjectCompletionDueDateSet,
   async ({ payload: { projectId, completionDueOn, reason }, occurredAt }, transaction) => {
+    if (reason === 'délaiCdc2022Annulé') {
+      await ProjectEvent.destroy({
+        where: { type: ProjectCompletionDueDateSet.type, 'payload.reason': 'délaiCdc2022' },
+        transaction,
+      });
+      return;
+    }
+
     await ProjectEvent.create(
       {
         projectId,

--- a/src/modules/notification/Notification.ts
+++ b/src/modules/notification/Notification.ts
@@ -243,6 +243,12 @@ type PP_DélaiCDC2022Appliqué = {
   variables: { nom_projet: string; projet_url: string };
 };
 
+type PP_DélaiCDC2022Annulé = {
+  type: 'pp-delai-cdc-2022-annulé';
+  context: { projetId: string; utilisateurId: string };
+  variables: { nom_projet: string; projet_url: string };
+};
+
 type Dreals_DélaiCDC2022Appliqué = {
   type: 'dreals-delai-cdc-2022-appliqué';
   context: { projetId: string; utilisateurId: string };
@@ -274,6 +280,7 @@ type NotificationVariants =
   | LegacyCandidateNotification
   | AccèsUtilisateurRévoqués
   | PP_DélaiCDC2022Appliqué
+  | PP_DélaiCDC2022Annulé
   | Dreals_DélaiCDC2022Appliqué
   | NouvellePériodeNotifiée;
 

--- a/src/modules/notification/Notification.ts
+++ b/src/modules/notification/Notification.ts
@@ -255,6 +255,12 @@ type Dreals_DélaiCDC2022Appliqué = {
   variables: { nom_projet: string; projet_url: string };
 };
 
+type Dreals_DélaiCDC2022Annulé = {
+  type: 'dreals-delai-cdc-2022-annulé';
+  context: { projetId: string; utilisateurId: string };
+  variables: { nom_projet: string; projet_url: string };
+};
+
 type NouvellePériodeNotifiée = {
   type: 'tous-rôles-sauf-dgec-et-porteurs-nouvelle-periode-notifiée';
   context: { userId: string };
@@ -282,6 +288,7 @@ type NotificationVariants =
   | PP_DélaiCDC2022Appliqué
   | PP_DélaiCDC2022Annulé
   | Dreals_DélaiCDC2022Appliqué
+  | Dreals_DélaiCDC2022Annulé
   | NouvellePériodeNotifiée;
 
 export type NotificationProps = BaseNotification & NotificationVariants;

--- a/src/modules/notification/eventHandlers/onProjectCompletionDueDateSet.ts
+++ b/src/modules/notification/eventHandlers/onProjectCompletionDueDateSet.ts
@@ -19,10 +19,6 @@ type MakeOnProjectCompletionDueDateSet = (dépendances: {
 export const makeOnProjectCompletionDueDateSet: MakeOnProjectCompletionDueDateSet =
   ({ sendNotification, getProjectUsers, getProjectById, findUsersForDreal }) =>
   async ({ payload: { projectId, reason } }) => {
-    if (reason !== 'délaiCdc2022') {
-      return;
-    }
-
     const projet = await getProjectById(projectId);
     if (!projet) {
       logger.error(
@@ -30,47 +26,72 @@ export const makeOnProjectCompletionDueDateSet: MakeOnProjectCompletionDueDateSe
       );
       return;
     }
+
     const porteursEmails = await getProjectUsers({ projetId: projectId });
 
-    await Promise.all(
-      porteursEmails.map(({ email, fullName, id }) =>
-        sendNotification({
-          type: 'pp-delai-cdc-2022-appliqué',
-          context: { projetId: projectId, utilisateurId: id },
-          variables: {
-            nom_projet: projet.nomProjet,
-            projet_url: routes.PROJECT_DETAILS(projectId),
-          },
-          message: {
-            email,
-            name: fullName,
-            subject: `Potentiel - Nouveau délai appliqué pour votre projet ${projet.nomProjet}`,
-          },
-        }),
-      ),
-    );
+    if (reason === 'délaiCdc2022') {
+      await Promise.all(
+        porteursEmails.map(({ email, fullName, id }) =>
+          sendNotification({
+            type: 'pp-delai-cdc-2022-appliqué',
+            context: { projetId: projectId, utilisateurId: id },
+            variables: {
+              nom_projet: projet.nomProjet,
+              projet_url: routes.PROJECT_DETAILS(projectId),
+            },
+            message: {
+              email,
+              name: fullName,
+              subject: `Potentiel - Nouveau délai appliqué pour votre projet ${projet.nomProjet}`,
+            },
+          }),
+        ),
+      );
 
-    const regions = projet.regionProjet.split(' / ');
-    await Promise.all(
-      regions.map(async (region) => {
-        const dreals = await findUsersForDreal(region);
-        Promise.all(
-          dreals.map(({ email, fullName, id }) =>
-            sendNotification({
-              type: 'dreals-delai-cdc-2022-appliqué',
-              context: { projetId: projectId, utilisateurId: id },
-              variables: {
-                nom_projet: projet.nomProjet,
-                projet_url: routes.PROJECT_DETAILS(projectId),
-              },
-              message: {
-                email,
-                name: fullName,
-                subject: `Potentiel - Nouveau délai appliqué pour le projet ${projet.nomProjet}`,
-              },
-            }),
-          ),
-        );
-      }),
-    );
+      const regions = projet.regionProjet.split(' / ');
+      await Promise.all(
+        regions.map(async (region) => {
+          const dreals = await findUsersForDreal(region);
+          Promise.all(
+            dreals.map(({ email, fullName, id }) =>
+              sendNotification({
+                type: 'dreals-delai-cdc-2022-appliqué',
+                context: { projetId: projectId, utilisateurId: id },
+                variables: {
+                  nom_projet: projet.nomProjet,
+                  projet_url: routes.PROJECT_DETAILS(projectId),
+                },
+                message: {
+                  email,
+                  name: fullName,
+                  subject: `Potentiel - Nouveau délai appliqué pour le projet ${projet.nomProjet}`,
+                },
+              }),
+            ),
+          );
+        }),
+      );
+      return;
+    }
+
+    if (reason === 'délaiCdc2022Annulé') {
+      await Promise.all(
+        porteursEmails.map(({ email, fullName, id }) =>
+          sendNotification({
+            type: 'pp-delai-cdc-2022-annulé',
+            context: { projetId: projectId, utilisateurId: id },
+            variables: {
+              nom_projet: projet.nomProjet,
+              projet_url: routes.PROJECT_DETAILS(projectId),
+            },
+            message: {
+              email,
+              name: fullName,
+              subject: `Potentiel - Date d'achèvement théorique mise à jour pour le projet ${projet.nomProjet}`,
+            },
+          }),
+        ),
+      );
+      return;
+    }
   };

--- a/src/modules/notification/eventHandlers/onProjectCompletionDueDateSet.ts
+++ b/src/modules/notification/eventHandlers/onProjectCompletionDueDateSet.ts
@@ -28,6 +28,7 @@ export const makeOnProjectCompletionDueDateSet: MakeOnProjectCompletionDueDateSe
     }
 
     const porteursEmails = await getProjectUsers({ projetId: projectId });
+    const regions = projet.regionProjet.split(' / ');
 
     if (reason === 'délaiCdc2022') {
       await Promise.all(
@@ -48,7 +49,6 @@ export const makeOnProjectCompletionDueDateSet: MakeOnProjectCompletionDueDateSe
         ),
       );
 
-      const regions = projet.regionProjet.split(' / ');
       await Promise.all(
         regions.map(async (region) => {
           const dreals = await findUsersForDreal(region);
@@ -91,6 +91,29 @@ export const makeOnProjectCompletionDueDateSet: MakeOnProjectCompletionDueDateSe
             },
           }),
         ),
+      );
+
+      await Promise.all(
+        regions.map(async (region) => {
+          const dreals = await findUsersForDreal(region);
+          Promise.all(
+            dreals.map(({ email, fullName, id }) =>
+              sendNotification({
+                type: 'dreals-delai-cdc-2022-annulé',
+                context: { projetId: projectId, utilisateurId: id },
+                variables: {
+                  nom_projet: projet.nomProjet,
+                  projet_url: routes.PROJECT_DETAILS(projectId),
+                },
+                message: {
+                  email,
+                  name: fullName,
+                  subject: `Potentiel - Date d'achèvement théorique mise à jour pour le projet ${projet.nomProjet}`,
+                },
+              }),
+            ),
+          );
+        }),
       );
       return;
     }

--- a/src/modules/project/Project.ts
+++ b/src/modules/project/Project.ts
@@ -1243,7 +1243,12 @@ export const makeProject = (args: {
       case ProjectCompletionDueDateSet.type:
         if (props.completionDueOn !== 0) props.hasCompletionDueDateMoved = true;
         props.completionDueOn = event.payload.completionDueOn;
-        if (event.payload.reason === 'délaiCdc2022') props.délaiCDC2022appliqué = true;
+        if (event.payload.reason === 'délaiCdc2022') {
+          props.délaiCDC2022appliqué = true;
+        }
+        if (event.payload.reason === 'délaiCdc2022Annulé') {
+          props.délaiCDC2022appliqué = false;
+        }
         break;
       case CovidDelayGranted.type:
         if (props.completionDueOn !== 0) props.hasCompletionDueDateMoved = true;

--- a/src/modules/project/eventHandlers/onDateMiseEnServiceTransmise.spec.ts
+++ b/src/modules/project/eventHandlers/onDateMiseEnServiceTransmise.spec.ts
@@ -66,11 +66,11 @@ describe(`Handler onDateMiseEnServiceTransmise`, () => {
   );
 
   describe(`Projet pouvant bénéficier du délai de 18 mois`, () => {
-    it(`Etant donné un projet éolien,
-      dont la date de mise en service est comprise entre le 1er juin 2022 et le 30 septembre 2024,
-      ayant souscrit au CDC 2022 dont la période de l'appel d'offre permet le délai de 18 mois,
-      et n'ayant pas déjà bénéficié du délai,
-      alors le délai de 18 mois en lien avec le CDC 2022 devrait être appliqué`, async () => {
+    it(`Etant donné un projet éolien
+        Et ayant souscrit au CDC 2022 dont la période de l'appel d'offre permet le délai de 18 mois
+        Et n'ayant pas déjà bénéficié du délai
+        Quand la date de mise en service transmise est comprise entre le 1er juin 2022 et le 30 septembre 2024
+        Alors le délai de 18 mois en lien avec le CDC 2022 devrait être appliqué`, async () => {
       const fakeProject = {
         ...makeFakeProjectAggregate(),
         cahierDesCharges: { type: 'modifié', paruLe: '30/08/2022' },
@@ -117,11 +117,11 @@ describe(`Handler onDateMiseEnServiceTransmise`, () => {
 
   describe(`Projets ne pouvant pas bénéficier du délai de 18 mois`, () => {
     describe(`Date mise en service hors limites du CDC`, () => {
-      it(`Etant donné un projet éolien,
-          dont la date de mise en service n'est pas comprise entre le 1er juin 2022 et le 30 septembre 2024,
-          ayant souscrit au CDC 2022,
-          n'ayant pas déjà bénéficié du délai,
-          alors le délai de 18 mois en lien avec le CDC 2022 ne devrait pas être appliqué`, async () => {
+      it(`Etant donné un projet éolien
+          Et ayant souscrit au CDC 2022
+          Et n'ayant pas déjà bénéficié du délai
+          Quand la date de mise en service n'est pas comprise entre le 1er juin 2022 et le 30 septembre 2024 
+          Alors le délai de 18 mois en lien avec le CDC 2022 ne devrait pas être appliqué`, async () => {
         const fakeProject = {
           ...makeFakeProjectAggregate(),
           cahierDesCharges: { type: 'modifié', paruLe: '30/08/2022' },
@@ -158,10 +158,10 @@ describe(`Handler onDateMiseEnServiceTransmise`, () => {
     });
 
     describe(`Cahier des charges 2022 non souscrit`, () => {
-      it(`Etant donné un projet éolien,
-          dont la date de mise en service est comprise entre le 1er juin 2022 et le 30 septembre 2024,
-          n'ayant pas souscrit au CDC 2022,
-          alors le délai de 18 mois en lien avec le CDC 2022 ne devrait pas être appliqué`, async () => {
+      it(`Etant donné un projet éolien
+          Et n'ayant pas souscrit au CDC 2022
+          Quandla date de mise en service transmise est comprise entre le 1er juin 2022 et le 30 septembre 2024
+          Alors le délai de 18 mois en lien avec le CDC 2022 ne devrait pas être appliqué`, async () => {
         const fakeProject = {
           ...makeFakeProjectAggregate(),
           cahierDesCharges: { type: 'initial' },
@@ -198,10 +198,10 @@ describe(`Handler onDateMiseEnServiceTransmise`, () => {
     });
 
     describe(`Cahier des charges souscrit mais délai de 18 mois non disponible pour la période`, () => {
-      it(`Etant donné un projet PPE2 Bâtiment d'une période ne permettant pas les 18 mois (période 3),
-          dont la date de mise en service est comprise entre le 1er juin 2022 et le 30 septembre 2024,
-          ayant souscrit au CDC 2022,
-          alors le délai de 18 mois en lien avec le CDC 2022 ne devrait pas être appliqué`, async () => {
+      it(`Etant donné un projet PPE2 Bâtiment d'une période ne permettant pas les 18 mois (période 3)
+          Et ayant souscrit au CDC 2022
+          Quand la date de mise en service transmiseest comprise entre le 1er juin 2022 et le 30 septembre 2024
+          Alors le délai de 18 mois en lien avec le CDC 2022 ne devrait pas être appliqué`, async () => {
         const fakeProject = {
           ...makeFakeProjectAggregate(),
           cahierDesCharges: { type: 'modifié', paruLe: '30/08/2022' },
@@ -253,11 +253,11 @@ describe(`Handler onDateMiseEnServiceTransmise`, () => {
     });
 
     describe(`Délai CDC 2022 déjà appliqué`, () => {
-      it(`Etant donné un projet éolien,
-          dont la date de mise en service est comprise entre le 1er juin 2022 et le 30 septembre 2024,
-          ayant souscrit au CDC 2022,
-          ayant déjà bénéficié du délai,
-          alors le délai de 18 mois en lien avec le CDC 2022 ne devrait pas être appliqué`, async () => {
+      it(`Etant donné un projet éolien
+          Et ayant souscrit au CDC 2022
+          Et ayant déjà bénéficié du délai
+          Quand la date de mise en service transmise est comprise entre le 1er juin 2022 et le 30 septembre 2024
+          Alors le délai de 18 mois en lien avec le CDC 2022 ne devrait pas être appliqué`, async () => {
         const fakeProject = {
           ...makeFakeProjectAggregate(),
           cahierDesCharges: { type: 'modifié', paruLe: '30/08/2022' },
@@ -347,6 +347,62 @@ describe(`Handler onDateMiseEnServiceTransmise`, () => {
 
         expect(publishToEventStore).toHaveBeenCalledTimes(0);
       });
+    });
+  });
+
+  describe(`Date hors intervalle du CDC pour le délai de 18 mois pour un projet ayant déjà bénéficié du délai`, () => {
+    it(`Etant donné un projet éolien
+        Et ayant souscrit au CDC 2022
+        Et ayant déjà bénéficié du délai
+        Quand une date de mise en service hors de l'intervalle est transmise
+        Alors le délai relatif du CDC 2022 appliqué devrait être annulé`, async () => {
+      const dateHorsIntervalle = new Date('2020-01-02');
+
+      const nouvelleDateAchèvementAttendue = new Date(
+        new Date(dateAchèvementInitiale).setMonth(new Date(dateAchèvementInitiale).getMonth() - 18),
+      );
+
+      const fakeProject = {
+        ...makeFakeProjectAggregate(),
+        cahierDesCharges: { type: 'modifié', paruLe: '30/08/2022' },
+        completionDueOn: dateAchèvementInitiale,
+        délaiCDC2022appliqué: true,
+        numeroCRE,
+        appelOffreId,
+        periodeId,
+        id: projetId,
+        familleId,
+      };
+      const projectRepo = fakeTransactionalRepo(fakeProject as Project);
+
+      const onDateMiseEnServiceTransmise = makeOnDateMiseEnServiceTransmise({
+        projectRepo,
+        publishToEventStore,
+        getProjectAppelOffre,
+        findProjectByIdentifiers,
+        récupérerDétailDossiersRaccordements,
+      });
+
+      const événementDateMiseEnServiceTransmise = new DateMiseEnServiceTransmise({
+        payload: {
+          dateMiseEnService: dateHorsIntervalle.toISOString(),
+          référenceDossierRaccordement: 'ref-du-dossier',
+          identifiantProjet: `${appelOffreId}#${periodeId}#${familleId}#${numeroCRE}`,
+        },
+      });
+
+      await onDateMiseEnServiceTransmise(événementDateMiseEnServiceTransmise);
+
+      expect(publishToEventStore).toHaveBeenCalledTimes(1);
+      const évènement = publishToEventStore.mock.calls[0][0];
+      expect(évènement.type).toEqual('ProjectCompletionDueDateSet');
+      expect(évènement.payload).toEqual(
+        expect.objectContaining({
+          projectId: fakeProject.id.toString(),
+          completionDueOn: nouvelleDateAchèvementAttendue.getTime(),
+          reason: 'délaiCdc2022Annulé',
+        }),
+      );
     });
   });
 });

--- a/src/modules/project/eventHandlers/onDateMiseEnServiceTransmise.spec.ts
+++ b/src/modules/project/eventHandlers/onDateMiseEnServiceTransmise.spec.ts
@@ -160,7 +160,7 @@ describe(`Handler onDateMiseEnServiceTransmise`, () => {
     describe(`Cahier des charges 2022 non souscrit`, () => {
       it(`Etant donné un projet éolien
           Et n'ayant pas souscrit au CDC 2022
-          Quandla date de mise en service transmise est comprise entre le 1er juin 2022 et le 30 septembre 2024
+          Quand la date de mise en service transmise est comprise entre le 1er juin 2022 et le 30 septembre 2024
           Alors le délai de 18 mois en lien avec le CDC 2022 ne devrait pas être appliqué`, async () => {
         const fakeProject = {
           ...makeFakeProjectAggregate(),
@@ -200,7 +200,7 @@ describe(`Handler onDateMiseEnServiceTransmise`, () => {
     describe(`Cahier des charges souscrit mais délai de 18 mois non disponible pour la période`, () => {
       it(`Etant donné un projet PPE2 Bâtiment d'une période ne permettant pas les 18 mois (période 3)
           Et ayant souscrit au CDC 2022
-          Quand la date de mise en service transmiseest comprise entre le 1er juin 2022 et le 30 septembre 2024
+          Quand la date de mise en service transmise est comprise entre le 1er juin 2022 et le 30 septembre 2024
           Alors le délai de 18 mois en lien avec le CDC 2022 ne devrait pas être appliqué`, async () => {
         const fakeProject = {
           ...makeFakeProjectAggregate(),
@@ -353,9 +353,9 @@ describe(`Handler onDateMiseEnServiceTransmise`, () => {
   describe(`Date hors intervalle du CDC pour le délai de 18 mois pour un projet ayant déjà bénéficié du délai`, () => {
     it(`Etant donné un projet éolien
         Et ayant souscrit au CDC 2022
-        Et ayant déjà bénéficié du délai
+        Et ayant déjà bénéficié du délai relatif au CDC 2022
         Quand une date de mise en service hors de l'intervalle est transmise
-        Alors le délai relatif du CDC 2022 appliqué devrait être annulé`, async () => {
+        Alors le délai relatif au CDC 2022 appliqué devrait être annulé`, async () => {
       const dateHorsIntervalle = new Date('2020-01-02');
 
       const nouvelleDateAchèvementAttendue = new Date(

--- a/src/modules/project/events/ProjectCompletionDueDateSet.ts
+++ b/src/modules/project/events/ProjectCompletionDueDateSet.ts
@@ -4,7 +4,7 @@ export interface ProjectCompletionDueDateSetPayload {
   projectId: string;
   completionDueOn: number;
   setBy?: string;
-  reason?: 'délaiCdc2022';
+  reason?: 'délaiCdc2022' | 'délaiCdc2022Annulé';
 }
 export class ProjectCompletionDueDateSet
   extends BaseDomainEvent<ProjectCompletionDueDateSetPayload>

--- a/src/views/pages/raccordement/miseEnService/TransmettreDateMiseEnServicePage.tsx
+++ b/src/views/pages/raccordement/miseEnService/TransmettreDateMiseEnServicePage.tsx
@@ -22,6 +22,7 @@ type TransmettreDateMiseEnServiceProps = {
   projet: CandidatureLegacyReadModel;
   dossierRaccordement: DossierRaccordementReadModel;
   error?: string;
+  délaiCDC2022Appliqué?: true;
 };
 
 export const TransmettreDateMiseEnService = ({
@@ -29,6 +30,7 @@ export const TransmettreDateMiseEnService = ({
   dossierRaccordement: { référence, miseEnService },
   error,
   projet,
+  délaiCDC2022Appliqué,
 }: TransmettreDateMiseEnServiceProps) => {
   const { identifiantProjet } = projet;
 
@@ -57,7 +59,7 @@ export const TransmettreDateMiseEnService = ({
               required
             />
           </div>
-          <div className="flex flex-col md:flex-row gap-4 m-auto">
+          <div className="flex flex-col md:flex-row gap-4 md:mt-4">
             <PrimaryButton type="submit">Transmettre</PrimaryButton>
             <Link
               href={routes.GET_LISTE_DOSSIERS_RACCORDEMENT(identifiantProjet)}
@@ -68,8 +70,20 @@ export const TransmettreDateMiseEnService = ({
           </div>
         </Form>
         <InfoBox className='flex md:w-1/3 md:mx-auto"'>
-          La date de mise en service est comprise dans l'intervalle entre la date de désignation du
-          projet ({afficherDate(new Date(projet.dateDésignation))}) et ce jour.
+          <ul>
+            <li>
+              La date de mise en service est comprise dans l'intervalle entre la date de désignation
+              du projet ({afficherDate(new Date(projet.dateDésignation))}) et ce jour.
+            </li>
+            {délaiCDC2022Appliqué && (
+              <li className="mt-4">
+                Ce projet a déjà bénéficié du délai supplémentaire relatif du cahier des charges
+                modification du 30/08/2022. Une modification de la date de mise en service peut
+                remettre en cause l'application de ce délai et entraîner une modification de la date
+                d'achèvement du projet.
+              </li>
+            )}
+          </ul>
         </InfoBox>
       </div>
     </PageProjetTemplate>

--- a/src/views/pages/raccordement/miseEnService/TransmettreDateMiseEnServicePage.tsx
+++ b/src/views/pages/raccordement/miseEnService/TransmettreDateMiseEnServicePage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import { UtilisateurReadModel } from '../../../../modules/utilisateur/récupérer/UtilisateurReadModel';
 import {
@@ -11,6 +11,7 @@ import {
   PageProjetTemplate,
   Form,
   InfoBox,
+  AlertBox,
 } from '../../../components';
 import { afficherDate, formatDateForInput, hydrateOnClient } from '../../../helpers';
 import { CandidatureLegacyReadModel, DossierRaccordementReadModel } from '@potentiel/domain-views';
@@ -23,6 +24,7 @@ type TransmettreDateMiseEnServiceProps = {
   dossierRaccordement: DossierRaccordementReadModel;
   error?: string;
   délaiCDC2022Appliqué?: true;
+  intervalleDatesMeSDélaiCDC2022?: { min: Date; max: Date };
 };
 
 export const TransmettreDateMiseEnService = ({
@@ -31,8 +33,23 @@ export const TransmettreDateMiseEnService = ({
   error,
   projet,
   délaiCDC2022Appliqué,
+  intervalleDatesMeSDélaiCDC2022,
 }: TransmettreDateMiseEnServiceProps) => {
   const { identifiantProjet } = projet;
+
+  const [afficherAlerteAnnulationDélaiCDC2022, setAfficherAlerteAnnulationDélaiCDC2022] =
+    useState(false);
+
+  const handleInputChanged = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (!délaiCDC2022Appliqué || !intervalleDatesMeSDélaiCDC2022) {
+      return;
+    }
+    const dateMiseEnService = new Date(e.target.value).getTime();
+    setAfficherAlerteAnnulationDélaiCDC2022(
+      dateMiseEnService < new Date(intervalleDatesMeSDélaiCDC2022.min).getTime() ||
+        dateMiseEnService > new Date(intervalleDatesMeSDélaiCDC2022.max).getTime(),
+    );
+  };
 
   return (
     <PageProjetTemplate titre={<TitrePageRaccordement />} user={user} résuméProjet={projet}>
@@ -57,8 +74,21 @@ export const TransmettreDateMiseEnService = ({
               max={new Date().toISOString().split('T').shift()}
               min={formatDateForInput(projet.dateDésignation)}
               required
+              onChange={(e) => handleInputChanged(e)}
             />
           </div>
+
+          {afficherAlerteAnnulationDélaiCDC2022 && (
+            <AlertBox>
+              La date que vous renseignez ne permet plus au projet de bénéficier du délai relatif au
+              cahier des charges du 30/08/2022.{' '}
+              <span className="font-bold">
+                Si vous transmettez cette date, la date limite d'achèvement du projet sera impactée
+                et le porteur en sera informé par mail.
+              </span>
+            </AlertBox>
+          )}
+
           <div className="flex flex-col md:flex-row gap-4 md:mt-4">
             <PrimaryButton type="submit">Transmettre</PrimaryButton>
             <Link
@@ -71,18 +101,28 @@ export const TransmettreDateMiseEnService = ({
         </Form>
         <InfoBox className='flex md:w-1/3 md:mx-auto"'>
           <ul>
-            <li>
-              La date de mise en service est comprise dans l'intervalle entre la date de désignation
-              du projet ({afficherDate(new Date(projet.dateDésignation))}) et ce jour.
-            </li>
             {délaiCDC2022Appliqué && (
-              <li className="mt-4">
+              <li className="mb-4">
                 Ce projet a déjà bénéficié du délai supplémentaire relatif du cahier des charges
                 modification du 30/08/2022. Une modification de la date de mise en service peut
                 remettre en cause l'application de ce délai et entraîner une modification de la date
                 d'achèvement du projet.
+                {intervalleDatesMeSDélaiCDC2022 && (
+                  <>
+                    <br />
+                    <span>
+                      Pour conserver le délai appliqué, la date de mise en service doit être entre
+                      le {afficherDate(new Date(intervalleDatesMeSDélaiCDC2022.min))} et le{' '}
+                      {afficherDate(new Date(intervalleDatesMeSDélaiCDC2022.max))}.
+                    </span>
+                  </>
+                )}
               </li>
             )}
+            <li>
+              La date de mise en service est comprise dans l'intervalle entre la date de désignation
+              du projet ({afficherDate(new Date(projet.dateDésignation))}) et ce jour.
+            </li>
           </ul>
         </InfoBox>
       </div>


### PR DESCRIPTION
Si une nouvelle date de mise en service est saisie sur un projet qui a bénéficié du délai CDC 2022, et que cette date sort de l'intervalle d'application de ce délai, alors le projet perd les 18 mois les porteurs doivent être notifiés. 