### PR TITLE
🚸 (Page projet): Afficher abandon

### DIFF
--- a/packages/domain/lauréat/src/abandon/abandon.register.ts
+++ b/packages/domain/lauréat/src/abandon/abandon.register.ts
@@ -29,8 +29,13 @@ import {
   ListerAbandonsAvecRecandidatureÀRelancerQueryDependencies,
   registerListerAbandonsAvecRecandidatureÀRelancerQuery,
 } from './lister/listerAbandonAvecRecandidatureÀRelancer.query';
+import {
+  DétecterAbandonDependencies,
+  registerDétecterAbandonQuery,
+} from './détecter/détecterAbandon.query';
 
-export type AbandonQueryDependencies = ConsulterAbandonDependencies &
+export type AbandonQueryDependencies = DétecterAbandonDependencies &
+  ConsulterAbandonDependencies &
   ListerAbandonDependencies &
   ListerAbandonsAvecRecandidatureÀRelancerQueryDependencies;
 export type AbandonCommandDependencies = {
@@ -63,4 +68,5 @@ export const registerAbandonQueries = (dependencies: AbandonQueryDependencies) =
   registerConsulterAbandonQuery(dependencies);
   registerListerAbandonQuery(dependencies);
   registerListerAbandonsAvecRecandidatureÀRelancerQuery(dependencies);
+  registerDétecterAbandonQuery(dependencies);
 };

--- a/packages/domain/lauréat/src/abandon/détecter/détecterAbandon.query.ts
+++ b/packages/domain/lauréat/src/abandon/détecter/détecterAbandon.query.ts
@@ -1,0 +1,29 @@
+import { Message, MessageHandler, mediator } from 'mediateur';
+
+import { isSome } from '@potentiel/monads';
+import { IdentifiantProjet } from '@potentiel-domain/common';
+
+import { AbandonProjection } from '../abandon.projection';
+import { Find } from '@potentiel-libraries/projection';
+
+export type DétecterAbandonQuery = Message<
+  'DÉTECTER_ABANDON_QUERY',
+  {
+    identifiantProjetValue: string;
+  },
+  boolean
+>;
+
+export type DétecterAbandonDependencies = {
+  find: Find;
+};
+
+export const registerDétecterAbandonQuery = ({ find }: DétecterAbandonDependencies) => {
+  const handler: MessageHandler<DétecterAbandonQuery> = async ({ identifiantProjetValue }) => {
+    const identifiantProjet = IdentifiantProjet.convertirEnValueType(identifiantProjetValue);
+    const result = await find<AbandonProjection>(`abandon|${identifiantProjet.formatter()}`);
+
+    return isSome(result);
+  };
+  mediator.register('DÉTECTER_ABANDON_QUERY', handler);
+};

--- a/packages/domain/lauréat/src/abandon/index.ts
+++ b/packages/domain/lauréat/src/abandon/index.ts
@@ -17,14 +17,17 @@ import { RejeterAbandonUseCase } from './rejeter/rejeterAbandon.usecase';
 import { DemanderPreuveRecandidatureAbandonUseCase } from './demander/demanderPreuveRecandidatureAbandon.usecase';
 import { TransmettrePreuveRecandidatureAbandonUseCase } from './transmettre/transmettrePreuveRecandidatureAbandon.usecase';
 import { ListerAbandonsAvecRecandidatureÀRelancerQuery } from './lister/listerAbandonAvecRecandidatureÀRelancer.query';
+import { DétecterAbandonQuery } from './détecter/détecterAbandon.query';
 
 // Query
 export type AbandonQuery =
+  | DétecterAbandonQuery
   | ConsulterAbandonQuery
   | ListerAbandonsQuery
   | ListerAbandonsAvecRecandidatureÀRelancerQuery;
 
 export {
+  DétecterAbandonQuery,
   ConsulterAbandonQuery,
   ListerAbandonsQuery,
   ListerAbandonsAvecRecandidatureÀRelancerQuery,

--- a/src/controllers/project/getProjectPage.ts
+++ b/src/controllers/project/getProjectPage.ts
@@ -28,6 +28,7 @@ import { Project } from '../../infra/sequelize';
 import { isNone, isSome } from '@potentiel/monads';
 import { AlerteRaccordement } from '../../views/pages/projectDetailsPage';
 import { UtilisateurReadModel } from '../../modules/utilisateur/récupérer/UtilisateurReadModel';
+import { Abandon } from '@potentiel-domain/laureat';
 
 const schema = yup.object({
   params: yup.object({ projectId: yup.string().required() }),
@@ -77,22 +78,28 @@ v1Router.get(
 
       const projet = rawProjet.value;
 
-      const alertesRaccordement = await getAlertesRaccordement({
-        userRole: user.role,
-        identifiantProjet: {
-          appelOffre: projet.appelOffreId,
-          période: projet.periodeId,
-          famille: projet.familleId,
-          numéroCRE: projet.numeroCRE,
-        },
-        CDC2022Choisi:
-          projet.cahierDesChargesActuel.type === 'modifié' &&
-          projet.cahierDesChargesActuel.paruLe === '30/08/2022',
-        projet: {
-          isClasse: projet.isClasse,
-          isAbandonned: projet.isAbandoned,
-        },
-      });
+      const identifiantProjet = {
+        appelOffre: projet.appelOffreId,
+        période: projet.periodeId,
+        famille: projet.familleId,
+        numéroCRE: projet.numeroCRE,
+      };
+
+      const abandonEnInstruction = await getAbandonEnInstruction(identifiantProjet);
+
+      const alertesRaccordement = !abandonEnInstruction
+        ? await getAlertesRaccordement({
+            userRole: user.role,
+            identifiantProjet,
+            CDC2022Choisi:
+              projet.cahierDesChargesActuel.type === 'modifié' &&
+              projet.cahierDesChargesActuel.paruLe === '30/08/2022',
+            projet: {
+              isClasse: projet.isClasse,
+              isAbandonned: projet.isAbandoned,
+            },
+          })
+        : undefined;
 
       const rawProjectEventList = await getProjectEvents({ projectId: projet.id, user });
 
@@ -119,11 +126,37 @@ v1Router.get(
           project: projet,
           projectEventList: rawProjectEventList.value,
           alertesRaccordement,
+          ...(abandonEnInstruction && { abandonEnInstruction }),
         }),
       );
     },
   ),
 );
+
+type AbandonEnInstructionProps =
+  | { statut: 'demandé' | 'en attente de confirmation' | 'confirmé' }
+  | undefined;
+const getAbandonEnInstruction = async (
+  identifiantProjet: IdentifiantProjet,
+): Promise<AbandonEnInstructionProps> => {
+  try {
+    const { statut } = await mediator.send<Abandon.ConsulterAbandonQuery>({
+      type: 'CONSULTER_ABANDON_QUERY',
+      data: { identifiantProjetValue: convertirEnIdentifiantProjet(identifiantProjet).formatter() },
+    });
+    return statut.estDemandé()
+      ? { statut: 'demandé' }
+      : statut.estConfirmé()
+      ? { statut: 'confirmé' }
+      : statut.estConfirmationDemandée() || statut.estEnAttenteConfirmation()
+      ? {
+          statut: 'en attente de confirmation',
+        }
+      : undefined;
+  } catch (error) {
+    return;
+  }
+};
 
 const getIdentifiantLegacyProjet = async (identifiantProjet: RawIdentifiantProjet) => {
   const identifiantProjetValueType = convertirEnIdentifiantProjet(identifiantProjet);

--- a/src/controllers/project/getProjectPage.ts
+++ b/src/controllers/project/getProjectPage.ts
@@ -140,9 +140,19 @@ const getAbandonEnInstruction = async (
   identifiantProjet: IdentifiantProjet,
 ): Promise<AbandonEnInstructionProps> => {
   try {
+    const identifiantProjetValue = convertirEnIdentifiantProjet(identifiantProjet).formatter();
+    const abandonDétecté = await mediator.send<Abandon.DétecterAbandonQuery>({
+      type: 'DÉTECTER_ABANDON_QUERY',
+      data: { identifiantProjetValue },
+    });
+
+    if (!abandonDétecté) {
+      return;
+    }
+
     const { statut } = await mediator.send<Abandon.ConsulterAbandonQuery>({
       type: 'CONSULTER_ABANDON_QUERY',
-      data: { identifiantProjetValue: convertirEnIdentifiantProjet(identifiantProjet).formatter() },
+      data: { identifiantProjetValue },
     });
     return statut.estDemandé()
       ? { statut: 'demandé' }

--- a/src/views/pages/projectDetailsPage/ProjectDetails.tsx
+++ b/src/views/pages/projectDetailsPage/ProjectDetails.tsx
@@ -38,6 +38,7 @@ type ProjectDetailsProps = {
   project: ProjectDataForProjectPage;
   projectEventList?: ProjectEventListDTO;
   alertesRaccordement?: AlerteRaccordement[];
+  abandonEnInstruction?: { statut: 'demandé' | 'en attente de confirmation' | 'confirmé' };
 };
 
 export const ProjectDetails = ({
@@ -45,6 +46,7 @@ export const ProjectDetails = ({
   project,
   projectEventList,
   alertesRaccordement,
+  abandonEnInstruction,
 }: ProjectDetailsProps) => {
   const { user } = request;
   const { error, success } = (request.query as any) || {};
@@ -63,6 +65,13 @@ export const ProjectDetails = ({
       </div>
       <div className="flex flex-col gap-3 mt-5">
         <div className="print:hidden flex flex-col gap-3">
+          {abandonEnInstruction && (
+            <AlertBox title="Abandon en instruction">
+              <a href={`/demande/${encodeURIComponent(project.id)}/details.html`}>
+                Voir l'abandon {abandonEnInstruction.statut}
+              </a>
+            </AlertBox>
+          )}
           {project.alerteAnnulationAbandon && userIs('porteur-projet')(user) && (
             <AlerteAnnulationAbandonPossible
               {...{ ...project, alerteAnnulationAbandon: project.alerteAnnulationAbandon }}

--- a/src/views/pages/projectDetailsPage/ProjectDetails.tsx
+++ b/src/views/pages/projectDetailsPage/ProjectDetails.tsx
@@ -38,7 +38,9 @@ type ProjectDetailsProps = {
   project: ProjectDataForProjectPage;
   projectEventList?: ProjectEventListDTO;
   alertesRaccordement?: AlerteRaccordement[];
-  abandonEnInstruction?: { statut: 'demandé' | 'en attente de confirmation' | 'confirmé' };
+  abandon?: {
+    statut: string;
+  };
 };
 
 export const ProjectDetails = ({
@@ -46,7 +48,7 @@ export const ProjectDetails = ({
   project,
   projectEventList,
   alertesRaccordement,
-  abandonEnInstruction,
+  abandon,
 }: ProjectDetailsProps) => {
   const { user } = request;
   const { error, success } = (request.query as any) || {};
@@ -69,10 +71,10 @@ export const ProjectDetails = ({
       </div>
       <div className="flex flex-col gap-3 mt-5">
         <div className="print:hidden flex flex-col gap-3">
-          {abandonEnInstruction && (
-            <AlertBox title="Abandon en cours">
+          {abandon && (
+            <AlertBox title="Abandon">
               <a href={`/laureat/${encodeURIComponent(identifiantProjet)}/abandon`}>
-                Voir l'abandon {abandonEnInstruction.statut}
+                Voir l'abandon {abandon.statut}
               </a>
             </AlertBox>
           )}

--- a/src/views/pages/projectDetailsPage/ProjectDetails.tsx
+++ b/src/views/pages/projectDetailsPage/ProjectDetails.tsx
@@ -51,6 +51,10 @@ export const ProjectDetails = ({
   const { user } = request;
   const { error, success } = (request.query as any) || {};
 
+  const identifiantProjet = convertirEnIdentifiantProjet(
+    `${project.appelOffreId}#${project.periodeId}#${project.familleId || ''}#${project.numeroCRE}`,
+  ).formatter();
+
   return (
     <LegacyPageTemplate user={request.user} currentPage="list-projects">
       <p className="hidden print:block m-0 mb-2 font-semibold">
@@ -66,8 +70,8 @@ export const ProjectDetails = ({
       <div className="flex flex-col gap-3 mt-5">
         <div className="print:hidden flex flex-col gap-3">
           {abandonEnInstruction && (
-            <AlertBox title="Abandon en instruction">
-              <a href={`/demande/${encodeURIComponent(project.id)}/details.html`}>
+            <AlertBox title="Abandon en cours">
+              <a href={`/laureat/${encodeURIComponent(identifiantProjet)}/abandon`}>
                 Voir l'abandon {abandonEnInstruction.statut}
               </a>
             </AlertBox>


### PR DESCRIPTION
Afficher l'abandon sur la page du projet + statut + lien vers le détail
Nécessite d'introduire une nouvelle query "détecterAbandon" pour détecter la présente d'un abandon, auquel cas on peut ensuite le consulter.