### PR TITLE
:recycle: (Migration domain GF) : importer type

### DIFF
--- a/packages/applications/bootstrap/src/setupLauréat.ts
+++ b/packages/applications/bootstrap/src/setupLauréat.ts
@@ -86,6 +86,7 @@ export const setupLauréat = async () => {
         'GarantiesFinancièresSoumises-V1',
         'GarantiesFinancièresÀTraiterSupprimées-V1',
         'GarantiesFinancièresValidées-V1',
+        'TypeGarantiesFinancièresImporté-V1',
         'RebuildTriggered',
       ],
       eventHandler: async (event) => {

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/garanties-financieres/page.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/garanties-financieres/page.tsx
@@ -77,9 +77,13 @@ const mapToProps: MapToProps = ({
     validées: garantiesFinancières.validées
       ? {
           type: garantiesFinancières.validées.type.type,
-          dateConstitution: garantiesFinancières.validées.dateConstitution.formatter(),
+          dateConstitution: garantiesFinancières.validées.dateConstitution
+            ? garantiesFinancières.validées.dateConstitution.formatter()
+            : undefined,
           dateÉchéance: garantiesFinancières.validées.dateÉchéance?.formatter(),
-          validéLe: garantiesFinancières.validées.validéLe.formatter(),
+          validéLe: garantiesFinancières.validées.validéLe
+            ? garantiesFinancières.validées.validéLe.formatter()
+            : undefined,
           // attestation: garantiesFinancières.validées.attestation,
           actions:
             utilisateur.role.estÉgaleÀ(Role.porteur) && !garantiesFinancières.àTraiter

--- a/packages/applications/ssr/src/components/pages/garanties-financières/détails/DétailsGarantiesFinancières.page.tsx
+++ b/packages/applications/ssr/src/components/pages/garanties-financières/détails/DétailsGarantiesFinancières.page.tsx
@@ -22,7 +22,7 @@ type AvailableActions = Array<'ajouter' | 'modifier' | 'enregistrer'>;
 type GarantiesFinancières = {
   type: GarantiesFinancières.TypeGarantiesFinancières.RawType;
   dateÉchéance?: string;
-  dateConstitution: string;
+  dateConstitution?: string;
   validéLe?: string;
   soumisLe?: string;
   attestation?: string;
@@ -165,12 +165,14 @@ const GarantiesFinancièresInfos: FC<GarantiesFinancièresInfosProps> = ({
           </li>
         )}
         <li>
-          <p>
-            Date de consitution :{' '}
-            <span className="font-bold">
-              {formatDateForText(garantiesFinancières.dateConstitution)}
-            </span>
-          </p>
+          {garantiesFinancières.dateConstitution && (
+            <p>
+              Date de consitution :{' '}
+              <span className="font-bold">
+                {formatDateForText(garantiesFinancières.dateConstitution)}
+              </span>
+            </p>
+          )}
         </li>
         {garantiesFinancières.soumisLe && (
           <li>

--- a/packages/domain/lauréat/src/garantiesFinancières/consulter/consulterGarantiesFinancières.query.ts
+++ b/packages/domain/lauréat/src/garantiesFinancières/consulter/consulterGarantiesFinancières.query.ts
@@ -21,10 +21,10 @@ export type ConsulterGarantiesFinancièresReadModel = {
   validées?: {
     type: TypeGarantiesFinancières.ValueType;
     dateÉchéance?: DateTime.ValueType;
-    dateConstitution: DateTime.ValueType;
-    soumisLe: DateTime.ValueType;
-    validéLe: DateTime.ValueType;
-    attestation: DocumentProjet.ValueType;
+    dateConstitution?: DateTime.ValueType;
+    soumisLe?: DateTime.ValueType;
+    validéLe?: DateTime.ValueType;
+    attestation?: DocumentProjet.ValueType;
   };
   àTraiter?: {
     type: TypeGarantiesFinancières.ValueType;
@@ -68,15 +68,24 @@ export const registerConsulterGarantiesFinancièresQuery = ({
       ...(result.validées.dateÉchéance && {
         dateÉchéance: DateTime.convertirEnValueType(result.validées.dateÉchéance),
       }),
-      dateConstitution: DateTime.convertirEnValueType(result.validées.dateConstitution),
-      soumisLe: DateTime.convertirEnValueType(result.validées.soumisLe),
-      validéLe: DateTime.convertirEnValueType(result.validées.validéLe),
-      attestation: DocumentProjet.convertirEnValueType(
-        identifiantProjet.formatter(),
-        TypeDocumentGarantiesFinancières.garantiesFinancièresValidéesValueType.formatter(),
-        DateTime.convertirEnValueType(result.validées.soumisLe).formatter(),
-        result.validées.attestation.format,
-      ),
+      dateConstitution: result.validées.dateConstitution
+        ? DateTime.convertirEnValueType(result.validées.dateConstitution)
+        : undefined,
+      soumisLe: result.validées.soumisLe
+        ? DateTime.convertirEnValueType(result.validées.soumisLe)
+        : undefined,
+      validéLe: result.validées.validéLe
+        ? DateTime.convertirEnValueType(result.validées.validéLe)
+        : undefined,
+      attestation:
+        result.validées.soumisLe && result.validées.attestation
+          ? DocumentProjet.convertirEnValueType(
+              identifiantProjet.formatter(),
+              TypeDocumentGarantiesFinancières.garantiesFinancièresValidéesValueType.formatter(),
+              DateTime.convertirEnValueType(result.validées.soumisLe).formatter(),
+              result.validées.attestation.format,
+            )
+          : undefined,
     };
     const àTraiter: ConsulterGarantiesFinancièresReadModel['àTraiter'] = result.àTraiter && {
       type: TypeGarantiesFinancières.convertirEnValueType(result.àTraiter.type),

--- a/packages/domain/lauréat/src/garantiesFinancières/demander/demanderGarantiesFinancières.behavior.ts
+++ b/packages/domain/lauréat/src/garantiesFinancières/demander/demanderGarantiesFinancières.behavior.ts
@@ -35,7 +35,7 @@ export async function demanderGarantiesFinancières(
   await this.publish(event);
 }
 
-export function applyDemanderGarantiesFinancières(
+export function applyGarantiesFinancièresDemandées(
   this: GarantiesFinancièresAggregate,
   { payload: { dateLimiteSoumission } }: GarantiesFinancièresDemandéesEvent,
 ) {

--- a/packages/domain/lauréat/src/garantiesFinancières/garantiesFinancières.aggregate.ts
+++ b/packages/domain/lauréat/src/garantiesFinancières/garantiesFinancières.aggregate.ts
@@ -10,7 +10,7 @@ import { StatutGarantiesFinancières, TypeGarantiesFinancières } from '.';
 import { AucunesGarantiesFinancières } from './aucunesGarantiesFinancières.error';
 import {
   GarantiesFinancièresDemandéesEvent,
-  applyDemanderGarantiesFinancières,
+  applyGarantiesFinancièresDemandées,
   demanderGarantiesFinancières,
 } from './demander/demanderGarantiesFinancières.behavior';
 import {
@@ -23,20 +23,27 @@ import {
   applyGarantiesFinancièresValidées,
   valider,
 } from './valider/validerGarantiesFinancières.behavior';
+import {
+  TypeGarantiesFinancièresImportéEvent,
+  applyTypeGarantiesFinancièresImporté,
+  importerType,
+} from './importer/importerTypeGarantiesFinancières.behavior';
 
 export type GarantiesFinancièresEvent =
   | GarantiesFinancièresSoumisesEvent
   | GarantiesFinancièresDemandéesEvent
   | GarantiesFinancièresÀTraiterSuppriméesEvent
-  | GarantiesFinancièresValidéesEvent;
+  | GarantiesFinancièresValidéesEvent
+  | TypeGarantiesFinancièresImportéEvent;
 
 export type GarantiesFinancièresAggregate = Aggregate<GarantiesFinancièresEvent> & {
   statut?: StatutGarantiesFinancières.ValueType;
   validées?: {
     type: TypeGarantiesFinancières.ValueType | 'type-inconnu';
     dateÉchéance?: DateTime.ValueType;
-    dateConstitution: DateTime.ValueType;
-    validéLe: DateTime.ValueType;
+    dateConstitution?: DateTime.ValueType;
+    validéLe?: DateTime.ValueType;
+    importéLe?: DateTime.ValueType;
   };
   àTraiter?: {
     type: TypeGarantiesFinancières.ValueType | 'type-inconnu';
@@ -49,6 +56,7 @@ export type GarantiesFinancièresAggregate = Aggregate<GarantiesFinancièresEven
   readonly demanderGarantiesFinancières: typeof demanderGarantiesFinancières;
   readonly supprimerGarantiesFinancièresÀTraiter: typeof supprimerGarantiesFinancièresÀTraiter;
   readonly valider: typeof valider;
+  readonly importerType: typeof importerType;
 };
 
 export const getDefaultGarantiesFinancièresAggregate: GetDefaultAggregateState<
@@ -60,6 +68,7 @@ export const getDefaultGarantiesFinancièresAggregate: GetDefaultAggregateState<
   demanderGarantiesFinancières,
   supprimerGarantiesFinancièresÀTraiter,
   valider,
+  importerType,
 });
 
 function apply(this: GarantiesFinancièresAggregate, event: GarantiesFinancièresEvent) {
@@ -68,13 +77,16 @@ function apply(this: GarantiesFinancièresAggregate, event: GarantiesFinancière
       applyGarantiesFinancièresSoumises.bind(this)(event);
       break;
     case 'GarantiesFinancièresDemandées-V1':
-      applyDemanderGarantiesFinancières.bind(this)(event);
+      applyGarantiesFinancièresDemandées.bind(this)(event);
       break;
     case 'GarantiesFinancièresÀTraiterSupprimées-V1':
       applyGarantiesFinancièresÀTraiterSupprimées.bind(this)();
       break;
     case 'GarantiesFinancièresValidées-V1':
       applyGarantiesFinancièresValidées.bind(this)(event);
+      break;
+    case 'TypeGarantiesFinancièresImporté-V1':
+      applyTypeGarantiesFinancièresImporté.bind(this)(event);
       break;
   }
 }

--- a/packages/domain/lauréat/src/garantiesFinancières/garantiesFinancières.entity.ts
+++ b/packages/domain/lauréat/src/garantiesFinancières/garantiesFinancières.entity.ts
@@ -16,10 +16,11 @@ export type GarantiesFinancièresEntity = Entity<
     validées?: {
       type: string;
       dateÉchéance?: string;
-      attestation: { format: string };
-      dateConstitution: string;
-      soumisLe: string;
-      validéLe: string;
+      attestation?: { format: string };
+      dateConstitution?: string;
+      soumisLe?: string;
+      validéLe?: string;
+      importéLe?: string;
     };
     àTraiter?: {
       type: string;

--- a/packages/domain/lauréat/src/garantiesFinancières/garantiesFinancières.register.ts
+++ b/packages/domain/lauréat/src/garantiesFinancières/garantiesFinancières.register.ts
@@ -15,6 +15,8 @@ import { registerSupprimerGarantiesFinancièresÀTraiterCommand } from './suppri
 import { registerSupprimerGarantiesFinancièresÀTraiterUseCase } from './supprimerGarantiesFinancièresÀTraiter/supprimerGarantiesFinancièresÀTraiter.usecase';
 import { registerValiderGarantiesFinancièresCommand } from './valider/validerGarantiesFinancières.command';
 import { registerValiderGarantiesFinancièresUseCase } from './valider/validerGarantiesFinancières.usecase';
+import { registerImporterTypeGarantiesFinancièresCommand } from './importer/importerTypeGarantiesFinancières.command';
+import { registerImporterTypeGarantiesFinancièresUseCase } from './importer/importerTypeGarantiesFinancières.usecase';
 
 export type GarantiesFinancièresQueryDependencies = ConsulterGarantiesFinancièresDependencies &
   ListerGarantiesFinancièresDependencies;
@@ -30,11 +32,13 @@ export const registerGarantiesFinancièresUseCases = ({
   registerDemanderGarantiesFinancièresCommand(loadAggregate);
   registerSupprimerGarantiesFinancièresÀTraiterCommand(loadAggregate);
   registerValiderGarantiesFinancièresCommand(loadAggregate);
+  registerImporterTypeGarantiesFinancièresCommand(loadAggregate);
 
   registerSoumettreGarantiesFinancièresUseCase();
   registerDemanderGarantiesFinancièresUseCase();
   registerSupprimerGarantiesFinancièresÀTraiterUseCase();
   registerValiderGarantiesFinancièresUseCase();
+  registerImporterTypeGarantiesFinancièresUseCase();
 };
 
 export const registerGarantiesFinancièresQueries = (

--- a/packages/domain/lauréat/src/garantiesFinancières/importer/importerTypeGarantiesFinancières.behavior.ts
+++ b/packages/domain/lauréat/src/garantiesFinancières/importer/importerTypeGarantiesFinancières.behavior.ts
@@ -1,0 +1,63 @@
+import { DateTime, IdentifiantProjet } from '@potentiel-domain/common';
+import { DomainEvent } from '@potentiel-domain/core';
+
+import { StatutGarantiesFinancières, TypeGarantiesFinancières } from '..';
+import { GarantiesFinancièresAggregate } from '../garantiesFinancières.aggregate';
+import { IdentifiantUtilisateur } from '@potentiel-domain/utilisateur';
+import { DateÉchéanceManquante } from '../dateÉchéanceManquante.error';
+import { DateÉchéanceNonAttendue } from '../dateÉchéanceNonAttendue.error';
+
+export type TypeGarantiesFinancièresImportéEvent = DomainEvent<
+  'TypeGarantiesFinancièresImporté-V1',
+  {
+    identifiantProjet: IdentifiantProjet.RawType;
+    type: TypeGarantiesFinancières.RawType;
+    dateÉchéance?: DateTime.RawType;
+    importéLe: DateTime.RawType;
+    importéPar: IdentifiantUtilisateur.RawType;
+  }
+>;
+
+export type Options = {
+  identifiantProjet: IdentifiantProjet.ValueType;
+  type: TypeGarantiesFinancières.ValueType;
+  dateÉchéance?: DateTime.ValueType;
+  importéLe: DateTime.ValueType;
+  importéPar: IdentifiantUtilisateur.ValueType;
+};
+
+export async function importerType(
+  this: GarantiesFinancièresAggregate,
+  { identifiantProjet, type, dateÉchéance, importéLe, importéPar }: Options,
+) {
+  if (type.estAvecDateÉchéance() && !dateÉchéance) {
+    throw new DateÉchéanceManquante();
+  }
+  if (!type.estAvecDateÉchéance() && dateÉchéance) {
+    throw new DateÉchéanceNonAttendue();
+  }
+  const event: TypeGarantiesFinancièresImportéEvent = {
+    type: 'TypeGarantiesFinancièresImporté-V1',
+    payload: {
+      identifiantProjet: identifiantProjet.formatter(),
+      type: type.type,
+      dateÉchéance: dateÉchéance?.formatter(),
+      importéLe: importéLe.formatter(),
+      importéPar: importéPar.formatter(),
+    },
+  };
+
+  await this.publish(event);
+}
+
+export function applyTypeGarantiesFinancièresImporté(
+  this: GarantiesFinancièresAggregate,
+  { payload: { type, dateÉchéance, importéLe } }: TypeGarantiesFinancièresImportéEvent,
+) {
+  this.statut = StatutGarantiesFinancières.àTraiter;
+  this.validées = {
+    type: TypeGarantiesFinancières.convertirEnValueType(type),
+    dateÉchéance: dateÉchéance && DateTime.convertirEnValueType(dateÉchéance),
+    importéLe: DateTime.convertirEnValueType(importéLe),
+  };
+}

--- a/packages/domain/lauréat/src/garantiesFinancières/importer/importerTypeGarantiesFinancières.command.ts
+++ b/packages/domain/lauréat/src/garantiesFinancières/importer/importerTypeGarantiesFinancières.command.ts
@@ -1,0 +1,44 @@
+import { Message, MessageHandler, mediator } from 'mediateur';
+
+import { DateTime, IdentifiantProjet } from '@potentiel-domain/common';
+
+import { LoadAggregate } from '@potentiel-domain/core';
+import { TypeGarantiesFinancières } from '..';
+import { loadGarantiesFinancièresFactory } from '../garantiesFinancières.aggregate';
+import { IdentifiantUtilisateur } from '@potentiel-domain/utilisateur';
+
+export type ImporterTypeGarantiesFinancièresCommand = Message<
+  'Lauréat.GarantiesFinancières.Command.ImporterTypeGarantiesFinancières',
+  {
+    identifiantProjet: IdentifiantProjet.ValueType;
+    type: TypeGarantiesFinancières.ValueType;
+    dateÉchéance?: DateTime.ValueType;
+    importéLe: DateTime.ValueType;
+    importéPar: IdentifiantUtilisateur.ValueType;
+  }
+>;
+
+export const registerImporterTypeGarantiesFinancièresCommand = (loadAggregate: LoadAggregate) => {
+  const loadGarantiesFinancières = loadGarantiesFinancièresFactory(loadAggregate);
+  const handler: MessageHandler<ImporterTypeGarantiesFinancièresCommand> = async ({
+    identifiantProjet,
+    importéLe,
+    type,
+    dateÉchéance,
+    importéPar,
+  }) => {
+    const garantiesFinancières = await loadGarantiesFinancières(identifiantProjet, false);
+
+    await garantiesFinancières.importerType({
+      identifiantProjet,
+      importéLe,
+      type,
+      dateÉchéance,
+      importéPar,
+    });
+  };
+  mediator.register(
+    'Lauréat.GarantiesFinancières.Command.ImporterTypeGarantiesFinancières',
+    handler,
+  );
+};

--- a/packages/domain/lauréat/src/garantiesFinancières/importer/importerTypeGarantiesFinancières.usecase.ts
+++ b/packages/domain/lauréat/src/garantiesFinancières/importer/importerTypeGarantiesFinancières.usecase.ts
@@ -1,0 +1,44 @@
+import { Message, MessageHandler, mediator } from 'mediateur';
+import { DateTime, IdentifiantProjet } from '@potentiel-domain/common';
+import { TypeGarantiesFinancières } from '..';
+import { IdentifiantUtilisateur } from '@potentiel-domain/utilisateur';
+import { ImporterTypeGarantiesFinancièresCommand } from './importerTypeGarantiesFinancières.command';
+
+export type ImporterTypeGarantiesFinancièresUseCase = Message<
+  'Lauréat.GarantiesFinancières.UseCase.ImporterTypeGarantiesFinancières',
+  {
+    identifiantProjetValue: string;
+    typeValue: string;
+    dateÉchéanceValue?: string;
+    importéLeValue: string;
+    importéParValue: string;
+  }
+>;
+
+export const registerImporterTypeGarantiesFinancièresUseCase = () => {
+  const runner: MessageHandler<ImporterTypeGarantiesFinancièresUseCase> = async ({
+    identifiantProjetValue,
+    typeValue,
+    dateÉchéanceValue,
+    importéLeValue,
+    importéParValue,
+  }) => {
+    const identifiantProjet = IdentifiantProjet.convertirEnValueType(identifiantProjetValue);
+    const type = TypeGarantiesFinancières.convertirEnValueType(typeValue);
+    const dateÉchéance = dateÉchéanceValue
+      ? DateTime.convertirEnValueType(dateÉchéanceValue)
+      : undefined;
+    const importéLe = DateTime.convertirEnValueType(importéLeValue);
+    const importéPar = IdentifiantUtilisateur.convertirEnValueType(importéParValue);
+
+    await mediator.send<ImporterTypeGarantiesFinancièresCommand>({
+      type: 'Lauréat.GarantiesFinancières.Command.ImporterTypeGarantiesFinancières',
+      data: { identifiantProjet, importéLe, importéPar, type, dateÉchéance },
+    });
+  };
+
+  mediator.register(
+    'Lauréat.GarantiesFinancières.UseCase.ImporterTypeGarantiesFinancières',
+    runner,
+  );
+};

--- a/packages/domain/lauréat/src/garantiesFinancières/index.ts
+++ b/packages/domain/lauréat/src/garantiesFinancières/index.ts
@@ -11,6 +11,7 @@ import {
 } from './lister/listerGarantiesFinancières.query';
 import { SupprimerGarantiesFinancièresÀTraiterUseCase } from './supprimerGarantiesFinancièresÀTraiter/supprimerGarantiesFinancièresÀTraiter.usecase';
 import { ValiderGarantiesFinancièresUseCase } from './valider/validerGarantiesFinancières.usecase';
+import { ImporterTypeGarantiesFinancièresUseCase } from './importer/importerTypeGarantiesFinancières.usecase';
 
 // Query
 export type GarantiesFinancièresQuery =
@@ -27,13 +28,15 @@ export type GarantiesFinancièresUseCase =
   | SoumettreGarantiesFinancièresUseCase
   | DemanderGarantiesFinancièresUseCase
   | SupprimerGarantiesFinancièresÀTraiterUseCase
-  | ValiderGarantiesFinancièresUseCase;
+  | ValiderGarantiesFinancièresUseCase
+  | ImporterTypeGarantiesFinancièresUseCase;
 
 export {
   SoumettreGarantiesFinancièresUseCase,
   DemanderGarantiesFinancièresUseCase,
   SupprimerGarantiesFinancièresÀTraiterUseCase,
   ValiderGarantiesFinancièresUseCase,
+  ImporterTypeGarantiesFinancièresUseCase,
 };
 
 // Event
@@ -42,6 +45,7 @@ export { GarantiesFinancièresSoumisesEvent } from './soumettre/soumettreGaranti
 export { GarantiesFinancièresDemandéesEvent } from './demander/demanderGarantiesFinancières.behavior';
 export { GarantiesFinancièresÀTraiterSuppriméesEvent } from './supprimerGarantiesFinancièresÀTraiter/supprimerGarantiesFinancièresÀTraiter.behavior';
 export { GarantiesFinancièresValidéesEvent } from './valider/validerGarantiesFinancières.behavior';
+export { TypeGarantiesFinancièresImportéEvent } from './importer/importerTypeGarantiesFinancières.behavior';
 
 // Register
 export {

--- a/packages/domain/lauréat/src/garantiesFinancières/lister/listerGarantiesFinancières.query.ts
+++ b/packages/domain/lauréat/src/garantiesFinancières/lister/listerGarantiesFinancières.query.ts
@@ -34,10 +34,10 @@ export type GarantiesFinancièresListItemReadModel = {
   validées?: {
     type: TypeGarantiesFinancières.ValueType;
     dateÉchéance?: DateTime.ValueType;
-    dateConstitution: DateTime.ValueType;
-    soumisLe: DateTime.ValueType;
-    validéLe: DateTime.ValueType;
-    attestation: DocumentProjet.ValueType;
+    dateConstitution?: DateTime.ValueType;
+    soumisLe?: DateTime.ValueType;
+    validéLe?: DateTime.ValueType;
+    attestation?: DocumentProjet.ValueType;
   };
   àTraiter?: {
     type: TypeGarantiesFinancières.ValueType;
@@ -130,15 +130,24 @@ const mapToListItemReadModel = (
     ...(entity.validées.dateÉchéance && {
       dateÉchéance: DateTime.convertirEnValueType(entity.validées.dateÉchéance),
     }),
-    dateConstitution: DateTime.convertirEnValueType(entity.validées.dateConstitution),
-    soumisLe: DateTime.convertirEnValueType(entity.validées.soumisLe),
-    validéLe: DateTime.convertirEnValueType(entity.validées.validéLe),
-    attestation: DocumentProjet.convertirEnValueType(
-      IdentifiantProjet.convertirEnValueType(entity.identifiantProjet).formatter(),
-      TypeDocumentGarantiesFinancières.garantiesFinancièresValidéesValueType.formatter(),
-      DateTime.convertirEnValueType(entity.validées.soumisLe).formatter(),
-      entity.validées.attestation.format,
-    ),
+    dateConstitution: entity.validées.dateConstitution
+      ? DateTime.convertirEnValueType(entity.validées.dateConstitution)
+      : undefined,
+    soumisLe: entity.validées.soumisLe
+      ? DateTime.convertirEnValueType(entity.validées.soumisLe)
+      : undefined,
+    validéLe: entity.validées.validéLe
+      ? DateTime.convertirEnValueType(entity.validées.validéLe)
+      : undefined,
+    attestation:
+      entity.validées.soumisLe && entity.validées.attestation
+        ? DocumentProjet.convertirEnValueType(
+            IdentifiantProjet.convertirEnValueType(entity.identifiantProjet).formatter(),
+            TypeDocumentGarantiesFinancières.garantiesFinancièresValidéesValueType.formatter(),
+            DateTime.convertirEnValueType(entity.validées.soumisLe).formatter(),
+            entity.validées.attestation.format,
+          )
+        : undefined,
   };
   const àTraiter: GarantiesFinancièresListItemReadModel['àTraiter'] = entity.àTraiter && {
     type: TypeGarantiesFinancières.convertirEnValueType(entity.àTraiter.type),

--- a/packages/domain/utilisateur/src/role.valueType.ts
+++ b/packages/domain/utilisateur/src/role.valueType.ts
@@ -126,6 +126,7 @@ const référencielPermissions = {
         supprimerGarantiesFinancièresÀTraiter:
           'Lauréat.GarantiesFinancières.UseCase.SupprimerGarantiesFinancièresÀTraiter',
         valider: 'Lauréat.GarantiesFinancières.UseCase.ValiderGarantiesFinancières',
+        importerType: 'Lauréat.GarantiesFinancières.UseCase.ImporterTypeGarantiesFinancières',
       },
       command: {
         demander: 'Lauréat.GarantiesFinancières.Command.DemanderGarantiesFinancières',
@@ -133,6 +134,7 @@ const référencielPermissions = {
         supprimerGarantiesFinancièresÀTraiter:
           'Lauréat.GarantiesFinancières.Command.SupprimerGarantiesFinancièresÀTraiter',
         valider: 'Lauréat.GarantiesFinancières.Command.ValiderGarantiesFinancières',
+        importerType: 'Lauréat.GarantiesFinancières.Command.ImporterTypeGarantiesFinancières',
       },
     },
   },
@@ -461,6 +463,10 @@ const policies = {
         .supprimerGarantiesFinancièresÀTraiter,
       référencielPermissions.lauréat.garantiesFinancières.query.consulter,
     ],
+    importer: [
+      référencielPermissions.lauréat.garantiesFinancières.usecase.importerType,
+      référencielPermissions.lauréat.garantiesFinancières.command.importerType,
+    ],
   },
 };
 
@@ -498,6 +504,7 @@ const permissionAdmin = [
   ...policies.garantiesFinancières.lister,
   ...policies.garantiesFinancières.demander,
   ...policies.garantiesFinancières.valider,
+  ...policies.garantiesFinancières.importer,
 ];
 
 const permissionCRE = [
@@ -559,6 +566,7 @@ const permissionDgecValidateur = [
   ...policies.garantiesFinancières.lister,
   ...policies.garantiesFinancières.demander,
   ...policies.garantiesFinancières.valider,
+  ...policies.garantiesFinancières.importer,
 ];
 
 const permissionPorteurProjet = [

--- a/packages/infrastructure/projectors/src/lauréat/garantiesFinancières.projector.ts
+++ b/packages/infrastructure/projectors/src/lauréat/garantiesFinancières.projector.ts
@@ -151,6 +151,24 @@ export const register = () => {
             },
           );
           break;
+
+        case 'TypeGarantiesFinancièresImporté-V1':
+          const projetPourTypeGarantiesFinancièresImporté = await getProjectData(identifiantProjet);
+          await upsertProjection<GarantiesFinancières.GarantiesFinancièresEntity>(
+            `garanties-financieres|${identifiantProjet}`,
+            {
+              ...garantiesFinancièresToUpsert,
+              ...projetPourTypeGarantiesFinancièresImporté,
+              misÀJourLe: payload.importéLe,
+              statut: GarantiesFinancières.StatutGarantiesFinancières.validé.statut,
+              validées: {
+                type: payload.type,
+                dateÉchéance: payload.dateÉchéance,
+                importéLe: payload.importéLe,
+              },
+            },
+          );
+          break;
       }
     }
   };

--- a/packages/specifications/src/projet/lauréat/garantiesFinancières/importerTypeGarantiesFinancières.feature
+++ b/packages/specifications/src/projet/lauréat/garantiesFinancières/importerTypeGarantiesFinancières.feature
@@ -1,0 +1,36 @@
+#Language: fr-FR
+@select
+Fonctionnalité: Importer le type (et la date d'échéance selon le cas) des garanties financières d'un projet
+    Contexte: 
+        Etant donné le projet lauréat "Centrale PV"
+    
+    Plan du Scénario: Un admin importe le type des garanties financières d'un projet
+        Quand l'admin importe le type des garanties financières pour le projet "Centrale PV" avec :
+            | type                 | <type>                 |
+            | date d'échéance      | <date d'échéance>      |
+            | date d'import        | <date import>          |
+        Alors des garanties financières devraient être validées pour le projet "Centrale PV" avec :
+            | type                 | <type>                 |
+            | date d'échéance      | <date d'échéance>      |
+            | date d'import        | <date import>          |
+    Exemples:
+            | type                      | date d'échéance   | date import |
+            | avec-date-échéance        | 2027-12-01        | 2024-01-01  |
+            | consignation              |                   | 2024-01-01  |
+            | six-mois-après-achèvement |                   | 2024-01-01  |
+    
+    Scénario: Erreur si date d'échéance manquante
+        Quand l'admin importe le type des garanties financières pour le projet "Centrale PV" avec :
+            | type                 | avec-date-échéance     |
+            | date d'échéance      |                        |    
+        Alors l'utilisateur devrait être informé que "Vous devez renseigner la date d'échéance pour ce type de garanties financières" 
+    
+    Plan du Scénario: Erreur si date d'échéance non compatible avec le type
+        Quand l'admin importe le type des garanties financières pour le projet "Centrale PV" avec :
+            | type            | <type>     |   
+            | date d'échéance | 2028-01-01 |   
+        Alors l'utilisateur devrait être informé que "Vous ne pouvez pas renseigner de date d'échéance pour ce type de garanties financières"
+    Exemples:
+            | type                         |
+            | consignation                 |
+            | six-mois-après-achèvement    |         

--- a/packages/specifications/src/projet/lauréat/garantiesFinancières/soumettreGarantiesFinancières.feature
+++ b/packages/specifications/src/projet/lauréat/garantiesFinancières/soumettreGarantiesFinancières.feature
@@ -63,13 +63,13 @@ Fonctionnalité: Soumettre de nouvelles garanties financières
             | date de constitution | 2055-01-01 |
         Alors l'utilisateur devrait être informé que "La date de constitution des garanties financières ne peut pas être une date future" 
     
-    Scénario: Erreur si date de d'échéance manquante
+    Scénario: Erreur si date d'échéance manquante
         Quand le porteur soumet des garanties financières pour le projet "Centrale PV" avec :
             | type          | avec-date-échéance   |     
             | dateÉchéance  |                      |     
         Alors l'utilisateur devrait être informé que "Vous devez renseigner la date d'échéance pour ce type de garanties financières" 
     
-    Plan du Scénario: Erreur si date de d'échéance non compatible avec le type
+    Plan du Scénario: Erreur si date d'échéance non compatible avec le type
         Quand le porteur soumet des garanties financières pour le projet "Centrale PV" avec :
             | type | <type>                |   
             | date d'échéance | 2028-01-01 |   

--- a/packages/specifications/src/projet/lauréat/garantiesFinancières/stepDefinitions/garantiesFinancières.then.ts
+++ b/packages/specifications/src/projet/lauréat/garantiesFinancières/stepDefinitions/garantiesFinancières.then.ts
@@ -180,6 +180,7 @@ Alors(
     const dateConstitution = exemple[`date de constitution`];
     const contenu = exemple['contenu fichier'];
     const dateValidation = exemple['date de validation'];
+    const dateImport = exemple[`date d'import `];
 
     const { identifiantProjet, appelOffre, période } =
       this.lauréatWorld.rechercherLauréatFixture(nomProjet);
@@ -201,25 +202,31 @@ Alors(
     if (dateÉchéance) {
       expect(actualReadModel.validées?.dateÉchéance?.date).to.deep.equal(new Date(dateÉchéance));
     }
-    expect(actualReadModel.validées?.dateConstitution?.date).to.deep.equal(
-      new Date(dateConstitution),
-    );
-    expect(actualReadModel.validées?.validéLe?.date).to.deep.equal(new Date(dateValidation));
+    if (dateConstitution) {
+      expect(actualReadModel.validées?.dateConstitution?.date).to.deep.equal(
+        new Date(dateConstitution),
+      );
+    }
+    if (dateValidation) {
+      expect(actualReadModel.validées?.validéLe?.date).to.deep.equal(new Date(dateValidation));
+    }
 
     // ASSERT ON FILE
 
-    expect(actualReadModel.validées?.attestation).not.to.be.undefined;
+    if (format && contenu) {
+      expect(actualReadModel.validées?.attestation).not.to.be.undefined;
 
-    if (actualReadModel.validées?.attestation) {
-      const file = await mediator.send<ConsulterDocumentProjetQuery>({
-        type: 'Document.Query.ConsulterDocumentProjet',
-        data: {
-          documentKey: actualReadModel.validées?.attestation.formatter(),
-        },
-      });
+      if (actualReadModel.validées?.attestation) {
+        const file = await mediator.send<ConsulterDocumentProjetQuery>({
+          type: 'Document.Query.ConsulterDocumentProjet',
+          data: {
+            documentKey: actualReadModel.validées?.attestation.formatter(),
+          },
+        });
 
-      const actualContent = await convertReadableStreamToString(file.content);
-      actualContent.should.be.equal(contenu);
+        const actualContent = await convertReadableStreamToString(file.content);
+        actualContent.should.be.equal(contenu);
+      }
     }
 
     // ASSERT ON LIST
@@ -240,9 +247,11 @@ Alors(
       période,
       nomProjet,
     });
-    expect(actualListeDépôtsReadModel.items[0].dateDernièreMiseÀJour.formatter()).to.deep.equal(
-      new Date(dateValidation).toISOString(),
-    );
+    if (dateValidation) {
+      expect(actualListeDépôtsReadModel.items[0].dateDernièreMiseÀJour.formatter()).to.deep.equal(
+        new Date(dateValidation).toISOString(),
+      );
+    }
     expect(actualListeDépôtsReadModel.items[0].identifiantProjet.formatter()).to.deep.equal(
       identifiantProjet.formatter(),
     );
@@ -255,9 +264,15 @@ Alors(
         new Date(dateÉchéance).toISOString(),
       );
     }
-    expect(
-      actualListeDépôtsReadModel.items[0].validées?.dateConstitution.formatter(),
-    ).to.deep.equal(new Date(dateConstitution).toISOString());
-    expect(actualListeDépôtsReadModel.items[0].validées?.attestation.format).to.deep.equal(format);
+    if (dateConstitution && actualListeDépôtsReadModel.items[0].validées?.dateConstitution) {
+      expect(
+        actualListeDépôtsReadModel.items[0].validées?.dateConstitution.formatter(),
+      ).to.deep.equal(new Date(dateConstitution).toISOString());
+    }
+    if (actualListeDépôtsReadModel.items[0].validées?.attestation && format) {
+      expect(actualListeDépôtsReadModel.items[0].validées?.attestation.format).to.deep.equal(
+        format,
+      );
+    }
   },
 );

--- a/packages/specifications/src/projet/lauréat/garantiesFinancières/stepDefinitions/garantiesFinancières.when.ts
+++ b/packages/specifications/src/projet/lauréat/garantiesFinancières/stepDefinitions/garantiesFinancières.when.ts
@@ -83,3 +83,32 @@ Quand(
     }
   },
 );
+
+Quand(
+  `l'admin importe le type des garanties financières pour le projet {string} avec :`,
+  async function (this: PotentielWorld, nomProjet: string, dataTable: DataTable) {
+    const exemple = dataTable.rowsHash();
+
+    try {
+      const typeGarantiesFinancières = exemple['type'] || 'consignation';
+      const dateÉchéance = exemple[`date d'échéance`] || undefined;
+      const importéLe = exemple[`date d'import `] || '2024-01-01';
+
+      const { identifiantProjet } = this.lauréatWorld.rechercherLauréatFixture(nomProjet);
+
+      await mediator.send<GarantiesFinancières.ImporterTypeGarantiesFinancièresUseCase>({
+        type: 'Lauréat.GarantiesFinancières.UseCase.ImporterTypeGarantiesFinancières',
+        data: {
+          identifiantProjetValue: identifiantProjet.formatter(),
+          typeValue: typeGarantiesFinancières,
+          importéLeValue: new Date(importéLe).toISOString(),
+          importéParValue: 'admin@test.test',
+          ...(dateÉchéance && { dateÉchéanceValue: new Date(dateÉchéance).toISOString() }),
+        },
+      });
+      await sleep(500);
+    } catch (error) {
+      this.error = error as Error;
+    }
+  },
+);


### PR DESCRIPTION
A l'import du type de GF d'un projet, des GF validées sont ajoutées au projet. 
Contrairement au cas où les GF sont validées dans Potentiel, nous n'avons pas l'attestation, la date de soumission et la date de validation. Nous avons en plus une date d'import. En raison des ces différences j'ai finalement opté pour une commande dédiée. 
Côté front il faudra indiquer que les garanties financières ont été soumises et validées à la candidature (faire appel à la query pour consulter l'AO du projet dans le page.tsx). 