### PR TITLE
:sparkles: Impact délai CDC 2022 en cas de changement de CDC d'un projet

### DIFF
--- a/src/config/eventHandlers/project.eventHandlers.ts
+++ b/src/config/eventHandlers/project.eventHandlers.ts
@@ -17,6 +17,8 @@ import {
   ProjectRawDataImported,
   makeOnAnnulationAbandonAccordée,
   DateMiseEnServiceTransmise,
+  makeOnCahierDesChargesChoisi,
+  CahierDesChargesChoisi,
 } from '../../modules/project';
 import { subscribeToRedis } from '../eventBus.config';
 import { eventStore } from '../eventStore.config';
@@ -137,6 +139,25 @@ const onAnnulationAbandonAccordée = async (event: DomainEvent) => {
 };
 
 subscribeToRedis(onAnnulationAbandonAccordée, 'Project');
+
+const onCahierDesChargesChoisiHandler = makeOnCahierDesChargesChoisi({
+  projectRepo,
+  publishToEventStore: eventStore.publish,
+  getProjectAppelOffre,
+});
+
+const onCahierDesChargesChoisi = async (event: DomainEvent) => {
+  if (!(event instanceof CahierDesChargesChoisi)) {
+    return Promise.resolve();
+  }
+
+  return onCahierDesChargesChoisiHandler(event).match(
+    () => Promise.resolve(),
+    (e) => Promise.reject(e),
+  );
+};
+
+subscribeToRedis(onCahierDesChargesChoisi, 'Project.onCahierDesChargesChoisi');
 
 console.log('Project Event Handlers Initialized');
 export const projectHandlersOk = true;

--- a/src/config/eventHandlers/project.eventHandlers.ts
+++ b/src/config/eventHandlers/project.eventHandlers.ts
@@ -144,6 +144,7 @@ const onCahierDesChargesChoisiHandler = makeOnCahierDesChargesChoisi({
   projectRepo,
   publishToEventStore: eventStore.publish,
   getProjectAppelOffre,
+  récupérerDétailDossiersRaccordements,
 });
 
 const onCahierDesChargesChoisi = async (event: DomainEvent) => {

--- a/src/infra/mail/mailjet.ts
+++ b/src/infra/mail/mailjet.ts
@@ -28,8 +28,8 @@ const TEMPLATE_ID_BY_TYPE: Record<NotificationProps['type'], number> = {
   'pp-delai-cdc-2022-appliqué': 4316228,
   'dreals-delai-cdc-2022-appliqué': 4326138,
   'tous-rôles-sauf-dgec-et-porteurs-nouvelle-periode-notifiée': 3849728,
-  'pp-delai-cdc-2022-annulé': 5166575,
-  'dreals-delai-cdc-2022-annulé': 5169667,
+  'changement-cdc-annule-delai-cdc-2022': 5166575,
+  'date-mise-en-service-transmise-annule-delai-cdc-2022': 5169667,
 };
 
 interface SendEmailFromMailjetDeps {

--- a/src/infra/sequelize/projectionsNext/projectEvents/updates/onProjectCompletionDueDateSet.integration.ts
+++ b/src/infra/sequelize/projectionsNext/projectEvents/updates/onProjectCompletionDueDateSet.integration.ts
@@ -17,7 +17,7 @@ describe('onProjectCompletionDueDateSet', () => {
     await resetDatabase();
   });
 
-  it(`Si la raison n'est pas "délaiCdc2022Annulé" 
+  it(`Si la raison n'est pas 'ChoixCDCAnnuleDélaiCdc2022' ou 'DateMiseEnServiceAnnuleDélaiCdc2022' 
       Alors un nouveau project event devrait être ajouté`, async () => {
     await onProjectCompletionDueDateSet(
       new ProjectCompletionDueDateSet({
@@ -42,7 +42,7 @@ describe('onProjectCompletionDueDateSet', () => {
     });
   });
 
-  it(`Si la raison est "délaiCdc2022Annulé"
+  it(`Si la raison est 'DateMiseEnServiceAnnuleDélaiCdc2022' 
       Alors le project event ProjectCompletionDueDateSet de raison "délaiCdc2022" devrait être supprimé`, async () => {
     // Event initial
     await onProjectCompletionDueDateSet(
@@ -75,7 +75,53 @@ describe('onProjectCompletionDueDateSet', () => {
         payload: {
           projectId,
           completionDueOn,
-          reason: 'délaiCdc2022Annulé',
+          reason: 'DateMiseEnServiceAnnuleDélaiCdc2022',
+        } as ProjectCompletionDueDateSetPayload,
+        original: {
+          version: 1,
+          occurredAt,
+        },
+      }),
+    );
+
+    const projectEvent = await ProjectEvent.findOne({ where: { projectId } });
+    expect(projectEvent).toBeNull();
+  });
+
+  it(`Si la raison est 'ChoixCDCAnnuleDélaiCdc2022' 
+      Alors le project event ProjectCompletionDueDateSet de raison "délaiCdc2022" devrait être supprimé`, async () => {
+    // Event initial
+    await onProjectCompletionDueDateSet(
+      new ProjectCompletionDueDateSet({
+        payload: {
+          projectId,
+          completionDueOn,
+          reason: 'délaiCdc2022',
+        } as ProjectCompletionDueDateSetPayload,
+        original: {
+          version: 1,
+          occurredAt,
+        },
+      }),
+    );
+
+    const eventInitial = await ProjectEvent.findOne({ where: { projectId } });
+    expect(eventInitial).not.toBeNull();
+    expect(eventInitial).toMatchObject({
+      projectId,
+      type: 'ProjectCompletionDueDateSet',
+      eventPublishedAt: occurredAt.getTime(),
+      valueDate: completionDueOn,
+      payload: { reason: 'délaiCdc2022' },
+    });
+
+    // Nouvel event
+    await onProjectCompletionDueDateSet(
+      new ProjectCompletionDueDateSet({
+        payload: {
+          projectId,
+          completionDueOn,
+          reason: 'ChoixCDCAnnuleDélaiCdc2022',
         } as ProjectCompletionDueDateSetPayload,
         original: {
           version: 1,

--- a/src/infra/sequelize/projectionsNext/projectEvents/updates/onProjectCompletionDueDateSet.ts
+++ b/src/infra/sequelize/projectionsNext/projectEvents/updates/onProjectCompletionDueDateSet.ts
@@ -6,7 +6,10 @@ import { ProjectEventProjector } from '../projectEvent.projector';
 export default ProjectEventProjector.on(
   ProjectCompletionDueDateSet,
   async ({ payload: { projectId, completionDueOn, reason }, occurredAt }, transaction) => {
-    if (reason === 'délaiCdc2022Annulé') {
+    if (
+      reason &&
+      ['ChoixCDCAnnuleDélaiCdc2022', 'DateMiseEnServiceAnnuleDélaiCdc2022'].includes(reason)
+    ) {
       await ProjectEvent.destroy({
         where: { type: ProjectCompletionDueDateSet.type, 'payload.reason': 'délaiCdc2022' },
         transaction,

--- a/src/infra/sequelize/queries/project/getProjectDataForChoisirCDCPage.integration.ts
+++ b/src/infra/sequelize/queries/project/getProjectDataForChoisirCDCPage.integration.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from '@jest/globals';
 import { UniqueEntityID } from '../../../../core/domain';
 import makeFakeProject from '../../../../__tests__/fixtures/project';
 import { resetDatabase } from '../../helpers';
-import { Project } from '../../projectionsNext';
+import { Project, ProjectEvent } from '../../projectionsNext';
 import { getProjectDataForChoisirCDCPage } from './getProjectDataForChoisirCDCPage';
 import { getProjectAppelOffre } from '../../../../config/queryProjectAO.config';
 import { ProjectDataForChoisirCDCPage } from '../../../../modules/project';
@@ -39,6 +39,56 @@ describe('Récupérer les données pour la page du choix du cahier des charges',
         familleId: '1',
       }),
       cahierDesChargesActuel: '30/07/2021',
+    };
+
+    const readModel = await getProjectDataForChoisirCDCPage(projetId);
+
+    expect(readModel.isOk()).toBe(true);
+
+    expect(readModel._unsafeUnwrap()).toMatchObject(expected);
+  });
+
+  it(`Etant donné un projet ayant déjà un gestionnaire de réseau renseigné
+      Et ayant bénéficié du délai relatif au CDC 2022
+      Lorsqu'on récupère les données pour la page du choix des CDC
+      Alors devraient être retournés :
+      - l'identifiant du projet,
+      - le CDC actuel,
+      - l'identifiant gestionnaire réseau si déjà renseigné,
+      - le gestionnaire réseau actuel,
+      - la liste des gestionnaires réseau,
+      - délaiCDC2022Appliqué`, async () => {
+    await resetDatabase();
+
+    await Project.create(
+      makeFakeProject({
+        id: projetId,
+        appelOffreId: 'Fessenheim',
+        periodeId: '1',
+        familleId: '1',
+        classe: 'Classé',
+        cahierDesChargesActuel: '30/07/2021',
+      }),
+    );
+
+    await ProjectEvent.create({
+      eventPublishedAt: new Date().getTime(),
+      id: new UniqueEntityID().toString(),
+      projectId: projetId,
+      type: 'ProjectCompletionDueDateSet',
+      valueDate: new Date().getTime(),
+      payload: { reason: 'délaiCdc2022' },
+    });
+
+    const expected: Partial<ProjectDataForChoisirCDCPage> = {
+      id: projetId,
+      appelOffre: getProjectAppelOffre({
+        appelOffreId: 'Fessenheim',
+        periodeId: '1',
+        familleId: '1',
+      }),
+      cahierDesChargesActuel: '30/07/2021',
+      délaiCDC2022Appliqué: true,
     };
 
     const readModel = await getProjectDataForChoisirCDCPage(projetId);

--- a/src/modules/notification/Notification.ts
+++ b/src/modules/notification/Notification.ts
@@ -243,22 +243,28 @@ type PP_DélaiCDC2022Appliqué = {
   variables: { nom_projet: string; projet_url: string };
 };
 
-type PP_DélaiCDC2022Annulé = {
-  type: 'pp-delai-cdc-2022-annulé';
-  context: { projetId: string; utilisateurId: string };
-  variables: { nom_projet: string; projet_url: string };
-};
-
 type Dreals_DélaiCDC2022Appliqué = {
   type: 'dreals-delai-cdc-2022-appliqué';
   context: { projetId: string; utilisateurId: string };
   variables: { nom_projet: string; projet_url: string };
 };
 
-type Dreals_DélaiCDC2022Annulé = {
-  type: 'dreals-delai-cdc-2022-annulé';
+type ChangementCDCAnnuleDélaiCDC2022 = {
+  type: 'changement-cdc-annule-delai-cdc-2022';
   context: { projetId: string; utilisateurId: string };
-  variables: { nom_projet: string; projet_url: string };
+  variables: {
+    nom_projet: string;
+    projet_url: string;
+  };
+};
+
+type DateMiseEnServiceTransmiseAnnuleDélaiCDC2022 = {
+  type: 'date-mise-en-service-transmise-annule-delai-cdc-2022';
+  context: { projetId: string; utilisateurId: string };
+  variables: {
+    nom_projet: string;
+    projet_url: string;
+  };
 };
 
 type NouvellePériodeNotifiée = {
@@ -286,10 +292,10 @@ type NotificationVariants =
   | LegacyCandidateNotification
   | AccèsUtilisateurRévoqués
   | PP_DélaiCDC2022Appliqué
-  | PP_DélaiCDC2022Annulé
   | Dreals_DélaiCDC2022Appliqué
-  | Dreals_DélaiCDC2022Annulé
-  | NouvellePériodeNotifiée;
+  | NouvellePériodeNotifiée
+  | ChangementCDCAnnuleDélaiCDC2022
+  | DateMiseEnServiceTransmiseAnnuleDélaiCDC2022;
 
 export type NotificationProps = BaseNotification & NotificationVariants;
 

--- a/src/modules/notification/eventHandlers/onProjectCompletionDueDateSet.spec.ts
+++ b/src/modules/notification/eventHandlers/onProjectCompletionDueDateSet.spec.ts
@@ -172,7 +172,7 @@ describe(`Notification handler onProjectCompletionDueDateSet`, () => {
         payload: {
           projectId: projetId,
           completionDueOn: new Date('2025-01-01').getTime(),
-          reason: 'délaiCdc2022Annulé',
+          reason: 'DateMiseEnServiceAnnuleDélaiCdc2022',
         },
       });
 

--- a/src/modules/notification/eventHandlers/onProjectCompletionDueDateSet.spec.ts
+++ b/src/modules/notification/eventHandlers/onProjectCompletionDueDateSet.spec.ts
@@ -135,7 +135,7 @@ describe(`Notification handler onProjectCompletionDueDateSet`, () => {
   describe(`Notifier l'annulation du délai de 18 mois relatif au CDC 2022`, () => {
     it(`Etant donné un projet suivi par deux utilisateurs "porteur-projet"
         Et suivi par deux utilisateurs "dreal"
-        Quand un délai de 18 mois relatif au CDC 2022 est annulé sur le projet
+        Quand un délai de 18 mois relatif au CDC 2022 est annulé sur le projet suite à un ajout de date de mise en service
         Alors les deux profils "porteur-projet" devraient être notifiés
         Et les deux profils "dreal" devraient être notifiés
         `, async () => {
@@ -183,7 +183,7 @@ describe(`Notification handler onProjectCompletionDueDateSet`, () => {
       expect(sendNotification).toHaveBeenNthCalledWith(
         1,
         expect.objectContaining({
-          type: 'pp-delai-cdc-2022-annulé',
+          type: 'date-mise-en-service-transmise-annule-delai-cdc-2022',
           context: expect.objectContaining({ projetId, utilisateurId: 'user-1' }),
           variables: expect.objectContaining({
             nom_projet: 'nom_projet',
@@ -200,7 +200,7 @@ describe(`Notification handler onProjectCompletionDueDateSet`, () => {
       expect(sendNotification).toHaveBeenNthCalledWith(
         2,
         expect.objectContaining({
-          type: 'pp-delai-cdc-2022-annulé',
+          type: 'date-mise-en-service-transmise-annule-delai-cdc-2022',
           context: expect.objectContaining({ projetId, utilisateurId: 'user-2' }),
           variables: expect.objectContaining({
             nom_projet: 'nom_projet',
@@ -217,7 +217,7 @@ describe(`Notification handler onProjectCompletionDueDateSet`, () => {
       expect(sendNotification).toHaveBeenNthCalledWith(
         3,
         expect.objectContaining({
-          type: 'dreals-delai-cdc-2022-annulé',
+          type: 'date-mise-en-service-transmise-annule-delai-cdc-2022',
           context: expect.objectContaining({ projetId, utilisateurId: 'user-A' }),
           variables: expect.objectContaining({
             nom_projet: 'nom_projet',
@@ -234,7 +234,123 @@ describe(`Notification handler onProjectCompletionDueDateSet`, () => {
       expect(sendNotification).toHaveBeenNthCalledWith(
         4,
         expect.objectContaining({
-          type: 'dreals-delai-cdc-2022-annulé',
+          type: 'date-mise-en-service-transmise-annule-delai-cdc-2022',
+          context: expect.objectContaining({ projetId, utilisateurId: 'user-B' }),
+          variables: expect.objectContaining({
+            nom_projet: 'nom_projet',
+            projet_url: expect.anything(),
+          }),
+          message: expect.objectContaining({
+            email: 'drealB@test.test',
+            name: 'drealB',
+            subject: `Potentiel - Date d'achèvement théorique mise à jour pour le projet nom_projet`,
+          }),
+        }),
+      );
+    });
+
+    it(`Etant donné un projet suivi par deux utilisateurs "porteur-projet"
+        Et suivi par deux utilisateurs "dreal"
+        Quand un délai de 18 mois relatif au CDC 2022 est annulé sur le projet suite à un changement de cahier des charges
+        Alors les deux profils "porteur-projet" devraient être notifiés
+        Et les deux profils "dreal" devraient être notifiés
+        `, async () => {
+      const porteur1 = makeFakeUser({
+        email: 'email1@test.test',
+        id: 'user-1',
+        fullName: 'nom_porteur1',
+      });
+      const porteur2 = makeFakeUser({
+        email: 'email2@test.test',
+        id: 'user-2',
+        fullName: 'nom_porteur2',
+      });
+
+      const onProjectCompletionDueDateSet = makeOnProjectCompletionDueDateSet({
+        sendNotification,
+        getProjectUsers: jest.fn(async () => [porteur1, porteur2]),
+        getProjectById: jest.fn(async () =>
+          makeFakeProject({
+            id: projetId,
+            nomProjet: 'nom_projet',
+            regionProjet: 'regionA / regionB',
+          }),
+        ),
+        findUsersForDreal: (region: string) =>
+          Promise.resolve(
+            region === 'regionA'
+              ? [{ email: 'drealA@test.test', fullName: 'drealA', id: 'user-A' } as User]
+              : [{ email: 'drealB@test.test', fullName: 'drealB', id: 'user-B' } as User],
+          ),
+      });
+
+      const évènement = new ProjectCompletionDueDateSet({
+        payload: {
+          projectId: projetId,
+          completionDueOn: new Date('2025-01-01').getTime(),
+          reason: 'ChoixCDCAnnuleDélaiCdc2022',
+        },
+      });
+
+      await onProjectCompletionDueDateSet(évènement);
+
+      expect(sendNotification).toHaveBeenCalledTimes(4);
+
+      expect(sendNotification).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          type: 'changement-cdc-annule-delai-cdc-2022',
+          context: expect.objectContaining({ projetId, utilisateurId: 'user-1' }),
+          variables: expect.objectContaining({
+            nom_projet: 'nom_projet',
+            projet_url: expect.anything(),
+          }),
+          message: expect.objectContaining({
+            email: 'email1@test.test',
+            name: 'nom_porteur1',
+            subject: `Potentiel - Date d'achèvement théorique mise à jour pour le projet nom_projet`,
+          }),
+        }),
+      );
+
+      expect(sendNotification).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          type: 'changement-cdc-annule-delai-cdc-2022',
+          context: expect.objectContaining({ projetId, utilisateurId: 'user-2' }),
+          variables: expect.objectContaining({
+            nom_projet: 'nom_projet',
+            projet_url: expect.anything(),
+          }),
+          message: expect.objectContaining({
+            email: 'email2@test.test',
+            name: 'nom_porteur2',
+            subject: `Potentiel - Date d'achèvement théorique mise à jour pour le projet nom_projet`,
+          }),
+        }),
+      );
+
+      expect(sendNotification).toHaveBeenNthCalledWith(
+        3,
+        expect.objectContaining({
+          type: 'changement-cdc-annule-delai-cdc-2022',
+          context: expect.objectContaining({ projetId, utilisateurId: 'user-A' }),
+          variables: expect.objectContaining({
+            nom_projet: 'nom_projet',
+            projet_url: expect.anything(),
+          }),
+          message: expect.objectContaining({
+            email: 'drealA@test.test',
+            name: 'drealA',
+            subject: `Potentiel - Date d'achèvement théorique mise à jour pour le projet nom_projet`,
+          }),
+        }),
+      );
+
+      expect(sendNotification).toHaveBeenNthCalledWith(
+        4,
+        expect.objectContaining({
+          type: 'changement-cdc-annule-delai-cdc-2022',
           context: expect.objectContaining({ projetId, utilisateurId: 'user-B' }),
           variables: expect.objectContaining({
             nom_projet: 'nom_projet',

--- a/src/modules/notification/eventHandlers/onProjectCompletionDueDateSet.ts
+++ b/src/modules/notification/eventHandlers/onProjectCompletionDueDateSet.ts
@@ -74,16 +74,25 @@ export const makeOnProjectCompletionDueDateSet: MakeOnProjectCompletionDueDateSe
       return;
     }
 
-    if (reason === 'DateMiseEnServiceAnnuleDélaiCdc2022') {
+    if (
+      reason &&
+      ['DateMiseEnServiceAnnuleDélaiCdc2022', 'ChoixCDCAnnuleDélaiCdc2022'].includes(reason)
+    ) {
+      const variables = {
+        nom_projet: projet.nomProjet,
+        projet_url: routes.PROJECT_DETAILS(projectId),
+      };
+      const type =
+        reason === 'DateMiseEnServiceAnnuleDélaiCdc2022'
+          ? 'date-mise-en-service-transmise-annule-delai-cdc-2022'
+          : 'changement-cdc-annule-delai-cdc-2022';
+
       await Promise.all(
         porteursEmails.map(({ email, fullName, id }) =>
           sendNotification({
-            type: 'pp-delai-cdc-2022-annulé',
+            type,
             context: { projetId: projectId, utilisateurId: id },
-            variables: {
-              nom_projet: projet.nomProjet,
-              projet_url: routes.PROJECT_DETAILS(projectId),
-            },
+            variables,
             message: {
               email,
               name: fullName,
@@ -99,12 +108,9 @@ export const makeOnProjectCompletionDueDateSet: MakeOnProjectCompletionDueDateSe
           Promise.all(
             dreals.map(({ email, fullName, id }) =>
               sendNotification({
-                type: 'dreals-delai-cdc-2022-annulé',
+                type,
                 context: { projetId: projectId, utilisateurId: id },
-                variables: {
-                  nom_projet: projet.nomProjet,
-                  projet_url: routes.PROJECT_DETAILS(projectId),
-                },
+                variables,
                 message: {
                   email,
                   name: fullName,

--- a/src/modules/notification/eventHandlers/onProjectCompletionDueDateSet.ts
+++ b/src/modules/notification/eventHandlers/onProjectCompletionDueDateSet.ts
@@ -74,7 +74,7 @@ export const makeOnProjectCompletionDueDateSet: MakeOnProjectCompletionDueDateSe
       return;
     }
 
-    if (reason === 'délaiCdc2022Annulé') {
+    if (reason === 'DateMiseEnServiceAnnuleDélaiCdc2022') {
       await Promise.all(
         porteursEmails.map(({ email, fullName, id }) =>
           sendNotification({

--- a/src/modules/project/Project.ts
+++ b/src/modules/project/Project.ts
@@ -1246,7 +1246,12 @@ export const makeProject = (args: {
         if (event.payload.reason === 'délaiCdc2022') {
           props.délaiCDC2022appliqué = true;
         }
-        if (event.payload.reason === 'délaiCdc2022Annulé') {
+        if (
+          event.payload.reason &&
+          ['ChoixCDCAnnuleDélaiCdc2022', 'DateMiseEnServiceAnnuleDélaiCdc2022'].includes(
+            event.payload.reason,
+          )
+        ) {
           props.délaiCDC2022appliqué = false;
         }
         break;

--- a/src/modules/project/eventHandlers/index.ts
+++ b/src/modules/project/eventHandlers/index.ts
@@ -6,3 +6,4 @@ export * from './onAbandonAccordé';
 export * from './onAnnulationAbandonAccordée';
 export * from './onDateMiseEnServiceTransmise';
 export * from './onDélaiAccordé';
+export * from './onCahierDesChargesChoisi';

--- a/src/modules/project/eventHandlers/onCahierDesChargesChoisi.spec.ts
+++ b/src/modules/project/eventHandlers/onCahierDesChargesChoisi.spec.ts
@@ -170,7 +170,7 @@ describe(`Pas d'effet`, () => {
   it(`
     Etant donné un projet sur le CDC initial
     Et n'ayant pas bénéficié du délai relatif au CDC du 30/08/2022
-    Lorsque le porteur choisit le CDC du 20/08/2022
+    Lorsque le porteur choisit le CDC du 30/08/2022
     Alors la date d'achèvement du projet ne devrait pas être modifiée
     `, async () => {
     const projetId = new UniqueEntityID();

--- a/src/modules/project/eventHandlers/onCahierDesChargesChoisi.spec.ts
+++ b/src/modules/project/eventHandlers/onCahierDesChargesChoisi.spec.ts
@@ -1,4 +1,4 @@
-import { jest, describe, it, expect } from '@jest/globals';
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
 import { CahierDesChargesChoisi } from '../events';
 import { DomainEvent, UniqueEntityID } from '../../../core/domain';
 import { InfraNotAvailableError } from '../../shared/errors';
@@ -12,228 +12,658 @@ import {
 import { makeOnCahierDesChargesChoisi } from './onCahierDesChargesChoisi';
 import { Project } from '../Project';
 
-describe(`Retirer le délai relatif au CDC 2022`, () => {
+describe(`onCahierDesChargesChoisi event handler`, () => {
   const publishToEventStore = jest.fn((event: DomainEvent) =>
     okAsync<null, InfraNotAvailableError>(null),
   );
 
-  it(`
+  const récupérerDétailDossiersRaccordements = jest.fn(async () => [
+    {
+      référence: 'ref-du-dossier',
+      demandeComplèteRaccordement: {
+        dateQualification: new Date('2022-01-01').toISOString(),
+      },
+      miseEnService: { dateMiseEnService: new Date('2023-01-01').toISOString() },
+    },
+  ]);
+
+  beforeEach(async () => {
+    publishToEventStore.mockClear();
+  });
+
+  describe(`Retirer le délai relatif au CDC 2022`, () => {
+    it(`
     Etant donné un projet sur le CDC du 30/08/2022
     Et ayant bénéficié du délai relatif au CDC du 30/08/2022
     Lorsque le porteur change de cahier des charges
     Alors le délai relatif au CDC du 30/08/2022 devrait être annulé
     `, async () => {
-    const projetId = new UniqueEntityID();
-    const appelOffreId = 'Eolien';
-    const periodeId = '1';
-    const numeroCRE = '123';
-    const familleId = '';
-    const CDCDélaiApplicable = 18;
-    const dateAchèvementInitiale = new Date('2025-01-01');
-    const nouvelleDateAchèvementAttendue = new Date(
-      new Date(dateAchèvementInitiale).setMonth(
-        new Date(dateAchèvementInitiale).getMonth() - CDCDélaiApplicable,
-      ),
-    );
+      const projetId = new UniqueEntityID();
+      const appelOffreId = 'Eolien';
+      const periodeId = '1';
+      const numeroCRE = '123';
+      const familleId = '';
+      const CDCDélaiApplicable = 18;
+      const dateAchèvementInitiale = new Date('2025-01-01');
+      const nouvelleDateAchèvementAttendue = new Date(
+        new Date(dateAchèvementInitiale).setMonth(
+          new Date(dateAchèvementInitiale).getMonth() - CDCDélaiApplicable,
+        ),
+      );
 
-    const fakeProject = {
-      ...makeFakeProjectAggregate(),
-      cahierDesCharges: { type: 'modifié', paruLe: '30/08/2022' },
-      completionDueOn: dateAchèvementInitiale.getTime(),
-      délaiCDC2022appliqué: true,
-      numeroCRE,
-      appelOffreId,
-      periodeId,
-      id: projetId,
-      familleId,
-    };
+      const fakeProject = {
+        ...makeFakeProjectAggregate(),
+        cahierDesCharges: { type: 'modifié', paruLe: '30/08/2022' },
+        completionDueOn: dateAchèvementInitiale.getTime(),
+        délaiCDC2022appliqué: true,
+        numeroCRE,
+        appelOffreId,
+        periodeId,
+        id: projetId,
+        familleId,
+      };
 
-    const projectRepo = fakeTransactionalRepo(fakeProject as Project);
+      const projectRepo = fakeTransactionalRepo(fakeProject as Project);
 
-    const getProjectAppelOffre = jest.fn(
-      () =>
-        ({
-          typeAppelOffre: 'eolien',
-          periode: {
-            cahiersDesChargesModifiésDisponibles: [
-              {
-                type: 'modifié',
-                paruLe: '30/08/2022',
-                délaiApplicable: {
-                  délaiEnMois: CDCDélaiApplicable,
-                  intervaleDateMiseEnService: {
-                    min: new Date('2022-06-01'),
-                    max: new Date('2024-09-30'),
+      const getProjectAppelOffre = jest.fn(
+        () =>
+          ({
+            typeAppelOffre: 'eolien',
+            periode: {
+              cahiersDesChargesModifiésDisponibles: [
+                {
+                  type: 'modifié',
+                  paruLe: '30/08/2022',
+                  délaiApplicable: {
+                    délaiEnMois: CDCDélaiApplicable,
+                    intervaleDateMiseEnService: {
+                      min: new Date('2022-06-01'),
+                      max: new Date('2024-09-30'),
+                    },
                   },
-                },
-              } as CahierDesChargesModifié,
-            ] as ReadonlyArray<CahierDesChargesModifié>,
-          },
-        } as ProjectAppelOffre),
-    );
+                } as CahierDesChargesModifié,
+              ] as ReadonlyArray<CahierDesChargesModifié>,
+            },
+          } as ProjectAppelOffre),
+      );
 
-    const onCahierDesChargesChoisi = makeOnCahierDesChargesChoisi({
-      publishToEventStore,
-      getProjectAppelOffre,
-      projectRepo,
+      const onCahierDesChargesChoisi = makeOnCahierDesChargesChoisi({
+        publishToEventStore,
+        getProjectAppelOffre,
+        projectRepo,
+        récupérerDétailDossiersRaccordements,
+      });
+
+      await onCahierDesChargesChoisi(
+        new CahierDesChargesChoisi({
+          payload: { choisiPar: 'id', type: 'initial', projetId: projetId.toString() },
+        }),
+      );
+
+      expect(publishToEventStore).toHaveBeenCalledTimes(1);
+      const évènement = publishToEventStore.mock.calls[0][0];
+      expect(évènement.type).toEqual('ProjectCompletionDueDateSet');
+      expect(évènement.payload).toEqual(
+        expect.objectContaining({
+          projectId: fakeProject.id.toString(),
+          completionDueOn: nouvelleDateAchèvementAttendue.getTime(),
+          reason: 'ChoixCDCAnnuleDélaiCdc2022',
+        }),
+      );
     });
-
-    await onCahierDesChargesChoisi(
-      new CahierDesChargesChoisi({
-        payload: { choisiPar: 'id', type: 'initial', projetId: projetId.toString() },
-      }),
-    );
-
-    expect(publishToEventStore).toHaveBeenCalledTimes(1);
-    const évènement = publishToEventStore.mock.calls[0][0];
-    expect(évènement.type).toEqual('ProjectCompletionDueDateSet');
-    expect(évènement.payload).toEqual(
-      expect.objectContaining({
-        projectId: fakeProject.id.toString(),
-        completionDueOn: nouvelleDateAchèvementAttendue.getTime(),
-        reason: 'ChoixCDCAnnuleDélaiCdc2022',
-      }),
-    );
   });
-});
 
-describe(`Pas d'effet`, () => {
-  const publishToEventStore = jest.fn((event: DomainEvent) =>
-    okAsync<null, InfraNotAvailableError>(null),
-  );
+  describe(`Ajouter le délai relatif au CDC 2022`, () => {
+    it(`
+    Etant donné un projet sur le CDC initial
+    Et dont la période prévoit un délai de 18 mois supplémentaire pour le CDC du 30/08/2022
+    Et n'ayant pas bénéficié du délai relatif au CDC du 30/08/2022
+    Et ayant ses dates de mise en service dans l'intervalle accepté pour l'application du délai
+    Lorsque le porteur choisit le CDC du 30/08/2022
+    Alors la date d'achèvement du projet devrait être modifiée
+    `, async () => {
+      const projetId = new UniqueEntityID();
+      const appelOffreId = 'Eolien';
+      const periodeId = '1';
+      const numeroCRE = '123';
+      const familleId = '';
+      const CDCDélaiApplicable = 18;
+      const dateAchèvementInitiale = new Date('2025-01-01');
+      const nouvelleDateAchèvementAttendue = new Date(
+        new Date(dateAchèvementInitiale).setMonth(
+          new Date(dateAchèvementInitiale).getMonth() + CDCDélaiApplicable,
+        ),
+      );
 
-  it(`
+      const fakeProject = {
+        ...makeFakeProjectAggregate(),
+        cahierDesCharges: { type: 'initial' },
+        completionDueOn: dateAchèvementInitiale.getTime(),
+        délaiCDC2022appliqué: false,
+        numeroCRE,
+        appelOffreId,
+        periodeId,
+        id: projetId,
+        familleId,
+      };
+
+      const projectRepo = fakeTransactionalRepo(fakeProject as Project);
+
+      const getProjectAppelOffre = jest.fn(
+        () =>
+          ({
+            typeAppelOffre: 'eolien',
+            periode: {
+              cahiersDesChargesModifiésDisponibles: [
+                {
+                  type: 'modifié',
+                  paruLe: '30/08/2022',
+                  délaiApplicable: {
+                    délaiEnMois: CDCDélaiApplicable,
+                    intervaleDateMiseEnService: {
+                      min: new Date('2022-06-01'),
+                      max: new Date('2024-09-30'),
+                    },
+                  },
+                } as CahierDesChargesModifié,
+              ] as ReadonlyArray<CahierDesChargesModifié>,
+            },
+          } as ProjectAppelOffre),
+      );
+
+      const onCahierDesChargesChoisi = makeOnCahierDesChargesChoisi({
+        publishToEventStore,
+        getProjectAppelOffre,
+        projectRepo,
+        récupérerDétailDossiersRaccordements,
+      });
+
+      await onCahierDesChargesChoisi(
+        new CahierDesChargesChoisi({
+          payload: {
+            choisiPar: 'id',
+            type: 'modifié',
+            paruLe: '30/08/2022',
+            projetId: projetId.toString(),
+          },
+        }),
+      );
+
+      expect(publishToEventStore).toHaveBeenCalledTimes(1);
+      const évènement = publishToEventStore.mock.calls[0][0];
+      expect(évènement.type).toEqual('ProjectCompletionDueDateSet');
+      expect(évènement.payload).toEqual(
+        expect.objectContaining({
+          projectId: fakeProject.id.toString(),
+          completionDueOn: nouvelleDateAchèvementAttendue.getTime(),
+          reason: 'délaiCdc2022',
+        }),
+      );
+    });
+  });
+
+  describe(`Pas d'effet`, () => {
+    it(`
     Etant donné un projet sur le CDC du 30/08/2022
     Et n'ayant pas bénéficié du délai relatif au CDC du 30/08/2022
     Lorsque le porteur change de cahier des charges
     Alors la date d'achèvement du projet ne devrait pas être modifiée
     `, async () => {
-    const projetId = new UniqueEntityID();
-    const appelOffreId = 'Eolien';
-    const periodeId = '1';
-    const numeroCRE = '123';
-    const familleId = '';
-    const CDCDélaiApplicable = 18;
-    const dateAchèvementInitiale = new Date('2025-01-01');
+      const projetId = new UniqueEntityID();
+      const appelOffreId = 'Eolien';
+      const periodeId = '1';
+      const numeroCRE = '123';
+      const familleId = '';
+      const CDCDélaiApplicable = 18;
+      const dateAchèvementInitiale = new Date('2025-01-01');
 
-    const fakeProject = {
-      ...makeFakeProjectAggregate(),
-      cahierDesCharges: { type: 'modifié', paruLe: '30/08/2022' },
-      completionDueOn: dateAchèvementInitiale.getTime(),
-      délaiCDC2022appliqué: false,
-      numeroCRE,
-      appelOffreId,
-      periodeId,
-      id: projetId,
-      familleId,
-    };
+      const fakeProject = {
+        ...makeFakeProjectAggregate(),
+        cahierDesCharges: { type: 'modifié', paruLe: '30/08/2022' },
+        completionDueOn: dateAchèvementInitiale.getTime(),
+        délaiCDC2022appliqué: false,
+        numeroCRE,
+        appelOffreId,
+        periodeId,
+        id: projetId,
+        familleId,
+      };
 
-    const projectRepo = fakeTransactionalRepo(fakeProject as Project);
+      const projectRepo = fakeTransactionalRepo(fakeProject as Project);
 
-    const getProjectAppelOffre = jest.fn(
-      () =>
-        ({
-          typeAppelOffre: 'eolien',
-          periode: {
-            cahiersDesChargesModifiésDisponibles: [
-              {
-                type: 'modifié',
-                paruLe: '30/08/2022',
-                délaiApplicable: {
-                  délaiEnMois: CDCDélaiApplicable,
-                  intervaleDateMiseEnService: {
-                    min: new Date('2022-06-01'),
-                    max: new Date('2024-09-30'),
+      const getProjectAppelOffre = jest.fn(
+        () =>
+          ({
+            typeAppelOffre: 'eolien',
+            periode: {
+              cahiersDesChargesModifiésDisponibles: [
+                {
+                  type: 'modifié',
+                  paruLe: '30/08/2022',
+                  délaiApplicable: {
+                    délaiEnMois: CDCDélaiApplicable,
+                    intervaleDateMiseEnService: {
+                      min: new Date('2022-06-01'),
+                      max: new Date('2024-09-30'),
+                    },
                   },
-                },
-              } as CahierDesChargesModifié,
-            ] as ReadonlyArray<CahierDesChargesModifié>,
-          },
-        } as ProjectAppelOffre),
-    );
+                } as CahierDesChargesModifié,
+              ] as ReadonlyArray<CahierDesChargesModifié>,
+            },
+          } as ProjectAppelOffre),
+      );
 
-    const onCahierDesChargesChoisi = makeOnCahierDesChargesChoisi({
-      publishToEventStore,
-      getProjectAppelOffre,
-      projectRepo,
+      const onCahierDesChargesChoisi = makeOnCahierDesChargesChoisi({
+        publishToEventStore,
+        getProjectAppelOffre,
+        projectRepo,
+        récupérerDétailDossiersRaccordements,
+      });
+
+      await onCahierDesChargesChoisi(
+        new CahierDesChargesChoisi({
+          payload: { choisiPar: 'id', type: 'initial', projetId: projetId.toString() },
+        }),
+      );
+
+      expect(publishToEventStore).not.toHaveBeenCalled();
     });
 
-    await onCahierDesChargesChoisi(
-      new CahierDesChargesChoisi({
-        payload: { choisiPar: 'id', type: 'initial', projetId: projetId.toString() },
-      }),
-    );
-
-    expect(publishToEventStore).not.toHaveBeenCalled();
-  });
-
-  it(`
+    // La période ne prévoit pas un délai supplémentaire
+    it(`
     Etant donné un projet sur le CDC initial
+    Et dont la période ne prévoit pas de délai de 18 mois supplémentaire pour le CDC du 30/08/2022
     Et n'ayant pas bénéficié du délai relatif au CDC du 30/08/2022
+    Et ayant ses dates de mise en service dans l'intervalle accepté pour l'application du délai
     Lorsque le porteur choisit le CDC du 30/08/2022
     Alors la date d'achèvement du projet ne devrait pas être modifiée
     `, async () => {
-    const projetId = new UniqueEntityID();
-    const appelOffreId = 'Eolien';
-    const periodeId = '1';
-    const numeroCRE = '123';
-    const familleId = '';
-    const CDCDélaiApplicable = 18;
-    const dateAchèvementInitiale = new Date('2025-01-01');
+      const projetId = new UniqueEntityID();
+      const appelOffreId = 'Eolien';
+      const periodeId = '1';
+      const numeroCRE = '123';
+      const familleId = '';
+      const dateAchèvementInitiale = new Date('2025-01-01');
 
-    const fakeProject = {
-      ...makeFakeProjectAggregate(),
-      cahierDesCharges: { type: 'initial' },
-      completionDueOn: dateAchèvementInitiale.getTime(),
-      délaiCDC2022appliqué: false,
-      numeroCRE,
-      appelOffreId,
-      periodeId,
-      id: projetId,
-      familleId,
-    };
+      const fakeProject = {
+        ...makeFakeProjectAggregate(),
+        cahierDesCharges: { type: 'initial' },
+        completionDueOn: dateAchèvementInitiale.getTime(),
+        délaiCDC2022appliqué: false,
+        numeroCRE,
+        appelOffreId,
+        periodeId,
+        id: projetId,
+        familleId,
+      };
 
-    const projectRepo = fakeTransactionalRepo(fakeProject as Project);
+      const projectRepo = fakeTransactionalRepo(fakeProject as Project);
 
-    const getProjectAppelOffre = jest.fn(
-      () =>
-        ({
-          typeAppelOffre: 'eolien',
-          periode: {
-            cahiersDesChargesModifiésDisponibles: [
-              {
-                type: 'modifié',
-                paruLe: '30/08/2022',
-                délaiApplicable: {
-                  délaiEnMois: CDCDélaiApplicable,
-                  intervaleDateMiseEnService: {
-                    min: new Date('2022-06-01'),
-                    max: new Date('2024-09-30'),
-                  },
-                },
-              } as CahierDesChargesModifié,
-            ] as ReadonlyArray<CahierDesChargesModifié>,
+      const getProjectAppelOffre = jest.fn(
+        () =>
+          ({
+            typeAppelOffre: 'eolien',
+            periode: {
+              cahiersDesChargesModifiésDisponibles: [
+                {
+                  type: 'modifié',
+                  paruLe: '30/08/2022',
+                } as CahierDesChargesModifié,
+              ] as ReadonlyArray<CahierDesChargesModifié>,
+            },
+          } as ProjectAppelOffre),
+      );
+
+      const onCahierDesChargesChoisi = makeOnCahierDesChargesChoisi({
+        publishToEventStore,
+        getProjectAppelOffre,
+        projectRepo,
+        récupérerDétailDossiersRaccordements,
+      });
+
+      await onCahierDesChargesChoisi(
+        new CahierDesChargesChoisi({
+          payload: {
+            choisiPar: 'id',
+            type: 'modifié',
+            paruLe: '30/08/2022',
+            projetId: projetId.toString(),
           },
-        } as ProjectAppelOffre),
-    );
+        }),
+      );
 
-    const onCahierDesChargesChoisi = makeOnCahierDesChargesChoisi({
-      publishToEventStore,
-      getProjectAppelOffre,
-      projectRepo,
+      expect(publishToEventStore).not.toHaveBeenCalled();
     });
 
-    await onCahierDesChargesChoisi(
-      new CahierDesChargesChoisi({
-        payload: {
-          choisiPar: 'id',
-          type: 'modifié',
-          paruLe: '30/08/2022',
-          projetId: projetId.toString(),
-        },
-      }),
-    );
+    // le projet a déjà bénéficié du délai
+    it(`
+    Etant donné un projet sur le CDC initial
+    Et dont la période prévoit un délai de 18 mois supplémentaire pour le CDC du 30/08/2022
+    Et ayant déjà bénéficié du délai relatif au CDC du 30/08/2022
+    Et ayant ses dates de mise en service dans l'intervalle accepté pour l'application du délai
+    Lorsque le porteur choisit le CDC du 30/08/2022
+    Alors la date d'achèvement du projet ne devrait pas être modifiée
+    `, async () => {
+      const projetId = new UniqueEntityID();
+      const appelOffreId = 'Eolien';
+      const periodeId = '1';
+      const numeroCRE = '123';
+      const familleId = '';
+      const CDCDélaiApplicable = 18;
+      const dateAchèvementInitiale = new Date('2025-01-01');
 
-    expect(publishToEventStore).not.toHaveBeenCalled();
+      const fakeProject = {
+        ...makeFakeProjectAggregate(),
+        cahierDesCharges: { type: 'initial' },
+        completionDueOn: dateAchèvementInitiale.getTime(),
+        délaiCDC2022appliqué: true,
+        numeroCRE,
+        appelOffreId,
+        periodeId,
+        id: projetId,
+        familleId,
+      };
+
+      const projectRepo = fakeTransactionalRepo(fakeProject as Project);
+
+      const getProjectAppelOffre = jest.fn(
+        () =>
+          ({
+            typeAppelOffre: 'eolien',
+            periode: {
+              cahiersDesChargesModifiésDisponibles: [
+                {
+                  type: 'modifié',
+                  paruLe: '30/08/2022',
+                  délaiApplicable: {
+                    délaiEnMois: CDCDélaiApplicable,
+                    intervaleDateMiseEnService: {
+                      min: new Date('2022-06-01'),
+                      max: new Date('2024-09-30'),
+                    },
+                  },
+                } as CahierDesChargesModifié,
+              ] as ReadonlyArray<CahierDesChargesModifié>,
+            },
+          } as ProjectAppelOffre),
+      );
+
+      const onCahierDesChargesChoisi = makeOnCahierDesChargesChoisi({
+        publishToEventStore,
+        getProjectAppelOffre,
+        projectRepo,
+        récupérerDétailDossiersRaccordements,
+      });
+
+      await onCahierDesChargesChoisi(
+        new CahierDesChargesChoisi({
+          payload: {
+            choisiPar: 'id',
+            type: 'modifié',
+            paruLe: '30/08/2022',
+            projetId: projetId.toString(),
+          },
+        }),
+      );
+
+      expect(publishToEventStore).not.toHaveBeenCalled();
+    });
+
+    // Le projet n'a pas toutes ses dates de mises en service renseignées
+    it(`
+    Etant donné un projet sur le CDC initial
+    Et dont la période prévoit un délai de 18 mois supplémentaire pour le CDC du 30/08/2022
+    Et n'ayant pas bénéficié du délai relatif au CDC du 30/08/2022
+    Et n'ayant pas toutes ses dates de mise en service renseignées
+    Lorsque le porteur choisit le CDC du 30/08/2022
+    Alors la date d'achèvement du projet ne devrait pas être modifiée
+    `, async () => {
+      const projetId = new UniqueEntityID();
+      const appelOffreId = 'Eolien';
+      const periodeId = '1';
+      const numeroCRE = '123';
+      const familleId = '';
+      const CDCDélaiApplicable = 18;
+      const dateAchèvementInitiale = new Date('2025-01-01');
+
+      const fakeProject = {
+        ...makeFakeProjectAggregate(),
+        cahierDesCharges: { type: 'initial' },
+        completionDueOn: dateAchèvementInitiale.getTime(),
+        délaiCDC2022appliqué: false,
+        numeroCRE,
+        appelOffreId,
+        periodeId,
+        id: projetId,
+        familleId,
+      };
+
+      const projectRepo = fakeTransactionalRepo(fakeProject as Project);
+
+      const getProjectAppelOffre = jest.fn(
+        () =>
+          ({
+            typeAppelOffre: 'eolien',
+            periode: {
+              cahiersDesChargesModifiésDisponibles: [
+                {
+                  type: 'modifié',
+                  paruLe: '30/08/2022',
+                  délaiApplicable: {
+                    délaiEnMois: CDCDélaiApplicable,
+                    intervaleDateMiseEnService: {
+                      min: new Date('2022-06-01'),
+                      max: new Date('2024-09-30'),
+                    },
+                  },
+                } as CahierDesChargesModifié,
+              ] as ReadonlyArray<CahierDesChargesModifié>,
+            },
+          } as ProjectAppelOffre),
+      );
+
+      const récupérerDétailDossiersRaccordements = jest.fn(async () => [
+        {
+          référence: 'ref-du-dossier',
+          demandeComplèteRaccordement: {
+            dateQualification: new Date('2022-01-01').toISOString(),
+            miseEnService: { dateMiseEnService: new Date('2023-01-01').toISOString() },
+          },
+        },
+        {
+          référence: 'ref-autre-dossier',
+          demandeComplèteRaccordement: {
+            dateQualification: new Date('2022-01-01').toISOString(),
+          },
+        },
+      ]);
+
+      const onCahierDesChargesChoisi = makeOnCahierDesChargesChoisi({
+        publishToEventStore,
+        getProjectAppelOffre,
+        projectRepo,
+        récupérerDétailDossiersRaccordements,
+      });
+
+      await onCahierDesChargesChoisi(
+        new CahierDesChargesChoisi({
+          payload: {
+            choisiPar: 'id',
+            type: 'modifié',
+            paruLe: '30/08/2022',
+            projetId: projetId.toString(),
+          },
+        }),
+      );
+
+      expect(publishToEventStore).not.toHaveBeenCalled();
+    });
+
+    // le projet n'a pas toutes ses dates de mise en service dans l'intervalle pour le délai
+    it(`
+    Etant donné un projet sur le CDC initial
+    Et dont la période prévoit un délai de 18 mois supplémentaire pour le CDC du 30/08/2022
+    Et n'ayant pas bénéficié du délai relatif au CDC du 30/08/2022
+    Et n'ayant pas toutes ses dates de mise en service dans l'intervalle accepté pour l'application du délai
+    Lorsque le porteur choisit le CDC du 30/08/2022
+    Alors la date d'achèvement du projet ne devrait pas être modifiée
+    `, async () => {
+      const projetId = new UniqueEntityID();
+      const appelOffreId = 'Eolien';
+      const periodeId = '1';
+      const numeroCRE = '123';
+      const familleId = '';
+      const CDCDélaiApplicable = 18;
+      const dateAchèvementInitiale = new Date('2025-01-01');
+
+      const fakeProject = {
+        ...makeFakeProjectAggregate(),
+        cahierDesCharges: { type: 'initial' },
+        completionDueOn: dateAchèvementInitiale.getTime(),
+        délaiCDC2022appliqué: false,
+        numeroCRE,
+        appelOffreId,
+        periodeId,
+        id: projetId,
+        familleId,
+      };
+
+      const projectRepo = fakeTransactionalRepo(fakeProject as Project);
+
+      const getProjectAppelOffre = jest.fn(
+        () =>
+          ({
+            typeAppelOffre: 'eolien',
+            periode: {
+              cahiersDesChargesModifiésDisponibles: [
+                {
+                  type: 'modifié',
+                  paruLe: '30/08/2022',
+                  délaiApplicable: {
+                    délaiEnMois: CDCDélaiApplicable,
+                    intervaleDateMiseEnService: {
+                      min: new Date('2022-06-01'),
+                      max: new Date('2024-09-30'),
+                    },
+                  },
+                } as CahierDesChargesModifié,
+              ] as ReadonlyArray<CahierDesChargesModifié>,
+            },
+          } as ProjectAppelOffre),
+      );
+
+      const dateMiseEnServiceHorsIntervalle = new Date('2022-01-01');
+
+      const récupérerDétailDossiersRaccordements = jest.fn(async () => [
+        {
+          référence: 'ref-du-dossier',
+          demandeComplèteRaccordement: {
+            dateQualification: new Date('2022-01-01').toISOString(),
+            miseEnService: { dateMiseEnService: dateMiseEnServiceHorsIntervalle.toISOString() },
+          },
+        },
+        {
+          référence: 'ref-autre-dossier',
+          demandeComplèteRaccordement: {
+            dateQualification: new Date('2022-01-01').toISOString(),
+            miseEnService: { dateMiseEnService: dateMiseEnServiceHorsIntervalle.toISOString() },
+          },
+        },
+      ]);
+
+      const onCahierDesChargesChoisi = makeOnCahierDesChargesChoisi({
+        publishToEventStore,
+        getProjectAppelOffre,
+        projectRepo,
+        récupérerDétailDossiersRaccordements,
+      });
+
+      await onCahierDesChargesChoisi(
+        new CahierDesChargesChoisi({
+          payload: {
+            choisiPar: 'id',
+            type: 'modifié',
+            paruLe: '30/08/2022',
+            projetId: projetId.toString(),
+          },
+        }),
+      );
+
+      expect(publishToEventStore).not.toHaveBeenCalled();
+    });
+
+    // le porteur choisit un CDC autre que le CDC du 30/08/2022
+    it(`
+    Etant donné un projet sur le CDC initial
+    Et dont la période prévoit un délai de 18 mois supplémentaire pour le CDC du 30/08/2022
+    Et n'ayant pas bénéficié du délai relatif au CDC du 30/08/2022
+    Et ayant ses dates de mise en service dans l'intervalle accepté pour l'application du délai
+    Lorsque le porteur choisit le CDC 2021
+    Alors la date d'achèvement du projet ne devrait pas être modifiée
+    `, async () => {
+      const projetId = new UniqueEntityID();
+      const appelOffreId = 'Eolien';
+      const periodeId = '1';
+      const numeroCRE = '123';
+      const familleId = '';
+      const CDCDélaiApplicable = 18;
+      const dateAchèvementInitiale = new Date('2025-01-01');
+
+      const fakeProject = {
+        ...makeFakeProjectAggregate(),
+        cahierDesCharges: { type: 'initial' },
+        completionDueOn: dateAchèvementInitiale.getTime(),
+        délaiCDC2022appliqué: false,
+        numeroCRE,
+        appelOffreId,
+        periodeId,
+        id: projetId,
+        familleId,
+      };
+
+      const projectRepo = fakeTransactionalRepo(fakeProject as Project);
+
+      const getProjectAppelOffre = jest.fn(
+        () =>
+          ({
+            typeAppelOffre: 'eolien',
+            periode: {
+              cahiersDesChargesModifiésDisponibles: [
+                {
+                  type: 'modifié',
+                  paruLe: '30/08/2022',
+                  délaiApplicable: {
+                    délaiEnMois: CDCDélaiApplicable,
+                    intervaleDateMiseEnService: {
+                      min: new Date('2022-06-01'),
+                      max: new Date('2024-09-30'),
+                    },
+                  },
+                } as CahierDesChargesModifié,
+              ] as ReadonlyArray<CahierDesChargesModifié>,
+            },
+          } as ProjectAppelOffre),
+      );
+
+      const onCahierDesChargesChoisi = makeOnCahierDesChargesChoisi({
+        publishToEventStore,
+        getProjectAppelOffre,
+        projectRepo,
+        récupérerDétailDossiersRaccordements,
+      });
+
+      await onCahierDesChargesChoisi(
+        new CahierDesChargesChoisi({
+          payload: {
+            choisiPar: 'id',
+            type: 'modifié',
+            paruLe: '30/07/2021',
+            projetId: projetId.toString(),
+          },
+        }),
+      );
+
+      expect(publishToEventStore).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/modules/project/eventHandlers/onCahierDesChargesChoisi.spec.ts
+++ b/src/modules/project/eventHandlers/onCahierDesChargesChoisi.spec.ts
@@ -91,7 +91,7 @@ describe(`Retirer le délai relatif au CDC 2022`, () => {
       expect.objectContaining({
         projectId: fakeProject.id.toString(),
         completionDueOn: nouvelleDateAchèvementAttendue.getTime(),
-        reason: 'délaiCdc2022Annulé',
+        reason: 'ChoixCDCAnnuleDélaiCdc2022',
       }),
     );
   });

--- a/src/modules/project/eventHandlers/onCahierDesChargesChoisi.spec.ts
+++ b/src/modules/project/eventHandlers/onCahierDesChargesChoisi.spec.ts
@@ -1,0 +1,239 @@
+import { jest, describe, it, expect } from '@jest/globals';
+import { CahierDesChargesChoisi } from '../events';
+import { DomainEvent, UniqueEntityID } from '../../../core/domain';
+import { InfraNotAvailableError } from '../../shared/errors';
+import { okAsync } from '../../../core/utils';
+import { CahierDesChargesModifié } from '@potentiel/domain-views';
+import { ProjectAppelOffre } from '../../../entities';
+import {
+  fakeTransactionalRepo,
+  makeFakeProject as makeFakeProjectAggregate,
+} from '../../../__tests__/fixtures/aggregates';
+import { makeOnCahierDesChargesChoisi } from './onCahierDesChargesChoisi';
+import { Project } from '../Project';
+
+describe(`Retirer le délai relatif au CDC 2022`, () => {
+  const publishToEventStore = jest.fn((event: DomainEvent) =>
+    okAsync<null, InfraNotAvailableError>(null),
+  );
+
+  it(`
+    Etant donné un projet sur le CDC du 30/08/2022
+    Et ayant bénéficié du délai relatif au CDC du 30/08/2022
+    Lorsque le porteur change de cahier des charges
+    Alors le délai relatif au CDC du 30/08/2022 devrait être annulé
+    `, async () => {
+    const projetId = new UniqueEntityID();
+    const appelOffreId = 'Eolien';
+    const periodeId = '1';
+    const numeroCRE = '123';
+    const familleId = '';
+    const CDCDélaiApplicable = 18;
+    const dateAchèvementInitiale = new Date('2025-01-01');
+    const nouvelleDateAchèvementAttendue = new Date(
+      new Date(dateAchèvementInitiale).setMonth(
+        new Date(dateAchèvementInitiale).getMonth() - CDCDélaiApplicable,
+      ),
+    );
+
+    const fakeProject = {
+      ...makeFakeProjectAggregate(),
+      cahierDesCharges: { type: 'modifié', paruLe: '30/08/2022' },
+      completionDueOn: dateAchèvementInitiale.getTime(),
+      délaiCDC2022appliqué: true,
+      numeroCRE,
+      appelOffreId,
+      periodeId,
+      id: projetId,
+      familleId,
+    };
+
+    const projectRepo = fakeTransactionalRepo(fakeProject as Project);
+
+    const getProjectAppelOffre = jest.fn(
+      () =>
+        ({
+          typeAppelOffre: 'eolien',
+          periode: {
+            cahiersDesChargesModifiésDisponibles: [
+              {
+                type: 'modifié',
+                paruLe: '30/08/2022',
+                délaiApplicable: {
+                  délaiEnMois: CDCDélaiApplicable,
+                  intervaleDateMiseEnService: {
+                    min: new Date('2022-06-01'),
+                    max: new Date('2024-09-30'),
+                  },
+                },
+              } as CahierDesChargesModifié,
+            ] as ReadonlyArray<CahierDesChargesModifié>,
+          },
+        } as ProjectAppelOffre),
+    );
+
+    const onCahierDesChargesChoisi = makeOnCahierDesChargesChoisi({
+      publishToEventStore,
+      getProjectAppelOffre,
+      projectRepo,
+    });
+
+    await onCahierDesChargesChoisi(
+      new CahierDesChargesChoisi({
+        payload: { choisiPar: 'id', type: 'initial', projetId: projetId.toString() },
+      }),
+    );
+
+    expect(publishToEventStore).toHaveBeenCalledTimes(1);
+    const évènement = publishToEventStore.mock.calls[0][0];
+    expect(évènement.type).toEqual('ProjectCompletionDueDateSet');
+    expect(évènement.payload).toEqual(
+      expect.objectContaining({
+        projectId: fakeProject.id.toString(),
+        completionDueOn: nouvelleDateAchèvementAttendue.getTime(),
+        reason: 'délaiCdc2022Annulé',
+      }),
+    );
+  });
+});
+
+describe(`Pas d'effet`, () => {
+  const publishToEventStore = jest.fn((event: DomainEvent) =>
+    okAsync<null, InfraNotAvailableError>(null),
+  );
+
+  it(`
+    Etant donné un projet sur le CDC du 30/08/2022
+    Et n'ayant pas bénéficié du délai relatif au CDC du 30/08/2022
+    Lorsque le porteur change de cahier des charges
+    Alors la date d'achèvement du projet ne devrait pas être modifiée
+    `, async () => {
+    const projetId = new UniqueEntityID();
+    const appelOffreId = 'Eolien';
+    const periodeId = '1';
+    const numeroCRE = '123';
+    const familleId = '';
+    const CDCDélaiApplicable = 18;
+    const dateAchèvementInitiale = new Date('2025-01-01');
+
+    const fakeProject = {
+      ...makeFakeProjectAggregate(),
+      cahierDesCharges: { type: 'modifié', paruLe: '30/08/2022' },
+      completionDueOn: dateAchèvementInitiale.getTime(),
+      délaiCDC2022appliqué: false,
+      numeroCRE,
+      appelOffreId,
+      periodeId,
+      id: projetId,
+      familleId,
+    };
+
+    const projectRepo = fakeTransactionalRepo(fakeProject as Project);
+
+    const getProjectAppelOffre = jest.fn(
+      () =>
+        ({
+          typeAppelOffre: 'eolien',
+          periode: {
+            cahiersDesChargesModifiésDisponibles: [
+              {
+                type: 'modifié',
+                paruLe: '30/08/2022',
+                délaiApplicable: {
+                  délaiEnMois: CDCDélaiApplicable,
+                  intervaleDateMiseEnService: {
+                    min: new Date('2022-06-01'),
+                    max: new Date('2024-09-30'),
+                  },
+                },
+              } as CahierDesChargesModifié,
+            ] as ReadonlyArray<CahierDesChargesModifié>,
+          },
+        } as ProjectAppelOffre),
+    );
+
+    const onCahierDesChargesChoisi = makeOnCahierDesChargesChoisi({
+      publishToEventStore,
+      getProjectAppelOffre,
+      projectRepo,
+    });
+
+    await onCahierDesChargesChoisi(
+      new CahierDesChargesChoisi({
+        payload: { choisiPar: 'id', type: 'initial', projetId: projetId.toString() },
+      }),
+    );
+
+    expect(publishToEventStore).not.toHaveBeenCalled();
+  });
+
+  it(`
+    Etant donné un projet sur le CDC initial
+    Et n'ayant pas bénéficié du délai relatif au CDC du 30/08/2022
+    Lorsque le porteur choisit le CDC du 20/08/2022
+    Alors la date d'achèvement du projet ne devrait pas être modifiée
+    `, async () => {
+    const projetId = new UniqueEntityID();
+    const appelOffreId = 'Eolien';
+    const periodeId = '1';
+    const numeroCRE = '123';
+    const familleId = '';
+    const CDCDélaiApplicable = 18;
+    const dateAchèvementInitiale = new Date('2025-01-01');
+
+    const fakeProject = {
+      ...makeFakeProjectAggregate(),
+      cahierDesCharges: { type: 'initial' },
+      completionDueOn: dateAchèvementInitiale.getTime(),
+      délaiCDC2022appliqué: false,
+      numeroCRE,
+      appelOffreId,
+      periodeId,
+      id: projetId,
+      familleId,
+    };
+
+    const projectRepo = fakeTransactionalRepo(fakeProject as Project);
+
+    const getProjectAppelOffre = jest.fn(
+      () =>
+        ({
+          typeAppelOffre: 'eolien',
+          periode: {
+            cahiersDesChargesModifiésDisponibles: [
+              {
+                type: 'modifié',
+                paruLe: '30/08/2022',
+                délaiApplicable: {
+                  délaiEnMois: CDCDélaiApplicable,
+                  intervaleDateMiseEnService: {
+                    min: new Date('2022-06-01'),
+                    max: new Date('2024-09-30'),
+                  },
+                },
+              } as CahierDesChargesModifié,
+            ] as ReadonlyArray<CahierDesChargesModifié>,
+          },
+        } as ProjectAppelOffre),
+    );
+
+    const onCahierDesChargesChoisi = makeOnCahierDesChargesChoisi({
+      publishToEventStore,
+      getProjectAppelOffre,
+      projectRepo,
+    });
+
+    await onCahierDesChargesChoisi(
+      new CahierDesChargesChoisi({
+        payload: {
+          choisiPar: 'id',
+          type: 'modifié',
+          paruLe: '30/08/2022',
+          projetId: projetId.toString(),
+        },
+      }),
+    );
+
+    expect(publishToEventStore).not.toHaveBeenCalled();
+  });
+});

--- a/src/modules/project/eventHandlers/onCahierDesChargesChoisi.ts
+++ b/src/modules/project/eventHandlers/onCahierDesChargesChoisi.ts
@@ -1,0 +1,69 @@
+import { EventStore, TransactionalRepository, UniqueEntityID } from '../../../core/domain';
+import { logger, okAsync } from '../../../core/utils';
+import { GetProjectAppelOffre } from '../../projectAppelOffre';
+import { CahierDesChargesChoisi, ProjectCompletionDueDateSet } from '../events';
+import { Project } from '../Project';
+
+type Dépendances = {
+  projectRepo: TransactionalRepository<Project>;
+  publishToEventStore: EventStore['publish'];
+  getProjectAppelOffre: GetProjectAppelOffre;
+};
+
+export const makeOnCahierDesChargesChoisi =
+  ({ projectRepo, publishToEventStore, getProjectAppelOffre }: Dépendances) =>
+  ({ payload }: CahierDesChargesChoisi) => {
+    const { projetId, type } = payload;
+    if (type === 'modifié' && payload.paruLe === '30/08/2022') {
+      return okAsync(null);
+    }
+
+    return projectRepo.transaction(
+      new UniqueEntityID(projetId),
+      ({
+        appelOffreId,
+        periodeId,
+        familleId,
+        cahierDesCharges,
+        délaiCDC2022appliqué,
+        completionDueOn,
+      }) => {
+        if (!délaiCDC2022appliqué) {
+          return okAsync(null);
+        }
+
+        const délaiCDC2022Applicable = getProjectAppelOffre({
+          appelOffreId,
+          periodeId,
+          familleId,
+        })?.periode.cahiersDesChargesModifiésDisponibles.find((CDC) =>
+          'alternatif' in cahierDesCharges
+            ? CDC.type === 'modifié' &&
+              CDC.paruLe === '30/08/2022' &&
+              CDC.alternatif === cahierDesCharges.alternatif
+            : CDC.type === 'modifié' && CDC.paruLe === '30/08/2022',
+        )?.délaiApplicable?.délaiEnMois;
+
+        if (!délaiCDC2022Applicable) {
+          logger.error(
+            `project eventHandler onCahierDesChargesChoisi : pas de délai CDC 2022 applicable trouvé alors que le projet a bénéficié du délai. Projet ${projetId}`,
+          );
+          return okAsync(null);
+        }
+
+        return publishToEventStore(
+          new ProjectCompletionDueDateSet({
+            payload: {
+              projectId: projetId,
+              completionDueOn: new Date(
+                new Date(completionDueOn).setMonth(
+                  new Date(completionDueOn).getMonth() - délaiCDC2022Applicable,
+                ),
+              ).getTime(),
+              reason: 'délaiCdc2022Annulé',
+            },
+          }),
+        );
+      },
+    );
+  };

--- a/src/modules/project/eventHandlers/onCahierDesChargesChoisi.ts
+++ b/src/modules/project/eventHandlers/onCahierDesChargesChoisi.ts
@@ -60,7 +60,7 @@ export const makeOnCahierDesChargesChoisi =
                   new Date(completionDueOn).getMonth() - délaiCDC2022Applicable,
                 ),
               ).getTime(),
-              reason: 'délaiCdc2022Annulé',
+              reason: 'ChoixCDCAnnuleDélaiCdc2022',
             },
           }),
         );

--- a/src/modules/project/eventHandlers/onDateMiseEnServiceTransmise.spec.ts
+++ b/src/modules/project/eventHandlers/onDateMiseEnServiceTransmise.spec.ts
@@ -569,7 +569,7 @@ describe(`Handler onDateMiseEnServiceTransmise`, () => {
           expect.objectContaining({
             projectId: fakeProject.id.toString(),
             completionDueOn: nouvelleDateAchèvementAttendue.getTime(),
-            reason: 'délaiCdc2022Annulé',
+            reason: 'DateMiseEnServiceAnnuleDélaiCdc2022',
           }),
         );
       });

--- a/src/modules/project/eventHandlers/onDateMiseEnServiceTransmise.ts
+++ b/src/modules/project/eventHandlers/onDateMiseEnServiceTransmise.ts
@@ -107,7 +107,7 @@ export const makeOnDateMiseEnServiceTransmise =
                             new Date(completionDueOn).getMonth() - délaiCDCApplicable.délaiEnMois,
                           ),
                         ).getTime(),
-                        reason: 'délaiCdc2022Annulé',
+                        reason: 'DateMiseEnServiceAnnuleDélaiCdc2022',
                       },
                     }),
                   )

--- a/src/modules/project/events/ProjectCompletionDueDateSet.ts
+++ b/src/modules/project/events/ProjectCompletionDueDateSet.ts
@@ -4,7 +4,7 @@ export interface ProjectCompletionDueDateSetPayload {
   projectId: string;
   completionDueOn: number;
   setBy?: string;
-  reason?: 'délaiCdc2022' | 'délaiCdc2022Annulé';
+  reason?: 'délaiCdc2022' | 'ChoixCDCAnnuleDélaiCdc2022' | 'DateMiseEnServiceAnnuleDélaiCdc2022';
 }
 export class ProjectCompletionDueDateSet
   extends BaseDomainEvent<ProjectCompletionDueDateSetPayload>

--- a/src/modules/project/queries/GetProjectDataForChoisirCDCPage.ts
+++ b/src/modules/project/queries/GetProjectDataForChoisirCDCPage.ts
@@ -8,6 +8,7 @@ export type ProjectDataForChoisirCDCPage = {
   appelOffre: ProjectAppelOffre;
   cahierDesChargesActuel: CahierDesChargesRéférence;
   identifiantGestionnaireRéseau?: string;
+  délaiCDC2022Appliqué?: true;
 };
 
 export type GetProjectDataForChoisirCDCPage = (

--- a/src/views/components/UI/organisms/choisirCahierDesCharges/ChoisirCahierDesChargesFormulaire.tsx
+++ b/src/views/components/UI/organisms/choisirCahierDesCharges/ChoisirCahierDesChargesFormulaire.tsx
@@ -95,9 +95,9 @@ export const ChoisirCahierDesChargesFormulaire: React.FC<
         !['30/08/2022', '30/08/2022-alternatif'].includes(cdcChoisi) && (
           <AlertBox>
             Le cahier des charges que vous séléctionnez ne permet plus au projet de bénéficier du
-            délai relatif au cahier des charges du 30/08/2022.{' '}
+            délai relatif au cahier des charges modificatif du 30/08/2022.{' '}
             <span className="font-bold">
-              Si vous validez de changement cahier des charges, la date limite d'achèvement du
+              Si vous validez ce changement de cahier des charges, la date limite d'achèvement du
               projet sera impactée.
             </span>
           </AlertBox>

--- a/src/views/components/UI/organisms/choisirCahierDesCharges/ChoisirCahierDesChargesFormulaire.tsx
+++ b/src/views/components/UI/organisms/choisirCahierDesCharges/ChoisirCahierDesChargesFormulaire.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Form, PrimaryButton, SecondaryLinkButton } from '../../..';
+import { AlertBox, Form, PrimaryButton, SecondaryLinkButton } from '../../..';
 import { ProjectDataForChoisirCDCPage } from '../../../../../modules/project';
 import routes from '../../../../../routes';
 import { formatCahierDesChargesRéférence } from '../../../../../entities/cahierDesCharges';
@@ -89,6 +89,19 @@ export const ChoisirCahierDesChargesFormulaire: React.FC<
           );
         })}
       </ul>
+
+      {projet.délaiCDC2022Appliqué &&
+        ['30/08/2022', '30/08/2022-alternatif'].includes(cahierDesChargesActuel) &&
+        !['30/08/2022', '30/08/2022-alternatif'].includes(cdcChoisi) && (
+          <AlertBox>
+            Le cahier des charges que vous séléctionnez ne permet plus au projet de bénéficier du
+            délai relatif au cahier des charges du 30/08/2022.{' '}
+            <span className="font-bold">
+              Si vous validez de changement cahier des charges, la date limite d'achèvement du
+              projet sera impactée.
+            </span>
+          </AlertBox>
+        )}
 
       <div className="mx-auto flex flex-col md:flex-row gap-4 items-center">
         <PrimaryButton type="submit" disabled={!peutEnregistrerLeChangement}>


### PR DESCRIPTION
**Cas 1 -  un changement de CDC annule le délai de 18 mois**
 Dans le contexte d'un projet ayant déjà bénéficié du délai de 18 mois relatif au CDC 2022.
Si le porteur change de cahier de charges pour repasser sur le CDC 2021 ou le CDC initial, 
- le projet ne doit plus bénéficier du délai de 18 mois
- les porteurs + dreal de la région du projet doivent être notifiés par email

Dans cette PR nous avons : 
- une alerte sur la page du formulaire de changement de CDC
- un nouveau handler pour la mise à jour de la date d'achèvement du projet (legacy)
- mise à jour des notifications par mail

**Cas 2 - un changement de CDC vers le 2022 ajoute le délai de 18 mois**
Dans le contexte d'un projet qui a une/plusieurs date(s) de mise en service renseignée(s).
Lorsque le porteur choisit le CDC 2022, alors il devrait bénéficier automatiquement du délai de 18 mois si toutes les conditions sont remplies :

- il n'a pas déjà bénéficié du délai
- tous les dossiers de raccordement du projet ont une date de mise en service, et cette date est dans le bon intervalle