### PR TITLE
✨ (Vérification volume réservé): prendre en compte la note du dernier retenu

### DIFF
--- a/src/controllers/modificationRequest/puissance/getDemanderChangementDePuissancePage.ts
+++ b/src/controllers/modificationRequest/puissance/getDemanderChangementDePuissancePage.ts
@@ -20,7 +20,7 @@ v1Router.get(
       return notFoundResponse({ request, response, ressourceTitle: 'Projet' });
     }
 
-    // TODO: lecture faite directement sur la table Project sans passé par une query...
+    // TODO: lecture faite directement sur la table Project sans passer par une query...
     const project = await Project.findByPk(projectId);
 
     if (!project) {

--- a/src/infra/sequelize/queries/modificationRequest/getModificationRequestDetails.ts
+++ b/src/infra/sequelize/queries/modificationRequest/getModificationRequestDetails.ts
@@ -46,6 +46,7 @@ export const getModificationRequestDetails: GetModificationRequestDetails = (
             'potentielIdentifier',
             'technologie',
             'cahierDesChargesActuel',
+            'note',
           ],
         },
         {

--- a/src/modules/demandeModification/demandeChangementDePuissance/demander/demanderChangementDePuissance.ts
+++ b/src/modules/demandeModification/demandeChangementDePuissance/demander/demanderChangementDePuissance.ts
@@ -104,7 +104,7 @@ export const makeDemanderChangementDePuissance: MakeDemanderChangementDePuissanc
           });
           const exceedsPuissanceMax = exceedsPuissanceMaxDuVolumeReserve({
             nouvellePuissance: newPuissance,
-            project: { ...project },
+            project: { ...project, note: project.data!!.note },
           });
 
           const newPuissanceIsAutoAccepted = !exceedsRatios && !exceedsPuissanceMax;

--- a/src/modules/demandeModification/demandeChangementDePuissance/demander/helpers/exceedsPuissanceMaxDuVolumeReserve.spec.ts
+++ b/src/modules/demandeModification/demandeChangementDePuissance/demander/helpers/exceedsPuissanceMaxDuVolumeReserve.spec.ts
@@ -4,36 +4,74 @@ import { Periode } from '@potentiel-domain/appel-offre';
 import { exceedsPuissanceMaxDuVolumeReserve } from './exceedsPuissanceMaxDuVolumeReserve';
 
 describe('exceedsPuissanceMaxDuVolumeReserve', () => {
-  describe(`when the project has an appel offre with a volume reservé`, () => {
+  describe(`Étant donné une période d'appel d'offres avec un volume réservé
+      pour les projets : 
+        - dont la puissance n'excède pas 10
+        - dont la du dernier retenu est de 15`, () => {
     const appelOffre = {
       periode: {
         noteThresholdBy: 'category',
-        noteThreshold: { volumeReserve: { puissanceMax: 10 } },
+        noteThreshold: { volumeReserve: { puissanceMax: 10, noteThreshold: 15 } },
       } as Periode,
     } as ProjectAppelOffre;
 
-    describe(`when the project was notified in the volume reservé`, () => {
-      describe(`when the new puissance exceed the puissance max of the volume reservé`, () => {
-        it(`should return true`, () => {
-          const actual = exceedsPuissanceMaxDuVolumeReserve({
-            project: { puissanceInitiale: 10, appelOffre },
-            nouvellePuissance: 10.1,
-          });
-          expect(actual).toBe(true);
+    describe(`Projet entrant dans le volume réservé`, () => {
+      it(`Étant donné un projet avec une puissance initiale de 9 et une note de 16
+          Lorsque la nouvelle puissance demandée dépasse 10 (puissance max du volume)
+          Alors la demande doit être considérée comme dépassant la puissance max du volume réservé`, () => {
+        const actual = exceedsPuissanceMaxDuVolumeReserve({
+          project: { puissanceInitiale: 9, note: 16, appelOffre },
+          nouvellePuissance: 10.1,
         });
+        expect(actual).toBe(true);
+      });
+
+      it(`Étant donné un projet avec une puissance initiale de 9 et une note de 16
+          Lorsque la nouvelle puissance demandée ne dépasse pas 10 (puissance max du volume)
+          Alors la demande ne doit pas être considérée comme dépassant la puissance max du volume réservé`, () => {
+        const actual = exceedsPuissanceMaxDuVolumeReserve({
+          project: { puissanceInitiale: 9, note: 16, appelOffre },
+          nouvellePuissance: 9.1,
+        });
+        expect(actual).toBe(false);
       });
     });
 
-    describe(`when the project was not notified in the volume reservé`, () => {
-      describe(`when the new puissance exceed the puissance max of the volume reservé`, () => {
-        it(`should return false`, () => {
-          const actual = exceedsPuissanceMaxDuVolumeReserve({
-            project: { puissanceInitiale: 15, appelOffre },
-            nouvellePuissance: 16,
-          });
-          expect(actual).toBe(false);
+    describe(`Projet hors volume réservé`, () => {
+      it(`Étant donné un projet avec une puissance initiale supérieure à celle du volume réservé
+          Lorsque la nouvelle puissance demandée dépasse 10 (puissance max du volume)
+          Alors la demande ne doit pas être considérée comme dépassant la puissance max du volume réservé`, () => {
+        const actual = exceedsPuissanceMaxDuVolumeReserve({
+          project: { puissanceInitiale: 12, note: 16, appelOffre },
+          nouvellePuissance: 10.1,
         });
+        expect(actual).toBe(false);
       });
+
+      it(`Étant donné un projet avec une note inférieure à celle du dernier retenu du volume réservé
+          Lorsque la nouvelle puissance demandée dépasse 10 (puissance max du volume)
+          Alors la demande ne doit pas être considérée comme dépassant la puissance max du volume réservé`, () => {
+        const actual = exceedsPuissanceMaxDuVolumeReserve({
+          project: { puissanceInitiale: 9, note: 10, appelOffre },
+          nouvellePuissance: 10.1,
+        });
+        expect(actual).toBe(false);
+      });
+    });
+  });
+
+  describe(`Étant donné une période d'appel d'offres sans volume réservé`, () => {
+    const appelOffre = {
+      periode: {} as Periode,
+    } as ProjectAppelOffre;
+    it(`Étant donné un projet
+        Lorsque qu'il y a une demande de changement de puissance
+        Alors la demande ne devrait pas être considérée comme dépassant un volume réservé`, () => {
+      const actual = exceedsPuissanceMaxDuVolumeReserve({
+        project: { puissanceInitiale: 9, note: 16, appelOffre },
+        nouvellePuissance: 10.1,
+      });
+      expect(actual).toBe(false);
     });
   });
 });

--- a/src/modules/demandeModification/demandeChangementDePuissance/demander/helpers/exceedsPuissanceMaxDuVolumeReserve.spec.ts
+++ b/src/modules/demandeModification/demandeChangementDePuissance/demander/helpers/exceedsPuissanceMaxDuVolumeReserve.spec.ts
@@ -7,7 +7,7 @@ describe('exceedsPuissanceMaxDuVolumeReserve', () => {
   describe(`Étant donné une période d'appel d'offres avec un volume réservé
       pour les projets : 
         - dont la puissance n'excède pas 10
-        - dont la du dernier retenu est de 15`, () => {
+        - dont la note du dernier retenu est de 15`, () => {
     const appelOffre = {
       periode: {
         noteThresholdBy: 'category',

--- a/src/modules/demandeModification/demandeChangementDePuissance/demander/helpers/exceedsPuissanceMaxDuVolumeReserve.ts
+++ b/src/modules/demandeModification/demandeChangementDePuissance/demander/helpers/exceedsPuissanceMaxDuVolumeReserve.ts
@@ -4,6 +4,7 @@ import { getVolumeReserve } from './getVolumeReserve';
 export type ExceedsPuissanceMaxDuVolumeReserve = (arg: {
   project: {
     puissanceInitiale: number;
+    note: number;
     appelOffre?: ProjectAppelOffre;
   };
   nouvellePuissance: number;
@@ -13,12 +14,12 @@ export const exceedsPuissanceMaxDuVolumeReserve: ExceedsPuissanceMaxDuVolumeRese
   project,
   nouvellePuissance,
 }) => {
-  const { appelOffre, puissanceInitiale } = project;
+  const { appelOffre, puissanceInitiale, note } = project;
   const volumeReserve = appelOffre && getVolumeReserve(appelOffre);
 
   if (volumeReserve) {
-    const { puissanceMax } = volumeReserve;
-    const wasNotifiedOnVolumeReserve = puissanceInitiale <= puissanceMax;
+    const { puissanceMax, noteThreshold } = volumeReserve;
+    const wasNotifiedOnVolumeReserve = puissanceInitiale <= puissanceMax && note >= noteThreshold;
     if (wasNotifiedOnVolumeReserve && nouvellePuissance > puissanceMax) {
       return true;
     }

--- a/src/modules/demandeModification/demandeChangementDePuissance/demander/helpers/getVolumeReserve.ts
+++ b/src/modules/demandeModification/demandeChangementDePuissance/demander/helpers/getVolumeReserve.ts
@@ -3,7 +3,7 @@ import { isNotifiedPeriode } from '../../../../../entities/periode';
 
 export const getVolumeReserve = (
   appelOffre: ProjectAppelOffre,
-): { puissanceMax: number } | undefined => {
+): { noteThreshold: number; puissanceMax: number } | undefined => {
   const { periode } = appelOffre;
 
   if (isNotifiedPeriode(periode)) {

--- a/src/modules/modificationRequest/dtos/ModificationRequestPageDTO.ts
+++ b/src/modules/modificationRequest/dtos/ModificationRequestPageDTO.ts
@@ -63,6 +63,7 @@ export type ModificationRequestPageDTO = {
     technologie: Technologie;
     appelOffre?: ProjectAppelOffre;
     cahierDesChargesActuel: CahierDesChargesRéférence;
+    note: number;
   };
 } & Variant;
 

--- a/src/views/pages/demanderChangementPuissancePage/DemanderChangementPuissance.tsx
+++ b/src/views/pages/demanderChangementPuissancePage/DemanderChangementPuissance.tsx
@@ -29,6 +29,7 @@ type DemanderChangementPuissanceProps = {
     puissanceInitiale: number;
     puissance: number;
     unitePuissance: string;
+    note: number;
   };
   appelOffre: ProjectAppelOffre;
 };
@@ -92,6 +93,7 @@ export const DemanderChangementPuissance = ({
               justification,
               appelOffre,
               puissanceSaisie,
+              noteProjet: project.note,
             }}
           />
           <div className="mx-auto flex flex-col md:flex-row gap-4 items-center">

--- a/src/views/pages/demanderChangementPuissancePage/components/ChangementPuissance.tsx
+++ b/src/views/pages/demanderChangementPuissancePage/components/ChangementPuissance.tsx
@@ -23,6 +23,7 @@ type ChangementPuissanceProps = {
   unitePuissance: string;
   puissance: number;
   puissanceInitiale: number;
+  noteProjet: number;
   justification: string;
   cahierDesChargesActuel: string;
   appelOffre: ProjectAppelOffre;
@@ -38,6 +39,7 @@ export const ChangementPuissance = ({
   appelOffre,
   technologie,
   puissanceSaisie,
+  noteProjet,
 }: ChangementPuissanceProps) => {
   const [displayAlertOnPuissanceType, setDisplayAlertOnPuissanceType] = useState(false);
   const [displayAlertHorsRatios, setDisplayAlertHorsRatios] = useState(false);
@@ -53,7 +55,7 @@ export const ChangementPuissance = ({
       nouvellePuissance,
     });
     const exceedsPuissanceMax = exceedsPuissanceMaxDuVolumeReserve({
-      project: { puissanceInitiale, appelOffre },
+      project: { puissanceInitiale, appelOffre, note: noteProjet },
       nouvellePuissance,
     });
 


### PR DESCRIPTION
Lorsqu'on vérifie si une demande de puissance dépasse le volume réservé, il faut vérifier que le projet est dans un volume réservé. Afin de vérifier cela nous ne vérifions que la puissance initiale du projet est dans le volume réservé. 
Dans cette PR on ajoute une vérification sur la note du projet : elle ne doit pas être inférieure à la note du dernier retenu du volume réservé. 