### PR TITLE
:sparkles: Import historique abandon projet

### DIFF
--- a/src/infra/sequelize/migrations/20240207133000-add-col-project-historique-abandon.ts
+++ b/src/infra/sequelize/migrations/20240207133000-add-col-project-historique-abandon.ts
@@ -1,0 +1,13 @@
+import { DataTypes, QueryInterface } from 'sequelize';
+
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await queryInterface.addColumn('projects', 'historiqueAbandon', {
+      type: DataTypes.STRING,
+      allowNull: true,
+    });
+  },
+  down: async (queryInterface: QueryInterface) => {
+    await queryInterface.removeColumn('projects', 'historiqueAbandon');
+  },
+};

--- a/src/infra/sequelize/projectionsNext/project/project.initializer.ts
+++ b/src/infra/sequelize/projectionsNext/project/project.initializer.ts
@@ -174,6 +174,10 @@ export const initializeProjectModel = (sequelize: Sequelize) => {
         type: DataTypes.STRING,
         allowNull: true,
       },
+      historiqueAbandon: {
+        type: DataTypes.STRING,
+        allowNull: true,
+      },
       createdAt: DataTypes.DATE,
       updatedAt: DataTypes.DATE,
     },

--- a/src/infra/sequelize/projectionsNext/project/project.model.ts
+++ b/src/infra/sequelize/projectionsNext/project/project.model.ts
@@ -53,6 +53,7 @@ export class Project extends Model<InferAttributes<Project>, InferCreationAttrib
   dateFileAttente?: Date;
   soumisAuxGF: boolean;
   désignationCatégorie?: 'volume-réservé' | 'hors-volume-réservé';
+  historiqueAbandon?: 'première-candidature' | 'abandon-classique' | 'abandon-avec-recandidature';
   garantiesFinancières?: NonAttribute<GarantiesFinancières>;
   users?: NonAttribute<User[]>;
   certificateFile?: NonAttribute<File>;

--- a/src/modules/project/events/ProjectImported.ts
+++ b/src/modules/project/events/ProjectImported.ts
@@ -1,6 +1,6 @@
 import { DomainEvent, BaseDomainEvent } from '../../../core/domain';
 import { Technologie } from '@potentiel-domain/appel-offre';
-import { DésignationCatégorie } from '../types';
+import { DésignationCatégorie, HistoriqueAbandon } from '../types';
 
 export interface ProjectImportedPayload {
   projectId: string;
@@ -41,6 +41,7 @@ export interface ProjectImportedPayload {
     actionnariat?: string;
     soumisAuxGF?: true;
     désignationCatégorie?: DésignationCatégorie;
+    historiqueAbandon?: HistoriqueAbandon;
   };
 }
 export class ProjectImported

--- a/src/modules/project/events/ProjectRawDataImported.ts
+++ b/src/modules/project/events/ProjectRawDataImported.ts
@@ -1,6 +1,6 @@
 import { BaseDomainEvent, DomainEvent } from '../../../core/domain';
 import { Technologie } from '@potentiel-domain/appel-offre';
-import { DésignationCatégorie } from '../types';
+import { DésignationCatégorie, HistoriqueAbandon } from '../types';
 
 export interface ProjectRawDataImportedPayload {
   importId: string;
@@ -36,6 +36,7 @@ export interface ProjectRawDataImportedPayload {
     garantiesFinancièresType?: string;
     garantiesFinancièresDateEchéance?: string;
     désignationCatégorie?: DésignationCatégorie;
+    historiqueAbandon?: HistoriqueAbandon;
   };
 }
 export class ProjectRawDataImported

--- a/src/modules/project/types/historiqueAbandon.ts
+++ b/src/modules/project/types/historiqueAbandon.ts
@@ -1,0 +1,4 @@
+export type HistoriqueAbandon =
+  | 'première-candidature'
+  | 'abandon-classique'
+  | 'abandon-avec-recandidature';

--- a/src/modules/project/types/index.ts
+++ b/src/modules/project/types/index.ts
@@ -1,3 +1,4 @@
 export * from './fournisseur';
 export * from './actionnariat';
 export * from './désignationCatégorie';
+export * from './historiqueAbandon';

--- a/src/modules/project/useCases/importProjects.spec.ts
+++ b/src/modules/project/useCases/importProjects.spec.ts
@@ -8,7 +8,7 @@ import { LegacyModificationRawDataImported } from '../../modificationRequest';
 import { InfraNotAvailableError } from '../../shared';
 import { ImportExecuted, ProjectRawDataImported } from '../events';
 import { makeImportProjects } from './importProjects';
-import { Periode } from 'packages/domain/appel-offre/dist';
+import { Periode } from '@potentiel-domain/appel-offre';
 
 const validLine = {
   "Appel d'offres": 'appelOffreId',
@@ -39,6 +39,7 @@ const validLine = {
   'Gouvernance partagée (Oui/Non)': 'Non',
   'Financement collectif (Oui/Non)': 'Non',
   Autre: 'valeur',
+  '1. 1ère candidature\n2. Abandon classique\n3. Abandon avec recandidature': '1',
 } as Record<string, string>;
 
 const appelOffreRepo = {

--- a/src/modules/project/utils/parseProjectLine.spec.ts
+++ b/src/modules/project/utils/parseProjectLine.spec.ts
@@ -1004,7 +1004,7 @@ describe('parseProjectLine', () => {
           ...fakeLineWithoutHistoriqueAbandon,
         }),
       ).toThrowError(
-        `La colonne "1. 1ère candidature/n2. Abandon classique/n3. Abandon avec recandidature" est obligatoire et doit être complétée par 1, 2, ou 3.`,
+        `La colonne "1. 1ère candidature 2. Abandon classique 3. Abandon avec recandidature" est obligatoire et doit être complétée par 1, 2, ou 3.`,
       );
     });
 
@@ -1016,7 +1016,7 @@ describe('parseProjectLine', () => {
           '1. 1ère candidature\n2. Abandon classique\n3. Abandon avec recandidature': '',
         }),
       ).toThrowError(
-        `La colonne "1. 1ère candidature/n2. Abandon classique/n3. Abandon avec recandidature" est obligatoire et doit être complétée par 1, 2, ou 3.`,
+        `La colonne "1. 1ère candidature 2. Abandon classique 3. Abandon avec recandidature" est obligatoire et doit être complétée par 1, 2, ou 3.`,
       );
     });
 
@@ -1028,7 +1028,7 @@ describe('parseProjectLine', () => {
           '1. 1ère candidature\n2. Abandon classique\n3. Abandon avec recandidature': 'bad value',
         }),
       ).toThrowError(
-        `La colonne "1. 1ère candidature/n2. Abandon classique/n3. Abandon avec recandidature" est obligatoire et doit être complétée par 1, 2, ou 3.`,
+        `La colonne "1. 1ère candidature 2. Abandon classique 3. Abandon avec recandidature" est obligatoire et doit être complétée par 1, 2, ou 3.`,
       );
     });
   });

--- a/src/modules/project/utils/parseProjectLine.spec.ts
+++ b/src/modules/project/utils/parseProjectLine.spec.ts
@@ -30,6 +30,7 @@ const fakeLine = {
   Autre: 'valeur',
   'Gouvernance partagée (Oui/Non)': 'Non',
   'Financement collectif (Oui/Non)': 'Non',
+  '1. 1ère candidature\n2. Abandon classique\n3. Abandon avec recandidature': '1',
 };
 
 const expected = {
@@ -61,6 +62,7 @@ const expected = {
   details: {
     Autre: 'valeur',
   },
+  historiqueAbandon: 'première-candidature',
 };
 
 describe('parseProjectLine', () => {
@@ -956,6 +958,78 @@ describe('parseProjectLine', () => {
           }),
         ).toThrowError(`Ce type de garanties financières n'accepte pas de date d'échéance`);
       });
+    });
+  });
+  describe(`Historique abandon (colonne "1. 1ère candidature/n2. Abandon classique/n3. Abandon avec recandidature")`, () => {
+    it(`Lorsque la valeur 1, 2, ou 3 est saisie
+        Alors la valeur correspondante devrait être enregistrée`, () => {
+      expect(
+        parseProjectLine({
+          ...fakeLine,
+          '1. 1ère candidature\n2. Abandon classique\n3. Abandon avec recandidature': '1',
+        }),
+      ).toMatchObject({
+        historiqueAbandon: `première-candidature`,
+      });
+
+      expect(
+        parseProjectLine({
+          ...fakeLine,
+          '1. 1ère candidature\n2. Abandon classique\n3. Abandon avec recandidature': '2',
+        }),
+      ).toMatchObject({
+        historiqueAbandon: `abandon-classique`,
+      });
+
+      expect(
+        parseProjectLine({
+          ...fakeLine,
+          '1. 1ère candidature\n2. Abandon classique\n3. Abandon avec recandidature': '3',
+        }),
+      ).toMatchObject({
+        historiqueAbandon: `abandon-avec-recandidature`,
+      });
+    });
+
+    it(`Si la colonne est manquante
+        Alors une erreur devrait être retournée`, () => {
+      const fakeLineWithoutHistoriqueAbandon = Object.fromEntries(
+        Object.entries(fakeLine).filter(
+          ([cle]) =>
+            cle !== '1. 1ère candidature\n2. Abandon classique\n3. Abandon avec recandidature',
+        ),
+      );
+      expect(() =>
+        parseProjectLine({
+          ...fakeLineWithoutHistoriqueAbandon,
+        }),
+      ).toThrowError(
+        `La colonne "1. 1ère candidature/n2. Abandon classique/n3. Abandon avec recandidature" est obligatoire et doit être complétée par 1, 2, ou 3.`,
+      );
+    });
+
+    it(`Si la colonne n'est pas complétée
+        Alors une erreur devrait être retournée`, () => {
+      expect(() =>
+        parseProjectLine({
+          ...fakeLine,
+          '1. 1ère candidature\n2. Abandon classique\n3. Abandon avec recandidature': '',
+        }),
+      ).toThrowError(
+        `La colonne "1. 1ère candidature/n2. Abandon classique/n3. Abandon avec recandidature" est obligatoire et doit être complétée par 1, 2, ou 3.`,
+      );
+    });
+
+    it(`Si la colonne estcomplétée avec une valeur autre que 1, 2, ou 3
+        Alors une erreur devrait être retournée`, () => {
+      expect(() =>
+        parseProjectLine({
+          ...fakeLine,
+          '1. 1ère candidature\n2. Abandon classique\n3. Abandon avec recandidature': 'bad value',
+        }),
+      ).toThrowError(
+        `La colonne "1. 1ère candidature/n2. Abandon classique/n3. Abandon avec recandidature" est obligatoire et doit être complétée par 1, 2, ou 3.`,
+      );
     });
   });
 });

--- a/src/modules/project/utils/parseProjectLine.ts
+++ b/src/modules/project/utils/parseProjectLine.ts
@@ -39,6 +39,7 @@ const mappedColumns = [
   'Gouvernance partagée (Oui/Non)',
   "1. Garantie financière jusqu'à 6 mois après la date d'achèvement\n2. Garantie financière avec date d'échéance et à renouveler\n3. Consignation",
   "Date d'échéance au format JJ/MM/AAAA",
+  '1. 1ère candidature\n2. Abandon classique\n3. Abandon avec recandidature',
 ];
 
 const prepareNumber = (str) => str && str.replace(/,/g, '.');
@@ -192,6 +193,25 @@ const columnMapper = {
     }
 
     return;
+  },
+  historiqueAbandon: (line: any) => {
+    if (
+      !line.hasOwnProperty(
+        '1. 1ère candidature\n2. Abandon classique\n3. Abandon avec recandidature',
+      )
+    ) {
+      return 'erreur';
+    }
+
+    const value = line['1. 1ère candidature\n2. Abandon classique\n3. Abandon avec recandidature'];
+
+    return value === '1'
+      ? 'première-candidature'
+      : value === '2'
+      ? 'abandon-classique'
+      : value === '3'
+      ? 'abandon-avec-recandidature'
+      : 'erreur';
   },
 } as const;
 
@@ -368,6 +388,12 @@ const projectSchema = yup.object().shape({
       `Le champ "1. Garantie financière jusqu'à 6 mois après la date d'achèvement\n2. Garantie financière avec date d'échéance et à renouveler\n3. Consignation" doit contenir l'une des valeurs suivantes : 1, 2, ou 3. La valeur N/A est acceptée pour les projets éliminés.`,
     ),
   garantiesFinancièresDateEchéance: yup.string().optional(),
+  historiqueAbandon: yup
+    .mixed()
+    .oneOf(
+      ['première-candidature', 'abandon-classique', 'abandon-avec-recandidature'],
+      `La colonne "1. 1ère candidature 2. Abandon classique 3. Abandon avec recandidature" est obligatoire et doit être complétée par 1, 2, ou 3.`,
+    ),
 });
 
 const appendInfo = (obj, key, value) => {


### PR DESCRIPTION
Besoin : avec le fichier de candidats, on importe une nouvelle donnée correspondant à l'historique d'abandon du projet. 
Dans un premier temps cette information sera utile à des fins de statistiques. Elle sera utile plus tard pour le traitement des demandes d'abandon (reste à concevoir). 

Dans cette PR, on se contente de valider la donnée importée (nouvelle colonne obligatoire), et de l'enregistrer dans le projet.