### PR TITLE
🎨 (import candidats): import avec date de notification ko pour les projets non-legacy

### DIFF
--- a/src/modules/project/useCases/importProjects.spec.ts
+++ b/src/modules/project/useCases/importProjects.spec.ts
@@ -453,53 +453,51 @@ describe('importProjects', () => {
     });
   });
 
-  // TO DO
-  // Règle supprimée temporairement
-  // describe('when a line is from a non-legacy periode and has a notification date', () => {
-  //   const invalidLine = {
-  //     ...validLine,
-  //     "Appel d'offres": 'appelOffreId',
-  //     Période: 'periodeId',
-  //     Notification: '12/12/2020',
-  //   };
+  describe('when a line is from a non-legacy periode and has a notification date', () => {
+    const invalidLine = {
+      ...validLine,
+      "Appel d'offres": 'appelOffreId',
+      Période: 'periodeId',
+      Notification: '12/12/2020',
+    };
 
-  //   const appelOffreRepo = {
-  //     findAll: async () => [
-  //       {
-  //         id: 'appelOffreId',
-  //         periodes: [{ id: 'periodeId', type: 'notified' }],
-  //         familles: [{ id: 'familleId' }],
-  //       },
-  //     ],
-  //   } as unknown as AppelOffreRepo;
+    const appelOffreRepo = {
+      findAll: async () => [
+        {
+          id: 'appelOffreId',
+          periodes: [{ id: 'periodeId', type: 'notified' }],
+          familles: [{ id: 'familleId' }],
+        },
+      ],
+    } as unknown as AppelOffreRepo;
 
-  //   const lines = [invalidLine] as Record<string, string>[];
-  //   const importId = new UniqueEntityID().toString();
+    const lines = [invalidLine] as Record<string, string>[];
+    const importId = new UniqueEntityID().toString();
 
-  //   const eventBus = {
-  //     publish: jest.fn((event: DomainEvent) => okAsync<null, InfraNotAvailableError>(null)),
-  //     subscribe: jest.fn(),
-  //   };
+    const eventBus = {
+      publish: jest.fn((event: DomainEvent) => okAsync<null, InfraNotAvailableError>(null)),
+      subscribe: jest.fn(),
+    };
 
-  //   const importProjects = makeImportProjects({
-  //     eventBus,
-  //     appelOffreRepo,
-  //   });
+    const importProjects = makeImportProjects({
+      eventBus,
+      appelOffreRepo,
+    });
 
-  //   it('should throw an error', async () => {
-  //     expect.assertions(4);
-  //     try {
-  //       await importProjects({ lines, importId, importedBy: user });
-  //     } catch (error) {
-  //       expect(error).toBeDefined();
-  //       expect(error).toBeInstanceOf(IllegalProjectDataError);
-  //       expect(error.errors[1]).toContain(
-  //         'notifiée sur Potentiel. Le projet concerné ne doit pas comporter de date de notification.',
-  //       );
-  //       expect(eventBus.publish).not.toHaveBeenCalled();
-  //     }
-  //   });
-  // });
+    it('should throw an error', async () => {
+      expect.assertions(4);
+      try {
+        await importProjects({ lines, importId, importedBy: user });
+      } catch (error) {
+        expect(error).toBeDefined();
+        expect(error).toBeInstanceOf(IllegalProjectDataError);
+        expect(error.errors[1]).toContain(
+          'notifiée sur Potentiel. Le projet concerné ne doit pas comporter de date de notification.',
+        );
+        expect(eventBus.publish).not.toHaveBeenCalled();
+      }
+    });
+  });
 
   describe('when a line is from a non-legacy periode and has a legacy modifications', () => {
     const invalidLine = {

--- a/src/modules/project/useCases/importProjects.ts
+++ b/src/modules/project/useCases/importProjects.ts
@@ -136,13 +136,11 @@ const checkLegacyRules = (args: {
       );
     }
   } else {
-    // TO DO
-    // Règle supprimée temporairement :
-    // if (projectData.notifiedOn) {
-    //   throw new Error(
-    //     `La période ${appelOffreId}-${periodeId} est notifiée sur Potentiel. Le projet concerné ne doit pas comporter de date de notification.`,
-    //   );
-    // }
+    if (projectData.notifiedOn) {
+      throw new Error(
+        `La période ${appelOffreId}-${periodeId} est notifiée sur Potentiel. Le projet concerné ne doit pas comporter de date de notification.`,
+      );
+    }
 
     if (hasLegacyModifications) {
       throw new Error(


### PR DESCRIPTION
Cette règle avait été supprimée temporairement afin d'importer un projet qui avait été par erreur omis dans un fichier de candidats de la CRE...