### PR TITLE
🚸 (wording): information validée devient information enregistrée

### DIFF
--- a/src/views/helpers/ModificationRequestStatusTitle.ts
+++ b/src/views/helpers/ModificationRequestStatusTitle.ts
@@ -2,7 +2,7 @@ import { ModificationRequestStatusDTO } from '../../modules/modificationRequest'
 
 export const ModificationRequestStatusTitle: Record<ModificationRequestStatusDTO, string> = {
   envoyée: 'Envoyée',
-  'information validée': 'Information validée',
+  'information validée': 'Information enregistrée',
   'en instruction': 'En instruction',
   'en attente de confirmation': 'En attente de confirmation',
   'demande confirmée': 'Demande confirmée',

--- a/src/views/pages/modificationRequestListPage/ModificationRequestList.tsx
+++ b/src/views/pages/modificationRequestListPage/ModificationRequestList.tsx
@@ -287,7 +287,7 @@ export const ModificationRequestList = ({
                 <option value="acceptée">Acceptée</option>
                 <option value="rejetée">Rejetée</option>
                 <option value="annulée">Annulée</option>
-                <option value="information validée">Information validée</option>
+                <option value="information validée">Information enregistrée</option>
               </Select>
             </div>
           </Form>


### PR DESCRIPTION
Le changement de wording n'est appliqué que sur les interfaces : page détail demande et filtres liste demandes.