### PR TITLE
:recycle: (migration domaine GF) : Enregistrer GF actuelles (validées)

### DIFF
--- a/packages/applications/bootstrap/src/setupLauréat.ts
+++ b/packages/applications/bootstrap/src/setupLauréat.ts
@@ -92,6 +92,7 @@ export const setupLauréat = async () => {
         'TypeGarantiesFinancièresImporté-V1',
         'GarantiesFinancièresModifiées-V1',
         'AttestationGarantiesFinancièresEnregistrée-V1',
+        'GarantiesFinancièresEnregistrées-V1',
         'RebuildTriggered',
       ],
       eventHandler: async (event) => {
@@ -112,6 +113,7 @@ export const setupLauréat = async () => {
         'DépôtGarantiesFinancièresEnCoursValidé-V1',
         'AttestationGarantiesFinancièresEnregistrée-V1',
         'GarantiesFinancièresModifiées-V1',
+        'GarantiesFinancièresEnregistrées-V1',
       ],
       eventHandler: async (event) => {
         await mediator.publish<GarantiesFinancièresNotification.Execute>({

--- a/packages/domain/lauréat/src/garantiesFinancières/enregistrer/enregistrerGarantiesFinancières.behavior.ts
+++ b/packages/domain/lauréat/src/garantiesFinancières/enregistrer/enregistrerGarantiesFinancières.behavior.ts
@@ -1,0 +1,93 @@
+import { DateTime, IdentifiantProjet } from '@potentiel-domain/common';
+import { DomainEvent, NotFoundError } from '@potentiel-domain/core';
+
+import { TypeGarantiesFinancières } from '..';
+import { GarantiesFinancièresAggregate } from '../garantiesFinancières.aggregate';
+import { DateÉchéanceManquante } from '../dateÉchéanceManquante.error';
+import { DateÉchéanceNonAttendue } from '../dateÉchéanceNonAttendue.error';
+import { IdentifiantUtilisateur } from '@potentiel-domain/utilisateur';
+import { DateConstitutionDansLeFutur } from '../dateConstitutionDansLeFutur.error';
+
+export type GarantiesFinancièresEnregistréesEvent = DomainEvent<
+  'GarantiesFinancièresEnregistrées-V1',
+  {
+    identifiantProjet: IdentifiantProjet.RawType;
+    type: TypeGarantiesFinancières.RawType;
+    dateÉchéance?: DateTime.RawType;
+    attestation: { format: string };
+    dateConstitution: DateTime.RawType;
+    enregistréLe: DateTime.RawType;
+    enregistréPar: IdentifiantUtilisateur.RawType;
+  }
+>;
+
+export type Options = {
+  identifiantProjet: IdentifiantProjet.ValueType;
+  type: TypeGarantiesFinancières.ValueType;
+  dateÉchéance?: DateTime.ValueType;
+  attestation: { format: string };
+  dateConstitution: DateTime.ValueType;
+  enregistréLe: DateTime.ValueType;
+  enregistréPar: IdentifiantUtilisateur.ValueType;
+};
+
+export async function enregistrer(
+  this: GarantiesFinancièresAggregate,
+  {
+    attestation,
+    dateConstitution,
+    identifiantProjet,
+    type,
+    dateÉchéance,
+    enregistréLe,
+    enregistréPar,
+  }: Options,
+) {
+  if (this.actuelles) {
+    throw new GarantiesFinancièresDéjàEnregistréesError();
+  }
+  if (type.estAvecDateÉchéance() && !dateÉchéance) {
+    throw new DateÉchéanceManquante();
+  }
+  if (!type.estAvecDateÉchéance() && dateÉchéance) {
+    throw new DateÉchéanceNonAttendue();
+  }
+  if (dateConstitution.estDansLeFutur()) {
+    throw new DateConstitutionDansLeFutur();
+  }
+
+  const event: GarantiesFinancièresEnregistréesEvent = {
+    type: 'GarantiesFinancièresEnregistrées-V1',
+    payload: {
+      attestation: { format: attestation.format },
+      dateConstitution: dateConstitution.formatter(),
+      identifiantProjet: identifiantProjet.formatter(),
+      type: type.type,
+      dateÉchéance: dateÉchéance?.formatter(),
+      enregistréLe: enregistréLe.formatter(),
+      enregistréPar: enregistréPar.formatter(),
+    },
+  };
+
+  await this.publish(event);
+}
+
+export function applyEnregistrerGarantiesFinancières(
+  this: GarantiesFinancièresAggregate,
+  {
+    payload: { type, dateÉchéance, dateConstitution, attestation },
+  }: GarantiesFinancièresEnregistréesEvent,
+) {
+  this.actuelles = {
+    type: TypeGarantiesFinancières.convertirEnValueType(type),
+    dateÉchéance: dateÉchéance && DateTime.convertirEnValueType(dateÉchéance),
+    dateConstitution: DateTime.convertirEnValueType(dateConstitution),
+    attestation,
+  };
+}
+
+class GarantiesFinancièresDéjàEnregistréesError extends NotFoundError {
+  constructor() {
+    super(`Il y a déjà des garanties financières pour ce projet`);
+  }
+}

--- a/packages/domain/lauréat/src/garantiesFinancières/enregistrer/enregistrerGarantiesFinancières.command.ts
+++ b/packages/domain/lauréat/src/garantiesFinancières/enregistrer/enregistrerGarantiesFinancières.command.ts
@@ -1,0 +1,50 @@
+import { Message, MessageHandler, mediator } from 'mediateur';
+
+import { DateTime, IdentifiantProjet } from '@potentiel-domain/common';
+import { DocumentProjet } from '@potentiel-domain/document';
+
+import { LoadAggregate } from '@potentiel-domain/core';
+import { TypeGarantiesFinancières } from '..';
+import { loadGarantiesFinancièresFactory } from '../garantiesFinancières.aggregate';
+import { IdentifiantUtilisateur } from '@potentiel-domain/utilisateur';
+
+export type EnregistrerGarantiesFinancièresCommand = Message<
+  'Lauréat.GarantiesFinancières.Command.EnregistrerGarantiesFinancières',
+  {
+    identifiantProjet: IdentifiantProjet.ValueType;
+    type: TypeGarantiesFinancières.ValueType;
+    dateÉchéance?: DateTime.ValueType;
+    attestation: DocumentProjet.ValueType;
+    dateConstitution: DateTime.ValueType;
+    enregistréPar: IdentifiantUtilisateur.ValueType;
+    enregistréLe: DateTime.ValueType;
+  }
+>;
+
+export const registerEnregistrerGarantiesFinancièresCommand = (loadAggregate: LoadAggregate) => {
+  const loadGarantiesFinancières = loadGarantiesFinancièresFactory(loadAggregate);
+  const handler: MessageHandler<EnregistrerGarantiesFinancièresCommand> = async ({
+    identifiantProjet,
+    attestation,
+    dateConstitution,
+    type,
+    dateÉchéance,
+    enregistréLe,
+    enregistréPar,
+  }) => {
+    const garantiesFinancières = await loadGarantiesFinancières(identifiantProjet, false);
+    await garantiesFinancières.enregistrer({
+      identifiantProjet,
+      attestation,
+      dateConstitution,
+      type,
+      dateÉchéance,
+      enregistréLe,
+      enregistréPar,
+    });
+  };
+  mediator.register(
+    'Lauréat.GarantiesFinancières.Command.EnregistrerGarantiesFinancières',
+    handler,
+  );
+};

--- a/packages/domain/lauréat/src/garantiesFinancières/enregistrer/enregistrerGarantiesFinancières.usecase.ts
+++ b/packages/domain/lauréat/src/garantiesFinancières/enregistrer/enregistrerGarantiesFinancières.usecase.ts
@@ -1,0 +1,71 @@
+import { Message, MessageHandler, mediator } from 'mediateur';
+import { DocumentProjet, EnregistrerDocumentProjetCommand } from '@potentiel-domain/document';
+import { DateTime, IdentifiantProjet } from '@potentiel-domain/common';
+import { TypeDocumentGarantiesFinancières, TypeGarantiesFinancières } from '..';
+import { IdentifiantUtilisateur } from '@potentiel-domain/utilisateur';
+import { EnregistrerGarantiesFinancièresCommand } from './enregistrerGarantiesFinancières.command';
+
+export type EnregistrerGarantiesFinancièresUseCase = Message<
+  'Lauréat.GarantiesFinancières.UseCase.EnregistrerGarantiesFinancières',
+  {
+    identifiantProjetValue: string;
+    typeValue: string;
+    dateÉchéanceValue?: string;
+    attestationValue: {
+      content: ReadableStream;
+      format: string;
+    };
+    dateConstitutionValue: string;
+    enregistréLeValue: string;
+    enregistréParValue: string;
+  }
+>;
+
+export const registerEnregistrerGarantiesFinancièresUseCase = () => {
+  const runner: MessageHandler<EnregistrerGarantiesFinancièresUseCase> = async ({
+    attestationValue,
+    dateConstitutionValue,
+    identifiantProjetValue,
+    enregistréLeValue,
+    typeValue,
+    dateÉchéanceValue,
+    enregistréParValue,
+  }) => {
+    const identifiantProjet = IdentifiantProjet.convertirEnValueType(identifiantProjetValue);
+    const type = TypeGarantiesFinancières.convertirEnValueType(typeValue);
+    const dateÉchéance = dateÉchéanceValue
+      ? DateTime.convertirEnValueType(dateÉchéanceValue)
+      : undefined;
+    const dateConstitution = DateTime.convertirEnValueType(dateConstitutionValue);
+    const enregistréLe = DateTime.convertirEnValueType(enregistréLeValue);
+    const attestation = DocumentProjet.convertirEnValueType(
+      identifiantProjetValue,
+      TypeDocumentGarantiesFinancières.attestationGarantiesFinancièresActuellesValueType.formatter(),
+      dateConstitutionValue,
+      attestationValue.format,
+    );
+    const enregistréPar = IdentifiantUtilisateur.convertirEnValueType(enregistréParValue);
+
+    await mediator.send<EnregistrerDocumentProjetCommand>({
+      type: 'Document.Command.EnregistrerDocumentProjet',
+      data: {
+        content: attestationValue.content,
+        documentProjet: attestation,
+      },
+    });
+
+    await mediator.send<EnregistrerGarantiesFinancièresCommand>({
+      type: 'Lauréat.GarantiesFinancières.Command.EnregistrerGarantiesFinancières',
+      data: {
+        attestation,
+        dateConstitution,
+        identifiantProjet,
+        type,
+        dateÉchéance,
+        enregistréLe: enregistréLe,
+        enregistréPar: enregistréPar,
+      },
+    });
+  };
+  mediator.register('Lauréat.GarantiesFinancières.UseCase.EnregistrerGarantiesFinancières', runner);
+};

--- a/packages/domain/lauréat/src/garantiesFinancières/garantiesFinancières.aggregate.ts
+++ b/packages/domain/lauréat/src/garantiesFinancières/garantiesFinancières.aggregate.ts
@@ -42,6 +42,11 @@ import {
   applyEnregistrerAttestationGarantiesFinancières,
   enregistrerAttestation,
 } from './enregistrerAttestation/enregistrerAttestationGarantiesFinancières.behavior';
+import {
+  GarantiesFinancièresEnregistréesEvent,
+  applyEnregistrerGarantiesFinancières,
+  enregistrer,
+} from './enregistrer/enregistrerGarantiesFinancières.behavior';
 
 export type GarantiesFinancièresEvent =
   | DépôtGarantiesFinancièresSoumisEvent
@@ -51,7 +56,8 @@ export type GarantiesFinancièresEvent =
   | DépôtGarantiesFinancièresEnCoursModifiéEvent
   | TypeGarantiesFinancièresImportéEvent
   | GarantiesFinancièresModifiéesEvent
-  | AttestationGarantiesFinancièresEnregistréeEvent;
+  | AttestationGarantiesFinancièresEnregistréeEvent
+  | GarantiesFinancièresEnregistréesEvent;
 
 export type GarantiesFinancièresAggregate = Aggregate<GarantiesFinancièresEvent> & {
   actuelles?: {
@@ -77,6 +83,7 @@ export type GarantiesFinancièresAggregate = Aggregate<GarantiesFinancièresEven
   readonly importerType: typeof importerType;
   readonly modifier: typeof modifier;
   readonly enregistrerAttestation: typeof enregistrerAttestation;
+  readonly enregistrer: typeof enregistrer;
 };
 
 export const getDefaultGarantiesFinancièresAggregate: GetDefaultAggregateState<
@@ -92,6 +99,7 @@ export const getDefaultGarantiesFinancièresAggregate: GetDefaultAggregateState<
   importerType,
   modifier,
   enregistrerAttestation,
+  enregistrer,
 });
 
 function apply(this: GarantiesFinancièresAggregate, event: GarantiesFinancièresEvent) {
@@ -116,6 +124,9 @@ function apply(this: GarantiesFinancièresAggregate, event: GarantiesFinancière
       break;
     case 'AttestationGarantiesFinancièresEnregistrée-V1':
       applyEnregistrerAttestationGarantiesFinancières.bind(this)(event);
+      break;
+    case 'GarantiesFinancièresEnregistrées-V1':
+      applyEnregistrerGarantiesFinancières.bind(this)(event);
       break;
   }
 }

--- a/packages/domain/lauréat/src/garantiesFinancières/garantiesFinancières.register.ts
+++ b/packages/domain/lauréat/src/garantiesFinancières/garantiesFinancières.register.ts
@@ -19,6 +19,8 @@ import { registerModifierGarantiesFinancièresUseCase } from './modifier/modifie
 import { registerModifierGarantiesFinancièresCommand } from './modifier/modifierGarantiesFinancières.command';
 import { registerEnregistrerAttestationGarantiesFinancièresCommand } from './enregistrerAttestation/enregistrerAttestationGarantiesFinancières.command';
 import { registerEnregistrerAttestationGarantiesFinancièresUseCase } from './enregistrerAttestation/enregistrerAttestationGarantiesFinancières.usecase';
+import { registerEnregistrerGarantiesFinancièresUseCase } from './enregistrer/enregistrerGarantiesFinancières.usecase';
+import { registerEnregistrerGarantiesFinancièresCommand } from './enregistrer/enregistrerGarantiesFinancières.command';
 
 export type GarantiesFinancièresQueryDependencies = ConsulterGarantiesFinancièresDependencies;
 
@@ -37,6 +39,7 @@ export const registerGarantiesFinancièresUseCases = ({
   registerImporterTypeGarantiesFinancièresCommand(loadAggregate);
   registerModifierGarantiesFinancièresCommand(loadAggregate);
   registerEnregistrerAttestationGarantiesFinancièresCommand(loadAggregate);
+  registerEnregistrerGarantiesFinancièresCommand(loadAggregate);
 
   registerSoumettreDépôtGarantiesFinancièresUseCase();
   registerDemanderGarantiesFinancièresUseCase();
@@ -46,6 +49,7 @@ export const registerGarantiesFinancièresUseCases = ({
   registerImporterTypeGarantiesFinancièresUseCase();
   registerModifierGarantiesFinancièresUseCase();
   registerEnregistrerAttestationGarantiesFinancièresUseCase();
+  registerEnregistrerGarantiesFinancièresUseCase();
 };
 
 export const registerGarantiesFinancièresQueries = (

--- a/packages/domain/lauréat/src/garantiesFinancières/index.ts
+++ b/packages/domain/lauréat/src/garantiesFinancières/index.ts
@@ -33,10 +33,10 @@ export type GarantiesFinancièresUseCase =
   | EnregistrerGarantiesFinancièresUseCase;
 
 export {
-  SoumettreDépôtGarantiesFinancièresUseCase as SoumettreGarantiesFinancièresUseCase,
+  SoumettreDépôtGarantiesFinancièresUseCase,
   DemanderGarantiesFinancièresUseCase,
   SupprimerGarantiesFinancièresÀTraiterUseCase,
-  ValiderDépôtGarantiesFinancièresEnCoursUseCase as ValiderGarantiesFinancièresUseCase,
+  ValiderDépôtGarantiesFinancièresEnCoursUseCase,
   ModifierDépôtGarantiesFinancièresEnCoursUseCase,
   ImporterTypeGarantiesFinancièresUseCase,
   ModifierGarantiesFinancièresUseCase,
@@ -46,11 +46,11 @@ export {
 
 // Event
 export { GarantiesFinancièresEvent } from './garantiesFinancières.aggregate';
-export { DépôtGarantiesFinancièresSoumisEvent as GarantiesFinancièresSoumisesEvent } from './dépôt/soumettreDépôt/soumettreDépôtGarantiesFinancières.behavior';
+export { DépôtGarantiesFinancièresSoumisEvent } from './dépôt/soumettreDépôt/soumettreDépôtGarantiesFinancières.behavior';
 export { GarantiesFinancièresDemandéesEvent } from './demander/demanderGarantiesFinancières.behavior';
-export { DépôtGarantiesFinancièresEnCoursSuppriméEvent as GarantiesFinancièresÀTraiterSuppriméesEvent } from './dépôt/supprimerDépôtEnCours/supprimerDépôtGarantiesFinancièresEnCours.behavior';
-export { DépôtGarantiesFinancièresEnCoursValidéEvent as GarantiesFinancièresValidéesEvent } from './dépôt/validerDépôtEnCours/validerDépôtGarantiesFinancièresEnCours.behavior';
-export { DépôtGarantiesFinancièresEnCoursModifiéEvent as GarantiesFinancièresÀTraiterModifiéesEvent } from './dépôt/modifierDépôtEnCours/modifierDépôtGarantiesFinancièresEnCours.behavior';
+export { DépôtGarantiesFinancièresEnCoursSuppriméEvent } from './dépôt/supprimerDépôtEnCours/supprimerDépôtGarantiesFinancièresEnCours.behavior';
+export { DépôtGarantiesFinancièresEnCoursValidéEvent } from './dépôt/validerDépôtEnCours/validerDépôtGarantiesFinancièresEnCours.behavior';
+export { DépôtGarantiesFinancièresEnCoursModifiéEvent } from './dépôt/modifierDépôtEnCours/modifierDépôtGarantiesFinancièresEnCours.behavior';
 export { TypeGarantiesFinancièresImportéEvent } from './importer/importerTypeGarantiesFinancières.behavior';
 export { GarantiesFinancièresModifiéesEvent } from './modifier/modifierGarantiesFinancières.behavior';
 export { AttestationGarantiesFinancièresEnregistréeEvent } from './enregistrerAttestation/enregistrerAttestationGarantiesFinancières.behavior';

--- a/packages/domain/lauréat/src/garantiesFinancières/index.ts
+++ b/packages/domain/lauréat/src/garantiesFinancières/index.ts
@@ -10,6 +10,7 @@ import { ModifierDépôtGarantiesFinancièresEnCoursUseCase } from './dépôt/mo
 import { ImporterTypeGarantiesFinancièresUseCase } from './importer/importerTypeGarantiesFinancières.usecase';
 import { ModifierGarantiesFinancièresUseCase } from './modifier/modifierGarantiesFinancières.usecase';
 import { EnregistrerAttestationGarantiesFinancièresUseCase } from './enregistrerAttestation/enregistrerAttestationGarantiesFinancières.usecase';
+import { EnregistrerGarantiesFinancièresUseCase } from './enregistrer/enregistrerGarantiesFinancières.usecase';
 
 // Query
 export type GarantiesFinancièresQuery = ConsulterGarantiesFinancièresQuery;
@@ -28,17 +29,19 @@ export type GarantiesFinancièresUseCase =
   | ModifierDépôtGarantiesFinancièresEnCoursUseCase
   | ImporterTypeGarantiesFinancièresUseCase
   | ModifierGarantiesFinancièresUseCase
-  | EnregistrerAttestationGarantiesFinancièresUseCase;
+  | EnregistrerAttestationGarantiesFinancièresUseCase
+  | EnregistrerGarantiesFinancièresUseCase;
 
 export {
   SoumettreDépôtGarantiesFinancièresUseCase as SoumettreGarantiesFinancièresUseCase,
   DemanderGarantiesFinancièresUseCase,
   SupprimerGarantiesFinancièresÀTraiterUseCase,
   ValiderDépôtGarantiesFinancièresEnCoursUseCase as ValiderGarantiesFinancièresUseCase,
-  ModifierDépôtGarantiesFinancièresEnCoursUseCase as ModifierDépôtGarantiesFinancièresEnCoursUseCase,
+  ModifierDépôtGarantiesFinancièresEnCoursUseCase,
   ImporterTypeGarantiesFinancièresUseCase,
   ModifierGarantiesFinancièresUseCase,
   EnregistrerAttestationGarantiesFinancièresUseCase,
+  EnregistrerGarantiesFinancièresUseCase,
 };
 
 // Event

--- a/packages/domain/utilisateur/src/role.valueType.ts
+++ b/packages/domain/utilisateur/src/role.valueType.ts
@@ -130,6 +130,7 @@ const référencielPermissions = {
         importerType: 'Lauréat.GarantiesFinancières.UseCase.ImporterTypeGarantiesFinancières',
         modifier: 'Lauréat.GarantiesFinancières.UseCase.ModifierGarantiesFinancières',
         enregistrerAttestation: 'Lauréat.GarantiesFinancières.UseCase.EnregistrerAttestation',
+        enregistrer: 'Lauréat.GarantiesFinancières.UseCase.EnregistrerGarantiesFinancières',
       },
       command: {
         demander: 'Lauréat.GarantiesFinancières.Command.DemanderGarantiesFinancières',
@@ -142,6 +143,7 @@ const référencielPermissions = {
         importerType: 'Lauréat.GarantiesFinancières.Command.ImporterTypeGarantiesFinancières',
         modifier: 'Lauréat.GarantiesFinancières.Command.ModifierGarantiesFinancières',
         enregistrerAttestation: 'Lauréat.GarantiesFinancières.Command.EnregistrerAttestation',
+        enregistrer: 'Lauréat.GarantiesFinancières.Command.EnregistrerGarantiesFinancières',
       },
     },
   },
@@ -483,6 +485,11 @@ const policies = {
       référencielPermissions.lauréat.garantiesFinancières.usecase.enregistrerAttestation,
       référencielPermissions.lauréat.garantiesFinancières.command.enregistrerAttestation,
     ],
+    enregistrer: [
+      référencielPermissions.document.command.enregister,
+      référencielPermissions.lauréat.garantiesFinancières.usecase.enregistrer,
+      référencielPermissions.lauréat.garantiesFinancières.command.enregistrer,
+    ],
   },
 };
 
@@ -519,6 +526,7 @@ const permissionAdmin = [
   ...policies.garantiesFinancières.importer,
   ...policies.garantiesFinancières.modifier,
   ...policies.garantiesFinancières.enregistrerAttestation,
+  ...policies.garantiesFinancières.enregistrer,
 ];
 
 const permissionCRE = [
@@ -533,6 +541,7 @@ const permissionCRE = [
   ...policies.garantiesFinancières.consulter,
   ...policies.garantiesFinancières.modifier,
   ...policies.garantiesFinancières.enregistrerAttestation,
+  ...policies.garantiesFinancières.enregistrer,
 ];
 
 const permissionDreal = [
@@ -550,6 +559,7 @@ const permissionDreal = [
   ...policies.garantiesFinancières['modifier-dépôt-garanties-financières-en-cours'],
   ...policies.garantiesFinancières.modifier,
   ...policies.garantiesFinancières.enregistrerAttestation,
+  ...policies.garantiesFinancières.enregistrer,
 ];
 
 const permissionDgecValidateur = [
@@ -585,6 +595,7 @@ const permissionDgecValidateur = [
   ...policies.garantiesFinancières.importer,
   ...policies.garantiesFinancières.modifier,
   ...policies.garantiesFinancières.enregistrerAttestation,
+  ...policies.garantiesFinancières.enregistrer,
 ];
 
 const permissionPorteurProjet = [
@@ -630,6 +641,7 @@ const permissionCaisseDesDépôts = [
   ...policies.garantiesFinancières.consulter,
   ...policies.garantiesFinancières.modifier,
   ...policies.garantiesFinancières.enregistrerAttestation,
+  ...policies.garantiesFinancières.enregistrer,
 ];
 
 const permissions: Record<RawType, string[]> = {

--- a/packages/infrastructure/notifications/src/lauréat/garantiesFinancières.notification.ts
+++ b/packages/infrastructure/notifications/src/lauréat/garantiesFinancières.notification.ts
@@ -111,6 +111,7 @@ export const register = () => {
           départementProjet,
           régionProjet,
         });
+        break;
 
       case 'AttestationGarantiesFinancièresEnregistrée-V1':
         await sendEmailGarantiesFinancièresChangementDeStatut({
@@ -122,8 +123,10 @@ export const register = () => {
           départementProjet,
           régionProjet,
         });
+        break;
 
       case 'GarantiesFinancièresModifiées-V1':
+      case 'GarantiesFinancièresEnregistrées-V1':
         await sendEmailGarantiesFinancièresChangementDeStatut({
           subject: `Potentiel - Garanties financières mises à jour pour le projet ${nomProjet} dans le département ${départementProjet}`,
           templateId: templateId.garantiesFinancières.GFActuellesModifiéesPourDreal,
@@ -134,7 +137,6 @@ export const register = () => {
           régionProjet,
         });
 
-      case 'GarantiesFinancièresModifiées-V1':
         await sendEmailGarantiesFinancièresChangementDeStatut({
           subject: `Potentiel - Garanties financières mises à jour pour le projet ${nomProjet} dans le département ${départementProjet}`,
           templateId: templateId.garantiesFinancières.GFActuellesModifiéesPourPorteur,
@@ -144,6 +146,7 @@ export const register = () => {
           départementProjet,
           régionProjet,
         });
+        break;
     }
   };
 

--- a/packages/infrastructure/projectors/src/lauréat/garantiesFinancières.projector.ts
+++ b/packages/infrastructure/projectors/src/lauréat/garantiesFinancières.projector.ts
@@ -229,6 +229,22 @@ export const register = () => {
             },
           );
           break;
+
+        case 'GarantiesFinancièresEnregistrées-V1':
+          await upsertProjection<GarantiesFinancières.GarantiesFinancièresEntity>(
+            `garanties-financieres|${identifiantProjet}`,
+            {
+              ...garantiesFinancièresToUpsert,
+              actuelles: {
+                type: payload.type,
+                dateÉchéance: payload.dateÉchéance,
+                dateConstitution: payload.dateConstitution,
+                attestation: payload.attestation,
+                dernièreMiseÀJour: { date: payload.enregistréLe, par: payload.enregistréPar },
+              },
+            },
+          );
+          break;
       }
     }
   };

--- a/packages/specifications/src/projet/lauréat/garantiesFinancières/enregistrerGarantiesFinancières.feature
+++ b/packages/specifications/src/projet/lauréat/garantiesFinancières/enregistrerGarantiesFinancières.feature
@@ -1,0 +1,62 @@
+#Language: fr-FR
+
+Fonctionnalité: Enregistrer des garanties financières validées
+    Contexte: 
+        Etant donné le projet lauréat "Centrale PV"
+    
+    Plan du Scénario: Un admin enregistre des garanties financières validées
+        Quand un admin enregistre les garanties financières validées pour le projet "Centrale PV" avec : 
+            | type                 | <type>                 |
+            | date d'échéance      | <date d'échéance>      |
+            | format               | application/pdf        |
+            | contenu fichier      | contenu fichier        |
+            | date de constitution | 2023-06-12             |
+            | date mise à jour     | 2024-03-01             |
+        Alors les garanties financières validées devraient consultables pour le projet "Centrale PV" avec :
+            | type                 | <type>                 |
+            | date d'échéance      | <date d'échéance>      |
+            | format               | application/pdf        |
+            | contenu fichier      | contenu fichier        |
+            | date de constitution | 2023-06-12             |
+            | date de soumission   | 2023-11-01             |
+            | soumis par           | porteur@test.test      |
+    Exemples:
+            | type                      | date d'échéance   |
+            | avec-date-échéance        | 2027-12-01        |
+            | consignation              |                   |
+            | six-mois-après-achèvement |                   |  
+
+    Plan du Scénario: Erreur si le type renseigné n'est pas compatible avec une date d'échéance
+        Quand un admin enregistre les garanties financières validées pour le projet "Centrale PV" avec : 
+            | type                 | <type>                 |
+            | date d'échéance      | <date d'échéance>      |
+        Alors l'utilisateur devrait être informé que "Vous ne pouvez pas renseigner de date d'échéance pour ce type de garanties financières"
+    Exemples:
+            | type                      | date d'échéance   |
+            | consignation              |  2027-12-01       |
+            | six-mois-après-achèvement |  2027-12-01       |       
+
+    Scénario: Erreur si la date d'échéance est manquante
+        Quand un admin enregistre les garanties financières validées pour le projet "Centrale PV" avec : 
+            | type                 | avec-date-échéance     |
+            | date d'échéance      |                        |
+        Alors l'utilisateur devrait être informé que "Vous devez renseigner la date d'échéance pour ce type de garanties financières" 
+
+    Scénario: Erreur si la date de constitution est dans le futur
+        Quand un admin enregistre les garanties financières validées pour le projet "Centrale PV" avec : 
+            | date de constitution | 2050-01-01             |
+        Alors l'utilisateur devrait être informé que "La date de constitution des garanties financières ne peut pas être une date future"                     
+
+    Scénario: Erreur s'il y a déjà des garanties financières validées 
+        Etant donné des garanties financières validées pour le projet "Centrale PV" avec :
+            | type                 | type-inconnu           |
+            | date d'échéance      |                        |
+            | format               | application/pdf        |
+            | contenu fichier      | contenu fichier 1      |
+            | date de constitution | 2023-06-10             |
+            | date de soumission   | 2023-11-01             |
+            | soumis par           | porteur@test.test      |
+            | date validation      | 2023-11-03             |
+        Quand un admin enregistre les garanties financières validées pour le projet "Centrale PV" avec : 
+            | date de constitution | 2020-01-01             |
+        Alors l'utilisateur devrait être informé que "Il y a déjà des garanties financières pour ce projet"          

--- a/packages/specifications/src/projet/lauréat/garantiesFinancières/stepDefinitions/garantiesFinancières.given.ts
+++ b/packages/specifications/src/projet/lauréat/garantiesFinancières/stepDefinitions/garantiesFinancières.given.ts
@@ -43,7 +43,7 @@ EtantDonné(
 
     const { identifiantProjet } = this.lauréatWorld.rechercherLauréatFixture(nomProjet);
 
-    await mediator.send<GarantiesFinancières.SoumettreGarantiesFinancièresUseCase>({
+    await mediator.send<GarantiesFinancières.SoumettreDépôtGarantiesFinancièresUseCase>({
       type: 'Lauréat.GarantiesFinancières.UseCase.SoumettreDépôtGarantiesFinancières',
       data: {
         identifiantProjetValue: identifiantProjet.formatter(),
@@ -76,7 +76,7 @@ EtantDonné(
 
     const { identifiantProjet } = this.lauréatWorld.rechercherLauréatFixture(nomProjet);
 
-    await mediator.send<GarantiesFinancières.SoumettreGarantiesFinancièresUseCase>({
+    await mediator.send<GarantiesFinancières.SoumettreDépôtGarantiesFinancièresUseCase>({
       type: 'Lauréat.GarantiesFinancières.UseCase.SoumettreDépôtGarantiesFinancières',
       data: {
         identifiantProjetValue: identifiantProjet.formatter(),
@@ -91,7 +91,7 @@ EtantDonné(
 
     await sleep(100);
 
-    await mediator.send<GarantiesFinancières.ValiderGarantiesFinancièresUseCase>({
+    await mediator.send<GarantiesFinancières.ValiderDépôtGarantiesFinancièresEnCoursUseCase>({
       type: 'Lauréat.GarantiesFinancières.UseCase.ValiderDépôtGarantiesFinancièresEnCours',
       data: {
         identifiantProjetValue: identifiantProjet.formatter(),

--- a/packages/specifications/src/projet/lauréat/garantiesFinancières/stepDefinitions/garantiesFinancières.when.ts
+++ b/packages/specifications/src/projet/lauréat/garantiesFinancières/stepDefinitions/garantiesFinancières.when.ts
@@ -21,7 +21,7 @@ Quand(
 
       const { identifiantProjet } = this.lauréatWorld.rechercherLauréatFixture(nomProjet);
 
-      await mediator.send<GarantiesFinancières.SoumettreGarantiesFinancièresUseCase>({
+      await mediator.send<GarantiesFinancières.SoumettreDépôtGarantiesFinancièresUseCase>({
         type: 'Lauréat.GarantiesFinancières.UseCase.SoumettreDépôtGarantiesFinancières',
         data: {
           identifiantProjetValue: identifiantProjet.formatter(),
@@ -69,7 +69,7 @@ Quand(
     try {
       const { identifiantProjet } = this.lauréatWorld.rechercherLauréatFixture(nomProjet);
 
-      await mediator.send<GarantiesFinancières.ValiderGarantiesFinancièresUseCase>({
+      await mediator.send<GarantiesFinancières.ValiderDépôtGarantiesFinancièresEnCoursUseCase>({
         type: 'Lauréat.GarantiesFinancières.UseCase.ValiderDépôtGarantiesFinancièresEnCours',
         data: {
           identifiantProjetValue: identifiantProjet.formatter(),

--- a/packages/specifications/src/projet/lauréat/garantiesFinancières/stepDefinitions/garantiesFinancières.when.ts
+++ b/packages/specifications/src/projet/lauréat/garantiesFinancières/stepDefinitions/garantiesFinancières.when.ts
@@ -211,3 +211,37 @@ Quand(
     }
   },
 );
+
+Quand(
+  `un admin enregistre les garanties financières validées pour le projet {string} avec :`,
+  async function (this: PotentielWorld, nomProjet: string, dataTable: DataTable) {
+    const exemple = dataTable.rowsHash();
+
+    try {
+      const typeGarantiesFinancières = exemple['type'] || 'consignation';
+      const dateÉchéance = exemple[`date d'échéance`] || undefined;
+      const format = exemple['format'] || 'application/pdf';
+      const dateConstitution = exemple[`date de constitution`] || '2024-01-01';
+      const contenuFichier = exemple['contenu fichier'] || 'contenu fichier';
+      const enregistréLe = exemple['date mise à jour'] || '2024-01-01';
+
+      const { identifiantProjet } = this.lauréatWorld.rechercherLauréatFixture(nomProjet);
+
+      await mediator.send<GarantiesFinancières.EnregistrerGarantiesFinancièresUseCase>({
+        type: 'Lauréat.GarantiesFinancières.UseCase.EnregistrerGarantiesFinancières',
+        data: {
+          identifiantProjetValue: identifiantProjet.formatter(),
+          typeValue: typeGarantiesFinancières,
+          ...(dateÉchéance && { dateÉchéanceValue: new Date(dateÉchéance).toISOString() }),
+          attestationValue: { content: convertStringToReadableStream(contenuFichier), format },
+          dateConstitutionValue: new Date(dateConstitution).toISOString(),
+          enregistréLeValue: new Date(enregistréLe).toISOString(),
+          enregistréParValue: 'admin@test.test',
+        },
+      });
+      await sleep(300);
+    } catch (error) {
+      this.error = error as Error;
+    }
+  },
+);


### PR DESCRIPTION
Pour rattraper l'historique, certains utilisateurs peuvent enregistrer les GF d'un projet. Elles sont alors automatiquement considérées comme validées. 