### PR TITLE
:sparkles: Modifications sur la feature "corriger délai accordé"

### DIFF
--- a/src/__tests__/fixtures/aggregates/makeFakeDemandeDélai.ts
+++ b/src/__tests__/fixtures/aggregates/makeFakeDemandeDélai.ts
@@ -8,6 +8,7 @@ export const makeFakeDemandeDélai = (overide?: {
   ancienneDateThéoriqueAchèvement?: string;
   dateAchèvementAccordée?: string;
   délaiEnMoisAccordé?: number;
+  correctionDélaiAccordé?: { dateCorrection: string; dateAchèvementAccordée: string };
 }): DemandeDélai => ({
   pendingEvents: [],
   id: new UniqueEntityID(overide?.id) || new UniqueEntityID(),
@@ -16,4 +17,5 @@ export const makeFakeDemandeDélai = (overide?: {
   ancienneDateThéoriqueAchèvement: overide?.ancienneDateThéoriqueAchèvement,
   dateAchèvementAccordée: overide?.dateAchèvementAccordée,
   délaiEnMoisAccordé: overide?.délaiEnMoisAccordé,
+  correctionDélaiAccordé: overide?.correctionDélaiAccordé,
 });

--- a/src/infra/sequelize/migrations/20231031171802-add-columns-modification-requests-correction-delai.ts
+++ b/src/infra/sequelize/migrations/20231031171802-add-columns-modification-requests-correction-delai.ts
@@ -1,0 +1,30 @@
+import { DataTypes, QueryInterface } from 'sequelize';
+
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await queryInterface.addColumn('modificationRequests', 'délaiAccordéCorrigéLe', {
+      type: DataTypes.STRING,
+      allowNull: true,
+    });
+    await queryInterface.addColumn(
+      'modificationRequests',
+      'dateAchèvementAprèsCorrectionDélaiAccordé',
+      {
+        type: DataTypes.STRING,
+        allowNull: true,
+      },
+    );
+    await queryInterface.addColumn('modificationRequests', 'délaiAccordéCorrigéPar', {
+      type: DataTypes.STRING,
+      allowNull: true,
+    });
+  },
+  down: async (queryInterface: QueryInterface) => {
+    await queryInterface.removeColumn('modificationRequests', 'délaiAccordéCorrigéLe');
+    await queryInterface.removeColumn(
+      'modificationRequests',
+      'dateAchèvementAprèsCorrectionDélaiAccordé',
+    );
+    await queryInterface.removeColumn('modificationRequests', 'délaiAccordéCorrigéPar');
+  },
+};

--- a/src/infra/sequelize/migrations/20231102120000-add-columns-modification-requests-correction-delai.ts
+++ b/src/infra/sequelize/migrations/20231102120000-add-columns-modification-requests-correction-delai.ts
@@ -15,7 +15,7 @@ export default {
       },
     );
     await queryInterface.addColumn('modificationRequests', 'délaiAccordéCorrigéPar', {
-      type: DataTypes.STRING,
+      type: DataTypes.UUID,
       allowNull: true,
     });
   },

--- a/src/infra/sequelize/projectionsNext/modificationRequest/modificationRequest.initializer.ts
+++ b/src/infra/sequelize/projectionsNext/modificationRequest/modificationRequest.initializer.ts
@@ -139,7 +139,7 @@ export const initializeModificationRequestModel = (sequelize: Sequelize) => {
         allowNull: true,
       },
       délaiAccordéCorrigéPar: {
-        type: DataTypes.STRING,
+        type: DataTypes.UUID,
         allowNull: true,
       },
       dateAchèvementAprèsCorrectionDélaiAccordé: {
@@ -192,6 +192,11 @@ export const initializeModificationRequestModelAssociations = () => {
   ModificationRequest.belongsTo(User, {
     foreignKey: 'cancelledBy',
     as: 'cancelledByUser',
+    constraints: false,
+  });
+  ModificationRequest.belongsTo(User, {
+    foreignKey: 'délaiAccordéCorrigéPar',
+    as: 'delaiCorrigeParUser',
     constraints: false,
   });
 };

--- a/src/infra/sequelize/projectionsNext/modificationRequest/modificationRequest.initializer.ts
+++ b/src/infra/sequelize/projectionsNext/modificationRequest/modificationRequest.initializer.ts
@@ -134,6 +134,18 @@ export const initializeModificationRequestModel = (sequelize: Sequelize) => {
         type: DataTypes.STRING,
         allowNull: true,
       },
+      délaiAccordéCorrigéLe: {
+        type: DataTypes.STRING,
+        allowNull: true,
+      },
+      délaiAccordéCorrigéPar: {
+        type: DataTypes.STRING,
+        allowNull: true,
+      },
+      dateAchèvementAprèsCorrectionDélaiAccordé: {
+        type: DataTypes.STRING,
+        allowNull: true,
+      },
     },
     {
       sequelize,

--- a/src/infra/sequelize/projectionsNext/modificationRequest/modificationRequest.model.ts
+++ b/src/infra/sequelize/projectionsNext/modificationRequest/modificationRequest.model.ts
@@ -51,6 +51,9 @@ export class ModificationRequest extends Model<
   cancelledOn?: number;
   isLegacy: CreationOptional<boolean | null>;
   cahierDesCharges?: string;
+  délaiAccordéCorrigéLe?: string;
+  délaiAccordéCorrigéPar?: string;
+  dateAchèvementAprèsCorrectionDélaiAccordé?: string;
 
   project: NonAttribute<Project>;
   requestedBy: NonAttribute<{ email: string; fullName: string }>;

--- a/src/infra/sequelize/projectionsNext/modificationRequest/updates/délai/onDélaiAccordéCorrigé.ts
+++ b/src/infra/sequelize/projectionsNext/modificationRequest/updates/délai/onDélaiAccordéCorrigé.ts
@@ -15,14 +15,11 @@ export const onDélaiAccordéCorrigé = ModificationRequestProjector.on(
 
       await ModificationRequest.update(
         {
-          status: 'acceptée',
-          respondedOn: occurredAt.getTime(),
-          respondedBy: corrigéPar,
           versionDate: occurredAt,
           responseFileId: fichierRéponseId,
-          acceptanceParams: {
-            dateAchèvementAccordée: dateAchèvementAccordée,
-          },
+          dateAchèvementAprèsCorrectionDélaiAccordé: new Date(dateAchèvementAccordée).toISOString(),
+          délaiAccordéCorrigéLe: new Date(occurredAt).toISOString(),
+          délaiAccordéCorrigéPar: corrigéPar,
         },
         {
           where: {

--- a/src/infra/sequelize/projectionsNext/projectEvents/events/DemandeDélaiEvent.ts
+++ b/src/infra/sequelize/projectionsNext/projectEvents/events/DemandeDélaiEvent.ts
@@ -46,10 +46,19 @@ type PayloadDemandeDélaiAvecDateEvent = {
     }
 );
 
+type PayloadDélaiAccordéCorrigé = {
+  statut: 'accordée-corrigée';
+  dateAchèvementAccordée: string;
+} & ({ ancienneDateThéoriqueAchèvement: string } | { délaiEnMoisDemandé: number });
+
 export type DemandeDélaiEvent = ProjectEvent & {
   type: 'DemandeDélai';
   payload: {
     autorité: 'dgec' | 'dreal';
     demandeDélaiId: string;
-  } & (PayloadDemandeDélaiAvecDateEvent | PayloadDemandeDélaiEnMoisEvent);
+  } & (
+    | PayloadDemandeDélaiAvecDateEvent
+    | PayloadDemandeDélaiEnMoisEvent
+    | PayloadDélaiAccordéCorrigé
+  );
 };

--- a/src/infra/sequelize/projectionsNext/projectEvents/updates/délai/onDélaiAccordéCorrigé.ts
+++ b/src/infra/sequelize/projectionsNext/projectEvents/updates/délai/onDélaiAccordéCorrigé.ts
@@ -29,7 +29,8 @@ export default ProjectEventProjector.on(DélaiAccordéCorrigé, async (évèneme
         eventPublishedAt: occurredAt.getTime(),
         payload: {
           ...projectEvent.payload,
-          corrigéPar,
+          statut: 'accordée-corrigée',
+          accordéPar: corrigéPar,
           dateAchèvementAccordée: new Date(dateAchèvementAccordée).toISOString(),
         },
       },

--- a/src/infra/sequelize/queries/frise/getProjectEvents.ts
+++ b/src/infra/sequelize/queries/frise/getProjectEvents.ts
@@ -644,7 +644,25 @@ export const getProjectEvents: GetProjectEvents = ({ projectId, user }) => {
                     ])(user)
                   ) {
                     const { statut, autorité } = payload;
-                    if (payload.dateAchèvementDemandée) {
+                    if (statut === 'accordée-corrigée') {
+                      events.push({
+                        statut: 'accordée-corrigée',
+                        type,
+                        date: valueDate,
+                        variant: user.role,
+                        dateAchèvementAccordée: payload.dateAchèvementAccordée,
+                        ...((userIs([
+                          'porteur-projet',
+                          'admin',
+                          'dgec-validateur',
+                          'cre',
+                          'acheteur-obligé',
+                        ])(user) ||
+                          (userIs('dreal')(user) && autorité === 'dreal')) && {
+                          demandeUrl: routes.GET_DETAILS_DEMANDE_DELAI_PAGE(id),
+                        }),
+                      });
+                    } else if (payload.dateAchèvementDemandée) {
                       const { dateAchèvementDemandée } = payload;
                       events.push({
                         type,
@@ -670,9 +688,7 @@ export const getProjectEvents: GetProjectEvents = ({ projectId, user }) => {
                           demandeUrl: routes.GET_DETAILS_DEMANDE_DELAI_PAGE(id),
                         }),
                       });
-                    }
-
-                    if (payload.délaiEnMoisDemandé) {
+                    } else if (payload.délaiEnMoisDemandé) {
                       const { délaiEnMoisDemandé } = payload;
                       events.push({
                         type,

--- a/src/infra/sequelize/queries/modificationRequest/getModificationRequestDetails.ts
+++ b/src/infra/sequelize/queries/modificationRequest/getModificationRequestDetails.ts
@@ -63,6 +63,11 @@ export const getModificationRequestDetails: GetModificationRequestDetails = (
           as: 'cancelledByUser',
           attributes: ['fullName'],
         },
+        {
+          model: User,
+          as: 'delaiCorrigeParUser',
+          attributes: ['fullName'],
+        },
       ],
     }),
   ).andThen((modificationRequestRaw: any) => {
@@ -93,6 +98,9 @@ export const getModificationRequestDetails: GetModificationRequestDetails = (
       dateAchèvementDemandée,
       authority,
       cahierDesCharges: cahierDesChargesRéférence,
+      délaiAccordéCorrigéLe,
+      delaiCorrigeParUser,
+      dateAchèvementAprèsCorrectionDélaiAccordé,
     } = modificationRequestRaw.get();
 
     const { appelOffreId, periodeId, notifiedOn, completionDueOn, technologie } = project.get();
@@ -136,6 +144,9 @@ export const getModificationRequestDetails: GetModificationRequestDetails = (
         appelOffre && cahierDesChargesRéférence
           ? formatCahierDesCharges({ appelOffre, cahierDesChargesRéférence })
           : undefined,
+      délaiAccordéCorrigéLe,
+      délaiAccordéCorrigéPar: delaiCorrigeParUser?.get().fullName,
+      dateAchèvementAprèsCorrectionDélaiAccordé,
     });
   });
 };

--- a/src/modules/demandeModification/demandeDélai/DemandeDélai.ts
+++ b/src/modules/demandeModification/demandeDélai/DemandeDélai.ts
@@ -2,6 +2,7 @@ import { DomainEvent, EventStoreAggregate, UniqueEntityID } from '../../../core/
 import { ok, Result } from '../../../core/utils';
 import {
   DélaiAccordé,
+  DélaiAccordéCorrigé,
   DélaiAnnulé,
   DélaiDemandé,
   DélaiEnInstruction,
@@ -39,6 +40,7 @@ export type DemandeDélai = EventStoreAggregate & {
   ancienneDateThéoriqueAchèvement: string | undefined;
   dateAchèvementAccordée: string | undefined;
   délaiEnMoisAccordé: number | undefined;
+  correctionDélaiAccordé?: { dateCorrection: string; dateAchèvementAccordée: string };
 };
 
 export const makeDemandeDélai = (
@@ -91,6 +93,14 @@ export const makeDemandeDélai = (
         return { ...agregat, statut: 'en instruction' };
       case RejetDélaiAnnulé.type:
         return { ...agregat, statut: 'envoyée' };
+      case DélaiAccordéCorrigé.type:
+        return {
+          ...agregat,
+          correctionDélaiAccordé: {
+            dateCorrection: event.occurredAt.toISOString(),
+            dateAchèvementAccordée: event.payload.dateAchèvementAccordée,
+          },
+        };
       default:
         return agregat;
     }

--- a/src/modules/demandeModification/demandeDélai/corrigerDélaiAccordé/NouvelleCorrectionDélaiAccordéImpossibleError.ts
+++ b/src/modules/demandeModification/demandeDélai/corrigerDélaiAccordé/NouvelleCorrectionDélaiAccordéImpossibleError.ts
@@ -1,0 +1,7 @@
+import { DomainError } from '../../../../core/domain';
+
+export class NouvelleCorrectionDélaiAccordéImpossible extends DomainError {
+  constructor() {
+    super(`Vous ne pouvez pas corriger de nouveau ce délai.`);
+  }
+}

--- a/src/modules/demandeModification/demandeDélai/corrigerDélaiAccordé/corrigerDélaiAccordé.ts
+++ b/src/modules/demandeModification/demandeDélai/corrigerDélaiAccordé/corrigerDélaiAccordé.ts
@@ -14,6 +14,7 @@ import { DélaiAccordéCorrigé } from '../events';
 import { CorrectionDélaiImpossibleCarProjetNonClasséError } from './CorrectionDélaiImpossibleCarProjetNonClasséError';
 import { CorrectionDélaiNonAccordéImpossibleError } from './CorrectionDélaiNonAccordéImpossibleError';
 import { DateAntérieureDateAchèvementInitialeError } from './DateAntérieureDateAchèvementInitialeError';
+import { NouvelleCorrectionDélaiAccordéImpossible } from './NouvelleCorrectionDélaiAccordéImpossibleError';
 
 type Dependencies = {
   publishToEventStore: EventStore['publish'];
@@ -76,10 +77,14 @@ export const makeCorrigerDélaiAccordé =
             return demandeDélaiRepo.transaction(
               new UniqueEntityID(demandeDélaiId),
               (demandeDélai) => {
-                const { statut } = demandeDélai;
+                const { statut, correctionDélaiAccordé } = demandeDélai;
 
                 if (statut !== 'accordée') {
                   return errAsync(new CorrectionDélaiNonAccordéImpossibleError());
+                }
+
+                if (correctionDélaiAccordé) {
+                  return errAsync(new NouvelleCorrectionDélaiAccordéImpossible());
                 }
 
                 return makeAndSaveFile({

--- a/src/modules/frise/dtos/ProjectEventListDTO.ts
+++ b/src/modules/frise/dtos/ProjectEventListDTO.ts
@@ -432,6 +432,10 @@ export type DemandeDélaiDTO = {
           délaiEnMoisAccordé: number;
         }
     ))
+  | {
+      statut: 'accordée-corrigée';
+      dateAchèvementAccordée: string;
+    }
 );
 
 export type DemandeAbandonDTO = {

--- a/src/modules/modificationRequest/dtos/ModificationRequestPageDTO.ts
+++ b/src/modules/modificationRequest/dtos/ModificationRequestPageDTO.ts
@@ -77,6 +77,9 @@ type Variant =
   | ({
       type: 'delai';
       acceptanceParams?: { delayInMonths: number; dateAchèvementAccordée?: string };
+      délaiAccordéCorrigéLe?: string;
+      délaiAccordéCorrigéPar?: string;
+      dateAchèvementAprèsCorrectionDélaiAccordé?: string;
     } & (
       | { delayInMonths: number; dateAchèvementDemandée?: undefined }
       | {

--- a/src/views/components/timeline/components/DemandeDélaiItem.tsx
+++ b/src/views/components/timeline/components/DemandeDélaiItem.tsx
@@ -23,6 +23,8 @@ export const DemandeDélaiItem = (props: DemandeDélaiItemProps) => {
       ? 'Délai supplémentaire demandé'
       : statut === 'en-instruction'
       ? 'Demande de délai supplémentaire en instruction'
+      : statut === 'accordée-corrigée'
+      ? 'Correction du délai accordé'
       : `Demande de délai supplémentaire ${statut}`;
 
   return (
@@ -30,7 +32,7 @@ export const DemandeDélaiItem = (props: DemandeDélaiItemProps) => {
       {['envoyée', 'en-instruction'].includes(statut) && <CurrentIcon />}
       {statut === 'annulée' && <CancelledStepIcon />}
       {statut === 'rejetée' && <UnvalidatedStepIcon />}
-      {statut === 'accordée' && <PastIcon />}
+      {['accordée', 'accordée-corrigée'].includes(statut) && <PastIcon />}
 
       <ContentArea>
         <div className="flex">
@@ -46,7 +48,13 @@ export const DemandeDélaiItem = (props: DemandeDélaiItemProps) => {
         <>
           <ItemTitle title={titre} />
           <p className="p-0 m-0">
-            {statut !== 'accordée' ? <DélaiDemandé {...props} /> : <DélaiAccordé {...props} />}
+            {statut === 'accordée' ? (
+              <DélaiAccordé {...props} />
+            ) : statut === 'accordée-corrigée' ? (
+              <DélaiAccordéCorrigé {...props} />
+            ) : (
+              <DélaiDemandé {...props} />
+            )}
             {demandeUrl && (
               <>
                 <br />
@@ -66,7 +74,8 @@ export const DemandeDélaiItem = (props: DemandeDélaiItemProps) => {
 };
 
 const DélaiDemandé = (
-  props: DemandeDélaiItemProps & Exclude<DemandeDélaiItemProps, { statut: 'demandée' }>,
+  props: DemandeDélaiItemProps &
+    Exclude<DemandeDélaiItemProps, { statut: 'accordée-corrigée' | 'accordée' }>,
 ) =>
   props.dateAchèvementDemandée ? (
     <>
@@ -96,3 +105,10 @@ const DélaiAccordé = (props: DemandeDélaiItemProps & { statut: 'accordée' })
 
   return null;
 };
+
+const DélaiAccordéCorrigé = (props: DemandeDélaiItemProps & { statut: 'accordée-corrigée' }) => (
+  <>
+    Nouvelle date limite d'achèvement :{' '}
+    {format(new Date(props.dateAchèvementAccordée), 'dd/MM/yyyy')}
+  </>
+);

--- a/src/views/pages/délai/CorrigerDelaiAccordePage.tsx
+++ b/src/views/pages/délai/CorrigerDelaiAccordePage.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {
+  AlertBox,
   ArrowLeftIcon,
   ChampsObligatoiresLégende,
   ErrorBox,
@@ -88,12 +89,20 @@ export const CorrigerDelaiAccorde = ({
               </li>
             </ol>
           </div>
+          <AlertBox>
+            Attention : une fois ce délai corrigé, nous ne pourrez plus le corriger de nouveau.
+          </AlertBox>
           <div className="flex flex-col md:flex-row gap-4 mx-auto">
             <SecondaryLinkButton href={routes.GET_DETAILS_DEMANDE_DELAI_PAGE(demandeDélai.id)}>
               <ArrowLeftIcon aria-hidden className="w-5 h-5 mr-2" />
               Retour vers la demande
             </SecondaryLinkButton>
-            <PrimaryButton type="submit">Enregistrer la correction</PrimaryButton>
+            <PrimaryButton
+              type="submit"
+              confirmation={`Vous ne pouvez corriger un délai accordé qu'une seule fois. Êtes-vous sûr de vouloir corriger le délai accordé ?`}
+            >
+              Enregistrer la correction
+            </PrimaryButton>
           </div>
         </Form>
         <InfoBox className="md:w-1/3 md:mx-auto">

--- a/src/views/pages/délai/CorrigerDelaiAccordePage.tsx
+++ b/src/views/pages/délai/CorrigerDelaiAccordePage.tsx
@@ -78,7 +78,7 @@ export const CorrigerDelaiAccorde = ({
             <Input type="text" id="explications" name="explications" />
           </div>
           <div>
-            <Label htmlFor="file">Nouvelle réponse signée (fichier pdf)</Label>
+            <Label htmlFor="file">Nouvelle réponse signée (fichier pdf)*</Label>
             <ol>
               <li>
                 <DownloadResponseTemplate modificationRequest={demandeDélai} />
@@ -120,9 +120,14 @@ export const CorrigerDelaiAccorde = ({
                 {afficherDate(new Date(demandeDélai.acceptanceParams.dateAchèvementAccordée))}.
               </li>
             )}
-            <li className="m-0">
+            <li className="mb-4">
               La date limite d'achèvement actuelle du projet est le{' '}
               {afficherDate(new Date(dateAchèvementActuelle))}.
+            </li>
+            <li>
+              * Il est nécéssaire de joindre un nouveau courrier de réponse pour valider la
+              correction. La DREAL/DEAL reste libre d'adapter le modèle de réponse fourni en
+              fonction de la situation.
             </li>
           </ul>
         </InfoBox>

--- a/src/views/pages/délai/DetailsDemandeDelaiPage.tsx
+++ b/src/views/pages/délai/DetailsDemandeDelaiPage.tsx
@@ -54,6 +54,9 @@ export const DetailsDemandeDelai = ({ request, modificationRequest }: DetailsDem
     acceptanceParams,
     responseFile,
     versionDate,
+    délaiAccordéCorrigéLe,
+    délaiAccordéCorrigéPar,
+    dateAchèvementAprèsCorrectionDélaiAccordé,
   } = modificationRequest;
 
   const dateDemandée = dateAchèvementDemandée
@@ -180,6 +183,23 @@ export const DetailsDemandeDelai = ({ request, modificationRequest }: DetailsDem
               .
             </div>
           )}
+          {délaiAccordéCorrigéLe &&
+            délaiAccordéCorrigéPar &&
+            dateAchèvementAprèsCorrectionDélaiAccordé && (
+              <div className="mt-4">
+                <div>
+                  <span className="font-bold">Correction du délai accordé</span> par{' '}
+                  {délaiAccordéCorrigéPar} le {afficherDate(new Date(délaiAccordéCorrigéLe))}
+                </div>
+                <div>
+                  L'administration vous accorde un report de date limite d'achèvement au{' '}
+                  <span className="font-bold">
+                    {afficherDate(new Date(dateAchèvementAprèsCorrectionDélaiAccordé))}
+                  </span>
+                  .
+                </div>
+              </div>
+            )}
           {responseFile && (
             <div className="mt-4">
               <DownloadLink

--- a/src/views/pages/délai/DetailsDemandeDelaiPage.tsx
+++ b/src/views/pages/délai/DetailsDemandeDelaiPage.tsx
@@ -321,13 +321,15 @@ export const DetailsDemandeDelai = ({ request, modificationRequest }: DetailsDem
             </PrimaryButton>
           </Form>
         )}
-        {status === 'acceptée' && userIs(['admin', 'dgec-validateur', 'dreal'])(user) && (
-          <div>
-            <LinkButton href={ROUTES.GET_CORRIGER_DELAI_ACCORDE_PAGE(id)}>
-              Corriger le délai accordé
-            </LinkButton>
-          </div>
-        )}
+        {!délaiAccordéCorrigéLe &&
+          status === 'acceptée' &&
+          userIs(['admin', 'dgec-validateur', 'dreal'])(user) && (
+            <div>
+              <LinkButton href={ROUTES.GET_CORRIGER_DELAI_ACCORDE_PAGE(id)}>
+                Corriger le délai accordé
+              </LinkButton>
+            </div>
+          )}
       </div>
     </LegacyPageTemplate>
   );


### PR DESCRIPTION
Suite à la demo avec des DREAL/DEAL et nouvelle conception voici les modifications : 
- afficher la correction sur la page de la demande (délai accordé initialement et nouveau délai)
- afficher la correction sur la frise (seulement le nouveau délai)
- ne permettre qu'une seule correction
- informer l'utilisateur qu'il est libre de modifier le contenu du courrier de réponse pour l'adapter au cas précis du projet