### PR TITLE
♻️ Découper en composants le détail de la page raccordement d'un projet

### DIFF
--- a/packages/applications/ssr/src/components/pages/réseau/raccordement/détails/AucunDossierDeRaccordement.page.tsx
+++ b/packages/applications/ssr/src/components/pages/réseau/raccordement/détails/AucunDossierDeRaccordement.page.tsx
@@ -1,0 +1,42 @@
+import Link from 'next/link';
+import { FC } from 'react';
+import Button from '@codegouvfr/react-dsfr/Button';
+
+import { Routes } from '@potentiel-libraries/routes';
+
+import { PageTemplate } from '@/components/templates/Page.template';
+import { ProjetBanner, ProjetBannerProps } from '@/components/molecules/projet/ProjetBanner';
+
+import { TitrePageRaccordement } from '../TitrePageRaccordement';
+
+export type AucunDossierDeRaccordementProps = {
+  projet: ProjetBannerProps;
+};
+
+export const AucunDossierDeRaccordementPage: FC<AucunDossierDeRaccordementProps> = ({ projet }) => (
+  <PageTemplate banner={<ProjetBanner {...projet} />}>
+    <TitrePageRaccordement />
+
+    <div className="flex flex-col gap-8">
+      <p>
+        Aucun dossier de raccordement trouvé pour ce projet, vous pouvez transmettre une{' '}
+        <Link
+          href={Routes.Raccordement.transmettreDemandeComplèteRaccordement(
+            projet.identifiantProjet,
+          )}
+          className="font-semibold"
+        >
+          nouvelle demande complète de raccordement
+        </Link>
+      </p>
+      <Button
+        priority="secondary"
+        linkProps={{ href: Routes.Projet.details(projet.identifiantProjet) }}
+        className="mt-4"
+        iconId="fr-icon-arrow-left-line"
+      >
+        Retour vers le projet
+      </Button>
+    </div>
+  </PageTemplate>
+);

--- a/packages/applications/ssr/src/components/pages/réseau/raccordement/détails/AucunDossierDeRaccordement.stories.tsx
+++ b/packages/applications/ssr/src/components/pages/réseau/raccordement/détails/AucunDossierDeRaccordement.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import {
+  AucunDossierDeRaccordementPage,
+  AucunDossierDeRaccordementProps,
+} from './AucunDossierDeRaccordement.page';
+
+// More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
+const meta = {
+  title: 'Pages/Réseau/Raccordement/Détails/Aucun dossier de raccordement',
+  component: AucunDossierDeRaccordementPage,
+  parameters: {},
+  tags: ['autodocs'],
+  argTypes: {},
+} satisfies Meta<AucunDossierDeRaccordementProps>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    projet: {
+      identifiantProjet: 'identifiantProjet#1',
+      appelOffre: 'Appel offre',
+      période: 'Période',
+      famille: 'Famille',
+      nom: 'Nom du projet',
+      dateDésignation: '2021-10-23',
+      localité: {
+        codePostal: 'XXXXX',
+        commune: 'Commune',
+        département: 'Département',
+        région: 'Région',
+      },
+      statut: 'classé',
+    },
+  },
+};

--- a/packages/applications/ssr/src/components/pages/réseau/raccordement/détails/DétailsRaccordement.page.tsx
+++ b/packages/applications/ssr/src/components/pages/réseau/raccordement/détails/DétailsRaccordement.page.tsx
@@ -94,15 +94,3 @@ export const DétailsRaccordementPage: FC<DétailsRaccordementPageProps> = ({
     </Button>
   </PageTemplate>
 );
-
-export const FormatFichierInvalide: FC = () => (
-  <div className="flex items-center gap-1">
-    <Icon
-      id="fr-icon-alert-fill"
-      size="sm"
-      className=" text-warning-425-base"
-      title="format du fichier invalide"
-    />
-    <p className="text-xs">Le format du fichier est invalide</p>
-  </div>
-);

--- a/packages/applications/ssr/src/components/pages/réseau/raccordement/détails/DétailsRaccordement.page.tsx
+++ b/packages/applications/ssr/src/components/pages/réseau/raccordement/détails/DétailsRaccordement.page.tsx
@@ -2,7 +2,6 @@
 
 import { FC } from 'react';
 import Button from '@codegouvfr/react-dsfr/Button';
-import Download from '@codegouvfr/react-dsfr/Download';
 import Alert from '@codegouvfr/react-dsfr/Alert';
 import Link from 'next/link';
 
@@ -11,10 +10,12 @@ import { Routes } from '@potentiel-libraries/routes';
 import { Tile } from '@/components/organisms/Tile';
 import { PageTemplate } from '@/components/templates/Page.template';
 import { ProjetBanner, ProjetBannerProps } from '@/components/molecules/projet/ProjetBanner';
-import { displayDate } from '@/utils/displayDate';
 import { Icon } from '@/components/atoms/Icon';
 
 import { TitrePageRaccordement } from '../TitrePageRaccordement';
+
+import { DossierRaccordement, DossierRaccordementProps } from './components/DossierRaccordement';
+
 export type DétailsRaccordementPageProps = {
   projet: ProjetBannerProps;
   gestionnaireRéseau?: {
@@ -34,459 +35,64 @@ export const DétailsRaccordementPage: FC<DétailsRaccordementPageProps> = ({
   projet,
   gestionnaireRéseau,
   dossiers,
-}) => {
-  const { identifiantProjet } = projet;
-
-  if (dossiers.length === 0) {
-    return (
-      <PageTemplate banner={<ProjetBanner {...projet} />}>
-        <TitrePageRaccordement />
-
-        <div className="flex flex-col gap-8">
-          <p>
-            Aucun dossier de raccordement trouvé pour ce projet, vous pouvez transmettre une{' '}
-            <Link
-              href={Routes.Raccordement.transmettreDemandeComplèteRaccordement(identifiantProjet)}
-              className="font-semibold"
-            >
-              nouvelle demande complète de raccordement
-            </Link>
-          </p>
-          <Button
-            priority="secondary"
-            linkProps={{ href: Routes.Projet.details(projet.identifiantProjet) }}
-            className="mt-4"
-            iconId="fr-icon-arrow-left-line"
-          >
-            Retour vers le projet
-          </Button>
-        </div>
-      </PageTemplate>
-    );
-  }
-
-  return (
-    <PageTemplate banner={<ProjetBanner {...projet} />}>
-      <TitrePageRaccordement />
-      <div className="my-2 md:my-4">
-        {gestionnaireRéseau && (
-          <p className="mt-2 mb-4 p-0">
-            Gestionnaire de réseau : {gestionnaireRéseau.raisonSociale}
-            {gestionnaireRéseau.canEdit && (
-              <a
-                className="ml-1"
-                href={Routes.Raccordement.modifierGestionnaireDeRéseau(identifiantProjet)}
-                aria-label={`Modifier le gestionnaire (actuel : ${gestionnaireRéseau.raisonSociale})`}
-              >
-                (<Icon id="fr-icon-pencil-fill" size="xs" className="mr-1" />
-                Modifier)
-              </a>
-            )}
-          </p>
-        )}
-        {dossiers.length === 1 ? (
-          <Dossier {...dossiers[0]} />
-        ) : (
-          dossiers.map((dossier) => (
-            <Tile key={dossier.référence} className="mb-3">
-              <Dossier {...dossier} />
-            </Tile>
-          ))
-        )}
-      </div>
-
-      <Alert
-        severity="info"
-        small
-        description={
-          <div className="p-3">
-            Si le raccordement comporte plusieurs points d'injection, vous pouvez{' '}
-            <Link
-              href={Routes.Raccordement.transmettreDemandeComplèteRaccordement(identifiantProjet)}
-              className="font-semibold"
-            >
-              transmettre une autre demande complète de raccordement
-            </Link>
-            .
-          </div>
-        }
-      />
-
-      <Button
-        priority="secondary"
-        linkProps={{ href: Routes.Projet.details(projet.identifiantProjet) }}
-        className="mt-4"
-        iconId="fr-icon-arrow-left-line"
-      >
-        Retour vers le projet
-      </Button>
-    </PageTemplate>
-  );
-};
-
-type DossierRaccordementProps = {
-  identifiantProjet: string;
-  référence: string;
-  demandeComplèteRaccordement: {
-    dateQualification?: string;
-    accuséRéception?: string;
-    canEdit: boolean;
-  };
-  propositionTechniqueEtFinancière: {
-    dateSignature?: string;
-    propositionTechniqueEtFinancièreSignée?: string;
-    canEdit: boolean;
-  };
-  miseEnService: {
-    dateMiseEnService?: string;
-    canEdit: boolean;
-  };
-};
-
-export const Dossier: FC<DossierRaccordementProps> = ({
-  identifiantProjet,
-  référence,
-  demandeComplèteRaccordement,
-  propositionTechniqueEtFinancière,
-  miseEnService,
 }) => (
-  <div className="flex flex-col md:flex-row justify-items-stretch">
-    <ÉtapeDemandeComplèteRaccordement
-      identifiantProjet={identifiantProjet}
-      référence={référence}
-      dateQualification={demandeComplèteRaccordement.dateQualification}
-      accuséRéception={demandeComplèteRaccordement.accuséRéception}
-      canEdit={demandeComplèteRaccordement.canEdit}
-    />
-
-    <Separateur />
-
-    <ÉtapePropositionTechniqueEtFinancière
-      identifiantProjet={identifiantProjet}
-      référence={référence}
-      dateSignature={propositionTechniqueEtFinancière.dateSignature}
-      propositionTechniqueEtFinancièreSignée={
-        propositionTechniqueEtFinancière.propositionTechniqueEtFinancièreSignée
-      }
-      canEdit={propositionTechniqueEtFinancière.canEdit}
-    />
-
-    <Separateur />
-
-    <ÉtapeMiseEnService
-      identifiantProjet={identifiantProjet}
-      référence={référence}
-      dateMiseEnService={miseEnService.dateMiseEnService}
-      canEdit={miseEnService.canEdit}
-    />
-  </div>
-);
-
-type ÉtapeDemandeComplèteRaccordementProps = {
-  identifiantProjet: string;
-  référence: string;
-  dateQualification?: string;
-  accuséRéception?: string;
-  canEdit: boolean;
-};
-
-export const ÉtapeDemandeComplèteRaccordement: FC<ÉtapeDemandeComplèteRaccordementProps> = ({
-  identifiantProjet,
-  référence,
-  dateQualification,
-  accuséRéception,
-  canEdit,
-}) => (
-  <Etape
-    className="relative"
-    statut={dateQualification ? 'étape validée' : 'étape incomplète'}
-    titre="Demande complète de raccordement"
-  >
-    <div className="flex flex-col text-sm gap-2">
-      <div className="flex items-center">
-        <Icon
-          id="fr-icon-information-line"
-          size="sm"
-          className="mr-1"
-          title="référence du dossier de raccordement"
-        />
-        <span className="font-bold">{référence}</span>
-      </div>
-
-      <div className="flex items-center">
-        <Icon
-          id="fr-icon-calendar-line"
-          size="xs"
-          className="mr-1"
-          title="date de l'accusé de réception"
-        />
-        {dateQualification ? (
-          displayDate(new Date(dateQualification))
-        ) : canEdit ? (
-          <Link
-            href={Routes.Raccordement.modifierDemandeComplèteRaccordement(
-              identifiantProjet,
-              référence,
-            )}
-          >
-            Date de l'accusé de réception à renseigner
-          </Link>
-        ) : (
-          <p className="font-bold">Date de l'accusé de réception manquante</p>
-        )}
-      </div>
-
-      {accuséRéception && (
-        <div>
-          {accuséRéception.endsWith('.bin') && <FormatFichierInvalide />}
-          <Download
-            className="flex items-center"
-            linkProps={{
-              href: Routes.Document.télécharger(accuséRéception),
-              'aria-label': `Télécharger l'accusé de réception pour le dossier ${référence}`,
-              title: `Télécharger l'accusé de réception pour le dossier ${référence}`,
-            }}
-            label="Télécharger la pièce justificative"
-            details=""
-          />
-        </div>
-      )}
-
-      {canEdit && (
-        <Link
-          href={Routes.Raccordement.modifierDemandeComplèteRaccordement(
-            identifiantProjet,
-            référence,
+  <PageTemplate banner={<ProjetBanner {...projet} />}>
+    <TitrePageRaccordement />
+    <div className="my-2 md:my-4">
+      {gestionnaireRéseau && (
+        <p className="mt-2 mb-4 p-0">
+          Gestionnaire de réseau : {gestionnaireRéseau.raisonSociale}
+          {gestionnaireRéseau.canEdit && (
+            <a
+              className="ml-1"
+              href={Routes.Raccordement.modifierGestionnaireDeRéseau(projet.identifiantProjet)}
+              aria-label={`Modifier le gestionnaire (actuel : ${gestionnaireRéseau.raisonSociale})`}
+            >
+              (<Icon id="fr-icon-pencil-fill" size="xs" className="mr-1" />
+              Modifier)
+            </a>
           )}
-          className="absolute top-2 right-2"
-          aria-label={`Modifier la demande de raccordement ${référence}`}
-        >
-          <Icon id="fr-icon-pencil-fill" size="xs" className="mr-1" />
-          Modifier
-        </Link>
+        </p>
+      )}
+      {dossiers.length === 1 ? (
+        <DossierRaccordement {...dossiers[0]} />
+      ) : (
+        dossiers.map((dossier) => (
+          <Tile key={dossier.référence} className="mb-3">
+            <DossierRaccordement {...dossier} />
+          </Tile>
+        ))
       )}
     </div>
-  </Etape>
-);
 
-type ÉtapePropositionTechniqueEtFinancièreProps = {
-  identifiantProjet: string;
-  référence: string;
-  dateSignature?: string;
-  propositionTechniqueEtFinancièreSignée?: string;
-  canEdit: boolean;
-};
-
-export const ÉtapePropositionTechniqueEtFinancière: FC<
-  ÉtapePropositionTechniqueEtFinancièreProps
-> = ({
-  identifiantProjet,
-  référence,
-  dateSignature,
-  propositionTechniqueEtFinancièreSignée,
-  canEdit,
-}) => (
-  <Etape
-    className="relative"
-    titre="Proposition technique et financière"
-    statut={
-      dateSignature && propositionTechniqueEtFinancièreSignée ? 'étape validée' : 'étape à venir'
-    }
-  >
-    {dateSignature && propositionTechniqueEtFinancièreSignée ? (
-      <div className="flex flex-col text-sm gap-2">
-        <div className="flex items-center">
-          <Icon
-            id="fr-icon-calendar-line"
-            size="xs"
-            className="mr-1"
-            title="date de signature de la proposition technique et financière"
-          />
-          {displayDate(new Date(dateSignature))}
-        </div>
-
-        {propositionTechniqueEtFinancièreSignée && (
-          <div>
-            {propositionTechniqueEtFinancièreSignée.endsWith('.bin') && <FormatFichierInvalide />}
-            <Download
-              className="flex items-center"
-              linkProps={{
-                href: Routes.Document.télécharger(propositionTechniqueEtFinancièreSignée),
-                'aria-label': `Télécharger la proposition technique et financière pour le dossier ${référence}`,
-                title: `Télécharger la proposition technique et financière pour le dossier ${référence}`,
-              }}
-              label="Télécharger la pièce justificative"
-              details=""
-            />
-          </div>
-        )}
-
-        {canEdit && (
+    <Alert
+      severity="info"
+      small
+      description={
+        <div className="p-3">
+          Si le raccordement comporte plusieurs points d'injection, vous pouvez{' '}
           <Link
-            href={Routes.Raccordement.modifierPropositionTechniqueEtFinancière(
-              identifiantProjet,
-              référence,
+            href={Routes.Raccordement.transmettreDemandeComplèteRaccordement(
+              projet.identifiantProjet,
             )}
-            className="absolute top-2 right-2"
-            aria-label={`Modifier la proposition technique et financière pour le dossier ${référence}`}
+            className="font-semibold"
           >
-            <Icon id="fr-icon-pencil-fill" size="xs" className="mr-1" />
-            Modifier
+            transmettre une autre demande complète de raccordement
           </Link>
-        )}
-      </div>
-    ) : (
-      <Link
-        className="mt-4 w-fit mx-auto"
-        href={Routes.Raccordement.transmettrePropositionTechniqueEtFinancière(
-          identifiantProjet,
-          référence,
-        )}
-        aria-label={`Transmettre la proposition technique et financière pour le dossier ${référence}`}
-      >
-        Transmettre
-      </Link>
-    )}
-  </Etape>
-);
-
-type ÉtapeMiseEnServiceProps = {
-  identifiantProjet: string;
-  référence: string;
-  dateMiseEnService?: string;
-  canEdit: boolean;
-};
-
-export const ÉtapeMiseEnService: FC<ÉtapeMiseEnServiceProps> = ({
-  identifiantProjet,
-  référence,
-  dateMiseEnService,
-  canEdit,
-}) => (
-  <Etape
-    className="relative"
-    statut={dateMiseEnService ? 'étape validée' : 'étape à venir'}
-    titre="Mise en service"
-  >
-    {dateMiseEnService ? (
-      <div className="flex items-center text-sm">
-        <div>
-          <Icon
-            id="fr-icon-calendar-line"
-            size="xs"
-            className="mr-1"
-            title="date de mise en service"
-          />
-          {displayDate(new Date(dateMiseEnService))}
+          .
         </div>
+      }
+    />
 
-        {canEdit && (
-          <Link
-            href={Routes.Raccordement.transmettreDateMiseEnService(identifiantProjet, référence)}
-            className="absolute top-2 right-2"
-            aria-label={`Modifier la date de mise en service pour le dossier ${référence}`}
-          >
-            <Icon id="fr-icon-pencil-fill" size="xs" className="mr-1" />
-            Modifier
-          </Link>
-        )}
-      </div>
-    ) : canEdit ? (
-      <Link
-        className="mt-4 w-fit mx-auto"
-        href={Routes.Raccordement.transmettreDateMiseEnService(identifiantProjet, référence)}
-        aria-label={`Transmettre la date de mise en service pour le dossier ${référence}`}
-      >
-        Transmettre
-      </Link>
-    ) : (
-      <p>La date de mise en service sera renseignée par la DGEC.</p>
-    )}
-  </Etape>
-);
-
-export const Etape: FC<{
-  statut: 'étape validée' | 'étape à venir' | 'étape incomplète';
-  titre: string;
-  className?: string;
-  children: React.ReactNode;
-}> = ({ statut, titre, children, className = '' }) => {
-  let icon;
-  let borderColor;
-  let backgroundColor;
-
-  switch (statut) {
-    case 'étape validée':
-      icon = (
-        <Icon
-          id="fr-icon-success-fill"
-          size="lg"
-          className="md:mx-auto text-success-425-base"
-          title="étape validée"
-        />
-      );
-      borderColor = 'border-success-425-base';
-      backgroundColor = 'bg-green-50';
-      break;
-    case 'étape incomplète':
-      icon = (
-        <Icon
-          id="fr-icon-alert-fill"
-          size="lg"
-          className="md:mx-auto text-warning-425-base"
-          title="étape incomplète"
-        />
-      );
-      borderColor = 'border-warning-425-base';
-      backgroundColor = 'bg-warning-975-base';
-      break;
-    case 'étape à venir':
-      icon = (
-        <Icon
-          id="fr-icon-time-line"
-          size="lg"
-          className="md:mx-auto text-grey-625-base"
-          title="étape à venir"
-        />
-      );
-
-      borderColor = 'border-grey-625-base';
-      backgroundColor = '';
-      break;
-    default:
-      icon = null;
-      borderColor = '';
-      backgroundColor = '';
-      break;
-  }
-
-  return (
-    <div
-      className={`flex flex-col p-5 border-2 border-solid md:w-1/3 ${borderColor} ${backgroundColor}
-      ${className}`}
+    <Button
+      priority="secondary"
+      linkProps={{ href: Routes.Projet.details(projet.identifiantProjet) }}
+      className="mt-4"
+      iconId="fr-icon-arrow-left-line"
     >
-      <div className="flex flex-row items-center md:flex-col gap-3 mb-5">
-        {icon}
-        <div className="uppercase font-bold text-sm">{titre}</div>
-      </div>
-      {children}
-    </div>
-  );
-};
-
-export const Separateur: FC = () => (
-  <div className="flex flex-col my-3 mx-auto md:mx-3">
-    <Icon
-      id="ri-arrow-right-circle-line"
-      size="lg"
-      className="my-auto text-blue-france-sun-base hidden md:block"
-    />
-    <Icon
-      id="ri-arrow-down-circle-line"
-      size="lg"
-      className="my-auto text-blue-france-sun-base block md:hidden"
-    />
-  </div>
+      Retour vers le projet
+    </Button>
+  </PageTemplate>
 );
 
 export const FormatFichierInvalide: FC = () => (

--- a/packages/applications/ssr/src/components/pages/réseau/raccordement/détails/components/DossierRaccordement.tsx
+++ b/packages/applications/ssr/src/components/pages/réseau/raccordement/détails/components/DossierRaccordement.tsx
@@ -1,0 +1,64 @@
+import { FC } from 'react';
+
+import { Separateur } from './Separateur';
+import { ÉtapeDemandeComplèteRaccordement } from './ÉtapeDemandeComplèteRaccordement';
+import { ÉtapeMiseEnService } from './ÉtapeMiseEnService';
+import { ÉtapePropositionTechniqueEtFinancière } from './ÉtapePropositionTechniqueEtFinancière';
+
+export type DossierRaccordementProps = {
+  identifiantProjet: string;
+  référence: string;
+  demandeComplèteRaccordement: {
+    dateQualification?: string;
+    accuséRéception?: string;
+    canEdit: boolean;
+  };
+  propositionTechniqueEtFinancière: {
+    dateSignature?: string;
+    propositionTechniqueEtFinancièreSignée?: string;
+    canEdit: boolean;
+  };
+  miseEnService: {
+    dateMiseEnService?: string;
+    canEdit: boolean;
+  };
+};
+
+export const DossierRaccordement: FC<DossierRaccordementProps> = ({
+  identifiantProjet,
+  référence,
+  demandeComplèteRaccordement,
+  propositionTechniqueEtFinancière,
+  miseEnService,
+}) => (
+  <div className="flex flex-col md:flex-row justify-items-stretch">
+    <ÉtapeDemandeComplèteRaccordement
+      identifiantProjet={identifiantProjet}
+      référence={référence}
+      dateQualification={demandeComplèteRaccordement.dateQualification}
+      accuséRéception={demandeComplèteRaccordement.accuséRéception}
+      canEdit={demandeComplèteRaccordement.canEdit}
+    />
+
+    <Separateur />
+
+    <ÉtapePropositionTechniqueEtFinancière
+      identifiantProjet={identifiantProjet}
+      référence={référence}
+      dateSignature={propositionTechniqueEtFinancière.dateSignature}
+      propositionTechniqueEtFinancièreSignée={
+        propositionTechniqueEtFinancière.propositionTechniqueEtFinancièreSignée
+      }
+      canEdit={propositionTechniqueEtFinancière.canEdit}
+    />
+
+    <Separateur />
+
+    <ÉtapeMiseEnService
+      identifiantProjet={identifiantProjet}
+      référence={référence}
+      dateMiseEnService={miseEnService.dateMiseEnService}
+      canEdit={miseEnService.canEdit}
+    />
+  </div>
+);

--- a/packages/applications/ssr/src/components/pages/réseau/raccordement/détails/components/FormatFichierInvalide.tsx
+++ b/packages/applications/ssr/src/components/pages/réseau/raccordement/détails/components/FormatFichierInvalide.tsx
@@ -1,0 +1,15 @@
+import { FC } from 'react';
+
+import { Icon } from '@/components/atoms/Icon';
+
+export const FormatFichierInvalide: FC = () => (
+  <div className="flex items-center gap-1">
+    <Icon
+      id="fr-icon-alert-fill"
+      size="sm"
+      className=" text-warning-425-base"
+      title="format du fichier invalide"
+    />
+    <p className="text-xs">Le format du fichier est invalide</p>
+  </div>
+);

--- a/packages/applications/ssr/src/components/pages/réseau/raccordement/détails/components/Separateur.tsx
+++ b/packages/applications/ssr/src/components/pages/réseau/raccordement/détails/components/Separateur.tsx
@@ -1,0 +1,18 @@
+import { FC } from 'react';
+
+import { Icon } from '@/components/atoms/Icon';
+
+export const Separateur: FC = () => (
+  <div className="flex flex-col my-3 mx-auto md:mx-3">
+    <Icon
+      id="fr-icon-arrow-right-fill"
+      size="lg"
+      className="my-auto text-blue-france-sun-base hidden md:block"
+    />
+    <Icon
+      id="fr-icon-arrow-down-fill"
+      size="lg"
+      className="my-auto text-blue-france-sun-base block md:hidden"
+    />
+  </div>
+);

--- a/packages/applications/ssr/src/components/pages/réseau/raccordement/détails/components/Étape.tsx
+++ b/packages/applications/ssr/src/components/pages/réseau/raccordement/détails/components/Étape.tsx
@@ -1,7 +1,6 @@
 import { FC } from 'react';
 
 import { Icon } from '@/components/atoms/Icon';
-import { ClockIcon, WarningIcon } from '@/components/atoms/icons';
 
 type EtapeProps = {
   statut: 'étape validée' | 'étape à venir' | 'étape incomplète';
@@ -30,8 +29,10 @@ export const Etape: FC<EtapeProps> = ({ statut, titre, children, className = '' 
       break;
     case 'étape incomplète':
       icon = (
-        <WarningIcon
-          className="w-8 h-8 md:mx-auto text-warning-425-base"
+        <Icon
+          id="fr-icon-alert-fill"
+          size="lg"
+          className="md:mx-auto text-warning-425-base"
           title="étape incomplète"
         />
       );
@@ -39,7 +40,14 @@ export const Etape: FC<EtapeProps> = ({ statut, titre, children, className = '' 
       backgroundColor = 'bg-warning-975-base';
       break;
     case 'étape à venir':
-      icon = <ClockIcon className="w-8 h-8 md:mx-auto text-grey-625-base" title="étape à venir" />;
+      icon = (
+        <Icon
+          id="fr-icon-time-line"
+          size="lg"
+          className="md:mx-auto text-grey-625-base"
+          title="étape à venir"
+        />
+      );
       borderColor = 'border-grey-625-base';
       backgroundColor = '';
       break;

--- a/packages/applications/ssr/src/components/pages/réseau/raccordement/détails/components/Étape.tsx
+++ b/packages/applications/ssr/src/components/pages/réseau/raccordement/détails/components/Étape.tsx
@@ -1,0 +1,65 @@
+import { FC } from 'react';
+
+import { Icon } from '@/components/atoms/Icon';
+import { ClockIcon, WarningIcon } from '@/components/atoms/icons';
+
+type EtapeProps = {
+  statut: 'étape validée' | 'étape à venir' | 'étape incomplète';
+  titre: string;
+  className?: string;
+  children: React.ReactNode;
+};
+
+export const Etape: FC<EtapeProps> = ({ statut, titre, children, className = '' }) => {
+  let icon;
+  let borderColor;
+  let backgroundColor;
+
+  switch (statut) {
+    case 'étape validée':
+      icon = (
+        <Icon
+          id="fr-icon-success-fill"
+          size="lg"
+          className="md:mx-auto text-success-425-base"
+          title="étape validée"
+        />
+      );
+      borderColor = 'border-success-425-base';
+      backgroundColor = 'bg-green-50';
+      break;
+    case 'étape incomplète':
+      icon = (
+        <WarningIcon
+          className="w-8 h-8 md:mx-auto text-warning-425-base"
+          title="étape incomplète"
+        />
+      );
+      borderColor = 'border-warning-425-base';
+      backgroundColor = 'bg-warning-975-base';
+      break;
+    case 'étape à venir':
+      icon = <ClockIcon className="w-8 h-8 md:mx-auto text-grey-625-base" title="étape à venir" />;
+      borderColor = 'border-grey-625-base';
+      backgroundColor = '';
+      break;
+    default:
+      icon = null;
+      borderColor = '';
+      backgroundColor = '';
+      break;
+  }
+
+  return (
+    <div
+      className={`flex flex-col p-5 border-2 border-solid md:w-1/3 ${borderColor} ${backgroundColor}
+      ${className}`}
+    >
+      <div className="flex flex-row items-center md:flex-col gap-3 mb-5">
+        {icon}
+        <div className="uppercase font-bold text-sm">{titre}</div>
+      </div>
+      {children}
+    </div>
+  );
+};

--- a/packages/applications/ssr/src/components/pages/réseau/raccordement/détails/components/ÉtapeDemandeComplèteRaccordement.tsx
+++ b/packages/applications/ssr/src/components/pages/réseau/raccordement/détails/components/ÉtapeDemandeComplèteRaccordement.tsx
@@ -1,0 +1,98 @@
+import Download from '@codegouvfr/react-dsfr/Download';
+import Link from 'next/link';
+import { FC } from 'react';
+
+import { Routes } from '@potentiel-libraries/routes';
+
+import { displayDate } from '@/utils/displayDate';
+import { WarningIcon } from '@/components/atoms/icons';
+import { Icon } from '@/components/atoms/Icon';
+
+import { Etape } from './Étape';
+
+type ÉtapeDemandeComplèteRaccordementProps = {
+  identifiantProjet: string;
+  référence: string;
+  dateQualification?: string;
+  accuséRéception?: string;
+  canEdit: boolean;
+};
+
+export const ÉtapeDemandeComplèteRaccordement: FC<ÉtapeDemandeComplèteRaccordementProps> = ({
+  identifiantProjet,
+  référence,
+  dateQualification,
+  accuséRéception,
+  canEdit,
+}) => (
+  <Etape
+    className="relative"
+    statut={dateQualification ? 'étape validée' : 'étape incomplète'}
+    titre="Demande complète de raccordement"
+  >
+    <div className="flex flex-col text-sm gap-2">
+      <div className="flex items-center">
+        <Icon id="fr-icon-information-line" size="sm" className="mr-1" />
+        <span className="font-bold">{référence}</span>
+      </div>
+
+      <div className="flex items-center">
+        <Icon
+          id="fr-icon-calendar-line"
+          size="xs"
+          className="mr-1"
+          title="date de l'accusé de réception"
+        />
+        {dateQualification ? (
+          displayDate(new Date(dateQualification))
+        ) : canEdit ? (
+          <Link
+            href={Routes.Raccordement.modifierDemandeComplèteRaccordement(
+              identifiantProjet,
+              référence,
+            )}
+          >
+            Date de l'accusé de réception à renseigner
+          </Link>
+        ) : (
+          <p className="font-bold">Date de l'accusé de réception manquante</p>
+        )}
+      </div>
+
+      {accuséRéception && (
+        <div>
+          {accuséRéception.endsWith('.bin') && (
+            <WarningIcon
+              className="w-8 h-8 md:mx-auto text-warning-425-base"
+              title="format du fichier invalide"
+            />
+          )}
+          <Download
+            className="flex items-center"
+            linkProps={{
+              href: Routes.Document.télécharger(accuséRéception),
+              'aria-label': `Télécharger l'accusé de réception pour le dossier ${référence}`,
+              title: `Télécharger l'accusé de réception pour le dossier ${référence}`,
+            }}
+            label="Télécharger la pièce justificative"
+            details=""
+          />
+        </div>
+      )}
+
+      {canEdit && (
+        <Link
+          href={Routes.Raccordement.modifierDemandeComplèteRaccordement(
+            identifiantProjet,
+            référence,
+          )}
+          className="absolute top-2 right-2"
+          aria-label={`Modifier la demande de raccordement ${référence}`}
+        >
+          <Icon id="fr-icon-pencil-fill" size="xs" className="mr-1" />
+          Modifier
+        </Link>
+      )}
+    </div>
+  </Etape>
+);

--- a/packages/applications/ssr/src/components/pages/réseau/raccordement/détails/components/ÉtapeDemandeComplèteRaccordement.tsx
+++ b/packages/applications/ssr/src/components/pages/réseau/raccordement/détails/components/ÉtapeDemandeComplèteRaccordement.tsx
@@ -5,10 +5,10 @@ import { FC } from 'react';
 import { Routes } from '@potentiel-libraries/routes';
 
 import { displayDate } from '@/utils/displayDate';
-import { WarningIcon } from '@/components/atoms/icons';
 import { Icon } from '@/components/atoms/Icon';
 
 import { Etape } from './Étape';
+import { FormatFichierInvalide } from './FormatFichierInvalide';
 
 type ÉtapeDemandeComplèteRaccordementProps = {
   identifiantProjet: string;
@@ -61,12 +61,7 @@ export const ÉtapeDemandeComplèteRaccordement: FC<ÉtapeDemandeComplèteRaccor
 
       {accuséRéception && (
         <div>
-          {accuséRéception.endsWith('.bin') && (
-            <WarningIcon
-              className="w-8 h-8 md:mx-auto text-warning-425-base"
-              title="format du fichier invalide"
-            />
-          )}
+          {accuséRéception.endsWith('.bin') && <FormatFichierInvalide />}
           <Download
             className="flex items-center"
             linkProps={{

--- a/packages/applications/ssr/src/components/pages/réseau/raccordement/détails/components/ÉtapeMiseEnService.tsx
+++ b/packages/applications/ssr/src/components/pages/réseau/raccordement/détails/components/ÉtapeMiseEnService.tsx
@@ -1,0 +1,64 @@
+import { FC } from 'react';
+import Link from 'next/link';
+
+import { Routes } from '@potentiel-libraries/routes';
+
+import { Icon } from '@/components/atoms/Icon';
+import { displayDate } from '@/utils/displayDate';
+
+import { Etape } from './Étape';
+
+type ÉtapeMiseEnServiceProps = {
+  identifiantProjet: string;
+  référence: string;
+  dateMiseEnService?: string;
+  canEdit: boolean;
+};
+
+export const ÉtapeMiseEnService: FC<ÉtapeMiseEnServiceProps> = ({
+  identifiantProjet,
+  référence,
+  dateMiseEnService,
+  canEdit,
+}) => (
+  <Etape
+    className="relative"
+    statut={dateMiseEnService ? 'étape validée' : 'étape à venir'}
+    titre="Mise en service"
+  >
+    {dateMiseEnService ? (
+      <div className="flex items-center text-sm">
+        <div>
+          <Icon
+            id="fr-icon-calendar-line"
+            size="xs"
+            className="mr-1"
+            title="date de mise en service"
+          />
+          {displayDate(new Date(dateMiseEnService))}
+        </div>
+
+        {canEdit && (
+          <Link
+            href={Routes.Raccordement.transmettreDateMiseEnService(identifiantProjet, référence)}
+            className="absolute top-2 right-2"
+            aria-label={`Modifier la date de mise en service pour le dossier ${référence}`}
+          >
+            <Icon id="fr-icon-pencil-fill" size="xs" className="mr-1" />
+            Modifier
+          </Link>
+        )}
+      </div>
+    ) : canEdit ? (
+      <Link
+        className="mt-4 w-fit mx-auto"
+        href={Routes.Raccordement.transmettreDateMiseEnService(identifiantProjet, référence)}
+        aria-label={`Transmettre la date de mise en service pour le dossier ${référence}`}
+      >
+        Transmettre
+      </Link>
+    ) : (
+      <p>La date de mise en service sera renseignée par la DGEC.</p>
+    )}
+  </Etape>
+);

--- a/packages/applications/ssr/src/components/pages/réseau/raccordement/détails/components/ÉtapePropositionTechniqueEtFinancière.tsx
+++ b/packages/applications/ssr/src/components/pages/réseau/raccordement/détails/components/ÉtapePropositionTechniqueEtFinancière.tsx
@@ -6,9 +6,9 @@ import { Routes } from '@potentiel-libraries/routes';
 
 import { Icon } from '@/components/atoms/Icon';
 import { displayDate } from '@/utils/displayDate';
-import { WarningIcon } from '@/components/atoms/icons';
 
 import { Etape } from './Étape';
+import { FormatFichierInvalide } from './FormatFichierInvalide';
 
 type ÉtapePropositionTechniqueEtFinancièreProps = {
   identifiantProjet: string;
@@ -48,12 +48,7 @@ export const ÉtapePropositionTechniqueEtFinancière: FC<
 
         {propositionTechniqueEtFinancièreSignée && (
           <div>
-            {propositionTechniqueEtFinancièreSignée.endsWith('.bin') && (
-              <WarningIcon
-                className="w-8 h-8 md:mx-auto text-warning-425-base"
-                title="format du fichier invalide"
-              />
-            )}
+            {propositionTechniqueEtFinancièreSignée.endsWith('.bin') && <FormatFichierInvalide />}
             <Download
               className="flex items-center"
               linkProps={{

--- a/packages/applications/ssr/src/components/pages/réseau/raccordement/détails/components/ÉtapePropositionTechniqueEtFinancière.tsx
+++ b/packages/applications/ssr/src/components/pages/réseau/raccordement/détails/components/ÉtapePropositionTechniqueEtFinancière.tsx
@@ -1,0 +1,97 @@
+import { FC } from 'react';
+import Download from '@codegouvfr/react-dsfr/Download';
+import Link from 'next/link';
+
+import { Routes } from '@potentiel-libraries/routes';
+
+import { Icon } from '@/components/atoms/Icon';
+import { displayDate } from '@/utils/displayDate';
+import { WarningIcon } from '@/components/atoms/icons';
+
+import { Etape } from './Étape';
+
+type ÉtapePropositionTechniqueEtFinancièreProps = {
+  identifiantProjet: string;
+  référence: string;
+  dateSignature?: string;
+  propositionTechniqueEtFinancièreSignée?: string;
+  canEdit: boolean;
+};
+
+export const ÉtapePropositionTechniqueEtFinancière: FC<
+  ÉtapePropositionTechniqueEtFinancièreProps
+> = ({
+  identifiantProjet,
+  référence,
+  dateSignature,
+  propositionTechniqueEtFinancièreSignée,
+  canEdit,
+}) => (
+  <Etape
+    className="relative"
+    titre="Proposition technique et financière"
+    statut={
+      dateSignature && propositionTechniqueEtFinancièreSignée ? 'étape validée' : 'étape à venir'
+    }
+  >
+    {dateSignature && propositionTechniqueEtFinancièreSignée ? (
+      <div className="flex flex-col text-sm gap-2">
+        <div className="flex items-center">
+          <Icon
+            id="fr-icon-calendar-line"
+            size="xs"
+            className="mr-1"
+            title="date de signature de la proposition technique et financière"
+          />
+          {displayDate(new Date(dateSignature))}
+        </div>
+
+        {propositionTechniqueEtFinancièreSignée && (
+          <div>
+            {propositionTechniqueEtFinancièreSignée.endsWith('.bin') && (
+              <WarningIcon
+                className="w-8 h-8 md:mx-auto text-warning-425-base"
+                title="format du fichier invalide"
+              />
+            )}
+            <Download
+              className="flex items-center"
+              linkProps={{
+                href: Routes.Document.télécharger(propositionTechniqueEtFinancièreSignée),
+                'aria-label': `Télécharger la proposition technique et financière pour le dossier ${référence}`,
+                title: `Télécharger la proposition technique et financière pour le dossier ${référence}`,
+              }}
+              label="Télécharger la pièce justificative"
+              details=""
+            />
+          </div>
+        )}
+
+        {canEdit && (
+          <Link
+            href={Routes.Raccordement.modifierPropositionTechniqueEtFinancière(
+              identifiantProjet,
+              référence,
+            )}
+            className="absolute top-2 right-2"
+            aria-label={`Modifier la proposition technique et financière pour le dossier ${référence}`}
+          >
+            <Icon id="fr-icon-pencil-fill" size="xs" className="mr-1" />
+            Modifier
+          </Link>
+        )}
+      </div>
+    ) : (
+      <Link
+        className="mt-4 w-fit mx-auto"
+        href={Routes.Raccordement.transmettrePropositionTechniqueEtFinancière(
+          identifiantProjet,
+          référence,
+        )}
+        aria-label={`Transmettre la proposition technique et financière pour le dossier ${référence}`}
+      >
+        Transmettre
+      </Link>
+    )}
+  </Etape>
+);


### PR DESCRIPTION
J'ai repris la logique de GF et j'ai découpé en plusieurs composants contextuel (propre au détail de la page raccordement) pour faciliter la navigation dans le fichier.

Au passage j'ai extrait dans une page `AucunDossierDeRaccordement.page` pour le cas où il n'y a pas de raccordement pour le projet, c'est le page.tsx qui décide ou non d'afficher cette page, c'est pas au "front" de faire ce choix.

à merger après #1677 