### PR TITLE
:recycle: Exporter les props des composants React (vs utilisation type Parameters)

### DIFF
--- a/packages/applications/ssr/src/app/laureats/[identifiant]/abandon/page.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/abandon/page.tsx
@@ -51,7 +51,7 @@ export default async function Page({ params: { identifiant } }: IdentifiantParam
 
     // TODO: extract the logic in a dedicated function mapToProps
     // identifiantProjet must come from the readmodel as a value type
-    const detailAbandonPageProps: Parameters<typeof DetailAbandonPage>[0] = {
+    const detailAbandonPageProps: DetailAbandonPageProps = {
       identifiantUtilisateur: utilisateur.email,
       projet: { ...candidature, identifiantProjet },
       statut: statut.statut,

--- a/packages/applications/ssr/src/app/laureats/abandons/page.tsx
+++ b/packages/applications/ssr/src/app/laureats/abandons/page.tsx
@@ -2,7 +2,10 @@ import { mediator } from 'mediateur';
 import { ListerAppelOffreQuery } from '@potentiel-domain/appel-offre';
 import { Abandon } from '@potentiel-domain/laureat';
 
-import { AbandonListPage } from '@/components/pages/abandon/lister/AbandonListPage';
+import {
+  AbandonListPage,
+  AbandonListPageProps,
+} from '@/components/pages/abandon/lister/AbandonListPage';
 import { displayDate } from '@/utils/displayDate';
 import { getUser } from '@/utils/getUtilisateur';
 import { redirect } from 'next/navigation';
@@ -93,7 +96,7 @@ export default async function Page({ searchParams }: PageProps) {
 
 const mapToListProps = (
   readModel: Abandon.ListerAbandonReadModel,
-): Parameters<typeof AbandonListPage>[0]['list'] => {
+): AbandonListPageProps['list'] => {
   const items = readModel.items.map(
     ({
       identifiantProjet,

--- a/packages/applications/ssr/src/app/taches/page.tsx
+++ b/packages/applications/ssr/src/app/taches/page.tsx
@@ -4,7 +4,7 @@ import { ListerTâcheQuery, ListerTâcheReadModel } from '@potentiel-domain/tach
 
 import { displayDate } from '@/utils/displayDate';
 import { IdentifiantParameter } from '@/utils/identifiantParameter';
-import { TâcheListPage } from '@/components/pages/tâche/TâcheListPage';
+import { TâcheListPage, TâcheListPageProps } from '@/components/pages/tâche/TâcheListPage';
 import { getUser } from '@/utils/getUtilisateur';
 import { OperationRejectedError } from '@potentiel-domain/core';
 import { PageWithErrorHandling } from '@/utils/PageWithErrorHandling';
@@ -55,9 +55,7 @@ export default async function Page({ searchParams }: IdentifiantParameter & Page
   });
 }
 
-const mapToListProps = (
-  readModel: ListerTâcheReadModel,
-): Parameters<typeof TâcheListPage>[0]['list'] => {
+const mapToListProps = (readModel: ListerTâcheReadModel): TâcheListPageProps['list'] => {
   const items = readModel.items.map(
     ({
       identifiantProjet,

--- a/packages/applications/ssr/src/components/molecules/projet/ProjetBanner.tsx
+++ b/packages/applications/ssr/src/components/molecules/projet/ProjetBanner.tsx
@@ -1,10 +1,13 @@
 import { FC } from 'react';
-import { StatutProjetBadge } from '@/components/molecules/projet/StatutProjetBadge';
+import {
+  StatutProjetBadge,
+  StatutProjetBadgeProps,
+} from '@/components/molecules/projet/StatutProjetBadge';
 import { displayDate } from '@/utils/displayDate';
 import { encodeParameter } from '@/utils/encodeParameter';
 
-type ProjetBannerProps = {
-  statut: Parameters<typeof StatutProjetBadge>[0]['statut'];
+export type ProjetBannerProps = {
+  statut: StatutProjetBadgeProps['statut'];
   nom: string;
   appelOffre: string;
   période: string;

--- a/packages/applications/ssr/src/components/molecules/projet/StatutProjetBadge.tsx
+++ b/packages/applications/ssr/src/components/molecules/projet/StatutProjetBadge.tsx
@@ -1,7 +1,7 @@
 import Badge from '@codegouvfr/react-dsfr/Badge';
 import { FC } from 'react';
 
-type StatutProjetBadgeProps = { statut: 'non-notifié' | 'abandonné' | 'classé' | 'éliminé' };
+export type StatutProjetBadgeProps = { statut: 'non-notifié' | 'abandonné' | 'classé' | 'éliminé' };
 
 export const StatutProjetBadge: FC<StatutProjetBadgeProps> = ({ statut }) => (
   <Badge

--- a/packages/applications/ssr/src/components/molecules/tâche/TâcheListItem.tsx
+++ b/packages/applications/ssr/src/components/molecules/tâche/TâcheListItem.tsx
@@ -1,7 +1,7 @@
 import { FC } from 'react';
 import { encodeParameter } from '@/utils/encodeParameter';
 
-type TâcheListItemProps = {
+export type TâcheListItemProps = {
   identifiantProjet: string;
   nomProjet: string;
   appelOffre: string;

--- a/packages/applications/ssr/src/components/organisms/ListFilters.tsx
+++ b/packages/applications/ssr/src/components/organisms/ListFilters.tsx
@@ -5,7 +5,7 @@ import { Heading2 } from '../atoms/headings';
 import { FC, useState } from 'react';
 import { Filter } from '../molecules/Filter';
 
-type ListFiltersProps = {
+export type ListFiltersProps = {
   filters: Array<{
     label: string;
     searchParamKey: string;

--- a/packages/applications/ssr/src/components/organisms/ListHeader.tsx
+++ b/packages/applications/ssr/src/components/organisms/ListHeader.tsx
@@ -3,7 +3,7 @@ import { FC } from 'react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import Tag from '@codegouvfr/react-dsfr/Tag';
 
-type ListHeaderProps = {
+export type ListHeaderProps = {
   tagFilters: Array<{
     label: string;
     searchParamKey: string;

--- a/packages/applications/ssr/src/components/pages/abandon/détails/DetailAbandonPage.tsx
+++ b/packages/applications/ssr/src/components/pages/abandon/détails/DetailAbandonPage.tsx
@@ -5,9 +5,12 @@ import {
   DetailDemandeAbandon,
   DetailDemandeAbandonProps,
 } from '@/components/pages/abandon/détails/DetailDemandeAbandon';
-import { DetailInstructionAbandon } from '@/components/pages/abandon/détails/DetailInstructionAbandon';
-import { StatutBadge } from '@/components/molecules/StatutBadge';
-import { ProjetPageTemplate } from '@/components/templates/ProjetPageTemplate';
+import {
+  DetailInstructionAbandon,
+  DetailInstructionAbandonProps,
+} from '@/components/pages/abandon/détails/DetailInstructionAbandon';
+import { StatutBadge, StatutBadgeProps } from '@/components/molecules/StatutBadge';
+import { ProjetPageTemplateProps } from '@/components/templates/ProjetPageTemplate';
 import { DemanderConfirmationAbandon } from './demanderConfirmation/DemanderConfirmationAbandon';
 import { RejeterAbandon } from './rejeter/RejeterAbandon';
 import { AccorderAbandonAvecRecandidature } from './accorder/AccorderAbandonAvecRecandidature';
@@ -26,10 +29,10 @@ type AvailableActions = Array<
 >;
 
 export type DetailAbandonPageProps = {
-  statut: Parameters<typeof StatutBadge>[0]['statut'];
-  projet: Parameters<typeof ProjetPageTemplate>[0]['projet'];
+  statut: StatutBadgeProps['statut'];
+  projet: ProjetPageTemplateProps['projet'];
   demande: DetailDemandeAbandonProps;
-  instruction: Parameters<typeof DetailInstructionAbandon>[0];
+  instruction: DetailInstructionAbandonProps;
   identifiantUtilisateur: string;
   actions: AvailableActions;
 };

--- a/packages/applications/ssr/src/components/pages/abandon/détails/DetailInstructionAbandon.tsx
+++ b/packages/applications/ssr/src/components/pages/abandon/détails/DetailInstructionAbandon.tsx
@@ -4,7 +4,7 @@ import { encodeParameter } from '@/utils/encodeParameter';
 import Download from '@codegouvfr/react-dsfr/Download';
 import { FC } from 'react';
 
-type DetailInstructionAbandonProps = {
+export type DetailInstructionAbandonProps = {
   confirmation?: {
     demandéLe: string;
     demandéPar: string;

--- a/packages/applications/ssr/src/components/pages/abandon/détails/accorder/accorderAbandonAvecRecandidature.action.ts
+++ b/packages/applications/ssr/src/components/pages/abandon/détails/accorder/accorderAbandonAvecRecandidature.action.ts
@@ -7,7 +7,7 @@ import { Abandon } from '@potentiel-domain/laureat';
 import { FormAction, FormState, formAction } from '@/utils/formAction';
 import { ConsulterCandidatureQuery } from '@potentiel-domain/candidature';
 import { ConsulterUtilisateurQuery } from '@potentiel-domain/utilisateur';
-import { buildDocument } from '@potentiel-infrastructure/document-builder';
+import { buildDocument, DonnéesDocument } from '@potentiel-infrastructure/document-builder';
 
 const schema = zod.object({
   identifiantProjet: zod.string(),
@@ -67,7 +67,7 @@ const buildReponseSignee = async (
 
   const période = appelOffre.periodes.find((p) => p.id === projet.période);
 
-  const props: Parameters<typeof buildDocument>[0] = {
+  const props: DonnéesDocument = {
     dateCourrier: new Date().toISOString(),
     projet: {
       identifiantProjet: abandon.identifiantProjet.formatter(),

--- a/packages/applications/ssr/src/components/pages/abandon/lister/AbandonListItem.tsx
+++ b/packages/applications/ssr/src/components/pages/abandon/lister/AbandonListItem.tsx
@@ -4,7 +4,7 @@ import { Abandon } from '@potentiel-domain/laureat';
 import { StatutBadge } from '../../../molecules/StatutBadge';
 import { encodeParameter } from '@/utils/encodeParameter';
 
-type AbandonListItemProps = {
+export type AbandonListItemProps = {
   identifiantProjet: string;
   nomProjet: string;
   appelOffre: string;

--- a/packages/applications/ssr/src/components/pages/abandon/lister/AbandonListPage.tsx
+++ b/packages/applications/ssr/src/components/pages/abandon/lister/AbandonListPage.tsx
@@ -3,17 +3,20 @@
 import { FC } from 'react';
 import { useSearchParams } from 'next/navigation';
 
-import { AbandonListItem } from '@/components/pages/abandon/lister/AbandonListItem';
-import { ListPageTemplate } from '@/components/templates/ListPageTemplate';
+import {
+  AbandonListItem,
+  AbandonListItemProps,
+} from '@/components/pages/abandon/lister/AbandonListItem';
+import { ListPageTemplate, ListPageTemplateProps } from '@/components/templates/ListPageTemplate';
 
-type AbandonListPageProps = {
+export type AbandonListPageProps = {
   list: {
-    items: Array<Parameters<typeof AbandonListItem>[0]>;
+    items: Array<AbandonListItemProps>;
     currentPage: number;
     totalItems: number;
     itemsPerPage: number;
   };
-  filters: Parameters<typeof ListPageTemplate>[0]['filters'];
+  filters: ListPageTemplateProps<typeof AbandonListItem>['filters'];
 };
 
 export const AbandonListPage: FC<AbandonListPageProps> = ({

--- a/packages/applications/ssr/src/components/pages/abandon/transmettrePreuveRecandidature/TransmettrePreuveRecandidatureForm.tsx
+++ b/packages/applications/ssr/src/components/pages/abandon/transmettrePreuveRecandidature/TransmettrePreuveRecandidatureForm.tsx
@@ -16,7 +16,7 @@ type ProjetÀSélectionner = {
   nom: string;
 };
 
-type TransmettrePreuveRecandidatureFormProps = {
+export type TransmettrePreuveRecandidatureFormProps = {
   identifiantProjet: string;
   projetsÀSélectionner: Array<ProjetÀSélectionner>;
   identifiantUtilisateur: string;

--- a/packages/applications/ssr/src/components/pages/abandon/transmettrePreuveRecandidature/TransmettrePreuveRecandidaturePage.tsx
+++ b/packages/applications/ssr/src/components/pages/abandon/transmettrePreuveRecandidature/TransmettrePreuveRecandidaturePage.tsx
@@ -1,17 +1,19 @@
 'use client';
 
-import { TransmettrePreuveRecandidatureForm } from './TransmettrePreuveRecandidatureForm';
-import { ProjetPageTemplate } from '@/components/templates/ProjetPageTemplate';
+import {
+  TransmettrePreuveRecandidatureForm,
+  TransmettrePreuveRecandidatureFormProps,
+} from './TransmettrePreuveRecandidatureForm';
+import {
+  ProjetPageTemplate,
+  ProjetPageTemplateProps,
+} from '@/components/templates/ProjetPageTemplate';
 import { FC } from 'react';
 
 export type TransmettrePreuveRecandidaturePageProps = {
-  projet: Parameters<typeof ProjetPageTemplate>[0]['projet'];
-  projetsÀSélectionner: Parameters<
-    typeof TransmettrePreuveRecandidatureForm
-  >[0]['projetsÀSélectionner'];
-  identifiantUtilisateur: Parameters<
-    typeof TransmettrePreuveRecandidatureForm
-  >[0]['identifiantUtilisateur'];
+  projet: ProjetPageTemplateProps['projet'];
+  projetsÀSélectionner: TransmettrePreuveRecandidatureFormProps['projetsÀSélectionner'];
+  identifiantUtilisateur: TransmettrePreuveRecandidatureFormProps['identifiantUtilisateur'];
 };
 
 export const TransmettrePreuveRecandidaturePage: FC<TransmettrePreuveRecandidaturePageProps> = ({

--- a/packages/applications/ssr/src/components/pages/tâche/TâcheListPage.tsx
+++ b/packages/applications/ssr/src/components/pages/tâche/TâcheListPage.tsx
@@ -3,20 +3,20 @@
 import { FC } from 'react';
 import { useSearchParams } from 'next/navigation';
 
-import { ListPageTemplate } from '@/components/templates/ListPageTemplate';
-import { TâcheListItem } from '@/components/molecules/tâche/TâcheListItem';
+import { ListPageTemplate, ListPageTemplateProps } from '@/components/templates/ListPageTemplate';
+import { TâcheListItem, TâcheListItemProps } from '@/components/molecules/tâche/TâcheListItem';
 
-type AbandonListPageProps = {
+export type TâcheListPageProps = {
   list: {
-    items: Array<Parameters<typeof TâcheListItem>[0]>;
+    items: Array<TâcheListItemProps>;
     currentPage: number;
     totalItems: number;
     itemsPerPage: number;
   };
-  filters: Parameters<typeof ListPageTemplate>[0]['filters'];
+  filters: ListPageTemplateProps<typeof TâcheListItem>['filters'];
 };
 
-export const TâcheListPage: FC<AbandonListPageProps> = ({
+export const TâcheListPage: FC<TâcheListPageProps> = ({
   list: { items: tâches, currentPage, totalItems, itemsPerPage },
   filters,
 }) => {

--- a/packages/applications/ssr/src/components/templates/DetailsAboutProjetPageTemplate.tsx
+++ b/packages/applications/ssr/src/components/templates/DetailsAboutProjetPageTemplate.tsx
@@ -1,8 +1,8 @@
 import { FC } from 'react';
-import { ProjetPageTemplate } from './ProjetPageTemplate';
+import { ProjetPageTemplate, ProjetPageTemplateProps } from './ProjetPageTemplate';
 
 type DetailsAboutProjetPageTemplateProps = {
-  projet: Parameters<typeof ProjetPageTemplate>[0]['projet'];
+  projet: ProjetPageTemplateProps['projet'];
   heading: React.ReactNode;
   details: React.ReactNode;
   actions?: React.ReactNode;

--- a/packages/applications/ssr/src/components/templates/ListPageTemplate.tsx
+++ b/packages/applications/ssr/src/components/templates/ListPageTemplate.tsx
@@ -3,16 +3,16 @@
 import { FC } from 'react';
 
 import { PageTemplate } from './PageTemplate';
-import { ListHeader } from '../organisms/ListHeader';
+import { ListHeader, ListHeaderProps } from '../organisms/ListHeader';
 import { List } from '../organisms/List';
-import { ListFilters } from '../organisms/ListFilters';
+import { ListFilters, ListFiltersProps } from '../organisms/ListFilters';
 import { useSearchParams } from 'next/navigation';
 import { Heading1 } from '../atoms/headings';
 
-type ListPageTemplateProps<TItem> = {
+export type ListPageTemplateProps<TItem> = {
   heading: string;
-  filters: Parameters<typeof ListFilters>[0]['filters'];
-  tagFilters: Parameters<typeof ListHeader>[0]['tagFilters'];
+  filters: ListFiltersProps['filters'];
+  tagFilters: ListHeaderProps['tagFilters'];
   currentPage: number;
   totalItems: number;
   itemsPerPage: number;

--- a/packages/applications/ssr/src/components/templates/ProjetPageTemplate.tsx
+++ b/packages/applications/ssr/src/components/templates/ProjetPageTemplate.tsx
@@ -1,10 +1,10 @@
-import { ProjetBanner } from '@/components/molecules/projet/ProjetBanner';
+import { ProjetBanner, ProjetBannerProps } from '@/components/molecules/projet/ProjetBanner';
 import { PageTemplate } from '@/components/templates/PageTemplate';
 import { Heading1 } from '../atoms/headings';
 
 export type ProjetPageTemplateProps = {
   heading: React.ReactNode;
-  projet: Parameters<typeof ProjetBanner>[0];
+  projet: ProjetBannerProps;
   children: React.ReactNode;
 };
 

--- a/packages/infrastructure/document-builder/src/abandon/accordAbandonAvecRecandidature/buildDocument.ts
+++ b/packages/infrastructure/document-builder/src/abandon/accordAbandonAvecRecandidature/buildDocument.ts
@@ -29,7 +29,7 @@ export type GénérerRéponseAccordAbandonAvecRecandidaturePort = (
   données: DonnéesDocument,
 ) => Promise<ReadableStream>;
 
-type DonnéesDocument = {
+export type DonnéesDocument = {
   dateCourrier: string;
   projet: {
     identifiantProjet: string;

--- a/packages/infrastructure/document-builder/src/index.ts
+++ b/packages/infrastructure/document-builder/src/index.ts
@@ -1,2 +1,5 @@
-export { buildDocument } from './abandon/accordAbandonAvecRecandidature/buildDocument';
+export {
+  buildDocument,
+  DonnéesDocument,
+} from './abandon/accordAbandonAvecRecandidature/buildDocument';
 export { getModèleRéponseAbandon } from './abandon/modèlesRéponseDocx/buildDocument';


### PR DESCRIPTION
Exporter les props des composants React afin de faciliter l'imbrication des composants (ne plus utiliser le type utilitaire Parameters)