### PR TITLE
:sparkles: Lister les abandons par statut et ajout d'un tag

### DIFF
--- a/packages/applications/ssr/src/app/laureat/abandon/[page]/page.tsx
+++ b/packages/applications/ssr/src/app/laureat/abandon/[page]/page.tsx
@@ -17,6 +17,21 @@ type PageProps = {
 export default async function ListeAbandonsPage({ params, searchParams }: PageProps) {
   const page = params?.page ? parseInt(params.page) : 1;
 
+  const getPageUrlForDismissedSearchParam = (dismissedSearchParam: string) => {
+    const redirectionSearchParams = { ...searchParams };
+    delete redirectionSearchParams[dismissedSearchParam];
+    return `/laureat/abandon/${page}${
+      redirectionSearchParams
+        ? `?${Object.keys(redirectionSearchParams)
+            .map(
+              (key) =>
+                `${encodeURIComponent(key)}=${encodeURIComponent(redirectionSearchParams[key])}`,
+            )
+            .join('&')}`
+        : ''
+    }`;
+  };
+
   const recandidature =
     searchParams?.recandidature === 'true'
       ? true
@@ -41,22 +56,34 @@ export default async function ListeAbandonsPage({ params, searchParams }: PagePr
     <PageTemplate heading="Abandon">
       {abandons.items.length ? (
         <>
-          {recandidature !== undefined && (
-            <Tag
-              linkProps={{
-                href: `/laureat/abandon/${page}`,
-              }}
-              className="fr-tag--dismiss"
-            >
-              {recandidature ? 'avec' : 'sans'} recandidature
-            </Tag>
-          )}
+          <div className="flex flex-row gap-4">
+            {statut !== undefined && (
+              <Tag
+                linkProps={{
+                  href: getPageUrlForDismissedSearchParam('statut'),
+                }}
+                className="fr-tag--dismiss"
+              >
+                {statut}
+              </Tag>
+            )}
+            {recandidature !== undefined && (
+              <Tag
+                linkProps={{
+                  href: getPageUrlForDismissedSearchParam('recandidature'),
+                }}
+                className="fr-tag--dismiss"
+              >
+                {recandidature ? 'avec' : 'sans'} recandidature
+              </Tag>
+            )}
+          </div>
           <p className="my-4 md:text-right font-semibold">
             {abandons.items.length} {abandons.items.length > 1 ? 'demandes' : 'demande'} d'abandon
             {recandidature === true
               ? ' avec recandidature'
               : recandidature === false
-              ? 'sans recandidature'
+              ? ' sans recandidature'
               : ''}
           </p>
           <ul>

--- a/packages/applications/ssr/src/app/laureat/abandon/[page]/page.tsx
+++ b/packages/applications/ssr/src/app/laureat/abandon/[page]/page.tsx
@@ -24,11 +24,16 @@ export default async function ListeAbandonsPage({ params, searchParams }: PagePr
       ? false
       : undefined;
 
+  const statut = searchParams?.statut || undefined;
+
   const abandons = await mediator.send<Abandon.ListerAbandonsQuery>({
     type: 'LISTER_ABANDONS_QUERY',
     data: {
       pagination: { page, itemsPerPage: 10 },
       recandidature,
+      ...(statut !== undefined && {
+        statut: Abandon.StatutAbandon.convertirEnValueType(statut).statut,
+      }),
     },
   });
 

--- a/packages/applications/ssr/src/app/laureat/abandon/[page]/page.tsx
+++ b/packages/applications/ssr/src/app/laureat/abandon/[page]/page.tsx
@@ -21,14 +21,7 @@ export default async function ListeAbandonsPage({ params, searchParams }: PagePr
     const redirectionSearchParams = { ...searchParams };
     delete redirectionSearchParams[dismissedSearchParam];
     return `/laureat/abandon/${page}${
-      redirectionSearchParams
-        ? `?${Object.keys(redirectionSearchParams)
-            .map(
-              (key) =>
-                `${encodeURIComponent(key)}=${encodeURIComponent(redirectionSearchParams[key])}`,
-            )
-            .join('&')}`
-        : ''
+      redirectionSearchParams ? `?${new URLSearchParams(redirectionSearchParams).toString()}` : ''
     }`;
   };
 
@@ -79,7 +72,7 @@ export default async function ListeAbandonsPage({ params, searchParams }: PagePr
             )}
           </div>
           <p className="my-4 md:text-right font-semibold">
-            {abandons.items.length} {abandons.items.length > 1 ? 'demandes' : 'demande'} d'abandon
+            {abandons.totalItems} {abandons.totalItems > 1 ? 'demandes' : 'demande'} d'abandon
             {recandidature === true
               ? ' avec recandidature'
               : recandidature === false
@@ -102,7 +95,7 @@ export default async function ListeAbandonsPage({ params, searchParams }: PagePr
       <Pagination
         getPageUrl={(pageNumber) => {
           const urlSearchParams = new URLSearchParams(searchParams).toString();
-          return `/laureat/abandon/${pageNumber}${urlSearchParams ? `?${searchParams}` : ''}`;
+          return `/laureat/abandon/${pageNumber}${urlSearchParams ? `?${urlSearchParams}` : ''}`;
         }}
         currentPage={page}
         pageCount={Math.ceil(abandons.totalItems / abandons.itemsPerPage)}


### PR DESCRIPTION
Dans l'attente de filtres, on peut tester l'affichage en jouant avec les search params dans l'url.
Les tags ont un lien de redirection pour supprimer le search param correspondant.