### PR TITLE
:art: Utiliser les liens "génériques" par AO pour renvoyer vers les détails des CDC

### DIFF
--- a/packages/domain-inmemory-referential/src/appelOffre/CRE4/autoconsommationMetropole.ts
+++ b/packages/domain-inmemory-referential/src/appelOffre/CRE4/autoconsommationMetropole.ts
@@ -21,6 +21,8 @@ export const autoconsommationMetropole: AppelOffre = {
     'portant sur la réalisation et l’exploitation d’Installations de production d’électricité à partir d’énergies renouvelables en autoconsommation et situées en métropole continentale',
   shortTitle: 'CRE4 - Autoconsommation métropole',
   launchDate: 'mars 2017',
+  cahiersDesChargesUrl:
+    'https://www.cre.fr/documents/Appels-d-offres/appel-d-offres-portant-sur-la-realisation-et-l-exploitation-d-installations-de-production-d-electricite-a-partir-d-energies-renouvelables-en-auto',
   unitePuissance: 'MWc',
   autoritéCompétenteDemandesDélai: 'dreal',
   delaiRealisationEnMois: 24,
@@ -73,7 +75,6 @@ Le Candidat peut également être délié de cette obligation selon appréciatio
       type: 'legacy',
       cahierDesCharges: {
         référence: '2017/S 054-100223',
-        url: 'https://www.cre.fr/media/fichiers/publications/appelsoffres/autoconso-metropole-ancienne-version-du-cahier-des-charges-dans-sa-version-applicable-a-la-1ere-periode',
       },
       delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       donnéesCourriersRéponse: {
@@ -110,7 +111,6 @@ Ils doivent faire l’objet d’une information au Préfet dans un délai d’un
       type: 'legacy',
       cahierDesCharges: {
         référence: '2017/S 054-100223',
-        url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/Autoconso-Ancienne-version-du-cahier-des-charges-dans-sa-version-applicable-a-la-2eme-periode',
       },
       delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       donnéesCourriersRéponse: {
@@ -145,7 +145,6 @@ Ils doivent faire l’objet d’une information au Préfet dans un délai d’un
       type: 'legacy',
       cahierDesCharges: {
         référence: '2017/S 054-100223',
-        url: 'https://www.cre.fr/media/fichiers/publications/appelsoffres/telecharger-le-cahier-des-charges-en-vigueur-dans-sa-version-modifiee-le-24-avril-2018',
       },
       delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       donnéesCourriersRéponse: {
@@ -180,7 +179,6 @@ Ils doivent faire l’objet d’une information au Préfet dans un délai d’un
       type: 'legacy',
       cahierDesCharges: {
         référence: '2017/S 054-100223',
-        url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/Ancienne-version-du-cahier-des-charges-dans-sa-version-applicable-a-la-4eme-periode',
       },
       delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       donnéesCourriersRéponse: {
@@ -215,7 +213,6 @@ Ils doivent faire l’objet d’une information au Préfet dans un délai d’un
       type: 'legacy',
       cahierDesCharges: {
         référence: '2017/S 054-100223',
-        url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/Telecharger-le-cahier-des-charges-en-vigueur-dans-sa-version-modifiee-le-22-novembre-20182',
       },
       delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       donnéesCourriersRéponse: {
@@ -250,7 +247,6 @@ Ils doivent faire l’objet d’une information au Préfet dans un délai d’un
       type: 'legacy',
       cahierDesCharges: {
         référence: '2017/S 054-100223',
-        url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/Autoconso-Telecharger-le-cahier-des-charges-en-vigueur-dans-sa-version-modifiee-le-18-juin-2019',
       },
       delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       donnéesCourriersRéponse: {
@@ -286,7 +282,6 @@ Ils doivent faire l’objet d’une information au Préfet dans un délai d’un
       certificateTemplate: 'cre4.v0',
       cahierDesCharges: {
         référence: '2017/S 054-100223',
-        url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/autoconsommation-02-01-2020-telecharger-le-cahier-des-charges-en-vigueur',
       },
       delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       donnéesCourriersRéponse: {
@@ -322,7 +317,6 @@ Ils doivent faire l’objet d’une information au Préfet dans un délai d’un
       certificateTemplate: 'cre4.v1',
       cahierDesCharges: {
         référence: '2017/S 054-100223',
-        url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/ao-autoconso-metro-telecharger-le-cahier-des-charges-en-vigueur-dans-sa-version-modifiee-le-04-juin-2020',
       },
       delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       donnéesCourriersRéponse: {
@@ -358,7 +352,6 @@ Ils doivent faire l’objet d’une information au Préfet dans un délai d’un
       certificateTemplate: 'cre4.v1',
       cahierDesCharges: {
         référence: '2017/S 054-100223',
-        url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/ao-autoconso-metro-telecharger-le-cahier-des-charges-en-vigueur-dans-sa-version-modifiee-le-04-juin-2020',
       },
       delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       donnéesCourriersRéponse: {
@@ -394,7 +387,6 @@ Ils doivent faire l’objet d’une information au Préfet dans un délai d’un
       certificateTemplate: 'cre4.v1',
       cahierDesCharges: {
         référence: '2017/S 054-100223',
-        url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/telecharger-le-cahier-des-charges-en-vigueur-dans-sa-version-modifiee-le-26-avril-2021',
       },
       delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       donnéesCourriersRéponse: {

--- a/packages/domain-inmemory-referential/src/appelOffre/CRE4/autoconsommationMetropole.ts
+++ b/packages/domain-inmemory-referential/src/appelOffre/CRE4/autoconsommationMetropole.ts
@@ -3,7 +3,6 @@ import { AppelOffre, CahierDesChargesModifié } from '@potentiel-domain/appel-of
 const CDCModifié30072021: CahierDesChargesModifié = {
   type: 'modifié',
   paruLe: '30/07/2021',
-  url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/30072021-avis-modificatif-cre4-autoconsommation-metropole-2',
   donnéesCourriersRéponse: {
     texteChangementDePuissance: {
       référenceParagraphe: '5.3.4',

--- a/packages/domain-inmemory-referential/src/appelOffre/CRE4/autoconsommationMetropole2016.ts
+++ b/packages/domain-inmemory-referential/src/appelOffre/CRE4/autoconsommationMetropole2016.ts
@@ -21,6 +21,8 @@ export const autoconsommationMetropole2016: AppelOffre = {
     'portant sur la réalisation et l’exploitation d’installations de production d’électricité à partir d’énergies renouvelables en autoconsommation',
   shortTitle: 'CRE4 - Autoconsommation métropole 2016',
   launchDate: 'juillet 2016',
+  cahiersDesChargesUrl:
+    'https://www.cre.fr/documents/Appels-d-offres/appel-d-offres-portant-sur-la-realisation-et-l-exploitation-d-installations-de-production-d-electricite-a-partir-d-energies-renouvelables-en-autoco',
   unitePuissance: 'MWc',
   autoritéCompétenteDemandesDélai: 'dreal',
   delaiRealisationEnMois: 30,
@@ -94,7 +96,6 @@ Ces retards sont réputés autorisés sous réserve de pouvoir les justifier aup
       type: 'legacy',
       cahierDesCharges: {
         référence: '2016/S 146-264282',
-        url: 'https://www.cre.fr/media/fichiers/publications/appelsoffres/cahier-des-charges-autoconsommation-modifie-du-14-09-2016',
       },
       delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       cahiersDesChargesModifiésDisponibles: [CDCModifié30072021],
@@ -106,7 +107,6 @@ Ces retards sont réputés autorisés sous réserve de pouvoir les justifier aup
       type: 'legacy',
       cahierDesCharges: {
         référence: '2016/S 146-264282',
-        url: 'https://www.cre.fr/media/fichiers/publications/appelsoffres/cahier-des-charges-autoconsommation-modifie-du-14-09-2016',
       },
       delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       cahiersDesChargesModifiésDisponibles: [CDCModifié30072021],

--- a/packages/domain-inmemory-referential/src/appelOffre/CRE4/autoconsommationMetropole2016.ts
+++ b/packages/domain-inmemory-referential/src/appelOffre/CRE4/autoconsommationMetropole2016.ts
@@ -3,7 +3,6 @@ import { AppelOffre, CahierDesChargesModifié } from '@potentiel-domain/appel-of
 const CDCModifié30072021: CahierDesChargesModifié = {
   paruLe: '30/07/2021',
   type: 'modifié',
-  url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/30072021-avis-modificatif-cre4-autoconsommation-metropole-1',
   donnéesCourriersRéponse: {
     texteChangementDePuissance: {
       référenceParagraphe: '5.2.4',

--- a/packages/domain-inmemory-referential/src/appelOffre/CRE4/autoconsommationZNI.ts
+++ b/packages/domain-inmemory-referential/src/appelOffre/CRE4/autoconsommationZNI.ts
@@ -44,6 +44,8 @@ export const autoconsommationZNI: AppelOffre = {
     'portant sur la réalisation et l’exploitation d’Installations de production d’électricité à partir d’énergies renouvelables en autoconsommation et situées dans les zones non interconnectées.',
   shortTitle: 'CRE4 - Autoconsommation ZNI',
   launchDate: 'juin 2019',
+  cahiersDesChargesUrl:
+    'https://www.cre.fr/documents/Appels-d-offres/appels-d-offres-portant-sur-la-realisation-et-l-exploitation-d-installations-de-production-d-electricite-a-partir-d-energies-renouvelables-en-autoc',
   unitePuissance: 'MWc',
   delaiRealisationEnMois: 30,
   autoritéCompétenteDemandesDélai: 'dreal',
@@ -113,7 +115,6 @@ Ces retards sont réputés autorisés sous réserve de pouvoir les justifier aup
       type: 'legacy',
       cahierDesCharges: {
         référence: '2019/S 113-276257',
-        url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/AUTOCONSO-ZNI-Telecharger-le-cahier-des-charges-publie-le-12-07-2019',
       },
       delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       donnéesCourriersRéponse: {
@@ -132,7 +133,6 @@ Ces retards sont réputés autorisés sous réserve de pouvoir les justifier aup
       noteThreshold: 32.9,
       cahierDesCharges: {
         référence: '2019/S 113-276257',
-        url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/zni-autoconso-telecharger-le-cahier-des-charges-publie-le-09-06-2020',
       },
       delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       donnéesCourriersRéponse: {

--- a/packages/domain-inmemory-referential/src/appelOffre/CRE4/autoconsommationZNI.ts
+++ b/packages/domain-inmemory-referential/src/appelOffre/CRE4/autoconsommationZNI.ts
@@ -3,7 +3,6 @@ import { AppelOffre, CahierDesChargesModifié } from '@potentiel-domain/appel-of
 const CDCModifié30072021: CahierDesChargesModifié = {
   paruLe: '30/07/2021',
   type: 'modifié',
-  url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/30072021-avis-modificatif-cre4-zni-autoconsommation-2',
   donnéesCourriersRéponse: {
     texteChangementDePuissance: {
       référenceParagraphe: '5.3.4',
@@ -18,7 +17,6 @@ const CDCModifié30082022: CahierDesChargesModifié = {
   type: 'modifié',
   paruLe: '30/08/2022',
   numéroGestionnaireRequis: true,
-  url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/cre-4-zni-autoconsommation-2-telecharger-l-avis-modificatif-publie-le-30-aout-2022',
   donnéesCourriersRéponse: {
     texteChangementDePuissance: {
       référenceParagraphe: '5.3.4',

--- a/packages/domain-inmemory-referential/src/appelOffre/CRE4/autoconsommationZNI2017.ts
+++ b/packages/domain-inmemory-referential/src/appelOffre/CRE4/autoconsommationZNI2017.ts
@@ -44,6 +44,8 @@ export const autoconsommationZNI2017: AppelOffre = {
     'portant sur la réalisation et l’exploitation d’Installations de production d’électricité à partir d’énergies renouvelables en autoconsommation et situées dans les zones non interconnectées',
   shortTitle: 'CRE4 - Autoconsommation ZNI 2017',
   launchDate: 'décembre 2016',
+  cahiersDesChargesUrl:
+    'https://www.cre.fr/documents/Appels-d-offres/appel-d-offres-portant-sur-la-realisation-et-l-exploitation-d-installations-de-production-d-electricite-a-partir-d-energies-renouvelables-en-autoco2',
   unitePuissance: 'MWc',
   delaiRealisationEnMois: 30,
   autoritéCompétenteDemandesDélai: 'dreal',
@@ -117,7 +119,6 @@ Ces retards sont réputés autorisés sous réserve de pouvoir les justifier aup
       type: 'legacy',
       cahierDesCharges: {
         référence: '2016/S 242-441979',
-        url: 'https://www.cre.fr/media/fichiers/publications/appelsoffres/telecharger-le-cahier-des-charges-dans-sa-derniere-version-modifiee-rendue-publique-le-29-mai-2017',
       },
       delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       cahiersDesChargesModifiésDisponibles: [CDCModifié30072021, CDCModifié30082022],

--- a/packages/domain-inmemory-referential/src/appelOffre/CRE4/autoconsommationZNI2017.ts
+++ b/packages/domain-inmemory-referential/src/appelOffre/CRE4/autoconsommationZNI2017.ts
@@ -3,7 +3,6 @@ import { AppelOffre, CahierDesChargesModifié } from '@potentiel-domain/appel-of
 const CDCModifié30072021: CahierDesChargesModifié = {
   type: 'modifié',
   paruLe: '30/07/2021',
-  url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/30072021-avis-modificatif-cre4-zni-autoconsommation-1',
   donnéesCourriersRéponse: {
     texteChangementDePuissance: {
       référenceParagraphe: '5.2.4',
@@ -17,7 +16,6 @@ const CDCModifié30072021: CahierDesChargesModifié = {
 const CDCModifié30082022: CahierDesChargesModifié = {
   type: 'modifié',
   paruLe: '30/08/2022',
-  url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/cre-4-zni-autoconsommation-1-telecharger-l-avis-modificatif-publie-le-30-aout-2022',
   numéroGestionnaireRequis: true,
   donnéesCourriersRéponse: {
     texteChangementDePuissance: {

--- a/packages/domain-inmemory-referential/src/appelOffre/CRE4/batiment.ts
+++ b/packages/domain-inmemory-referential/src/appelOffre/CRE4/batiment.ts
@@ -5,7 +5,6 @@ const garantieFinanciereEnMois = 36;
 const CDCModifié30072021: CahierDesChargesModifié = {
   type: 'modifié',
   paruLe: '30/07/2021',
-  url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/30072021-avis-modificatif-cre4-batiment',
   donnéesCourriersRéponse: {
     texteChangementDePuissance: {
       référenceParagraphe: '5.4.4',
@@ -19,7 +18,6 @@ const CDCModifié30072021: CahierDesChargesModifié = {
 const CDCModifié30082022: CahierDesChargesModifié = {
   type: 'modifié',
   paruLe: '30/08/2022',
-  url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/cre4-batiment-telecharger-l-avis-modificatif-publie-le-30-aout-2022',
   numéroGestionnaireRequis: true,
   délaiApplicable: {
     délaiEnMois: 18,

--- a/packages/domain-inmemory-referential/src/appelOffre/CRE4/batiment.ts
+++ b/packages/domain-inmemory-referential/src/appelOffre/CRE4/batiment.ts
@@ -44,6 +44,8 @@ export const batiment: AppelOffre = {
     'portant sur la réalisation et l’exploitation d’Installations de production d’électricité à partir de l’énergie solaire « Centrales sur bâtiments, serres et hangars agricoles et ombrières de parking de puissance comprise entre 100 kWc et 8 MWc »',
   shortTitle: 'CRE4 - Bâtiment',
   launchDate: 'septembre 2016',
+  cahiersDesChargesUrl:
+    'https://www.cre.fr/documents/Appels-d-offres/appel-d-offres-portant-sur-la-realisation-et-l-exploitation-d-installations-de-production-d-electricite-a-partir-de-l-energie-solaire-centrales-s',
   unitePuissance: 'MWc',
   delaiRealisationEnMois: 20,
   autoritéCompétenteDemandesDélai: 'dreal',
@@ -124,7 +126,6 @@ Ils doivent faire l’objet d’une information au Préfet dans un délai d’un
       type: 'legacy',
       cahierDesCharges: {
         référence: '2016/S 174-312851',
-        url: 'https://www.cre.fr/media/fichiers/publications/appelsoffres/aopvbat-ancienne-version-du-cahier-des-charges-dans-sa-version-applicable-a-la-1ere-periode',
       },
       delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       cahiersDesChargesModifiésDisponibles: [
@@ -161,7 +162,6 @@ Ces retards sont réputés autorisés sous réserve de pouvoir les justifier aup
       type: 'legacy',
       cahierDesCharges: {
         référence: '2016/S 174-312851',
-        url: 'https://www.cre.fr/media/fichiers/publications/appelsoffres/aopvbat-ancienne-version-du-cahier-des-charges-dans-sa-version-applicable-aux-2eme-et-3eme-periodes',
       },
       delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       cahiersDesChargesModifiésDisponibles: [
@@ -198,7 +198,6 @@ Ces retards sont réputés autorisés sous réserve de pouvoir les justifier aup
       type: 'legacy',
       cahierDesCharges: {
         référence: '2016/S 174-312851',
-        url: 'https://www.cre.fr/media/fichiers/publications/appelsoffres/aopvbat-ancienne-version-du-cahier-des-charges-dans-sa-version-applicable-aux-2eme-et-3eme-periodes',
       },
       delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       cahiersDesChargesModifiésDisponibles: [
@@ -235,7 +234,6 @@ Ces retards sont réputés autorisés sous réserve de pouvoir les justifier aup
       type: 'legacy',
       cahierDesCharges: {
         référence: '2016/S 174-312851',
-        url: 'https://www.cre.fr/media/fichiers/publications/appelsoffres/telecharger-le-cahier-des-charges-dans-sa-version-modifiee-le-11-decembre-2017',
       },
       delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       cahiersDesChargesModifiésDisponibles: [
@@ -272,7 +270,6 @@ Ces retards sont réputés autorisés sous réserve de pouvoir les justifier aup
       type: 'legacy',
       cahierDesCharges: {
         référence: '2016/S 174-312851',
-        url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/Telecharger-le-cahier-des-charges-en-vigueur-dans-sa-version-modifiee-le-11-juin-2018',
       },
       delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       cahiersDesChargesModifiésDisponibles: [
@@ -309,7 +306,6 @@ Ces retards sont réputés autorisés sous réserve de pouvoir les justifier aup
       type: 'legacy',
       cahierDesCharges: {
         référence: '2016/S 174-312851',
-        url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/Ancienne-version-du-cahier-des-charges-dans-sa-version-applicable-a-la-6eme-periode',
       },
       delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       cahiersDesChargesModifiésDisponibles: [
@@ -346,7 +342,6 @@ Ces retards sont réputés autorisés sous réserve de pouvoir les justifier aup
       type: 'legacy',
       cahierDesCharges: {
         référence: '2016/S 174-312851',
-        url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/Telecharger-le-cahier-des-charges-en-vigueur-dans-sa-version-modifiee-le-22-novembre-2018',
       },
       delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       cahiersDesChargesModifiésDisponibles: [
@@ -383,7 +378,6 @@ Ces retards sont réputés autorisés sous réserve de pouvoir les justifier aup
       type: 'legacy',
       cahierDesCharges: {
         référence: '2016/S 174-312851',
-        url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/PV-batiment-Telecharger-le-cahier-des-charges-en-vigueur-dans-sa-version-modifiee-le-18-juin-2019',
       },
       delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       cahiersDesChargesModifiésDisponibles: [
@@ -420,7 +414,6 @@ Ces retards sont réputés autorisés sous réserve de pouvoir les justifier aup
       type: 'legacy',
       cahierDesCharges: {
         référence: '2016/S 174-312851',
-        url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/PV-BAT-Telecharger-le-cahier-des-charges-en-vigueur-dans-sa-version-modifiee-le-07-octobre-2019',
       },
       delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       cahiersDesChargesModifiésDisponibles: [
@@ -462,7 +455,6 @@ Ces retards sont réputés autorisés sous réserve de pouvoir les justifier aup
       certificateTemplate: 'cre4.v0',
       cahierDesCharges: {
         référence: '2016/S 174-312851',
-        url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/ao-pv-bat-telecharger-le-cahier-des-charges-en-vigueur-dans-sa-version-modifiee-le-05-fevrier-2020',
       },
       delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       cahiersDesChargesModifiésDisponibles: [
@@ -504,7 +496,6 @@ Ces retards sont réputés autorisés sous réserve de pouvoir les justifier aup
       certificateTemplate: 'cre4.v1',
       cahierDesCharges: {
         référence: '2016/S 174-312851',
-        url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/telecharger-le-cahier-des-charges-en-vigueur-dans-sa-version-modifiee-le-16-juin-2020',
       },
       delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       cahiersDesChargesModifiésDisponibles: [
@@ -546,7 +537,6 @@ Ces retards sont réputés autorisés sous réserve de pouvoir les justifier aup
       certificateTemplate: 'cre4.v1',
       cahierDesCharges: {
         référence: '2016/S 174-312851',
-        url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/ao-bat-telecharger-le-cahier-des-charges-en-vigueur-dans-sa-version-modifiee-le-03-fevrier-2021',
       },
       delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       cahiersDesChargesModifiésDisponibles: [
@@ -588,7 +578,6 @@ Ces retards sont réputés autorisés sous réserve de pouvoir les justifier aup
       certificateTemplate: 'cre4.v1',
       cahierDesCharges: {
         référence: '2016/S 174-312851',
-        url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/telecharger-le-cahier-des-charges-en-vigueur-dans-sa-version-modifiee-le-23-juin-2021',
       },
       delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       cahiersDesChargesModifiésDisponibles: [

--- a/packages/domain-inmemory-referential/src/appelOffre/CRE4/eolien.ts
+++ b/packages/domain-inmemory-referential/src/appelOffre/CRE4/eolien.ts
@@ -4,7 +4,6 @@ const CDCModifié30082022: CahierDesChargesModifié = {
   type: 'modifié',
   paruLe: '30/08/2022',
   numéroGestionnaireRequis: true,
-  url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/cre-4-eolien-telecharger-l-avis-modificatif-publie-le-30-aout-2022',
   délaiApplicable: {
     délaiEnMois: 18,
     intervaleDateMiseEnService: { min: new Date('2022-06-01'), max: new Date('2024-09-30') },

--- a/packages/domain-inmemory-referential/src/appelOffre/CRE4/eolien.ts
+++ b/packages/domain-inmemory-referential/src/appelOffre/CRE4/eolien.ts
@@ -27,6 +27,8 @@ export const eolien: AppelOffre = {
   shortTitle: 'Eolien',
   dossierSuiviPar: 'Sandra Stojkovic (sandra.stojkovic@developpement-durable.gouv.fr)',
   launchDate: 'mai 2017',
+  cahiersDesChargesUrl:
+    'https://www.cre.fr/documents/Appels-d-offres/appel-d-offres-portant-sur-la-realisation-et-l-exploitation-d-installations-de-production-d-electricite-a-partir-de-l-energie-mecanique-du-vent-im',
   unitePuissance: 'MW',
   tarifOuPrimeRetenue: 'le prix de référence T de l’électricité retenu',
   tarifOuPrimeRetenueAlt: 'ce prix de référence',
@@ -97,7 +99,6 @@ Les changements de Producteur postérieurement à l’Achèvement sont réputés
       type: 'legacy',
       cahierDesCharges: {
         référence: '2017/S 083-161855',
-        url: 'https://www.cre.fr/media/fichiers/publications/appelsoffres/ancienne-version-du-cahier-des-charges-dans-sa-version-applicable-a-la-1ere-periode-ao-eolien-08112017',
       },
       delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       garantieFinanciereEnMoisSansAutorisationEnvironnementale: 57,
@@ -150,7 +151,6 @@ Dans tous les cas, l’attribution des délais est soumis à la prolongation de 
       type: 'legacy',
       cahierDesCharges: {
         référence: '2017/S 083-161855',
-        url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/cdc-eolien-ancienne-version-du-cahier-des-charges-dans-sa-version-applicable-a-la-2eme-periode',
       },
       delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       donnéesCourriersRéponse: {
@@ -201,7 +201,6 @@ Dans tous les cas, l’attribution des délais est soumis à la prolongation de 
       type: 'legacy',
       cahierDesCharges: {
         référence: '2017/S 083-161855',
-        url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/cahier-des-charges_3eperioTelecharger-le-cahier-des-charges-en-vigueur-dans-sa-version-modifiee-le-04-mars-2019',
       },
       delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       garantieFinanciereEnMoisSansAutorisationEnvironnementale: 57,
@@ -252,7 +251,6 @@ Dans tous les cas, l’attribution des délais supplémentaires est conditionné
       type: 'legacy',
       cahierDesCharges: {
         référence: '2017/S 083-161855',
-        url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/Eolien-Telecharger-le-cahier-des-charges-en-vigueur-dans-sa-version-modifiee-le-18-juin-2019',
       },
       delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       donnéesCourriersRéponse: {
@@ -302,7 +300,6 @@ Dans tous les cas, l’attribution des délais supplémentaires est conditionné
       type: 'legacy',
       cahierDesCharges: {
         référence: '2017/S 083-161855',
-        url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/telecharger-le-cahier-des-charges-en-vigueur-dans-sa-version-modifiee-le-23-octobre-2019',
       },
       delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       donnéesCourriersRéponse: {
@@ -353,7 +350,6 @@ Dans tous les cas, l’attribution des délais supplémentaires est conditionné
       noteThreshold: 10.19,
       cahierDesCharges: {
         référence: '2017/S 083-161855',
-        url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/eolien-terrestre-telecharger-le-cahier-des-charges-en-vigueur-dans-sa-version-modifiee-le-4-mai-2020',
       },
       delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       donnéesCourriersRéponse: {
@@ -404,7 +400,6 @@ Dans tous les cas, l’attribution des délais supplémentaires est conditionné
       noteThreshold: 13,
       cahierDesCharges: {
         référence: '2017/S 083-161855',
-        url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/eolien-terrestre-telecharger-le-cahier-des-charges-en-vigueur-dans-sa-version-modifiee-le-4-mai-2020',
       },
       delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       donnéesCourriersRéponse: {
@@ -455,7 +450,6 @@ Dans tous les cas, l’attribution des délais supplémentaires est conditionné
       noteThreshold: 9.8,
       cahierDesCharges: {
         référence: '2017/S 083-161855',
-        url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/ao-terrestre-telecharger-le-cahier-des-charges-en-vigueur-dans-sa-version-modifiee-le-19-fevrier-2021',
       },
       delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       donnéesCourriersRéponse: {

--- a/packages/domain-inmemory-referential/src/appelOffre/CRE4/fessenheim.ts
+++ b/packages/domain-inmemory-referential/src/appelOffre/CRE4/fessenheim.ts
@@ -5,7 +5,6 @@ const garantieFinanciereEnMois = 42;
 const CDCModifié30072021: CahierDesChargesModifié = {
   type: 'modifié',
   paruLe: '30/07/2021',
-  url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/30072021-avis-modificatif-cre4-fessenheim',
   donnéesCourriersRéponse: {
     texteChangementDePuissance: {
       référenceParagraphe: '5.4.4',
@@ -20,7 +19,6 @@ const CDCModifié30082022: CahierDesChargesModifié = {
   type: 'modifié',
   paruLe: '30/08/2022',
   numéroGestionnaireRequis: true,
-  url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/cre-4-fessenheim-telecharger-l-avis-modificatif-publie-le-30-aout-2022',
   donnéesCourriersRéponse: {
     texteChangementDePuissance: {
       référenceParagraphe: '5.4.4',

--- a/packages/domain-inmemory-referential/src/appelOffre/CRE4/fessenheim.ts
+++ b/packages/domain-inmemory-referential/src/appelOffre/CRE4/fessenheim.ts
@@ -61,6 +61,8 @@ export const fessenheim: AppelOffre = {
     'portant sur la réalisation et l’exploitation d’Installations de production d’électricité à partir de l’énergie solaire « transition énergétique du territoire de Fessenheim »',
   shortTitle: 'Fessenheim',
   launchDate: 'janvier 2019',
+  cahiersDesChargesUrl:
+    'https://www.cre.fr/documents/Appels-d-offres/appel-d-offres-portant-sur-la-realisation-et-l-exploitation-d-installations-de-production-d-electricite-a-partir-de-l-energie-solaire-transition',
   unitePuissance: 'MWc',
   delaiRealisationEnMois: 24,
   autoritéCompétenteDemandesDélai: 'dreal',
@@ -136,7 +138,6 @@ Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent 
       type: 'legacy',
       cahierDesCharges: {
         référence: '2019/S 019-040037',
-        url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/Telecharger-le-cahier-des-charges-publie-le-24-01-20192',
       },
       delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       donnéesCourriersRéponse: {
@@ -159,7 +160,6 @@ Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent 
       certificateTemplate: 'cre4.v0',
       cahierDesCharges: {
         référence: '2019/S 019-040037',
-        url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/AO-Fessemheim-Telecharger-le-cahier-des-charges-en-vigueur-dans-sa-version-modifiee-le-04-octobre-2019',
       },
       delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       donnéesCourriersRéponse: {
@@ -183,7 +183,6 @@ Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent 
       certificateTemplate: 'cre4.v0',
       cahierDesCharges: {
         référence: '2019/S 019-040037',
-        url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/ao-fessenheim-telecharger-le-cahier-des-charges-en-vigueur-dans-sa-version-modifiee-le-27-mai-2020',
       },
       delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       donnéesCourriersRéponse: {

--- a/packages/domain-inmemory-referential/src/appelOffre/CRE4/innovation.ts
+++ b/packages/domain-inmemory-referential/src/appelOffre/CRE4/innovation.ts
@@ -65,6 +65,8 @@ export const innovation: AppelOffre = {
     'portant sur la réalisation et l’exploitation d’Installations de production d’électricité innovantes à partir de l’énergie solaire, sans dispositifs de stockage',
   shortTitle: 'CRE4 - Innovation',
   launchDate: 'mars 2017',
+  cahiersDesChargesUrl:
+    'https://www.cre.fr/documents/Appels-d-offres/appel-d-offres-portant-sur-la-realisation-et-l-exploitation-d-installations-de-production-d-electricite-innovantes-a-partir-de-l-energie-solaire',
   unitePuissance: 'MWc',
   delaiRealisationEnMois: 24,
   autoritéCompétenteDemandesDélai: 'dreal',
@@ -139,7 +141,6 @@ Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent 
       type: 'legacy',
       cahierDesCharges: {
         référence: '2017/S 051-094731',
-        url: 'https://www.cre.fr/media/fichiers/publications/appelsoffres/telecharger-le-cahier-des-charges-dans-sa-version-modifiee-le-5-septembre-2017',
       },
       delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       donnéesCourriersRéponse: {
@@ -162,7 +163,6 @@ Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent 
       certificateTemplate: 'cre4.v0',
       cahierDesCharges: {
         référence: '2017/S 051-094731',
-        url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/Telecharger-le-cahier-des-charges-en-vigueur-dans-sa-version-modifiee-le-26-fevrier-2019',
       },
       delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       donnéesCourriersRéponse: {
@@ -185,7 +185,6 @@ Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent 
       certificateTemplate: 'cre4.v1',
       cahierDesCharges: {
         référence: '2017/S 051-094731',
-        url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/ao-innovant-telecharger-le-cahier-des-charges-en-vigueur-dans-sa-version-modifiee-le-31-mars-2020',
       },
       delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       donnéesCourriersRéponse: {

--- a/packages/domain-inmemory-referential/src/appelOffre/CRE4/innovation.ts
+++ b/packages/domain-inmemory-referential/src/appelOffre/CRE4/innovation.ts
@@ -3,7 +3,6 @@ import { AppelOffre, CahierDesChargesModifié } from '@potentiel-domain/appel-of
 const CDCModifié30072021: CahierDesChargesModifié = {
   type: 'modifié',
   paruLe: '30/07/2021',
-  url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/30072021-avis-modificatif-cre4-innovation',
   donnéesCourriersRéponse: {
     texteChangementDePuissance: {
       référenceParagraphe: '5.4.5',
@@ -17,7 +16,6 @@ const CDCModifié30072021: CahierDesChargesModifié = {
 const CDCModifié30082022: CahierDesChargesModifié = {
   type: 'modifié',
   paruLe: '30/08/2022',
-  url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/cre4-innovation-telecharger-l-avis-modificatif-publie-le-30-aout-2022',
   numéroGestionnaireRequis: true,
   donnéesCourriersRéponse: {
     texteChangementDePuissance: {

--- a/packages/domain-inmemory-referential/src/appelOffre/CRE4/pvEolien.ts
+++ b/packages/domain-inmemory-referential/src/appelOffre/CRE4/pvEolien.ts
@@ -48,6 +48,8 @@ export const pvEolien: AppelOffre = {
   title: `portant sur la réalisation de l'exploitation d'installations de production d'électricité à partir d'énergie solaire photovoltaïque ou élolienne situées en métropole continentale`,
   shortTitle: 'PV - Eolien',
   launchDate: 'Décembre 2017',
+  cahiersDesChargesUrl:
+    'https://www.cre.fr/documents/Appels-d-offres/appel-d-offres-portant-sur-la-realisation-et-l-exploitation-d-installations-de-production-d-electricite-a-partir-d-energie-solaire-photovoltaique-o',
   unitePuissance: 'MW',
   autoritéCompétenteDemandesDélai: 'dreal',
   delaiRealisationTexte: 'vingt-quatre (24) mois',
@@ -124,7 +126,6 @@ Des délais supplémentaires, laissés à l’appréciation du ministre chargé 
       type: 'legacy',
       cahierDesCharges: {
         référence: '2017/S 238-494941',
-        url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/Telecharger-le-cahier-des-charges-dans-sa-version-mise-en-ligne-le-18-juillet-2018',
       },
       delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       donnéesCourriersRéponse: {

--- a/packages/domain-inmemory-referential/src/appelOffre/CRE4/pvEolien.ts
+++ b/packages/domain-inmemory-referential/src/appelOffre/CRE4/pvEolien.ts
@@ -4,7 +4,6 @@ const garantieFinanciereEnMois = 36;
 
 const CDCModifié30082022: CahierDesChargesModifié = {
   type: 'modifié',
-  url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/cre-4-pv-eolien-telecharger-l-avis-modificatif-publie-le-30-aout-2022',
   paruLe: '30/08/2022',
   numéroGestionnaireRequis: true,
   donnéesCourriersRéponse: {

--- a/packages/domain-inmemory-referential/src/appelOffre/CRE4/sol.ts
+++ b/packages/domain-inmemory-referential/src/appelOffre/CRE4/sol.ts
@@ -5,7 +5,6 @@ const garantieFinanciereEnMois = 42;
 const CDCModifié30072021: CahierDesChargesModifié = {
   type: 'modifié',
   paruLe: '30/07/2021',
-  url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/30072021-avis-modificatif-cre4-sol',
   donnéesCourriersRéponse: {
     texteChangementDePuissance: {
       référenceParagraphe: '5.4.4',
@@ -19,7 +18,6 @@ const CDCModifié30072021: CahierDesChargesModifié = {
 const CDCModifié30082022: CahierDesChargesModifié = {
   type: 'modifié',
   paruLe: '30/08/2022',
-  url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/cre4-sol-telecharger-l-avis-modificatif-publie-le-30-aout-2022',
   numéroGestionnaireRequis: true,
   délaiApplicable: {
     délaiEnMois: 18,

--- a/packages/domain-inmemory-referential/src/appelOffre/CRE4/sol.ts
+++ b/packages/domain-inmemory-referential/src/appelOffre/CRE4/sol.ts
@@ -43,6 +43,8 @@ export const sol: AppelOffre = {
     'portant sur la réalisation et l’exploitation d’installations de production d’électricité à partir de l’énergie solaire « Centrale au sol »',
   shortTitle: 'CRE4 - Sol',
   launchDate: 'août 2016',
+  cahiersDesChargesUrl:
+    'https://www.cre.fr/documents/Appels-d-offres/appel-d-offres-portant-sur-la-realisation-et-l-exploitation-d-installations-de-production-d-electricite-a-partir-de-l-energie-solaire-centrales-a',
   unitePuissance: 'MWc',
   delaiRealisationEnMois: 24,
   autoritéCompétenteDemandesDélai: 'dreal',
@@ -125,7 +127,6 @@ Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent 
       type: 'legacy',
       cahierDesCharges: {
         référence: '2016/S 148-268152',
-        url: 'https://www.cre.fr/media/fichiers/publications/appelsoffres/ancienne-version-du-cahier-des-charges-dans-sa-version-applicable-a-la-1ere-periode',
       },
       delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       cahiersDesChargesModifiésDisponibles: [
@@ -163,7 +164,6 @@ Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent 
       type: 'legacy',
       cahierDesCharges: {
         référence: '2016/S 148-268152',
-        url: 'https://www.cre.fr/media/fichiers/publications/appelsoffres/ancienne-version-du-cahier-des-charges-dans-sa-version-applicable-a-la-2eme-periode',
       },
       delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       cahiersDesChargesModifiésDisponibles: [
@@ -201,7 +201,6 @@ Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent 
       type: 'legacy',
       cahierDesCharges: {
         référence: '2016/S 148-268152',
-        url: 'https://www.cre.fr/media/fichiers/publications/appelsoffres/ancienne-version-du-cahier-des-charges-dans-sa-version-applicable-a-la-3eme-periode',
       },
       delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       cahiersDesChargesModifiésDisponibles: [
@@ -239,7 +238,6 @@ Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent 
       type: 'legacy',
       cahierDesCharges: {
         référence: '2016/S 148-268152',
-        url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/Ancienne-version-du-cahier-des-charges-dans-sa-version-applicable-aux-4eme-et-5eme-periodes',
       },
       delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       cahiersDesChargesModifiésDisponibles: [
@@ -277,7 +275,6 @@ Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent 
       type: 'legacy',
       cahierDesCharges: {
         référence: '2016/S 148-268152',
-        url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/Ancienne-version-du-cahier-des-charges-dans-sa-version-applicable-aux-4eme-et-5eme-periodes',
       },
       delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       cahiersDesChargesModifiésDisponibles: [
@@ -315,7 +312,6 @@ Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent 
       type: 'legacy',
       cahierDesCharges: {
         référence: '2016/S 148-268152',
-        url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/Telecharger-le-cahier-des-charges-en-vigueur-dans-sa-version-modifiee-le-4-avril-2019',
       },
       delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       cahiersDesChargesModifiésDisponibles: [
@@ -358,7 +354,6 @@ Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent 
       certificateTemplate: 'cre4.v0',
       cahierDesCharges: {
         référence: '2016/S 148-268152',
-        url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/Telecharger-le-cahier-des-charges-en-vigueur-dans-sa-derniere-version-modifiee-le-5-septembre-2019',
       },
       delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       cahiersDesChargesModifiésDisponibles: [
@@ -402,7 +397,6 @@ Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent 
       certificateTemplate: 'cre4.v1',
       cahierDesCharges: {
         référence: '2016/S 148-268152',
-        url: 'https://www.cre.fr/media/Fichiers/ao-solaire-au-sol-telecharger-le-cahier-des-charges-en-vigueur-dans-sa-derniere-version-modifiee-le-29-octobre-2020',
       },
       delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       cahiersDesChargesModifiésDisponibles: [
@@ -446,7 +440,6 @@ Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent 
       certificateTemplate: 'cre4.v1',
       cahierDesCharges: {
         référence: '2016/S 148-268152',
-        url: 'https://www.cre.fr/media/Fichiers/ao-solaire-au-sol-telecharger-le-cahier-des-charges-en-vigueur-dans-sa-derniere-version-modifiee-le-29-octobre-2020',
       },
       delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       cahiersDesChargesModifiésDisponibles: [
@@ -490,7 +483,6 @@ Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent 
       certificateTemplate: 'cre4.v1',
       cahierDesCharges: {
         référence: '2016/S 148-268152',
-        url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/telecharger-le-cahier-des-charges-en-vigueur-dans-sa-derniere-version-modifiee-le-12-fevrier-2021',
       },
       delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       cahiersDesChargesModifiésDisponibles: [

--- a/packages/domain-inmemory-referential/src/appelOffre/CRE4/zni.ts
+++ b/packages/domain-inmemory-referential/src/appelOffre/CRE4/zni.ts
@@ -5,7 +5,6 @@ const garantieFinanciereEnMois = 36;
 const CDCModifié30072021: CahierDesChargesModifié = {
   type: 'modifié',
   paruLe: '30/07/2021',
-  url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/30072021-avis-modificatif-cre4-zni-2',
   donnéesCourriersRéponse: {
     texteChangementDePuissance: {
       référenceParagraphe: '5.4.4',
@@ -19,7 +18,6 @@ const CDCModifié30072021: CahierDesChargesModifié = {
 const CDCModifié30082022: CahierDesChargesModifié = {
   type: 'modifié',
   paruLe: '30/08/2022',
-  url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/cre-4-zni-2-2022-telecharger-l-avis-modificatif-publie-le-30-aout-2022',
   numéroGestionnaireRequis: true,
   donnéesCourriersRéponse: {
     texteChangementDePuissance: {
@@ -43,7 +41,6 @@ const CDCModifié30082022Alternatif: CahierDesChargesModifié = {
   type: 'modifié',
   paruLe: '30/08/2022',
   alternatif: true,
-  url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/cre-4-zni-2-bis-2022-telecharger-l-avis-modificatif-publie-le-30-aout-2022',
   numéroGestionnaireRequis: true,
   donnéesCourriersRéponse: {
     texteChangementDePuissance: {
@@ -63,7 +60,6 @@ const CDCModifié30082022Alternatif: CahierDesChargesModifié = {
 const CDCModifié07022023: CahierDesChargesModifié = {
   type: 'modifié',
   paruLe: '07/02/2023',
-  url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/telecharger-l-avis-modificatif-publie-le-07-02-2023',
   numéroGestionnaireRequis: true,
   délaiAnnulationAbandon: new Date('2023-02-23'),
 };
@@ -72,7 +68,6 @@ const CDCModifié07022023Alternatif: CahierDesChargesModifié = {
   type: 'modifié',
   paruLe: '07/02/2023',
   alternatif: true,
-  url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/telecharger-l-avis-modificatif-alternatif-publie-le-07-02-2023',
   numéroGestionnaireRequis: true,
   délaiAnnulationAbandon: new Date('2023-02-23'),
 };

--- a/packages/domain-inmemory-referential/src/appelOffre/CRE4/zni.ts
+++ b/packages/domain-inmemory-referential/src/appelOffre/CRE4/zni.ts
@@ -84,6 +84,8 @@ export const zni: AppelOffre = {
     'portant sur la réalisation et l’exploitation d’installations de production d’électricité à partir de l’énergie solaire et situées dans les zones non interconnectées',
   shortTitle: 'CRE4 - ZNI',
   launchDate: 'juin 2019',
+  cahiersDesChargesUrl:
+    'https://www.cre.fr/documents/Appels-d-offres/appels-d-offres-portant-sur-la-realisation-et-l-exploitation-d-installations-de-production-d-electricite-a-partir-de-l-energie-solaire-et-situees-d',
   unitePuissance: 'MWc',
   delaiRealisationEnMois: 24,
   autoritéCompétenteDemandesDélai: 'dreal',
@@ -163,7 +165,6 @@ Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent 
       certificateTemplate: 'cre4.v0',
       cahierDesCharges: {
         référence: '2019/S 113-276264',
-        url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/AO-ZNI-solaire',
       },
       delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       noteThresholdBy: 'family',
@@ -200,7 +201,6 @@ Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent 
       certificateTemplate: 'cre4.v0',
       cahierDesCharges: {
         référence: '2019/S 113-276264',
-        url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/AO-ZNI-solaire',
       },
       delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       noteThresholdBy: 'family',
@@ -236,7 +236,6 @@ Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent 
       certificateTemplate: 'cre4.v1',
       cahierDesCharges: {
         référence: '2019/S 113-276264',
-        url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/zni-sol-telecharger-le-cahier-des-charges-publie-le-09-06-2020',
       },
       delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       noteThresholdBy: 'family',
@@ -270,7 +269,6 @@ Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent 
       certificateTemplate: 'cre4.v1',
       cahierDesCharges: {
         référence: '2019/S 113-276264',
-        url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/telecharger-le-cahier-des-charges-publie-le-12-10-2020',
       },
       delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       noteThresholdBy: 'family',
@@ -306,7 +304,6 @@ Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent 
       certificateTemplate: 'cre4.v1',
       cahierDesCharges: {
         référence: '2019/S 113-276264',
-        url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/telecharger-le-cahier-des-charges-publie-le-12-10-2020',
       },
       noteThresholdBy: 'family',
       delaiDcrEnMois: { valeur: 2, texte: 'deux' },
@@ -335,7 +332,6 @@ Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent 
       certificateTemplate: 'cre4.v1',
       cahierDesCharges: {
         référence: '2020/S 202-487521',
-        url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/telecharger-le-cahier-des-charges-publie-le-12-10-2020',
       },
       noteThresholdBy: 'family',
       delaiDcrEnMois: { valeur: 2, texte: 'deux' }, // à confirmer si c'est bien deux mois ici

--- a/packages/domain-inmemory-referential/src/appelOffre/CRE4/zni2017.ts
+++ b/packages/domain-inmemory-referential/src/appelOffre/CRE4/zni2017.ts
@@ -5,7 +5,6 @@ const garantieFinanciereEnMois = 36;
 const CDCModifié30072021: CahierDesChargesModifié = {
   type: 'modifié',
   paruLe: '30/07/2021',
-  url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/30072021-avis-modificatif-cre4-zni-1',
   donnéesCourriersRéponse: {
     texteChangementDePuissance: {
       référenceParagraphe: '5.3.4',
@@ -19,7 +18,6 @@ const CDCModifié30072021: CahierDesChargesModifié = {
 const CDCModifié30082022: CahierDesChargesModifié = {
   type: 'modifié',
   paruLe: '30/08/2022',
-  url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/cre-4-zni-1-2022-telecharger-l-avis-modificatif-publie-le-30-aout-2022',
   numéroGestionnaireRequis: true,
   donnéesCourriersRéponse: {
     texteChangementDePuissance: {

--- a/packages/domain-inmemory-referential/src/appelOffre/CRE4/zni2017.ts
+++ b/packages/domain-inmemory-referential/src/appelOffre/CRE4/zni2017.ts
@@ -46,6 +46,8 @@ export const zni2017: AppelOffre = {
     'portant sur la réalisation et l’exploitation d’installations de production d’électricité à partir de techniques de conversion du rayonnement solaire d’une puissance supérieure à 100 kWc et situées dans les zones non interconnectées',
   shortTitle: 'CRE4 - ZNI 2017',
   launchDate: 'mai 2015',
+  cahiersDesChargesUrl:
+    'https://www.cre.fr/documents/Appels-d-offres/appel-d-offres-portant-sur-la-realisation-et-l-exploitation-d-installations-de-production-d-electricite-a-partir-de-techniques-de-conversion-du-ray2',
   unitePuissance: 'MWc',
   delaiRealisationEnMois: 36,
   autoritéCompétenteDemandesDélai: 'dreal',
@@ -125,7 +127,6 @@ Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent 
       type: 'legacy',
       cahierDesCharges: {
         référence: '2016/S 242-441980',
-        url: 'https://www.cre.fr/media/fichiers/publications/appelsoffres/telecharger-le-cahier-des-charges-pv-stockage-zni',
       },
       delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       cahiersDesChargesModifiésDisponibles: [CDCModifié30072021, CDCModifié30082022],

--- a/packages/domain-inmemory-referential/src/appelOffre/PPE2/ppe2.autoconsommationMetropole.ts
+++ b/packages/domain-inmemory-referential/src/appelOffre/PPE2/ppe2.autoconsommationMetropole.ts
@@ -69,6 +69,8 @@ export const autoconsommationMetropolePPE2: AppelOffre = {
     'portant sur la réalisation et l’exploitation d’Installations de production d’électricité à partir d’énergies renouvelables en autoconsommation et situées en métropole continentale',
   shortTitle: 'PPE2 - Autoconsommation métropole',
   launchDate: 'Août 2021',
+  cahiersDesChargesUrl:
+    'https://www.cre.fr/documents/Appels-d-offres/appel-d-offres-portant-sur-la-realisation-et-l-exploitation-d-installations-de-production-d-electricite-a-partir-d-energies-renouvelables-en-autoco3',
   unitePuissance: 'MW',
   autoritéCompétenteDemandesDélai: 'dreal',
   delaiRealisationEnMoisParTechnologie: { eolien: 36, pv: 30, hydraulique: 0 },
@@ -157,7 +159,6 @@ Des délais supplémentaires peuvent être accordés par le Préfet, à son appr
       noteThreshold: 62.5,
       cahierDesCharges: {
         référence: '2021 S 176-457526',
-        url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/2021-autoconsommation-telecharger-le-cahier-des-charges-en-vigueur',
       },
       delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       cahiersDesChargesModifiésDisponibles: [CDCModifié30082022],
@@ -170,7 +171,6 @@ Des délais supplémentaires peuvent être accordés par le Préfet, à son appr
       noteThreshold: 66.95,
       cahierDesCharges: {
         référence: '2022 S 038 098159',
-        url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/2021-autoconsommation-telecharger-le-cahier-des-charges-en-vigueur',
       },
       delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       cahiersDesChargesModifiésDisponibles: [CDCModifié30082022],
@@ -183,7 +183,6 @@ Des délais supplémentaires peuvent être accordés par le Préfet, à son appr
       noteThreshold: 72.13,
       cahierDesCharges: {
         référence: '2022 S 150-427955',
-        url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/2021-autoconsommation-telecharger-le-cahier-des-charges-en-vigueur',
       },
       delaiDcrEnMois: { valeur: 3, texte: 'trois' },
       cahiersDesChargesModifiésDisponibles: [],
@@ -196,7 +195,6 @@ Des délais supplémentaires peuvent être accordés par le Préfet, à son appr
       noteThreshold: 76.25,
       cahierDesCharges: {
         référence: '2023/S 176-551607',
-        url: 'https://www.cre.fr/documents/Appels-d-offres/appel-d-offres-portant-sur-la-realisation-et-l-exploitation-d-installations-de-production-d-electricite-a-partir-d-energies-renouvelables-en-autoco3',
       },
       delaiDcrEnMois: { valeur: 3, texte: 'trois' },
       cahiersDesChargesModifiésDisponibles: [],

--- a/packages/domain-inmemory-referential/src/appelOffre/PPE2/ppe2.autoconsommationMetropole.ts
+++ b/packages/domain-inmemory-referential/src/appelOffre/PPE2/ppe2.autoconsommationMetropole.ts
@@ -3,7 +3,6 @@ import { AppelOffre, CahierDesChargesModifié } from '@potentiel-domain/appel-of
 const CDCModifié30082022: CahierDesChargesModifié = {
   type: 'modifié',
   paruLe: '30/08/2022',
-  url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/ppe2-auto-2022-telecharger-l-avis-modificatif-publie-le-30-aout-2022',
   numéroGestionnaireRequis: true,
   donnéesCourriersRéponse: {
     texteChangementDePuissance: {

--- a/packages/domain-inmemory-referential/src/appelOffre/PPE2/ppe2.batiment.ts
+++ b/packages/domain-inmemory-referential/src/appelOffre/PPE2/ppe2.batiment.ts
@@ -3,7 +3,6 @@ import { AppelOffre, CahierDesChargesModifié } from '@potentiel-domain/appel-of
 const CDCModifié30082022: CahierDesChargesModifié = {
   type: 'modifié',
   paruLe: '30/08/2022',
-  url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/telecharger-l-avis-modificatif-publie-le-30-aout-2022',
   numéroGestionnaireRequis: true,
   donnéesCourriersRéponse: {
     texteChangementDePuissance: {

--- a/packages/domain-inmemory-referential/src/appelOffre/PPE2/ppe2.batiment.ts
+++ b/packages/domain-inmemory-referential/src/appelOffre/PPE2/ppe2.batiment.ts
@@ -35,6 +35,8 @@ export const batimentPPE2: AppelOffre = {
     'portant sur la réalisation et l’exploitation d’Installations de production d’électricité à partir de l’énergie solaire « Centrales sur bâtiments, serres et hangars agricoles et ombrières de parking de puissance supérieure à 500 kWc»',
   shortTitle: 'PPE2 - Bâtiment',
   launchDate: 'Août 2021',
+  cahiersDesChargesUrl:
+    'https://www.cre.fr/documents/Appels-d-offres/appel-d-offres-portant-sur-la-realisation-et-l-exploitation-d-installations-de-production-d-electricite-a-partir-de-l-energie-solaire-centrales-s2',
   unitePuissance: 'MW',
   delaiRealisationEnMois: 30,
   autoritéCompétenteDemandesDélai: 'dreal',
@@ -101,7 +103,6 @@ Des délais supplémentaires peuvent être accordés par le Préfet, à son appr
       certificateTemplate: 'ppe2.v1',
       cahierDesCharges: {
         référence: '2021 S 176-457518',
-        url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/ao-bat-cahier-des-charges-applicable-pour-la-1ere-periode-publie-le-05-10-2021',
       },
       delaiDcrEnMois: { valeur: 3, texte: 'trois' },
       noteThresholdBy: 'category',
@@ -141,7 +142,6 @@ Des délais supplémentaires peuvent être accordés par le Préfet, à son appr
       certificateTemplate: 'ppe2.v1',
       cahierDesCharges: {
         référence: '2022 S 020-047803',
-        url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/2021-pv-batiment-telecharger-le-cahier-des-charges-en-vigueur',
       },
       delaiDcrEnMois: { valeur: 3, texte: 'trois' },
       noteThresholdBy: 'category',
@@ -181,7 +181,6 @@ Des délais supplémentaires peuvent être accordés par le Préfet, à son appr
       certificateTemplate: 'ppe2.v2',
       cahierDesCharges: {
         référence: '2022 S 093-254888',
-        url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/2021-pv-batiment-telecharger-le-cahier-des-charges-en-vigueur',
       },
       delaiDcrEnMois: { valeur: 3, texte: 'trois' },
       noteThresholdBy: 'category',
@@ -214,7 +213,6 @@ Des délais supplémentaires peuvent être accordés par le Préfet, à son appr
       certificateTemplate: 'ppe2.v2',
       cahierDesCharges: {
         référence: '2022 S 216-620968',
-        url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/2021-pv-batiment-telecharger-le-cahier-des-charges-en-vigueur',
       },
       delaiDcrEnMois: { valeur: 3, texte: 'trois' },
       noteThresholdBy: 'category',
@@ -235,7 +233,6 @@ Des délais supplémentaires peuvent être accordés par le Préfet, à son appr
       certificateTemplate: 'ppe2.v2',
       cahierDesCharges: {
         référence: '2023 S 071-217458',
-        url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/maj-cdc-pv-bat-v140423',
       },
       delaiDcrEnMois: { valeur: 3, texte: 'trois' },
       noteThresholdBy: 'category',

--- a/packages/domain-inmemory-referential/src/appelOffre/PPE2/ppe2.eolien.ts
+++ b/packages/domain-inmemory-referential/src/appelOffre/PPE2/ppe2.eolien.ts
@@ -3,7 +3,6 @@ import { AppelOffre, CahierDesChargesModifié } from '@potentiel-domain/appel-of
 const CDCModifié30082022: CahierDesChargesModifié = {
   type: 'modifié',
   paruLe: '30/08/2022',
-  url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/ppe-2-eolien-telecharger-l-avis-modificatif-publie-le-30-aout-2022',
   numéroGestionnaireRequis: true,
   donnéesCourriersRéponse: {
     texteChangementDePuissance: {

--- a/packages/domain-inmemory-referential/src/appelOffre/PPE2/ppe2.eolien.ts
+++ b/packages/domain-inmemory-referential/src/appelOffre/PPE2/ppe2.eolien.ts
@@ -37,6 +37,8 @@ export const eolienPPE2: AppelOffre = {
   shortTitle: 'PPE2 - Eolien',
   dossierSuiviPar: 'tiphany.genin@developpement-durable.gouv.fr',
   launchDate: 'Août 2021',
+  cahiersDesChargesUrl:
+    'https://www.cre.fr/documents/Appels-d-offres/appel-d-offres-portant-sur-la-realisation-et-l-exploitation-d-installations-de-production-d-electricite-a-partir-de-l-energie-mecanique-du-vent-imp',
   unitePuissance: 'MW',
   autoritéCompétenteDemandesDélai: 'dreal',
   tarifOuPrimeRetenue: 'le prix de référence T de l’électricité retenu',
@@ -102,7 +104,6 @@ Des délais supplémentaires peuvent être accordés par le Préfet, à son appr
       noteThreshold: 0.68,
       cahierDesCharges: {
         référence: '2021/S 146-386083',
-        url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/2021-eolien-telecharger-le-cahier-des-charges-en-vigueur',
       },
       delaiDcrEnMois: { valeur: 3, texte: 'trois' },
       dossierSuiviPar: 'violaine.tarizzo@developpement-durable.gouv.fr',
@@ -134,7 +135,6 @@ Des délais supplémentaires peuvent être accordés par le Préfet, à son appr
       noteThreshold: 0.692142857142864,
       cahierDesCharges: {
         référence: '2022/S 035-088651',
-        url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/2021-eolien-telecharger-le-cahier-des-charges-en-vigueur',
       },
       delaiDcrEnMois: { valeur: 3, texte: 'trois' },
       cahiersDesChargesModifiésDisponibles: [
@@ -170,7 +170,6 @@ Le Candidat peut également être délié de cette obligation selon l’appréci
       noteThreshold: 1.2,
       cahierDesCharges: {
         référence: '2022/S 214-614410',
-        url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/2021-eolien-telecharger-le-cahier-des-charges-en-vigueur',
       },
       delaiDcrEnMois: { valeur: 3, texte: 'trois' },
       donnéesCourriersRéponse: {
@@ -194,7 +193,6 @@ Le Candidat peut également être délié de cette obligation selon l’appréci
       noteThreshold: 13.8,
       cahierDesCharges: {
         référence: '2023/S 063-187148',
-        url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/2021-eolien-telecharger-le-cahier-des-charges-en-vigueur',
       },
       delaiDcrEnMois: { valeur: 3, texte: 'trois' },
       donnéesCourriersRéponse: {
@@ -217,7 +215,6 @@ Le Candidat peut également être délié de cette obligation selon l’appréci
       noteThreshold: 14.22,
       cahierDesCharges: {
         référence: '2023/S 183-570186',
-        url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/cdc-eolien-ppe2-cahier-des-charges-5eme-periode ',
       },
       delaiDcrEnMois: { valeur: 3, texte: 'trois' },
       cahiersDesChargesModifiésDisponibles: [],

--- a/packages/domain-inmemory-referential/src/appelOffre/PPE2/ppe2.innovation.ts
+++ b/packages/domain-inmemory-referential/src/appelOffre/PPE2/ppe2.innovation.ts
@@ -50,6 +50,8 @@ export const innovationPPE2: AppelOffre = {
     'portant sur la réalisation et l’exploitation d’Installations de production d’électricité innovantes à partir de l’énergie solaire sans dispositifs de stockage',
   shortTitle: 'PPE2 - Innovation',
   launchDate: 'Août 2021',
+  cahiersDesChargesUrl:
+    'https://www.cre.fr/documents/Appels-d-offres/appel-d-offres-portant-sur-la-realisation-et-l-exploitation-d-installations-de-production-d-electricite-innovantes-a-partir-de-l-energie-solaire-sa',
   unitePuissance: 'MW',
   autoritéCompétenteDemandesDélai: 'dreal',
   delaiRealisationEnMois: 30,
@@ -116,7 +118,6 @@ Des délais supplémentaires peuvent être accordés par le Préfet, à son appr
       certificateTemplate: 'ppe2.v2',
       cahierDesCharges: {
         référence: '2021 S 203-530267',
-        url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/ppe2-innovant-telecharger-le-cahier-des-charges-en-vigueur-dans-sa-version-modifiee-le-19-octobre-2021',
       },
       delaiDcrEnMois: { valeur: 3, texte: 'trois' },
       noteThresholdBy: 'family',

--- a/packages/domain-inmemory-referential/src/appelOffre/PPE2/ppe2.innovation.ts
+++ b/packages/domain-inmemory-referential/src/appelOffre/PPE2/ppe2.innovation.ts
@@ -3,7 +3,6 @@ import { AppelOffre, CahierDesChargesModifié } from '@potentiel-domain/appel-of
 const CDCModifié30082022: CahierDesChargesModifié = {
   type: 'modifié',
   paruLe: '30/08/2022',
-  url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/ppe2-inno-2022-telecharger-l-avis-modificatif-publie-le-30-aout-2022',
   numéroGestionnaireRequis: true,
   donnéesCourriersRéponse: {
     texteChangementDePuissance: {

--- a/packages/domain-inmemory-referential/src/appelOffre/PPE2/ppe2.neutre.ts
+++ b/packages/domain-inmemory-referential/src/appelOffre/PPE2/ppe2.neutre.ts
@@ -8,6 +8,8 @@ export const neutrePPE2: AppelOffre = {
   shortTitle: 'PPE2 - Neutre',
   dossierSuiviPar: 'aopv.dgec@developpement-durable.gouv.fr',
   launchDate: 'Août 2021',
+  cahiersDesChargesUrl:
+    'https://www.cre.fr/documents/Appels-d-offres/appel-d-offres-portant-sur-la-realisation-et-l-exploitation-d-installations-de-production-d-electricite-a-partir-d-energie-solaire-photovoltaique',
   unitePuissance: 'MW',
   autoritéCompétenteDemandesDélai: 'dreal',
   tarifOuPrimeRetenue: 'le prix de référence T de l’électricité retenu',
@@ -75,7 +77,6 @@ Des délais supplémentaires peuvent être accordés par le Préfet, à son appr
       noteThreshold: 26.89,
       cahierDesCharges: {
         référence: '2022 S 100-276861',
-        url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/2021-neutre-telecharger-le-cahier-des-charges-en-vigueur',
       },
       delaiDcrEnMois: { valeur: 3, texte: 'trois' },
       donnéesCourriersRéponse: {
@@ -100,7 +101,6 @@ Le Candidat peut également être délié de cette obligation selon l’appréci
       noteThreshold: 26.87,
       cahierDesCharges: {
         référence: '2023 S 147-469153',
-        url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/neutre-2023-2e-periode',
       },
       delaiDcrEnMois: { valeur: 3, texte: 'trois' },
       donnéesCourriersRéponse: {

--- a/packages/domain-inmemory-referential/src/appelOffre/PPE2/ppe2.sol.ts
+++ b/packages/domain-inmemory-referential/src/appelOffre/PPE2/ppe2.sol.ts
@@ -3,7 +3,6 @@ import { AppelOffre, CahierDesChargesModifié } from '@potentiel-domain/appel-of
 const CDCModifié30082022: CahierDesChargesModifié = {
   type: 'modifié',
   paruLe: '30/08/2022',
-  url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/ppe-2-sol-telecharger-l-avis-modificatif-publie-le-30-aout-2022',
   numéroGestionnaireRequis: true,
   donnéesCourriersRéponse: {
     texteChangementDePuissance: {

--- a/packages/domain-inmemory-referential/src/appelOffre/PPE2/ppe2.sol.ts
+++ b/packages/domain-inmemory-referential/src/appelOffre/PPE2/ppe2.sol.ts
@@ -37,6 +37,8 @@ export const solPPE2: AppelOffre = {
     'portant sur la réalisation et l’exploitation d’Installations de production d’électricité à partir de l’énergie solaire « Centrales au sol »',
   shortTitle: 'PPE2 - Sol',
   launchDate: 'Août 2021',
+  cahiersDesChargesUrl:
+    'https://www.cre.fr/documents/Appels-d-offres/appel-d-offres-portant-sur-la-realisation-et-l-exploitation-d-installations-de-production-d-electricite-a-partir-de-l-energie-solaire-centrales-a2',
   unitePuissance: 'MW',
   autoritéCompétenteDemandesDélai: 'dreal',
   delaiRealisationEnMois: 30,
@@ -102,7 +104,6 @@ Des délais supplémentaires peuvent être accordés par le Préfet, à son appr
       certificateTemplate: 'ppe2.v1',
       cahierDesCharges: {
         référence: '2021 S 211-553136',
-        url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/2021-pv-sol-telecharger-le-cahier-des-charges-en-vigueur',
       },
       delaiDcrEnMois: { valeur: 3, texte: 'trois' },
       noteThresholdBy: 'category',
@@ -145,7 +146,6 @@ Des délais supplémentaires peuvent être accordés par le Préfet, à son appr
       certificateTemplate: 'ppe2.v1',
       cahierDesCharges: {
         référence: '2022/S 061-160516',
-        url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/2022-pv-sol-telecharger-le-cahier-des-charges-en-vigueur',
       },
       delaiDcrEnMois: { valeur: 3, texte: 'trois' },
       noteThresholdBy: 'category',
@@ -181,7 +181,6 @@ Des délais supplémentaires peuvent être accordés par le Préfet, à son appr
       certificateTemplate: 'ppe2.v2',
       cahierDesCharges: {
         référence: '2022 S 214-614411',
-        url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/2022-pv-sol-telecharger-le-cahier-des-charges-en-vigueur',
       },
       delaiDcrEnMois: { valeur: 3, texte: 'trois' },
       noteThresholdBy: 'category',
@@ -202,7 +201,6 @@ Des délais supplémentaires peuvent être accordés par le Préfet, à son appr
       certificateTemplate: 'ppe2.v2',
       cahierDesCharges: {
         référence: '2023 S 063-187860',
-        url: 'https://www.cre.fr/media/Fichiers/publications/appelsoffres/maj-cdc-pv-sol-v140423',
       },
       delaiDcrEnMois: { valeur: 3, texte: 'trois' },
       noteThresholdBy: 'category',

--- a/packages/domain/appel-offre/src/appelOffre.projection.ts
+++ b/packages/domain/appel-offre/src/appelOffre.projection.ts
@@ -85,7 +85,6 @@ export type DateParutionCahierDesChargesModifié =
 
 export type CahierDesChargesModifié = {
   type: 'modifié';
-  url: string;
   paruLe: DateParutionCahierDesChargesModifié;
   alternatif?: true;
   numéroGestionnaireRequis?: true;

--- a/packages/domain/appel-offre/src/appelOffre.projection.ts
+++ b/packages/domain/appel-offre/src/appelOffre.projection.ts
@@ -60,7 +60,6 @@ export type DonnéesCourriersRéponse = Record<
 // Cahier des charges
 export type CahierDesCharges = {
   référence: string;
-  url: string;
 };
 
 export type DélaiApplicable = {
@@ -199,6 +198,7 @@ export type AppelOffre = {
   title: string;
   shortTitle: string;
   launchDate: string;
+  cahiersDesChargesUrl: string;
   unitePuissance: string;
   delaiRealisationTexte: string;
   paragraphePrixReference: string;

--- a/src/entities/donnéesCourriersRéponse.spec.ts
+++ b/src/entities/donnéesCourriersRéponse.spec.ts
@@ -96,7 +96,6 @@ describe(`Récupération des données des courriers de réponse`, () => {
         {
           type: 'modifié',
           paruLe: '30/07/2021',
-          url: 'url',
           donnéesCourriersRéponse: {
             texteEngagementRéalisationEtModalitésAbandon: {
               référenceParagraphe: 'VALEUR NON ATTENDU',
@@ -108,7 +107,6 @@ describe(`Récupération des données des courriers de réponse`, () => {
           type: 'modifié',
           paruLe: '30/08/2022',
           alternatif: true,
-          url: 'url',
           donnéesCourriersRéponse: {
             texteEngagementRéalisationEtModalitésAbandon: {
               référenceParagraphe: 'CDC-1',
@@ -167,7 +165,6 @@ describe(`Récupération des données des courriers de réponse`, () => {
         {
           type: 'modifié',
           paruLe: '30/08/2022',
-          url: 'url',
           donnéesCourriersRéponse: {
             texteEngagementRéalisationEtModalitésAbandon: {
               référenceParagraphe: 'CDC-1',

--- a/src/infra/sequelize/queries/modificationRequest/getModificationRequestDetails.ts
+++ b/src/infra/sequelize/queries/modificationRequest/getModificationRequestDetails.ts
@@ -136,6 +136,7 @@ export const getModificationRequestDetails: GetModificationRequestDetails = (
         completionDueOn: new Date(completionDueOn).getTime(),
         unitePuissance: appelOffre?.unitePuissance || '??',
         technologie: technologie || 'N/A',
+        cahiersDesChargesUrl: appelOffre?.cahiersDesChargesUrl,
       },
       ...(type === 'puissance' && {
         puissanceAuMomentDuDepot,
@@ -164,7 +165,7 @@ const formatCahierDesCharges = ({
   if (cahierDesChargesRéférenceParsed.type === 'initial') {
     return {
       type: 'initial',
-      url: appelOffre.periode.cahierDesCharges.url,
+      url: appelOffre.cahiersDesChargesUrl,
     };
   }
 
@@ -179,7 +180,7 @@ const formatCahierDesCharges = ({
 
   return {
     type: 'modifié',
-    url: cahiersDesChargesModifié.url,
+    url: appelOffre.cahiersDesChargesUrl,
     paruLe: cahiersDesChargesModifié.paruLe,
     alternatif: cahiersDesChargesModifié.alternatif,
   };

--- a/src/infra/sequelize/queries/project/consulter/getProjectDataForProjectPage.ts
+++ b/src/infra/sequelize/queries/project/consulter/getProjectDataForProjectPage.ts
@@ -90,15 +90,11 @@ export const getProjectDataForProjectPage: GetProjectDataForProjectPage = ({ pro
       cahierDesChargesActuel.type === 'initial'
         ? {
             type: 'initial',
-            url: appelOffre.periode.cahierDesCharges.url,
+            url: appelOffre.cahiersDesChargesUrl,
           }
         : {
             type: 'modifié',
-            url: appelOffre.periode.cahiersDesChargesModifiésDisponibles.find(
-              (c) =>
-                c.paruLe === cahierDesChargesActuel.paruLe &&
-                c.alternatif === cahierDesChargesActuel.alternatif,
-            )?.url,
+            url: appelOffre.cahiersDesChargesUrl,
             paruLe: cahierDesChargesActuel.paruLe,
             alternatif: cahierDesChargesActuel.alternatif,
           };

--- a/src/modules/modificationRequest/dtos/ModificationRequestPageDTO.ts
+++ b/src/modules/modificationRequest/dtos/ModificationRequestPageDTO.ts
@@ -63,6 +63,7 @@ export type ModificationRequestPageDTO = {
     technologie: Technologie;
     appelOffre?: ProjectAppelOffre;
     cahierDesChargesActuel: CahierDesChargesRéférence;
+    cahiersDesChargesUrl?: string;
     note: number;
   };
 } & Variant;

--- a/src/modules/project/useCases/choisirCahierDesCharges.spec.ts
+++ b/src/modules/project/useCases/choisirCahierDesCharges.spec.ts
@@ -41,9 +41,9 @@ describe('Choisir un cahier des charges', () => {
           id: periodeId,
           type: 'notified',
           cahiersDesChargesModifiésDisponibles: [
-            { type: 'modifié', paruLe: '30/07/2021', url: 'url' },
-            { type: 'modifié', paruLe: '30/08/2022', url: 'url' },
-            { type: 'modifié', paruLe: '30/08/2022', url: 'url', alternatif: true },
+            { type: 'modifié', paruLe: '30/07/2021' },
+            { type: 'modifié', paruLe: '30/08/2022' },
+            { type: 'modifié', paruLe: '30/08/2022', alternatif: true },
           ] as ReadonlyArray<CahierDesChargesModifié>,
         },
       ],
@@ -218,7 +218,7 @@ describe('Choisir un cahier des charges', () => {
               id: periodeId,
               type: 'notified',
               cahiersDesChargesModifiésDisponibles: [
-                { type: 'modifié', paruLe: '30/08/2022', url: 'url' },
+                { type: 'modifié', paruLe: '30/08/2022' },
               ] as ReadonlyArray<CahierDesChargesModifié>,
             },
           ],
@@ -275,7 +275,6 @@ describe('Choisir un cahier des charges', () => {
                 {
                   type: 'modifié',
                   paruLe: '30/08/2022',
-                  url: 'url',
                   numéroGestionnaireRequis: true,
                 },
               ] as ReadonlyArray<CahierDesChargesModifié>,
@@ -403,7 +402,6 @@ describe('Choisir un cahier des charges', () => {
                 {
                   type: 'modifié',
                   paruLe: '30/08/2022',
-                  url: 'url',
                   numéroGestionnaireRequis: true,
                 },
               ] as ReadonlyArray<CahierDesChargesModifié>,

--- a/src/views/components/InfoLienGuideUtilisationCDC.tsx
+++ b/src/views/components/InfoLienGuideUtilisationCDC.tsx
@@ -1,12 +1,28 @@
 import React from 'react';
 import { ExternalLink } from './UI';
 
-export const InfoLienGuideUtilisationCDC = () => (
-  <span>
-    Pour plus d'informations sur les modalités d'instruction veuillez consulter cette&nbsp;
-    <ExternalLink href="https://docs.potentiel.beta.gouv.fr/guide-dutilisation/gestion-de-mon-projet-sur-potentiel/cahiers-des-charges-modificatifs">
-      page d'aide
-    </ExternalLink>
-    .
-  </span>
+export const InfoLienGuideUtilisationCDC = ({
+  cahiersDesChargesUrl,
+}: {
+  cahiersDesChargesUrl?: string;
+}) => (
+  <>
+    <span>
+      Pour plus d'informations sur les modalités d'instruction veuillez consulter cette&nbsp;
+      <ExternalLink href="https://docs.potentiel.beta.gouv.fr/guide-dutilisation/gestion-de-mon-projet-sur-potentiel/cahiers-des-charges-modificatifs">
+        page d'aide
+      </ExternalLink>
+      .
+    </span>
+    {cahiersDesChargesUrl && (
+      <>
+        <br />
+        <span className="block mt-3">
+          Pour consulter les détails des cahiers des charges disponibles pour votre appel d'offres,
+          veuillez consulter&nbsp;
+          <ExternalLink href={cahiersDesChargesUrl}>cette page de la CRE</ExternalLink>.
+        </span>
+      </>
+    )}
+  </>
 );

--- a/src/views/components/ProjectInfo.tsx
+++ b/src/views/components/ProjectInfo.tsx
@@ -18,6 +18,7 @@ export type ProjectProps = {
   gestionnaireRéseau?: { codeEIC: string; raisonSociale: string };
   puissance?: number;
   unitePuissance?: string;
+  cahiersDesChargesUrl?: string;
 };
 
 type ProjectInfoProps = {

--- a/src/views/components/UI/organisms/choisirCahierDesCharges/CahierDesChargesInitial.tsx
+++ b/src/views/components/UI/organisms/choisirCahierDesCharges/CahierDesChargesInitial.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { ExternalLink } from '../../..';
 import { ProjectAppelOffre } from '../../../../../entities/appelOffre';
 
 type CahierDesChargesInitialProps = {
@@ -14,15 +13,6 @@ export const CahierDesChargesInitial: React.FC<CahierDesChargesInitialProps> = (
           Instruction selon les dispositions du cahier des charges en vigueur au moment de la
           candidature &nbsp;
         </span>
-        {appelOffre.periode.cahierDesCharges.url && (
-          <>
-            {'('}
-            <ExternalLink href={appelOffre.periode.cahierDesCharges.url}>
-              voir le cahier des charges
-            </ExternalLink>
-            {')'}
-          </>
-        )}
         .
       </div>
 

--- a/src/views/components/UI/organisms/choisirCahierDesCharges/CahierDesChargesModifiéDisponible.tsx
+++ b/src/views/components/UI/organisms/choisirCahierDesCharges/CahierDesChargesModifiéDisponible.tsx
@@ -1,21 +1,15 @@
 import React from 'react';
-import { ExternalLink } from '../../..';
 import { CahierDesChargesModifié } from '@potentiel-domain/appel-offre';
 
 type CahierDesChargesModifiéDisponibleProps = CahierDesChargesModifié;
 
 export const CahierDesChargesModifiéDisponible: React.FC<
   CahierDesChargesModifiéDisponibleProps
-> = ({ paruLe, alternatif, url }) => (
+> = ({ paruLe, alternatif }) => (
   <div className="flex-column">
-    <div>
-      <span className="font-bold">
-        Instruction selon le cahier des charges{alternatif ? ' alternatif' : ''} modifié{' '}
-        rétroactivement et publié le {paruLe}{' '}
-      </span>
-      {'('}
-      <ExternalLink href={url}>voir le cahier des charges</ExternalLink>
-      {')'}.
+    <div className="font-bold">
+      Instruction selon le cahier des charges{alternatif ? ' alternatif' : ''} modifié{' '}
+      rétroactivement et publié le {paruLe}{' '}
     </div>
 
     <ul className="mt-2 list-none p-1 md:list-disc md:pl-10">

--- a/src/views/pages/changerFournisseurPage/ChangerFournisseur.tsx
+++ b/src/views/pages/changerFournisseurPage/ChangerFournisseur.tsx
@@ -58,7 +58,7 @@ export const ChangerFournisseur = ({ request, project, appelOffre }: ChangerFour
                   cahier des charges à appliquer"
               className="mb-5"
             >
-              <InfoLienGuideUtilisationCDC />
+              <InfoLienGuideUtilisationCDC cahiersDesChargesUrl={project.cahiersDesChargesUrl} />
             </InfoBox>
           }
           projet={{

--- a/src/views/pages/changerProducteurPage/ChangerProducteur.tsx
+++ b/src/views/pages/changerProducteurPage/ChangerProducteur.tsx
@@ -50,7 +50,7 @@ export const ChangerProducteur = ({ request, project, appelOffre }: ChangerProdu
                   cahier des charges à appliquer"
               className="mb-5"
             >
-              <InfoLienGuideUtilisationCDC />
+              <InfoLienGuideUtilisationCDC cahiersDesChargesUrl={project.cahiersDesChargesUrl} />
             </InfoBox>
           }
           projet={{

--- a/src/views/pages/choisirCahierDesChargesPage/ChoisirCahierDesCharges.tsx
+++ b/src/views/pages/choisirCahierDesChargesPage/ChoisirCahierDesCharges.tsx
@@ -23,7 +23,9 @@ export const ChoisirCahierDesCharges = ({ projet, request }: ChoisirCahierDesCha
         projet={projet}
         infoBox={
           <InfoBox>
-            <InfoLienGuideUtilisationCDC />
+            <InfoLienGuideUtilisationCDC
+              cahiersDesChargesUrl={projet.appelOffre.cahiersDesChargesUrl}
+            />
           </InfoBox>
         }
       />

--- a/src/views/pages/demanderChangementPuissancePage/DemanderChangementPuissance.tsx
+++ b/src/views/pages/demanderChangementPuissancePage/DemanderChangementPuissance.tsx
@@ -70,7 +70,7 @@ export const DemanderChangementPuissance = ({
                   cahier des charges à appliquer"
               className="mb-5"
             >
-              <InfoLienGuideUtilisationCDC />
+              <InfoLienGuideUtilisationCDC cahiersDesChargesUrl={project.cahiersDesChargesUrl} />
             </InfoBox>
           }
         />

--- a/src/views/pages/délai/DemanderDelaiPage.tsx
+++ b/src/views/pages/délai/DemanderDelaiPage.tsx
@@ -67,7 +67,7 @@ export const DemanderDelai = ({ request, project, appelOffre }: DemanderDelaiPro
                   cahier des charges à appliquer"
               className="mb-5"
             >
-              <InfoLienGuideUtilisationCDC />
+              <InfoLienGuideUtilisationCDC cahiersDesChargesUrl={project.cahiersDesChargesUrl} />
             </InfoBox>
           }
         />

--- a/src/views/pages/newModificationRequestPage/NewModificationRequest.tsx
+++ b/src/views/pages/newModificationRequestPage/NewModificationRequest.tsx
@@ -69,7 +69,7 @@ export const NewModificationRequest = ({
                   cahier des charges à appliquer"
               className="mb-5"
             >
-              <InfoLienGuideUtilisationCDC />
+              <InfoLienGuideUtilisationCDC cahiersDesChargesUrl={project.cahiersDesChargesUrl} />
             </InfoBox>
           }
         />


### PR DESCRIPTION
Pour éviter les erreurs, on ne renvoie plus vers les textes des CDC, mais vers la page de la CRE listant tous les CDC pour un AO donné.