### PR TITLE
:sparkles: Appliquer règle ajout délai 18 mois au changement de CDC

### DIFF
--- a/src/config/eventHandlers/project.eventHandlers.ts
+++ b/src/config/eventHandlers/project.eventHandlers.ts
@@ -144,6 +144,7 @@ const onCahierDesChargesChoisiHandler = makeOnCahierDesChargesChoisi({
   projectRepo,
   publishToEventStore: eventStore.publish,
   getProjectAppelOffre,
+  récupérerDétailDossiersRaccordements,
 });
 
 const onCahierDesChargesChoisi = async (event: DomainEvent) => {

--- a/src/modules/project/eventHandlers/onCahierDesChargesChoisi.spec.ts
+++ b/src/modules/project/eventHandlers/onCahierDesChargesChoisi.spec.ts
@@ -1,4 +1,4 @@
-import { jest, describe, it, expect } from '@jest/globals';
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
 import { CahierDesChargesChoisi } from '../events';
 import { DomainEvent, UniqueEntityID } from '../../../core/domain';
 import { InfraNotAvailableError } from '../../shared/errors';
@@ -12,228 +12,658 @@ import {
 import { makeOnCahierDesChargesChoisi } from './onCahierDesChargesChoisi';
 import { Project } from '../Project';
 
-describe(`Retirer le délai relatif au CDC 2022`, () => {
+describe(`onCahierDesChargesChoisi event handler`, () => {
   const publishToEventStore = jest.fn((event: DomainEvent) =>
     okAsync<null, InfraNotAvailableError>(null),
   );
 
-  it(`
+  const récupérerDétailDossiersRaccordements = jest.fn(async () => [
+    {
+      référence: 'ref-du-dossier',
+      demandeComplèteRaccordement: {
+        dateQualification: new Date('2022-01-01').toISOString(),
+      },
+      miseEnService: { dateMiseEnService: new Date('2023-01-01').toISOString() },
+    },
+  ]);
+
+  beforeEach(async () => {
+    publishToEventStore.mockClear();
+  });
+
+  describe(`Retirer le délai relatif au CDC 2022`, () => {
+    it(`
     Etant donné un projet sur le CDC du 30/08/2022
     Et ayant bénéficié du délai relatif au CDC du 30/08/2022
     Lorsque le porteur change de cahier des charges
     Alors le délai relatif au CDC du 30/08/2022 devrait être annulé
     `, async () => {
-    const projetId = new UniqueEntityID();
-    const appelOffreId = 'Eolien';
-    const periodeId = '1';
-    const numeroCRE = '123';
-    const familleId = '';
-    const CDCDélaiApplicable = 18;
-    const dateAchèvementInitiale = new Date('2025-01-01');
-    const nouvelleDateAchèvementAttendue = new Date(
-      new Date(dateAchèvementInitiale).setMonth(
-        new Date(dateAchèvementInitiale).getMonth() - CDCDélaiApplicable,
-      ),
-    );
+      const projetId = new UniqueEntityID();
+      const appelOffreId = 'Eolien';
+      const periodeId = '1';
+      const numeroCRE = '123';
+      const familleId = '';
+      const CDCDélaiApplicable = 18;
+      const dateAchèvementInitiale = new Date('2025-01-01');
+      const nouvelleDateAchèvementAttendue = new Date(
+        new Date(dateAchèvementInitiale).setMonth(
+          new Date(dateAchèvementInitiale).getMonth() - CDCDélaiApplicable,
+        ),
+      );
 
-    const fakeProject = {
-      ...makeFakeProjectAggregate(),
-      cahierDesCharges: { type: 'modifié', paruLe: '30/08/2022' },
-      completionDueOn: dateAchèvementInitiale.getTime(),
-      délaiCDC2022appliqué: true,
-      numeroCRE,
-      appelOffreId,
-      periodeId,
-      id: projetId,
-      familleId,
-    };
+      const fakeProject = {
+        ...makeFakeProjectAggregate(),
+        cahierDesCharges: { type: 'modifié', paruLe: '30/08/2022' },
+        completionDueOn: dateAchèvementInitiale.getTime(),
+        délaiCDC2022appliqué: true,
+        numeroCRE,
+        appelOffreId,
+        periodeId,
+        id: projetId,
+        familleId,
+      };
 
-    const projectRepo = fakeTransactionalRepo(fakeProject as Project);
+      const projectRepo = fakeTransactionalRepo(fakeProject as Project);
 
-    const getProjectAppelOffre = jest.fn(
-      () =>
-        ({
-          typeAppelOffre: 'eolien',
-          periode: {
-            cahiersDesChargesModifiésDisponibles: [
-              {
-                type: 'modifié',
-                paruLe: '30/08/2022',
-                délaiApplicable: {
-                  délaiEnMois: CDCDélaiApplicable,
-                  intervaleDateMiseEnService: {
-                    min: new Date('2022-06-01'),
-                    max: new Date('2024-09-30'),
+      const getProjectAppelOffre = jest.fn(
+        () =>
+          ({
+            typeAppelOffre: 'eolien',
+            periode: {
+              cahiersDesChargesModifiésDisponibles: [
+                {
+                  type: 'modifié',
+                  paruLe: '30/08/2022',
+                  délaiApplicable: {
+                    délaiEnMois: CDCDélaiApplicable,
+                    intervaleDateMiseEnService: {
+                      min: new Date('2022-06-01'),
+                      max: new Date('2024-09-30'),
+                    },
                   },
-                },
-              } as CahierDesChargesModifié,
-            ] as ReadonlyArray<CahierDesChargesModifié>,
-          },
-        } as ProjectAppelOffre),
-    );
+                } as CahierDesChargesModifié,
+              ] as ReadonlyArray<CahierDesChargesModifié>,
+            },
+          } as ProjectAppelOffre),
+      );
 
-    const onCahierDesChargesChoisi = makeOnCahierDesChargesChoisi({
-      publishToEventStore,
-      getProjectAppelOffre,
-      projectRepo,
+      const onCahierDesChargesChoisi = makeOnCahierDesChargesChoisi({
+        publishToEventStore,
+        getProjectAppelOffre,
+        projectRepo,
+        récupérerDétailDossiersRaccordements,
+      });
+
+      await onCahierDesChargesChoisi(
+        new CahierDesChargesChoisi({
+          payload: { choisiPar: 'id', type: 'initial', projetId: projetId.toString() },
+        }),
+      );
+
+      expect(publishToEventStore).toHaveBeenCalledTimes(1);
+      const évènement = publishToEventStore.mock.calls[0][0];
+      expect(évènement.type).toEqual('ProjectCompletionDueDateSet');
+      expect(évènement.payload).toEqual(
+        expect.objectContaining({
+          projectId: fakeProject.id.toString(),
+          completionDueOn: nouvelleDateAchèvementAttendue.getTime(),
+          reason: 'ChoixCDCAnnuleDélaiCdc2022',
+        }),
+      );
     });
-
-    await onCahierDesChargesChoisi(
-      new CahierDesChargesChoisi({
-        payload: { choisiPar: 'id', type: 'initial', projetId: projetId.toString() },
-      }),
-    );
-
-    expect(publishToEventStore).toHaveBeenCalledTimes(1);
-    const évènement = publishToEventStore.mock.calls[0][0];
-    expect(évènement.type).toEqual('ProjectCompletionDueDateSet');
-    expect(évènement.payload).toEqual(
-      expect.objectContaining({
-        projectId: fakeProject.id.toString(),
-        completionDueOn: nouvelleDateAchèvementAttendue.getTime(),
-        reason: 'ChoixCDCAnnuleDélaiCdc2022',
-      }),
-    );
   });
-});
 
-describe(`Pas d'effet`, () => {
-  const publishToEventStore = jest.fn((event: DomainEvent) =>
-    okAsync<null, InfraNotAvailableError>(null),
-  );
+  describe(`Ajouter le délai relatif au CDC 2022`, () => {
+    it(`
+    Etant donné un projet sur le CDC initial
+    Et dont la période prévoit un délai de 18 mois supplémentaire pour le CDC du 30/08/2022
+    Et n'ayant pas bénéficié du délai relatif au CDC du 30/08/2022
+    Et ayant ses dates de mise en service dans l'intervalle accepté pour l'application du délai
+    Lorsque le porteur choisit le CDC du 30/08/2022
+    Alors la date d'achèvement du projet devrait être modifiée
+    `, async () => {
+      const projetId = new UniqueEntityID();
+      const appelOffreId = 'Eolien';
+      const periodeId = '1';
+      const numeroCRE = '123';
+      const familleId = '';
+      const CDCDélaiApplicable = 18;
+      const dateAchèvementInitiale = new Date('2025-01-01');
+      const nouvelleDateAchèvementAttendue = new Date(
+        new Date(dateAchèvementInitiale).setMonth(
+          new Date(dateAchèvementInitiale).getMonth() + CDCDélaiApplicable,
+        ),
+      );
 
-  it(`
+      const fakeProject = {
+        ...makeFakeProjectAggregate(),
+        cahierDesCharges: { type: 'initial' },
+        completionDueOn: dateAchèvementInitiale.getTime(),
+        délaiCDC2022appliqué: false,
+        numeroCRE,
+        appelOffreId,
+        periodeId,
+        id: projetId,
+        familleId,
+      };
+
+      const projectRepo = fakeTransactionalRepo(fakeProject as Project);
+
+      const getProjectAppelOffre = jest.fn(
+        () =>
+          ({
+            typeAppelOffre: 'eolien',
+            periode: {
+              cahiersDesChargesModifiésDisponibles: [
+                {
+                  type: 'modifié',
+                  paruLe: '30/08/2022',
+                  délaiApplicable: {
+                    délaiEnMois: CDCDélaiApplicable,
+                    intervaleDateMiseEnService: {
+                      min: new Date('2022-06-01'),
+                      max: new Date('2024-09-30'),
+                    },
+                  },
+                } as CahierDesChargesModifié,
+              ] as ReadonlyArray<CahierDesChargesModifié>,
+            },
+          } as ProjectAppelOffre),
+      );
+
+      const onCahierDesChargesChoisi = makeOnCahierDesChargesChoisi({
+        publishToEventStore,
+        getProjectAppelOffre,
+        projectRepo,
+        récupérerDétailDossiersRaccordements,
+      });
+
+      await onCahierDesChargesChoisi(
+        new CahierDesChargesChoisi({
+          payload: {
+            choisiPar: 'id',
+            type: 'modifié',
+            paruLe: '30/08/2022',
+            projetId: projetId.toString(),
+          },
+        }),
+      );
+
+      expect(publishToEventStore).toHaveBeenCalledTimes(1);
+      const évènement = publishToEventStore.mock.calls[0][0];
+      expect(évènement.type).toEqual('ProjectCompletionDueDateSet');
+      expect(évènement.payload).toEqual(
+        expect.objectContaining({
+          projectId: fakeProject.id.toString(),
+          completionDueOn: nouvelleDateAchèvementAttendue.getTime(),
+          reason: 'délaiCdc2022',
+        }),
+      );
+    });
+  });
+
+  describe(`Pas d'effet`, () => {
+    it(`
     Etant donné un projet sur le CDC du 30/08/2022
     Et n'ayant pas bénéficié du délai relatif au CDC du 30/08/2022
     Lorsque le porteur change de cahier des charges
     Alors la date d'achèvement du projet ne devrait pas être modifiée
     `, async () => {
-    const projetId = new UniqueEntityID();
-    const appelOffreId = 'Eolien';
-    const periodeId = '1';
-    const numeroCRE = '123';
-    const familleId = '';
-    const CDCDélaiApplicable = 18;
-    const dateAchèvementInitiale = new Date('2025-01-01');
+      const projetId = new UniqueEntityID();
+      const appelOffreId = 'Eolien';
+      const periodeId = '1';
+      const numeroCRE = '123';
+      const familleId = '';
+      const CDCDélaiApplicable = 18;
+      const dateAchèvementInitiale = new Date('2025-01-01');
 
-    const fakeProject = {
-      ...makeFakeProjectAggregate(),
-      cahierDesCharges: { type: 'modifié', paruLe: '30/08/2022' },
-      completionDueOn: dateAchèvementInitiale.getTime(),
-      délaiCDC2022appliqué: false,
-      numeroCRE,
-      appelOffreId,
-      periodeId,
-      id: projetId,
-      familleId,
-    };
+      const fakeProject = {
+        ...makeFakeProjectAggregate(),
+        cahierDesCharges: { type: 'modifié', paruLe: '30/08/2022' },
+        completionDueOn: dateAchèvementInitiale.getTime(),
+        délaiCDC2022appliqué: false,
+        numeroCRE,
+        appelOffreId,
+        periodeId,
+        id: projetId,
+        familleId,
+      };
 
-    const projectRepo = fakeTransactionalRepo(fakeProject as Project);
+      const projectRepo = fakeTransactionalRepo(fakeProject as Project);
 
-    const getProjectAppelOffre = jest.fn(
-      () =>
-        ({
-          typeAppelOffre: 'eolien',
-          periode: {
-            cahiersDesChargesModifiésDisponibles: [
-              {
-                type: 'modifié',
-                paruLe: '30/08/2022',
-                délaiApplicable: {
-                  délaiEnMois: CDCDélaiApplicable,
-                  intervaleDateMiseEnService: {
-                    min: new Date('2022-06-01'),
-                    max: new Date('2024-09-30'),
+      const getProjectAppelOffre = jest.fn(
+        () =>
+          ({
+            typeAppelOffre: 'eolien',
+            periode: {
+              cahiersDesChargesModifiésDisponibles: [
+                {
+                  type: 'modifié',
+                  paruLe: '30/08/2022',
+                  délaiApplicable: {
+                    délaiEnMois: CDCDélaiApplicable,
+                    intervaleDateMiseEnService: {
+                      min: new Date('2022-06-01'),
+                      max: new Date('2024-09-30'),
+                    },
                   },
-                },
-              } as CahierDesChargesModifié,
-            ] as ReadonlyArray<CahierDesChargesModifié>,
-          },
-        } as ProjectAppelOffre),
-    );
+                } as CahierDesChargesModifié,
+              ] as ReadonlyArray<CahierDesChargesModifié>,
+            },
+          } as ProjectAppelOffre),
+      );
 
-    const onCahierDesChargesChoisi = makeOnCahierDesChargesChoisi({
-      publishToEventStore,
-      getProjectAppelOffre,
-      projectRepo,
+      const onCahierDesChargesChoisi = makeOnCahierDesChargesChoisi({
+        publishToEventStore,
+        getProjectAppelOffre,
+        projectRepo,
+        récupérerDétailDossiersRaccordements,
+      });
+
+      await onCahierDesChargesChoisi(
+        new CahierDesChargesChoisi({
+          payload: { choisiPar: 'id', type: 'initial', projetId: projetId.toString() },
+        }),
+      );
+
+      expect(publishToEventStore).not.toHaveBeenCalled();
     });
 
-    await onCahierDesChargesChoisi(
-      new CahierDesChargesChoisi({
-        payload: { choisiPar: 'id', type: 'initial', projetId: projetId.toString() },
-      }),
-    );
-
-    expect(publishToEventStore).not.toHaveBeenCalled();
-  });
-
-  it(`
+    // La période ne prévoit pas un délai supplémentaire
+    it(`
     Etant donné un projet sur le CDC initial
+    Et dont la période ne prévoit pas de délai de 18 mois supplémentaire pour le CDC du 30/08/2022
     Et n'ayant pas bénéficié du délai relatif au CDC du 30/08/2022
+    Et ayant ses dates de mise en service dans l'intervalle accepté pour l'application du délai
     Lorsque le porteur choisit le CDC du 30/08/2022
     Alors la date d'achèvement du projet ne devrait pas être modifiée
     `, async () => {
-    const projetId = new UniqueEntityID();
-    const appelOffreId = 'Eolien';
-    const periodeId = '1';
-    const numeroCRE = '123';
-    const familleId = '';
-    const CDCDélaiApplicable = 18;
-    const dateAchèvementInitiale = new Date('2025-01-01');
+      const projetId = new UniqueEntityID();
+      const appelOffreId = 'Eolien';
+      const periodeId = '1';
+      const numeroCRE = '123';
+      const familleId = '';
+      const dateAchèvementInitiale = new Date('2025-01-01');
 
-    const fakeProject = {
-      ...makeFakeProjectAggregate(),
-      cahierDesCharges: { type: 'initial' },
-      completionDueOn: dateAchèvementInitiale.getTime(),
-      délaiCDC2022appliqué: false,
-      numeroCRE,
-      appelOffreId,
-      periodeId,
-      id: projetId,
-      familleId,
-    };
+      const fakeProject = {
+        ...makeFakeProjectAggregate(),
+        cahierDesCharges: { type: 'initial' },
+        completionDueOn: dateAchèvementInitiale.getTime(),
+        délaiCDC2022appliqué: false,
+        numeroCRE,
+        appelOffreId,
+        periodeId,
+        id: projetId,
+        familleId,
+      };
 
-    const projectRepo = fakeTransactionalRepo(fakeProject as Project);
+      const projectRepo = fakeTransactionalRepo(fakeProject as Project);
 
-    const getProjectAppelOffre = jest.fn(
-      () =>
-        ({
-          typeAppelOffre: 'eolien',
-          periode: {
-            cahiersDesChargesModifiésDisponibles: [
-              {
-                type: 'modifié',
-                paruLe: '30/08/2022',
-                délaiApplicable: {
-                  délaiEnMois: CDCDélaiApplicable,
-                  intervaleDateMiseEnService: {
-                    min: new Date('2022-06-01'),
-                    max: new Date('2024-09-30'),
-                  },
-                },
-              } as CahierDesChargesModifié,
-            ] as ReadonlyArray<CahierDesChargesModifié>,
+      const getProjectAppelOffre = jest.fn(
+        () =>
+          ({
+            typeAppelOffre: 'eolien',
+            periode: {
+              cahiersDesChargesModifiésDisponibles: [
+                {
+                  type: 'modifié',
+                  paruLe: '30/08/2022',
+                } as CahierDesChargesModifié,
+              ] as ReadonlyArray<CahierDesChargesModifié>,
+            },
+          } as ProjectAppelOffre),
+      );
+
+      const onCahierDesChargesChoisi = makeOnCahierDesChargesChoisi({
+        publishToEventStore,
+        getProjectAppelOffre,
+        projectRepo,
+        récupérerDétailDossiersRaccordements,
+      });
+
+      await onCahierDesChargesChoisi(
+        new CahierDesChargesChoisi({
+          payload: {
+            choisiPar: 'id',
+            type: 'modifié',
+            paruLe: '30/08/2022',
+            projetId: projetId.toString(),
           },
-        } as ProjectAppelOffre),
-    );
+        }),
+      );
 
-    const onCahierDesChargesChoisi = makeOnCahierDesChargesChoisi({
-      publishToEventStore,
-      getProjectAppelOffre,
-      projectRepo,
+      expect(publishToEventStore).not.toHaveBeenCalled();
     });
 
-    await onCahierDesChargesChoisi(
-      new CahierDesChargesChoisi({
-        payload: {
-          choisiPar: 'id',
-          type: 'modifié',
-          paruLe: '30/08/2022',
-          projetId: projetId.toString(),
-        },
-      }),
-    );
+    // le projet a déjà bénéficié du délai
+    it(`
+    Etant donné un projet sur le CDC initial
+    Et dont la période prévoit un délai de 18 mois supplémentaire pour le CDC du 30/08/2022
+    Et ayant déjà bénéficié du délai relatif au CDC du 30/08/2022
+    Et ayant ses dates de mise en service dans l'intervalle accepté pour l'application du délai
+    Lorsque le porteur choisit le CDC du 30/08/2022
+    Alors la date d'achèvement du projet ne devrait pas être modifiée
+    `, async () => {
+      const projetId = new UniqueEntityID();
+      const appelOffreId = 'Eolien';
+      const periodeId = '1';
+      const numeroCRE = '123';
+      const familleId = '';
+      const CDCDélaiApplicable = 18;
+      const dateAchèvementInitiale = new Date('2025-01-01');
 
-    expect(publishToEventStore).not.toHaveBeenCalled();
+      const fakeProject = {
+        ...makeFakeProjectAggregate(),
+        cahierDesCharges: { type: 'initial' },
+        completionDueOn: dateAchèvementInitiale.getTime(),
+        délaiCDC2022appliqué: true,
+        numeroCRE,
+        appelOffreId,
+        periodeId,
+        id: projetId,
+        familleId,
+      };
+
+      const projectRepo = fakeTransactionalRepo(fakeProject as Project);
+
+      const getProjectAppelOffre = jest.fn(
+        () =>
+          ({
+            typeAppelOffre: 'eolien',
+            periode: {
+              cahiersDesChargesModifiésDisponibles: [
+                {
+                  type: 'modifié',
+                  paruLe: '30/08/2022',
+                  délaiApplicable: {
+                    délaiEnMois: CDCDélaiApplicable,
+                    intervaleDateMiseEnService: {
+                      min: new Date('2022-06-01'),
+                      max: new Date('2024-09-30'),
+                    },
+                  },
+                } as CahierDesChargesModifié,
+              ] as ReadonlyArray<CahierDesChargesModifié>,
+            },
+          } as ProjectAppelOffre),
+      );
+
+      const onCahierDesChargesChoisi = makeOnCahierDesChargesChoisi({
+        publishToEventStore,
+        getProjectAppelOffre,
+        projectRepo,
+        récupérerDétailDossiersRaccordements,
+      });
+
+      await onCahierDesChargesChoisi(
+        new CahierDesChargesChoisi({
+          payload: {
+            choisiPar: 'id',
+            type: 'modifié',
+            paruLe: '30/08/2022',
+            projetId: projetId.toString(),
+          },
+        }),
+      );
+
+      expect(publishToEventStore).not.toHaveBeenCalled();
+    });
+
+    // Le projet n'a pas toutes ses dates de mises en service renseignées
+    it(`
+    Etant donné un projet sur le CDC initial
+    Et dont la période prévoit un délai de 18 mois supplémentaire pour le CDC du 30/08/2022
+    Et n'ayant pas bénéficié du délai relatif au CDC du 30/08/2022
+    Et n'ayant pas toutes ses dates de mise en service renseignées
+    Lorsque le porteur choisit le CDC du 30/08/2022
+    Alors la date d'achèvement du projet ne devrait pas être modifiée
+    `, async () => {
+      const projetId = new UniqueEntityID();
+      const appelOffreId = 'Eolien';
+      const periodeId = '1';
+      const numeroCRE = '123';
+      const familleId = '';
+      const CDCDélaiApplicable = 18;
+      const dateAchèvementInitiale = new Date('2025-01-01');
+
+      const fakeProject = {
+        ...makeFakeProjectAggregate(),
+        cahierDesCharges: { type: 'initial' },
+        completionDueOn: dateAchèvementInitiale.getTime(),
+        délaiCDC2022appliqué: false,
+        numeroCRE,
+        appelOffreId,
+        periodeId,
+        id: projetId,
+        familleId,
+      };
+
+      const projectRepo = fakeTransactionalRepo(fakeProject as Project);
+
+      const getProjectAppelOffre = jest.fn(
+        () =>
+          ({
+            typeAppelOffre: 'eolien',
+            periode: {
+              cahiersDesChargesModifiésDisponibles: [
+                {
+                  type: 'modifié',
+                  paruLe: '30/08/2022',
+                  délaiApplicable: {
+                    délaiEnMois: CDCDélaiApplicable,
+                    intervaleDateMiseEnService: {
+                      min: new Date('2022-06-01'),
+                      max: new Date('2024-09-30'),
+                    },
+                  },
+                } as CahierDesChargesModifié,
+              ] as ReadonlyArray<CahierDesChargesModifié>,
+            },
+          } as ProjectAppelOffre),
+      );
+
+      const récupérerDétailDossiersRaccordements = jest.fn(async () => [
+        {
+          référence: 'ref-du-dossier',
+          demandeComplèteRaccordement: {
+            dateQualification: new Date('2022-01-01').toISOString(),
+            miseEnService: { dateMiseEnService: new Date('2023-01-01').toISOString() },
+          },
+        },
+        {
+          référence: 'ref-autre-dossier',
+          demandeComplèteRaccordement: {
+            dateQualification: new Date('2022-01-01').toISOString(),
+          },
+        },
+      ]);
+
+      const onCahierDesChargesChoisi = makeOnCahierDesChargesChoisi({
+        publishToEventStore,
+        getProjectAppelOffre,
+        projectRepo,
+        récupérerDétailDossiersRaccordements,
+      });
+
+      await onCahierDesChargesChoisi(
+        new CahierDesChargesChoisi({
+          payload: {
+            choisiPar: 'id',
+            type: 'modifié',
+            paruLe: '30/08/2022',
+            projetId: projetId.toString(),
+          },
+        }),
+      );
+
+      expect(publishToEventStore).not.toHaveBeenCalled();
+    });
+
+    // le projet n'a pas toutes ses dates de mise en service dans l'intervalle pour le délai
+    it(`
+    Etant donné un projet sur le CDC initial
+    Et dont la période prévoit un délai de 18 mois supplémentaire pour le CDC du 30/08/2022
+    Et n'ayant pas bénéficié du délai relatif au CDC du 30/08/2022
+    Et n'ayant pas toutes ses dates de mise en service dans l'intervalle accepté pour l'application du délai
+    Lorsque le porteur choisit le CDC du 30/08/2022
+    Alors la date d'achèvement du projet ne devrait pas être modifiée
+    `, async () => {
+      const projetId = new UniqueEntityID();
+      const appelOffreId = 'Eolien';
+      const periodeId = '1';
+      const numeroCRE = '123';
+      const familleId = '';
+      const CDCDélaiApplicable = 18;
+      const dateAchèvementInitiale = new Date('2025-01-01');
+
+      const fakeProject = {
+        ...makeFakeProjectAggregate(),
+        cahierDesCharges: { type: 'initial' },
+        completionDueOn: dateAchèvementInitiale.getTime(),
+        délaiCDC2022appliqué: false,
+        numeroCRE,
+        appelOffreId,
+        periodeId,
+        id: projetId,
+        familleId,
+      };
+
+      const projectRepo = fakeTransactionalRepo(fakeProject as Project);
+
+      const getProjectAppelOffre = jest.fn(
+        () =>
+          ({
+            typeAppelOffre: 'eolien',
+            periode: {
+              cahiersDesChargesModifiésDisponibles: [
+                {
+                  type: 'modifié',
+                  paruLe: '30/08/2022',
+                  délaiApplicable: {
+                    délaiEnMois: CDCDélaiApplicable,
+                    intervaleDateMiseEnService: {
+                      min: new Date('2022-06-01'),
+                      max: new Date('2024-09-30'),
+                    },
+                  },
+                } as CahierDesChargesModifié,
+              ] as ReadonlyArray<CahierDesChargesModifié>,
+            },
+          } as ProjectAppelOffre),
+      );
+
+      const dateMiseEnServiceHorsIntervalle = new Date('2022-01-01');
+
+      const récupérerDétailDossiersRaccordements = jest.fn(async () => [
+        {
+          référence: 'ref-du-dossier',
+          demandeComplèteRaccordement: {
+            dateQualification: new Date('2022-01-01').toISOString(),
+            miseEnService: { dateMiseEnService: dateMiseEnServiceHorsIntervalle.toISOString() },
+          },
+        },
+        {
+          référence: 'ref-autre-dossier',
+          demandeComplèteRaccordement: {
+            dateQualification: new Date('2022-01-01').toISOString(),
+            miseEnService: { dateMiseEnService: dateMiseEnServiceHorsIntervalle.toISOString() },
+          },
+        },
+      ]);
+
+      const onCahierDesChargesChoisi = makeOnCahierDesChargesChoisi({
+        publishToEventStore,
+        getProjectAppelOffre,
+        projectRepo,
+        récupérerDétailDossiersRaccordements,
+      });
+
+      await onCahierDesChargesChoisi(
+        new CahierDesChargesChoisi({
+          payload: {
+            choisiPar: 'id',
+            type: 'modifié',
+            paruLe: '30/08/2022',
+            projetId: projetId.toString(),
+          },
+        }),
+      );
+
+      expect(publishToEventStore).not.toHaveBeenCalled();
+    });
+
+    // le porteur choisit un CDC autre que le CDC du 30/08/2022
+    it(`
+    Etant donné un projet sur le CDC initial
+    Et dont la période prévoit un délai de 18 mois supplémentaire pour le CDC du 30/08/2022
+    Et n'ayant pas bénéficié du délai relatif au CDC du 30/08/2022
+    Et ayant ses dates de mise en service dans l'intervalle accepté pour l'application du délai
+    Lorsque le porteur choisit le CDC 2021
+    Alors la date d'achèvement du projet ne devrait pas être modifiée
+    `, async () => {
+      const projetId = new UniqueEntityID();
+      const appelOffreId = 'Eolien';
+      const periodeId = '1';
+      const numeroCRE = '123';
+      const familleId = '';
+      const CDCDélaiApplicable = 18;
+      const dateAchèvementInitiale = new Date('2025-01-01');
+
+      const fakeProject = {
+        ...makeFakeProjectAggregate(),
+        cahierDesCharges: { type: 'initial' },
+        completionDueOn: dateAchèvementInitiale.getTime(),
+        délaiCDC2022appliqué: false,
+        numeroCRE,
+        appelOffreId,
+        periodeId,
+        id: projetId,
+        familleId,
+      };
+
+      const projectRepo = fakeTransactionalRepo(fakeProject as Project);
+
+      const getProjectAppelOffre = jest.fn(
+        () =>
+          ({
+            typeAppelOffre: 'eolien',
+            periode: {
+              cahiersDesChargesModifiésDisponibles: [
+                {
+                  type: 'modifié',
+                  paruLe: '30/08/2022',
+                  délaiApplicable: {
+                    délaiEnMois: CDCDélaiApplicable,
+                    intervaleDateMiseEnService: {
+                      min: new Date('2022-06-01'),
+                      max: new Date('2024-09-30'),
+                    },
+                  },
+                } as CahierDesChargesModifié,
+              ] as ReadonlyArray<CahierDesChargesModifié>,
+            },
+          } as ProjectAppelOffre),
+      );
+
+      const onCahierDesChargesChoisi = makeOnCahierDesChargesChoisi({
+        publishToEventStore,
+        getProjectAppelOffre,
+        projectRepo,
+        récupérerDétailDossiersRaccordements,
+      });
+
+      await onCahierDesChargesChoisi(
+        new CahierDesChargesChoisi({
+          payload: {
+            choisiPar: 'id',
+            type: 'modifié',
+            paruLe: '30/07/2021',
+            projetId: projetId.toString(),
+          },
+        }),
+      );
+
+      expect(publishToEventStore).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
Dans le contexte d'un projet qui a une/plusieurs date(s) de mise en service renseignée(s).
Lorsque le porteur choisit le CDC 2022, alors il devrait bénéficier automatiquement du délai de 18 mois si toutes les conditions sont remplies :
- il n'a pas déjà bénéficié du délai
- tous les dossiers de raccordement du projet ont une date de mise en service, et cette date est dans le bon intervalle