### PR TITLE
🐛 Fix jumping CSS in signup-box

### DIFF
--- a/src/views/pages/homePage/components/InscriptionConnexion.tsx
+++ b/src/views/pages/homePage/components/InscriptionConnexion.tsx
@@ -89,18 +89,20 @@ const SignupBox = () => {
           isActive={active === 'autre-partenaire'}
         />
       </div>
-      {active === 'porteur-projet' && (
-        <SecondaryLinkButton href={routes.SIGNUP} className="inline-flex items-center mx-auto">
-          <AccountIcon className="mr-4" aria-hidden />
-          M'inscrire
-        </SecondaryLinkButton>
-      )}
-      {active === 'autre-partenaire' && (
-        <p className="m-0 p-0 font-semibold text-lg">
-          Contactez-nous par email <br />
-          pour obtenir un accès à Potentiel.
-        </p>
-      )}
+      <div className="h-14 flex flex-col justify-center">
+        {active === 'porteur-projet' && (
+          <SecondaryLinkButton href={routes.SIGNUP} className="inline-flex items-center mx-auto">
+            <AccountIcon className="mr-4" aria-hidden />
+            M'inscrire
+          </SecondaryLinkButton>
+        )}
+        {active === 'autre-partenaire' && (
+          <p className="m-0 p-0 font-semibold text-lg">
+            Contactez-nous par email <br />
+            pour obtenir un accès à Potentiel.
+          </p>
+        )}
+      </div>
       <p className="m-0">
         <Link href={routes.LOGIN}>Vous avez déjà un compte ?</Link>
       </p>
@@ -121,7 +123,7 @@ const Tab = ({ title, onItemClicked, isActive = false }: TabProps) => {
         onClick={onItemClicked}
         className={`rounded-none bg-white px-5 py-3 text-lg font-semibold ${
           isActive
-            ? ' border border-solid border-t-4 border-x-1 border-b-0 border-t-slate-700 border-x-slate-300'
+            ? 'border border-solid border-t-4 border-x-1 border-b-0 border-t-slate-700 border-x-slate-300'
             : 'bg-blue-france-975-base border-none text-blue-france-sun-base'
         }`}
       >
@@ -134,7 +136,7 @@ const Tab = ({ title, onItemClicked, isActive = false }: TabProps) => {
 const LoginBox = () => {
   return (
     <div
-      className="px-2 py-4 md:px-12 md:py-10 shadow-md text-center flex-1 flex flex-col gap-6"
+      className="px-2 py-4 md:px-12 md:py-10 shadow-md text-center flex-1 flex flex-col gap-[1.72rem]"
       style={{ backgroundColor: '#f5f5fe' }}
     >
       <h3


### PR DESCRIPTION
Bonjour :)

En arrivant sur la page d'accueil du site, j'ai remarqué que le CSS "saute" lorsque l'on clique sur `Autre partenaire` dans la box `Inscription` : la box s'aggrandit, ce qui décale aussi la fin du fond bleu derrière.
Je me suis dit que ce comportement n'était pas voulu alors je vous propose la correction suivante.

**Avant**
<img src="https://github.com/MTES-MCT/potentiel/assets/11708220/d5bac86e-8ee7-447a-add2-1d93374fdd67)" width="400"/>

**Maintenant**
<img src="https://github.com/MTES-MCT/potentiel/assets/11708220/3ffda9df-7811-45df-bc3b-b93bffa5a7bf" width="400"/>

Qu'en pensez-vous ?

Bonne journée !