### PR TITLE
🚸 Restriction affichage lien "demander abandon" depuis le projet

### DIFF
--- a/src/views/components/UI/molecules/dropdowns/DropdownMenuSecondaryButton.tsx
+++ b/src/views/components/UI/molecules/dropdowns/DropdownMenuSecondaryButton.tsx
@@ -99,7 +99,7 @@ const DropdownItem = ({ children, href, isCurrent, download, disabled }: Dropdow
     {isCurrent && <div className="h-[24px] w-[2px] bg-blue-france-sun-base" />}
     <a
       className={`flex-1 px-4 py-3 block no-underline whitespace-nowrap ${
-        disabled && 'pointer-events-none'
+        disabled && 'pointer-events-none !text-gray-400'
       }`}
       href={href}
       {...(download && { download: true })}

--- a/src/views/pages/projectDetailsPage/ProjectDetails.tsx
+++ b/src/views/pages/projectDetailsPage/ProjectDetails.tsx
@@ -12,6 +12,7 @@ import {
   ErrorBox,
   AlertBox,
   Heading2,
+  InfoBox,
 } from '../../components';
 import { afficherDate, hydrateOnClient } from '../../helpers';
 import {
@@ -55,6 +56,9 @@ export const ProjectDetails = ({
   ).formatter();
 
   const abandonEnCours = !!abandon && abandon.statut !== 'rejeté';
+  const modificationsNonPermisesParLeCDCActuel =
+    project.cahierDesChargesActuel.type === 'initial' &&
+    !!project.appelOffre.choisirNouveauCahierDesCharges;
 
   return (
     <LegacyPageTemplate user={request.user} currentPage="list-projects">
@@ -63,7 +67,9 @@ export const ProjectDetails = ({
         Les informations affichées sur cette page reflètent la situation du projet en fonction des
         éléments fournis à Potentiel à date. Elles sont susceptibles de modifications ultérieures.
       </p>
-      <ProjectHeader {...{ project, user, abandonEnCours }} />
+      <ProjectHeader
+        {...{ project, user, abandonEnCours, modificationsNonPermisesParLeCDCActuel }}
+      />
       <div className="print:hidden">
         {success && <SuccessBox title={success} />}
         {error && <ErrorBox title={error} />}
@@ -76,6 +82,13 @@ export const ProjectDetails = ({
                 Voir l'abandon {abandon.statut}
               </a>
             </AlertBox>
+          )}
+          {modificationsNonPermisesParLeCDCActuel && (
+            <InfoBox>
+              Afin d'accéder aux fonctionnalités dématérialisées d'information au Préfet et de
+              modification de votre projet (recours, abandon, délai), vous devez d'abord changer le
+              cahier des charges applicable (encart "Cahier des charges" ci-dessous).
+            </InfoBox>
           )}
 
           {alertesRaccordement && (

--- a/src/views/pages/projectDetailsPage/ProjectDetails.tsx
+++ b/src/views/pages/projectDetailsPage/ProjectDetails.tsx
@@ -54,6 +54,8 @@ export const ProjectDetails = ({
     `${project.appelOffreId}#${project.periodeId}#${project.familleId || ''}#${project.numeroCRE}`,
   ).formatter();
 
+  const abandonEnCours = !!abandon && abandon.statut !== 'rejeté';
+
   return (
     <LegacyPageTemplate user={request.user} currentPage="list-projects">
       <p className="hidden print:block m-0 mb-2 font-semibold">
@@ -61,7 +63,7 @@ export const ProjectDetails = ({
         Les informations affichées sur cette page reflètent la situation du projet en fonction des
         éléments fournis à Potentiel à date. Elles sont susceptibles de modifications ultérieures.
       </p>
-      <ProjectHeader {...{ project, user }} />
+      <ProjectHeader {...{ project, user, abandonEnCours }} />
       <div className="print:hidden">
         {success && <SuccessBox title={success} />}
         {error && <ErrorBox title={error} />}

--- a/src/views/pages/projectDetailsPage/components/ProjectActions.stories.tsx
+++ b/src/views/pages/projectDetailsPage/components/ProjectActions.stories.tsx
@@ -8,4 +8,8 @@ export default { title: 'Components/ProjectDetailsPage/ProjectActions' };
 const project = { id: 'projectId', isClasse: true } as ProjectDataForProjectPage;
 const user = { role: 'dreal' } as User;
 
-export const ForDreals = () => <ProjectActions {...{ project, user }} />;
+export const ForDreals = () => (
+  <ProjectActions
+    {...{ project, user, abandonEnCours: false, modificationsNonPermisesParLeCDCActuel: false }}
+  />
+);

--- a/src/views/pages/projectDetailsPage/components/ProjectActions.tsx
+++ b/src/views/pages/projectDetailsPage/components/ProjectActions.tsx
@@ -15,6 +15,7 @@ type ProjectActionsProps = {
   project: ProjectDataForProjectPage;
   user: User;
   abandonEnCours: boolean;
+  modificationsNonPermisesParLeCDCActuel: boolean;
 };
 
 type EnregistrerUneModificationProps = {
@@ -56,8 +57,13 @@ const getProjectStatus = (project: ProjectDataForProjectPage) =>
 type PorteurProjetActionsProps = {
   project: ProjectDataForProjectPage;
   abandonEnCours: boolean;
+  modificationsNonPermisesParLeCDCActuel: boolean;
 };
-const PorteurProjetActions = ({ project, abandonEnCours }: PorteurProjetActionsProps) => (
+const PorteurProjetActions = ({
+  project,
+  abandonEnCours,
+  modificationsNonPermisesParLeCDCActuel,
+}: PorteurProjetActionsProps) => (
   <div className="flex flex-col gap-3">
     <div className="flex flex-col xl:flex-row gap-2">
       {!project.isClasse && (
@@ -94,6 +100,7 @@ const PorteurProjetActions = ({ project, abandonEnCours }: PorteurProjetActionsP
               href={`/laureats/${encodeURIComponent(
                 `${project.appelOffreId}#${project.periodeId}#${project.familleId}#${project.numeroCRE}`,
               )}/abandon/demander`}
+              {...(modificationsNonPermisesParLeCDCActuel && { disabled: true })}
             >
               <span>Demander un abandon</span>
             </DropdownMenuSecondaryButton.DropdownItem>
@@ -162,14 +169,23 @@ const AdminActions = ({
   </div>
 );
 
-export const ProjectActions = ({ project, user, abandonEnCours }: ProjectActionsProps) => (
+export const ProjectActions = ({
+  project,
+  user,
+  abandonEnCours,
+  modificationsNonPermisesParLeCDCActuel,
+}: ProjectActionsProps) => (
   <div className="print:hidden whitespace-nowrap">
     {userIs(['admin', 'dgec-validateur'])(user) && (
       <AdminActions
         {...{ project, signalementAbandonAutorisé: true, signalementRecoursAutorisé: true }}
       />
     )}
-    {userIs(['porteur-projet'])(user) && <PorteurProjetActions {...{ project, abandonEnCours }} />}
+    {userIs(['porteur-projet'])(user) && (
+      <PorteurProjetActions
+        {...{ project, abandonEnCours, modificationsNonPermisesParLeCDCActuel }}
+      />
+    )}
     {userIs(['dreal'])(user) && <EnregistrerUneModification {...{ project }} />}
   </div>
 );

--- a/src/views/pages/projectDetailsPage/components/ProjectActions.tsx
+++ b/src/views/pages/projectDetailsPage/components/ProjectActions.tsx
@@ -14,6 +14,7 @@ import React from 'react';
 type ProjectActionsProps = {
   project: ProjectDataForProjectPage;
   user: User;
+  abandonEnCours: boolean;
 };
 
 type EnregistrerUneModificationProps = {
@@ -54,8 +55,9 @@ const getProjectStatus = (project: ProjectDataForProjectPage) =>
 
 type PorteurProjetActionsProps = {
   project: ProjectDataForProjectPage;
+  abandonEnCours: boolean;
 };
-const PorteurProjetActions = ({ project }: PorteurProjetActionsProps) => (
+const PorteurProjetActions = ({ project, abandonEnCours }: PorteurProjetActionsProps) => (
   <div className="flex flex-col gap-3">
     <div className="flex flex-col xl:flex-row gap-2">
       {!project.isClasse && (
@@ -87,13 +89,15 @@ const PorteurProjetActions = ({ project }: PorteurProjetActionsProps) => (
           >
             <span>Changer de puissance</span>
           </DropdownMenuSecondaryButton.DropdownItem>
-          <DropdownMenuSecondaryButton.DropdownItem
-            href={`/laureats/${encodeURIComponent(
-              `${project.appelOffreId}#${project.periodeId}#${project.familleId}#${project.numeroCRE}`,
-            )}/abandon/demander`}
-          >
-            <span>Demander un abandon</span>
-          </DropdownMenuSecondaryButton.DropdownItem>
+          {!abandonEnCours && (
+            <DropdownMenuSecondaryButton.DropdownItem
+              href={`/laureats/${encodeURIComponent(
+                `${project.appelOffreId}#${project.periodeId}#${project.familleId}#${project.numeroCRE}`,
+              )}/abandon/demander`}
+            >
+              <span>Demander un abandon</span>
+            </DropdownMenuSecondaryButton.DropdownItem>
+          )}
         </DropdownMenuSecondaryButton>
       )}
 
@@ -158,14 +162,14 @@ const AdminActions = ({
   </div>
 );
 
-export const ProjectActions = ({ project, user }: ProjectActionsProps) => (
+export const ProjectActions = ({ project, user, abandonEnCours }: ProjectActionsProps) => (
   <div className="print:hidden whitespace-nowrap">
     {userIs(['admin', 'dgec-validateur'])(user) && (
       <AdminActions
         {...{ project, signalementAbandonAutorisé: true, signalementRecoursAutorisé: true }}
       />
     )}
-    {userIs(['porteur-projet'])(user) && <PorteurProjetActions {...{ project }} />}
+    {userIs(['porteur-projet'])(user) && <PorteurProjetActions {...{ project, abandonEnCours }} />}
     {userIs(['dreal'])(user) && <EnregistrerUneModification {...{ project }} />}
   </div>
 );

--- a/src/views/pages/projectDetailsPage/components/ProjectHeader.tsx
+++ b/src/views/pages/projectDetailsPage/components/ProjectHeader.tsx
@@ -8,9 +8,15 @@ type ProjectHeaderProps = {
   project: ProjectDataForProjectPage;
   user: User;
   abandonEnCours: boolean;
+  modificationsNonPermisesParLeCDCActuel: boolean;
 };
 
-export const ProjectHeader = ({ project, user, abandonEnCours }: ProjectHeaderProps) => (
+export const ProjectHeader = ({
+  project,
+  user,
+  abandonEnCours,
+  modificationsNonPermisesParLeCDCActuel,
+}: ProjectHeaderProps) => (
   <div className="w-full pt-3 md:pt-0 print:pt-0 lg:flex justify-between gap-2">
     <div className="pl-3 print:pl-0 mb-3 text-sm">
       <div
@@ -45,7 +51,9 @@ export const ProjectHeader = ({ project, user, abandonEnCours }: ProjectHeaderPr
     </div>
 
     <div className="px-3">
-      <ProjectActions {...{ project, user, abandonEnCours }} />
+      <ProjectActions
+        {...{ project, user, abandonEnCours, modificationsNonPermisesParLeCDCActuel }}
+      />
     </div>
   </div>
 );

--- a/src/views/pages/projectDetailsPage/components/ProjectHeader.tsx
+++ b/src/views/pages/projectDetailsPage/components/ProjectHeader.tsx
@@ -7,9 +7,10 @@ import { ProjectActions } from './ProjectActions';
 type ProjectHeaderProps = {
   project: ProjectDataForProjectPage;
   user: User;
+  abandonEnCours: boolean;
 };
 
-export const ProjectHeader = ({ project, user }: ProjectHeaderProps) => (
+export const ProjectHeader = ({ project, user, abandonEnCours }: ProjectHeaderProps) => (
   <div className="w-full pt-3 md:pt-0 print:pt-0 lg:flex justify-between gap-2">
     <div className="pl-3 print:pl-0 mb-3 text-sm">
       <div
@@ -44,7 +45,7 @@ export const ProjectHeader = ({ project, user }: ProjectHeaderProps) => (
     </div>
 
     <div className="px-3">
-      <ProjectActions {...{ project, user }} />
+      <ProjectActions {...{ project, user, abandonEnCours }} />
     </div>
   </div>
 );


### PR DESCRIPTION
Ajout de restrictions : 
- si le projet a déjà un abandon en cours : retirer "abandon" de la liste des modifications possibles
- si le CDC ne permet pas un abandon depuis potentiel : "abandon" non cliquable dans la liste + message info