### PR TITLE
:children_crossing: Afficher info appartenance ou non au vol réservé si puissance inférieure au max du volume

### DIFF
--- a/src/infra/sequelize/migrations/20240125103501-add-col-project-designation-categorie.ts
+++ b/src/infra/sequelize/migrations/20240125103501-add-col-project-designation-categorie.ts
@@ -1,0 +1,13 @@
+import { DataTypes, QueryInterface } from 'sequelize';
+
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await queryInterface.addColumn('projects', 'désignationCatégorie', {
+      type: DataTypes.STRING,
+      allowNull: true,
+    });
+  },
+  down: async (queryInterface: QueryInterface) => {
+    await queryInterface.removeColumn('projects', 'désignationCatégorie');
+  },
+};

--- a/src/infra/sequelize/migrations/20240126105000-apply-designationCategorie-to-projects.ts
+++ b/src/infra/sequelize/migrations/20240126105000-apply-designationCategorie-to-projects.ts
@@ -1,0 +1,120 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    const transaction = await queryInterface.sequelize.transaction();
+    try {
+      // périodes avec volume réservé
+      const periodesProjetsÀModifier = [
+        { appelOffreId: 'PPE2 - Bâtiment', periodeId: '1' },
+        { appelOffreId: 'PPE2 - Bâtiment', periodeId: '2' },
+        { appelOffreId: 'PPE2 - Bâtiment', periodeId: '3' },
+        { appelOffreId: 'PPE2 - Bâtiment', periodeId: '4' },
+        { appelOffreId: 'PPE2 - Bâtiment', periodeId: '5' },
+        { appelOffreId: 'PPE2 - Sol', periodeId: '1' },
+        { appelOffreId: 'PPE2 - Sol', periodeId: '2' },
+        { appelOffreId: 'PPE2 - Sol', periodeId: '3' },
+        { appelOffreId: 'PPE2 - Sol', periodeId: '4' },
+      ];
+
+      for (const { appelOffreId, periodeId } of periodesProjetsÀModifier) {
+        const projets = await queryInterface.sequelize.query(
+          `
+          SELECT * 
+          FROM projects 
+          WHERE "appelOffreId" = ?
+          AND "periodeId" = ?
+        `,
+          {
+            type: queryInterface.sequelize.QueryTypes.SELECT,
+            replacements: [appelOffreId, periodeId],
+            transaction,
+          },
+        );
+
+        console.log(`${projets.length} projets à mettre à jour pour ${appelOffreId} P${periodeId}`);
+
+        if (projets.length > 0) {
+          const aoPeriodes = await queryInterface.sequelize.query(
+            `
+          SELECT value ->> 'periodes' as "periodes"
+          FROM domain_views.projection p 
+          WHERE key = 'appel-offre' || '|' || ?;
+        `,
+            {
+              type: queryInterface.sequelize.QueryTypes.SELECT,
+              replacements: [appelOffreId],
+              transaction,
+            },
+          );
+
+          const periodeDetails = JSON.parse(aoPeriodes[0].periodes).find(
+            (periode) => periode.id === periodeId,
+          );
+
+          const { puissanceMax, noteThreshold } = periodeDetails.noteThreshold.volumeReserve;
+
+          for (const projet of projets) {
+            const désignationCatégorie =
+              projet.puissance <= puissanceMax && projet.note >= noteThreshold
+                ? 'volume-réservé'
+                : 'hors-volume-réservé';
+
+            // Mise à jour des projets
+            await queryInterface.sequelize.query(
+              `
+              UPDATE "projects" 
+              SET "désignationCatégorie" = ? 
+              WHERE id = ?
+              `,
+              {
+                type: queryInterface.sequelize.UPDATE,
+                replacements: [désignationCatégorie, projet.id],
+                transaction,
+              },
+            );
+
+            // Mise à jour events ProjectImported
+            const actualPayload = await queryInterface.sequelize.query(
+              `
+              SELECT payload
+              FROM "eventStores" 
+              WHERE type = 'ProjectImported' 
+              AND payload ->> 'projectId' = ?
+              `,
+              {
+                type: queryInterface.sequelize.SELECT,
+                replacements: [projet.id],
+                transaction,
+              },
+            );
+
+            await queryInterface.sequelize.query(
+              `
+              UPDATE "eventStores" 
+              SET payload = ?
+              WHERE type = 'ProjectImported' 
+              AND payload ->> 'projectId' = ?
+              `,
+              {
+                type: queryInterface.sequelize.UPDATE,
+                replacements: [
+                  JSON.stringify({ ...actualPayload, désignationCatégorie }),
+                  projet.id,
+                ],
+                transaction,
+              },
+            );
+          }
+        }
+      }
+
+      await transaction.commit();
+    } catch (err) {
+      await transaction.rollback();
+      throw err;
+    }
+  },
+
+  down: async (queryInterface, Sequelize) => {},
+};

--- a/src/infra/sequelize/projectionsNext/project/project.initializer.ts
+++ b/src/infra/sequelize/projectionsNext/project/project.initializer.ts
@@ -170,6 +170,10 @@ export const initializeProjectModel = (sequelize: Sequelize) => {
         allowNull: false,
         defaultValue: false,
       },
+      désignationCatégorie: {
+        type: DataTypes.STRING,
+        allowNull: true,
+      },
       createdAt: DataTypes.DATE,
       updatedAt: DataTypes.DATE,
     },

--- a/src/infra/sequelize/projectionsNext/project/project.model.ts
+++ b/src/infra/sequelize/projectionsNext/project/project.model.ts
@@ -52,7 +52,7 @@ export class Project extends Model<InferAttributes<Project>, InferCreationAttrib
   dateMiseEnService?: Date;
   dateFileAttente?: Date;
   soumisAuxGF: boolean;
-  désignationCatégorie?: 'volume-reservé' | 'hors-volume-reservé';
+  désignationCatégorie?: 'volume-réservé' | 'hors-volume-réservé';
   garantiesFinancières?: NonAttribute<GarantiesFinancières>;
   users?: NonAttribute<User[]>;
   certificateFile?: NonAttribute<File>;

--- a/src/infra/sequelize/projectionsNext/project/project.model.ts
+++ b/src/infra/sequelize/projectionsNext/project/project.model.ts
@@ -52,6 +52,7 @@ export class Project extends Model<InferAttributes<Project>, InferCreationAttrib
   dateMiseEnService?: Date;
   dateFileAttente?: Date;
   soumisAuxGF: boolean;
+  désignationCatégorie?: 'volume-reservé' | 'hors-volume-reservé';
   garantiesFinancières?: NonAttribute<GarantiesFinancières>;
   users?: NonAttribute<User[]>;
   certificateFile?: NonAttribute<File>;

--- a/src/infra/sequelize/queries/project/consulter/getProjectDataForProjectPage.ts
+++ b/src/infra/sequelize/queries/project/consulter/getProjectDataForProjectPage.ts
@@ -146,6 +146,7 @@ export const getProjectDataForProjectPage: GetProjectDataForProjectPage = ({ pro
           updatedAt,
           potentielIdentifier,
           dcrDueOn,
+          désignationCatégorie,
         },
       }): ResultAsync<ProjectDataForProjectPage, never> =>
         okAsync({
@@ -180,6 +181,7 @@ export const getProjectDataForProjectPage: GetProjectDataForProjectPage = ({ pro
           isLegacy: appelOffre.periode.type === 'legacy',
           motifsElimination,
           dcrDueOn,
+          désignationCatégorie,
           users: users
             ?.map(({ user }) => user.get())
             .map(({ id, email, fullName }) => ({

--- a/src/modules/demandeModification/demandeChangementDePuissance/demander/demanderChangementDePuissance.ts
+++ b/src/modules/demandeModification/demandeChangementDePuissance/demander/demanderChangementDePuissance.ts
@@ -100,7 +100,10 @@ export const makeDemanderChangementDePuissance: MakeDemanderChangementDePuissanc
 
           const exceedsPuissanceMax = exceedsPuissanceMaxDuVolumeReserve({
             nouvellePuissance: newPuissance,
-            project: { ...project, note: project.data!!.note },
+            project: {
+              appelOffre: appelOffreProjet,
+              désignationCatégorie: project.data?.désignationCatégorie,
+            },
           });
 
           if (exceedsPuissanceMax) {

--- a/src/modules/demandeModification/demandeChangementDePuissance/demander/helpers/exceedsPuissanceMaxDuVolumeReserve.spec.ts
+++ b/src/modules/demandeModification/demandeChangementDePuissance/demander/helpers/exceedsPuissanceMaxDuVolumeReserve.spec.ts
@@ -20,7 +20,7 @@ describe('exceedsPuissanceMaxDuVolumeReserve', () => {
           Lorsque la nouvelle puissance demandée dépasse 10 (puissance max du volume)
           Alors la demande doit être considérée comme dépassant la puissance max du volume réservé`, () => {
         const actual = exceedsPuissanceMaxDuVolumeReserve({
-          project: { puissanceInitiale: 9, note: 16, appelOffre },
+          project: { appelOffre, désignationCatégorie: 'volume-réservé' },
           nouvellePuissance: 10.1,
         });
         expect(actual).toBe(true);
@@ -30,7 +30,7 @@ describe('exceedsPuissanceMaxDuVolumeReserve', () => {
           Lorsque la nouvelle puissance demandée ne dépasse pas 10 (puissance max du volume)
           Alors la demande ne doit pas être considérée comme dépassant la puissance max du volume réservé`, () => {
         const actual = exceedsPuissanceMaxDuVolumeReserve({
-          project: { puissanceInitiale: 9, note: 16, appelOffre },
+          project: { appelOffre, désignationCatégorie: 'volume-réservé' },
           nouvellePuissance: 9.1,
         });
         expect(actual).toBe(false);
@@ -42,7 +42,7 @@ describe('exceedsPuissanceMaxDuVolumeReserve', () => {
           Lorsque la nouvelle puissance demandée dépasse 10 (puissance max du volume)
           Alors la demande ne doit pas être considérée comme dépassant la puissance max du volume réservé`, () => {
         const actual = exceedsPuissanceMaxDuVolumeReserve({
-          project: { puissanceInitiale: 12, note: 16, appelOffre },
+          project: { appelOffre, désignationCatégorie: 'hors-volume-réservé' },
           nouvellePuissance: 10.1,
         });
         expect(actual).toBe(false);
@@ -52,7 +52,7 @@ describe('exceedsPuissanceMaxDuVolumeReserve', () => {
           Lorsque la nouvelle puissance demandée dépasse 10 (puissance max du volume)
           Alors la demande ne doit pas être considérée comme dépassant la puissance max du volume réservé`, () => {
         const actual = exceedsPuissanceMaxDuVolumeReserve({
-          project: { puissanceInitiale: 9, note: 10, appelOffre },
+          project: { appelOffre, désignationCatégorie: 'hors-volume-réservé' },
           nouvellePuissance: 10.1,
         });
         expect(actual).toBe(false);
@@ -68,7 +68,7 @@ describe('exceedsPuissanceMaxDuVolumeReserve', () => {
         Lorsque qu'il y a une demande de changement de puissance
         Alors la demande ne devrait pas être considérée comme dépassant un volume réservé`, () => {
       const actual = exceedsPuissanceMaxDuVolumeReserve({
-        project: { puissanceInitiale: 9, note: 16, appelOffre },
+        project: { appelOffre },
         nouvellePuissance: 10.1,
       });
       expect(actual).toBe(false);

--- a/src/modules/demandeModification/demandeChangementDePuissance/demander/helpers/exceedsPuissanceMaxDuVolumeReserve.ts
+++ b/src/modules/demandeModification/demandeChangementDePuissance/demander/helpers/exceedsPuissanceMaxDuVolumeReserve.ts
@@ -1,26 +1,26 @@
+import { DésignationCatégorie } from 'src/modules/project';
 import { ProjectAppelOffre } from '../../../../../entities';
 import { getVolumeReserve } from './getVolumeReserve';
 
 export type ExceedsPuissanceMaxDuVolumeReserve = (arg: {
   project: {
-    puissanceInitiale: number;
-    note: number;
     appelOffre?: ProjectAppelOffre;
+    désignationCatégorie?: DésignationCatégorie;
   };
   nouvellePuissance: number;
 }) => boolean;
 
 export const exceedsPuissanceMaxDuVolumeReserve: ExceedsPuissanceMaxDuVolumeReserve = ({
-  project,
+  project: { désignationCatégorie, appelOffre },
   nouvellePuissance,
 }) => {
-  const { appelOffre, puissanceInitiale, note } = project;
+  if (!désignationCatégorie) {
+    return false;
+  }
   const volumeReserve = appelOffre && getVolumeReserve(appelOffre);
-
   if (volumeReserve) {
-    const { puissanceMax, noteThreshold } = volumeReserve;
-    const wasNotifiedOnVolumeReserve = puissanceInitiale <= puissanceMax && note >= noteThreshold;
-    if (wasNotifiedOnVolumeReserve && nouvellePuissance > puissanceMax) {
+    const { puissanceMax } = volumeReserve;
+    if (désignationCatégorie == 'volume-réservé' && nouvellePuissance > puissanceMax) {
       return true;
     }
   }

--- a/src/modules/project/Project.ts
+++ b/src/modules/project/Project.ts
@@ -15,7 +15,7 @@ import { CertificateTemplate, Technologie } from '@potentiel-domain/appel-offre'
 import { add, isSameDay, sub } from 'date-fns';
 import remove from 'lodash/remove';
 import sanitize from 'sanitize-filename';
-import { BuildProjectIdentifier, Fournisseur } from '.';
+import { BuildProjectIdentifier, DésignationCatégorie, Fournisseur } from '.';
 import { shallowDelta } from '../../helpers/shallowDelta';
 import {
   EntityNotFoundError,
@@ -246,6 +246,7 @@ export interface ProjectDataProps {
   technologie: Technologie;
   actionnariat?: 'financement-collectif' | 'gouvernance-partagee';
   classe: 'Classé' | 'Eliminé';
+  désignationCatégorie?: DésignationCatégorie;
 }
 
 export interface ProjectProps {

--- a/src/modules/project/dtos/ProjectDataForCertificate.ts
+++ b/src/modules/project/dtos/ProjectDataForCertificate.ts
@@ -1,5 +1,6 @@
 import { ProjectAppelOffre } from '../../../entities';
 import { Technologie } from '@potentiel-domain/appel-offre';
+import { DésignationCatégorie } from '../types/désignationCatégorie';
 
 export type ProjectDataForCertificate = {
   appelOffre: ProjectAppelOffre;
@@ -25,4 +26,5 @@ export type ProjectDataForCertificate = {
   territoireProjet: string;
   technologie: Technologie;
   actionnariat?: 'financement-collectif' | 'gouvernance-partagee';
+  désignationCatégorie?: DésignationCatégorie;
 };

--- a/src/modules/project/events/ProjectImported.ts
+++ b/src/modules/project/events/ProjectImported.ts
@@ -1,5 +1,6 @@
 import { DomainEvent, BaseDomainEvent } from '../../../core/domain';
 import { Technologie } from '@potentiel-domain/appel-offre';
+import { DésignationCatégorie } from '../types';
 
 export interface ProjectImportedPayload {
   projectId: string;
@@ -39,6 +40,7 @@ export interface ProjectImportedPayload {
     technologie: Technologie;
     actionnariat?: string;
     soumisAuxGF?: true;
+    désignationCatégorie?: DésignationCatégorie;
   };
 }
 export class ProjectImported

--- a/src/modules/project/events/ProjectRawDataImported.ts
+++ b/src/modules/project/events/ProjectRawDataImported.ts
@@ -1,5 +1,6 @@
 import { BaseDomainEvent, DomainEvent } from '../../../core/domain';
 import { Technologie } from '@potentiel-domain/appel-offre';
+import { DésignationCatégorie } from '../types';
 
 export interface ProjectRawDataImportedPayload {
   importId: string;
@@ -34,6 +35,7 @@ export interface ProjectRawDataImportedPayload {
     actionnariat?: string;
     garantiesFinancièresType?: string;
     garantiesFinancièresDateEchéance?: string;
+    désignationCatégorie?: DésignationCatégorie;
   };
 }
 export class ProjectRawDataImported

--- a/src/modules/project/mappers/toProjectDataForCertificate.ts
+++ b/src/modules/project/mappers/toProjectDataForCertificate.ts
@@ -52,6 +52,7 @@ export const toProjectDataForCertificate = (
     territoireProjet,
     technologie,
     actionnariat,
+    désignationCatégorie,
   } = data;
 
   return ok({
@@ -78,5 +79,6 @@ export const toProjectDataForCertificate = (
     territoireProjet,
     technologie,
     actionnariat,
+    désignationCatégorie,
   });
 };

--- a/src/modules/project/queries/GetProjectDataForProjectPage.ts
+++ b/src/modules/project/queries/GetProjectDataForProjectPage.ts
@@ -2,7 +2,7 @@ import { ResultAsync } from '../../../core/utils';
 import { ProjectAppelOffre, User } from '../../../entities';
 import { Permission } from '../../authN';
 import { InfraNotAvailableError, EntityNotFoundError } from '../../shared';
-import { Actionnariat } from '../types';
+import { Actionnariat, DésignationCatégorie } from '../types';
 
 export const PermissionConsulterProjet: Permission = {
   nom: 'consulter-projet',
@@ -64,6 +64,8 @@ export type ProjectDataForProjectPage = {
   note: number;
   notesInnovation?: NotesInnovation;
   notePrix?: string;
+
+  désignationCatégorie?: DésignationCatégorie;
 
   details: Record<string, any>;
 

--- a/src/modules/project/types/désignationCatégorie.ts
+++ b/src/modules/project/types/désignationCatégorie.ts
@@ -1,0 +1,1 @@
+export type DésignationCatégorie = 'volume-réservé' | 'hors-volume-réservé';

--- a/src/modules/project/types/index.ts
+++ b/src/modules/project/types/index.ts
@@ -1,2 +1,3 @@
 export * from './fournisseur';
 export * from './actionnariat';
+export * from './désignationCatégorie';

--- a/src/views/certificates/ppe2.v2/components/Laureat.tsx
+++ b/src/views/certificates/ppe2.v2/components/Laureat.tsx
@@ -30,6 +30,17 @@ export const makeLaureat: MakeLaureat = (project) => {
         {periode.title} tranche de l’appel d’offres visé en objet.
       </Text>
 
+      {project.désignationCatégorie && project.désignationCatégorie === 'volume-réservé' && (
+        <Text
+          style={{
+            marginTop: 10,
+          }}
+        >
+          Le projet fait partie du volume réservé tel que défini au chapitre 1. du cahier des
+          charges de la période d'appel d'offres cité en objet.
+        </Text>
+      )}
+
       <Text style={{ marginTop: 10 }}>
         Conformément à l’engagement contenu dans votre offre, je vous informe que{' '}
         {appelOffre.tarifOuPrimeRetenue} en application des dispositions du point{' '}

--- a/src/views/pages/demanderChangementPuissancePage/DemanderChangementPuissance.tsx
+++ b/src/views/pages/demanderChangementPuissancePage/DemanderChangementPuissance.tsx
@@ -16,7 +16,7 @@ import {
   Form,
 } from '../../components';
 import { hydrateOnClient } from '../../helpers';
-import { ChangementPuissance } from './components/ChangementPuissance';
+import { ChangementPuissance, ChangementPuissanceProps } from './components/ChangementPuissance';
 import routes from '../../../routes';
 
 type DemanderChangementPuissanceProps = {
@@ -27,7 +27,7 @@ type DemanderChangementPuissanceProps = {
     puissanceInitiale: number;
     puissance: number;
     unitePuissance: string;
-    note: number;
+    désignationCatégorie?: ChangementPuissanceProps['désignationCatégorie'];
   };
   appelOffre: ProjectAppelOffre;
 };
@@ -87,7 +87,6 @@ export const DemanderChangementPuissance = ({
               justification,
               appelOffre,
               puissanceSaisie,
-              noteProjet: project.note,
               onUpdateEtatFormulaire: (bloquerEnvoi) => setDisableSubmit(bloquerEnvoi),
             }}
           />

--- a/src/views/pages/demanderChangementPuissancePage/components/ChangementPuissance.tsx
+++ b/src/views/pages/demanderChangementPuissancePage/components/ChangementPuissance.tsx
@@ -20,16 +20,16 @@ import { ProjectAppelOffre, parseCahierDesChargesRéférence } from '../../../..
 import { Technologie } from '@potentiel-domain/appel-offre';
 import { AlertePuissanceFourchetteRatioInitialEtCDC2022 } from './AlertePuissanceFourchetteRatioInitialEtCDC2022';
 
-type ChangementPuissanceProps = {
+export type ChangementPuissanceProps = {
   unitePuissance: string;
   puissance: number;
   puissanceInitiale: number;
-  noteProjet: number;
   justification: string;
   cahierDesChargesActuel: string;
   appelOffre: ProjectAppelOffre;
   technologie: Technologie;
   puissanceSaisie?: number;
+  désignationCatégorie?: 'volume-réservé' | 'hors-volume-réservé';
   onUpdateEtatFormulaire: (bloquerEnvoi: boolean) => void;
 };
 
@@ -41,7 +41,7 @@ export const ChangementPuissance = ({
   appelOffre,
   technologie,
   puissanceSaisie,
-  noteProjet,
+  désignationCatégorie,
   onUpdateEtatFormulaire,
 }: ChangementPuissanceProps) => {
   const [displayAlertOnPuissanceType, setDisplayAlertOnPuissanceType] = useState(false);
@@ -75,7 +75,7 @@ export const ChangementPuissance = ({
       nouvellePuissance,
     });
     const exceedsPuissanceMax = exceedsPuissanceMaxDuVolumeReserve({
-      project: { puissanceInitiale, appelOffre, note: noteProjet },
+      project: { appelOffre, désignationCatégorie },
       nouvellePuissance,
     });
 

--- a/src/views/pages/projectDetailsPage/sections/InfoGenerales.tsx
+++ b/src/views/pages/projectDetailsPage/sections/InfoGenerales.tsx
@@ -10,44 +10,59 @@ type InfoGeneralesProps = {
   role: UserRole;
 };
 
-export const InfoGenerales = ({ project, role }: InfoGeneralesProps) => (
-  <Section title="Informations générales" icon={<BuildingIcon />} className="flex gap-4 flex-col">
-    <div>
-      <Heading3 className="m-0">Performances</Heading3>
-      <p className="m-0">
-        Puissance installée: {project.puissance} {project.appelOffre?.unitePuissance}
-      </p>
-    </div>
-    <div>
-      <Heading3 className="mb-0">Site de production</Heading3>
-      <p className="m-0">{project.adresseProjet}</p>
-      <p className="m-0">
-        {project.codePostalProjet} {project.communeProjet}
-      </p>
-      <p className="m-0">
-        {project.departementProjet}, {project.regionProjet}
-      </p>
-    </div>
-    {project.isClasse &&
-      !project.isAbandoned &&
-      ['admin', 'dgec-validateur', 'porteur-projet', 'dreal', 'acheteur-obligé', 'cre'].includes(
-        role,
-      ) && (
-        <div className="print:hidden mb-3">
-          <Heading3 className="mb-0">Raccordement au réseau</Heading3>
-          <Link
-            href={routes.GET_LISTE_DOSSIERS_RACCORDEMENT(
-              convertirEnIdentifiantProjet({
-                appelOffre: project.appelOffreId,
-                période: project.periodeId,
-                famille: project.familleId,
-                numéroCRE: project.numeroCRE,
-              }).formatter(),
-            )}
-          >
-            Mettre à jour ou consulter les données de raccordement
-          </Link>
-        </div>
-      )}
-  </Section>
-);
+export const InfoGenerales = ({ project, role }: InfoGeneralesProps) => {
+  const puissanceInférieurePuissanceMaxVolRéservé =
+    project.appelOffre.periode.noteThresholdBy === 'category' &&
+    project.puissance < project.appelOffre.periode.noteThreshold.volumeReserve.puissanceMax;
+
+  return (
+    <Section title="Informations générales" icon={<BuildingIcon />} className="flex gap-4 flex-col">
+      <div>
+        <Heading3 className="m-0">Performances</Heading3>
+        <p className="m-0">
+          Puissance installée: {project.puissance} {project.appelOffre?.unitePuissance}
+        </p>
+        {project.désignationCatégorie === 'volume-réservé' && (
+          <p className="mb-0 mt-1">Ce projet fait partie du volume réservé de la période.</p>
+        )}
+        {project.désignationCatégorie === 'hors-volume-réservé' &&
+          puissanceInférieurePuissanceMaxVolRéservé && (
+            <p className="mb-0 mt-1">
+              Ce projet ne fait pas partie du volume réservé de la période.
+            </p>
+          )}
+      </div>
+      <div>
+        <Heading3 className="mb-0">Site de production</Heading3>
+        <p className="m-0">{project.adresseProjet}</p>
+        <p className="m-0">
+          {project.codePostalProjet} {project.communeProjet}
+        </p>
+        <p className="m-0">
+          {project.departementProjet}, {project.regionProjet}
+        </p>
+      </div>
+      {project.isClasse &&
+        !project.isAbandoned &&
+        ['admin', 'dgec-validateur', 'porteur-projet', 'dreal', 'acheteur-obligé', 'cre'].includes(
+          role,
+        ) && (
+          <div className="print:hidden mb-3">
+            <Heading3 className="mb-0">Raccordement au réseau</Heading3>
+            <Link
+              href={routes.GET_LISTE_DOSSIERS_RACCORDEMENT(
+                convertirEnIdentifiantProjet({
+                  appelOffre: project.appelOffreId,
+                  période: project.periodeId,
+                  famille: project.familleId,
+                  numéroCRE: project.numeroCRE,
+                }).formatter(),
+              )}
+            >
+              Mettre à jour ou consulter les données de raccordement
+            </Link>
+          </div>
+        )}
+    </Section>
+  );
+};


### PR DESCRIPTION
**Besoins métier :** 
- Tout porteur de projet dont la puissance du projet est inférieure ou égale à la puissance max du volume réservé doit savoir s'il est ou non dans le volume réservé. 
- Afficher l'appartenance à un volume réservé pour les prochaines désignations dans l'attestation de désignation.

**Tech**
- Ajout d'une colonne "désignationCatégorie" dans projects
- Script de migration pour mettre à jour les projets déjà importés