### PR TITLE
🐛 (page abandon): rubrique "preuve recandidature" seulement pour les projets concernés

### DIFF
--- a/packages/applications/ssr/src/components/molecules/abandon/DetailDemandeAbandon.tsx
+++ b/packages/applications/ssr/src/components/molecules/abandon/DetailDemandeAbandon.tsx
@@ -8,7 +8,7 @@ import Alert from '@codegouvfr/react-dsfr/Alert';
 import { Heading2 } from '@/components/atoms/headings';
 import { encodeParameter } from '@/utils/encodeParameter';
 
-type DetailDemandeAbandonProps = {
+export type DetailDemandeAbandonProps = {
   demandéPar: string;
   demandéLe: string;
   recandidature: boolean;
@@ -17,13 +17,14 @@ type DetailDemandeAbandonProps = {
   preuveRecandidature?: string;
 };
 
-export const DetailDemandeAbandon: FC<DetailDemandeAbandonProps> = ({
+export const DetailDemandeAbandon: FC<DetailDemandeAbandonProps & { statut: string }> = ({
   demandéPar,
   demandéLe,
   recandidature,
   raison,
   pièceJustificative,
   preuveRecandidature,
+  statut,
 }) => (
   <div className="mb-7">
     <CallOut>
@@ -52,20 +53,24 @@ export const DetailDemandeAbandon: FC<DetailDemandeAbandonProps> = ({
       </span>
     </CallOut>
 
-    <Heading2 className="mb-2">Preuve de recandidature</Heading2>
-    {preuveRecandidature ? (
-      <p>
-        Le porteur a bien transmis un{' '}
-        <a
-          href={`/projet/${encodeParameter(preuveRecandidature)}/details.html`}
-          aria-label={`voir le projet faisant office de preuve de recandidature`}
-        >
-          projet comme preuve de recandidature
-        </a>
-        .
-      </p>
-    ) : (
-      <p>Le porteur n'a pas encore transmis de projet comme preuve de recandidature.</p>
+    {recandidature && statut === 'accordé' && (
+      <>
+        <Heading2 className="mb-2">Preuve de recandidature</Heading2>
+        {preuveRecandidature ? (
+          <p>
+            Le porteur a bien transmis un{' '}
+            <a
+              href={`/projet/${encodeParameter(preuveRecandidature)}/details.html`}
+              aria-label={`voir le projet faisant office de preuve de recandidature`}
+            >
+              projet comme preuve de recandidature
+            </a>
+            .
+          </p>
+        ) : (
+          <p>Le porteur n'a pas encore transmis de projet comme preuve de recandidature.</p>
+        )}
+      </>
     )}
 
     {recandidature && (

--- a/packages/applications/ssr/src/components/pages/abandon/DetailAbandonPage.tsx
+++ b/packages/applications/ssr/src/components/pages/abandon/DetailAbandonPage.tsx
@@ -2,7 +2,10 @@
 
 import { AnnulerAbandonForm } from './annuler/AnnulerAbandonForm';
 import { ConfirmerAbandonForm } from './confirmer/ConfirmerAbandonForm';
-import { DetailDemandeAbandon } from '@/components/molecules/abandon/DetailDemandeAbandon';
+import {
+  DetailDemandeAbandon,
+  DetailDemandeAbandonProps,
+} from '@/components/molecules/abandon/DetailDemandeAbandon';
 import { DetailInstructionAbandon } from '@/components/molecules/abandon/DetailInstructionAbandon';
 import { InstructionAbandonForm } from './InstructionAbandonForm';
 import { StatutAbandonBadge } from '@/components/molecules/abandon/StatutAbandonBadge';
@@ -12,7 +15,7 @@ import { FC } from 'react';
 export type DetailAbandonPageProps = {
   statut: Parameters<typeof StatutAbandonBadge>[0]['statut'];
   projet: Parameters<typeof ProjetPageTemplate>[0]['projet'];
-  demande: Parameters<typeof DetailDemandeAbandon>[0];
+  demande: DetailDemandeAbandonProps;
   instruction: Parameters<typeof DetailInstructionAbandon>[0];
   utilisateur: Parameters<typeof InstructionAbandonForm>[0]['utilisateur'];
 };
@@ -35,7 +38,7 @@ export const DetailAbandonPage: FC<DetailAbandonPageProps> = ({
       }
     >
       <>
-        <DetailDemandeAbandon {...demande} />
+        <DetailDemandeAbandon {...{ ...demande, statut }} />
         <div className="flex flex-col gap-6">
           {(instruction.accord || instruction.confirmation || instruction.rejet) && (
             <DetailInstructionAbandon {...instruction} />


### PR DESCRIPTION
Rubrique "preuve de recandidature" de la page projet à afficher seulement pour les abandons : 
- avec recandidature
- accordés