### PR TITLE
:recycle: [MIGRATION GARANTIES FINANCIÈRES] Branchements avec le legacy

### DIFF
--- a/packages/applications/bootstrap/src/setupLauréat.ts
+++ b/packages/applications/bootstrap/src/setupLauréat.ts
@@ -90,6 +90,7 @@ export const setupLauréat = async () => {
         'GarantiesFinancièresModifiées-V1',
         'AttestationGarantiesFinancièresEnregistrée-V1',
         'GarantiesFinancièresEnregistrées-V1',
+        'HistoriqueGarantiesFinancièresEffacé-V1',
         'RebuildTriggered',
       ],
       eventHandler: async (event) => {

--- a/packages/applications/legacy/src/config/useCases.config.ts
+++ b/packages/applications/legacy/src/config/useCases.config.ts
@@ -58,8 +58,6 @@ import {
   getUserByEmail,
   getUserById,
   hasDemandeDeMêmeTypeOuverte,
-  hasGarantiesFinancières,
-  isProjectParticipatif,
 } from './queries.config';
 import {
   demandeDélaiRepo,
@@ -187,9 +185,6 @@ export const requestActionnaireModification = makeRequestActionnaireModification
   shouldUserAccessProject: shouldUserAccessProject.check.bind(shouldUserAccessProject),
   projectRepo,
   fileRepo,
-  isProjectParticipatif,
-  hasGarantiesFinancières,
-  getProjectAppelOffreId,
 });
 
 export const changerProducteur = makeChangerProducteur({

--- a/packages/applications/legacy/src/controllers/helpers/index.ts
+++ b/packages/applications/legacy/src/controllers/helpers/index.ts
@@ -12,3 +12,4 @@ export * from './vérifierPermissionUtilisateur';
 export * from './yupTransformations';
 export * from './getCurrentUrl';
 export * from './getPagination';
+export * from './isSoumisAuxGF';

--- a/packages/applications/legacy/src/controllers/helpers/isSoumisAuxGF.ts
+++ b/packages/applications/legacy/src/controllers/helpers/isSoumisAuxGF.ts
@@ -1,0 +1,14 @@
+import { ConsulterAppelOffreReadModel } from '@potentiel-domain/appel-offre';
+
+export const isSoumisAuxGF = ({
+  appelOffres,
+  famille,
+}: {
+  appelOffres: ConsulterAppelOffreReadModel;
+  famille?: string;
+}) => {
+  return famille
+    ? appelOffres.familles.find((f) => f.id === famille)?.soumisAuxGarantiesFinancieres !==
+        'non soumis'
+    : appelOffres.soumisAuxGarantiesFinancieres !== 'non soumis';
+};

--- a/packages/applications/legacy/src/controllers/modificationRequest/postReplyToModificationRequest.ts
+++ b/packages/applications/legacy/src/controllers/modificationRequest/postReplyToModificationRequest.ts
@@ -38,6 +38,7 @@ import {
   ConsulterAppelOffreQuery,
   ConsulterAppelOffreReadModel,
 } from '@potentiel-domain/appel-offre';
+import { featureFlags } from '@potentiel-applications/feature-flags';
 
 const FORMAT_DATE = 'DD/MM/YYYY';
 
@@ -152,7 +153,10 @@ v1Router.post(
         acceptanceParams,
         submittedBy: request.user,
       }).match(async () => {
-        if (type === 'recours' || type === 'producteur') {
+        if (
+          featureFlags.SHOW_GARANTIES_FINANCIERES &&
+          (type === 'recours' || type === 'producteur')
+        ) {
           try {
             // récupérer identifiant projet value
             const modificationRequest = await ModificationRequest.findByPk(modificationRequestId);

--- a/packages/applications/legacy/src/controllers/modificationRequest/postReplyToModificationRequest.ts
+++ b/packages/applications/legacy/src/controllers/modificationRequest/postReplyToModificationRequest.ts
@@ -21,7 +21,7 @@ import {
   UnauthorizedError,
 } from '../../modules/shared';
 import routes from '../../routes';
-import { errorResponse, notFoundResponse, unauthorizedResponse } from '../helpers';
+import { errorResponse, isSoumisAuxGF, notFoundResponse, unauthorizedResponse } from '../helpers';
 import asyncHandler from '../helpers/asyncHandler';
 import { upload } from '../upload';
 import { v1Router } from '../v1Router';
@@ -34,10 +34,7 @@ import { IdentifiantProjet } from '@potentiel-domain/common';
 import { ModificationRequest, Project } from '../../infra/sequelize';
 import { mediator } from 'mediateur';
 import { GarantiesFinancières } from '@potentiel-domain/laureat';
-import {
-  ConsulterAppelOffreQuery,
-  ConsulterAppelOffreReadModel,
-} from '@potentiel-domain/appel-offre';
+import { ConsulterAppelOffreQuery } from '@potentiel-domain/appel-offre';
 import { featureFlags } from '@potentiel-applications/feature-flags';
 
 const FORMAT_DATE = 'DD/MM/YYYY';
@@ -310,16 +307,3 @@ function _handleErrors(request, response, modificationRequestId) {
     return errorResponse({ request, response });
   };
 }
-
-const isSoumisAuxGF = ({
-  appelOffres,
-  famille,
-}: {
-  appelOffres: ConsulterAppelOffreReadModel;
-  famille?: string;
-}) => {
-  return famille
-    ? appelOffres.familles.find((f) => f.id === famille)?.soumisAuxGarantiesFinancieres !==
-        'non soumis'
-    : appelOffres.soumisAuxGarantiesFinancieres !== 'non soumis';
-};

--- a/packages/applications/legacy/src/controllers/modificationRequest/postReplyToModificationRequest.ts
+++ b/packages/applications/legacy/src/controllers/modificationRequest/postReplyToModificationRequest.ts
@@ -184,6 +184,8 @@ v1Router.post(
                   dateLimiteSoumissionValue: new Date(
                     dateActuelle.setMonth(dateActuelle.getMonth() + 2),
                   ).toISOString(),
+                  motifValue:
+                    GarantiesFinancières.MotifDemandeGarantiesFinancières.recoursAccordé.motif,
                 },
               });
             }

--- a/packages/applications/legacy/src/controllers/modificationRequest/producteur/postChangerProducteur.ts
+++ b/packages/applications/legacy/src/controllers/modificationRequest/producteur/postChangerProducteur.ts
@@ -8,12 +8,20 @@ import { UnauthorizedError } from '../../../modules/shared';
 import routes from '../../../routes';
 
 import { addQueryParams } from '../../../helpers/addQueryParams';
-import { errorResponse, unauthorizedResponse } from '../../helpers';
+import { errorResponse, notFoundResponse, unauthorizedResponse } from '../../helpers';
 import { upload } from '../../upload';
 import { v1Router } from '../../v1Router';
 import { ChangementProducteurImpossiblePourEolienError } from '../../../modules/project/errors';
 import { NouveauCahierDesChargesNonChoisiError } from '../../../modules/demandeModification';
 import safeAsyncHandler from '../../helpers/safeAsyncHandler';
+import {
+  ConsulterAppelOffreQuery,
+  ConsulterAppelOffreReadModel,
+} from '@potentiel-domain/appel-offre';
+import { Project } from '../../../infra/sequelize';
+import { IdentifiantProjet } from '@potentiel-domain/common';
+import { mediator } from 'mediateur';
+import { GarantiesFinancières } from '@potentiel-domain/laureat';
 
 const schema = yup.object({
   body: yup.object({
@@ -48,47 +56,112 @@ v1Router.post(
         filename: `${Date.now()}-${request.file.originalname}`,
       };
 
-      return changerProducteur({
-        porteur: user,
-        projetId,
-        ...(fichier && { fichier }),
-        ...(justification && { justification }),
-        nouveauProducteur: producteur,
-      }).match(
-        () => {
-          return response.redirect(
-            routes.SUCCESS_OR_ERROR_PAGE({
-              success: `Votre changement de producteur a bien été enregistré. Vous n'avez plus accès au projet sur Potentiel.`,
-              redirectUrl: routes.LISTE_PROJETS,
-              redirectTitle: 'Retourner à la liste des mes projets',
-            }),
-          );
-        },
-        (error) => {
-          if (error instanceof UnauthorizedError) {
-            return unauthorizedResponse({ request, response });
-          }
+      try {
+        await changerProducteur({
+          porteur: user,
+          projetId,
+          ...(fichier && { fichier }),
+          ...(justification && { justification }),
+          nouveauProducteur: producteur,
+        });
 
-          if (
-            error instanceof ChangementProducteurImpossiblePourEolienError ||
-            error instanceof NouveauCahierDesChargesNonChoisiError
-          ) {
-            return errorResponse({
-              request,
-              response,
-              customMessage: error.message,
-            });
-          }
+        const projet = await Project.findByPk(projetId);
+        if (!projet) {
+          return notFoundResponse({ request, response });
+        }
+        const identifiantProjetValue = IdentifiantProjet.convertirEnValueType(
+          `${projet.appelOffreId}#${projet.periodeId}#${projet.familleId}#${projet.numeroCRE}`,
+        ).formatter();
 
-          logger.error(error);
+        // récupérer appel offres
+        const appelOffres = await mediator.send<ConsulterAppelOffreQuery>({
+          type: 'AppelOffre.Query.ConsulterAppelOffre',
+          data: { identifiantAppelOffre: projet.appelOffreId },
+        });
+        if (isSoumisAuxGF({ appelOffres, famille: projet.familleId })) {
+          // supprimer les éventuelles garanties financières du projet
+          const dateActuelle = new Date();
+          try {
+            const garantiesFinancières =
+              await mediator.send<GarantiesFinancières.ConsulterGarantiesFinancièresQuery>({
+                type: 'Lauréat.GarantiesFinancières.Query.ConsulterGarantiesFinancières',
+                data: {
+                  identifiantProjetValue,
+                },
+              });
+            if (garantiesFinancières) {
+              await mediator.send<GarantiesFinancières.EffacerHistoriqueGarantiesFinancièresUseCase>(
+                {
+                  type: 'Lauréat.GarantiesFinancières.UseCase.EffacerHistoriqueGarantiesFinancières',
+                  data: {
+                    identifiantProjetValue,
+                    effacéLeValue: dateActuelle.toISOString(),
+                    effacéParValue: user.email,
+                  },
+                },
+              );
+            }
+          } catch (error) {}
+
+          // demander de nouvelles garanties financières
+          await mediator.send<GarantiesFinancières.DemanderGarantiesFinancièresUseCase>({
+            type: 'Lauréat.GarantiesFinancières.UseCase.DemanderGarantiesFinancières',
+            data: {
+              demandéLeValue: dateActuelle.toISOString(),
+              identifiantProjetValue,
+              dateLimiteSoumissionValue: new Date(
+                dateActuelle.setMonth(dateActuelle.getMonth() + 2),
+              ).toISOString(),
+              motifValue:
+                GarantiesFinancières.MotifDemandeGarantiesFinancières.changementProducteur.motif,
+            },
+          });
+        }
+
+        return response.redirect(
+          routes.SUCCESS_OR_ERROR_PAGE({
+            success: `Votre changement de producteur a bien été enregistré. Vous n'avez plus accès au projet sur Potentiel.`,
+            redirectUrl: routes.LISTE_PROJETS,
+            redirectTitle: 'Retourner à la liste des mes projets',
+          }),
+        );
+      } catch (error) {
+        if (error instanceof UnauthorizedError) {
+          return unauthorizedResponse({ request, response });
+        }
+
+        if (
+          error instanceof ChangementProducteurImpossiblePourEolienError ||
+          error instanceof NouveauCahierDesChargesNonChoisiError
+        ) {
           return errorResponse({
             request,
             response,
-            customMessage:
-              'Il y a eu une erreur lors de la soumission de votre demande. Merci de recommencer.',
+            customMessage: error.message,
           });
-        },
-      );
+        }
+
+        logger.error(error);
+        return errorResponse({
+          request,
+          response,
+          customMessage:
+            'Il y a eu une erreur lors de la soumission de votre demande. Merci de recommencer.',
+        });
+      }
     },
   ),
 );
+
+const isSoumisAuxGF = ({
+  appelOffres,
+  famille,
+}: {
+  appelOffres: ConsulterAppelOffreReadModel;
+  famille?: string;
+}) => {
+  return famille
+    ? appelOffres.familles.find((f) => f.id === famille)?.soumisAuxGarantiesFinancieres !==
+        'non soumis'
+    : appelOffres.soumisAuxGarantiesFinancieres !== 'non soumis';
+};

--- a/packages/applications/legacy/src/controllers/modificationRequest/producteur/postChangerProducteur.ts
+++ b/packages/applications/legacy/src/controllers/modificationRequest/producteur/postChangerProducteur.ts
@@ -8,16 +8,18 @@ import { UnauthorizedError } from '../../../modules/shared';
 import routes from '../../../routes';
 
 import { addQueryParams } from '../../../helpers/addQueryParams';
-import { errorResponse, notFoundResponse, unauthorizedResponse } from '../../helpers';
+import {
+  errorResponse,
+  isSoumisAuxGF,
+  notFoundResponse,
+  unauthorizedResponse,
+} from '../../helpers';
 import { upload } from '../../upload';
 import { v1Router } from '../../v1Router';
 import { ChangementProducteurImpossiblePourEolienError } from '../../../modules/project/errors';
 import { NouveauCahierDesChargesNonChoisiError } from '../../../modules/demandeModification';
 import safeAsyncHandler from '../../helpers/safeAsyncHandler';
-import {
-  ConsulterAppelOffreQuery,
-  ConsulterAppelOffreReadModel,
-} from '@potentiel-domain/appel-offre';
+import { ConsulterAppelOffreQuery } from '@potentiel-domain/appel-offre';
 import { Project } from '../../../infra/sequelize';
 import { IdentifiantProjet } from '@potentiel-domain/common';
 import { mediator } from 'mediateur';
@@ -155,16 +157,3 @@ v1Router.post(
     },
   ),
 );
-
-const isSoumisAuxGF = ({
-  appelOffres,
-  famille,
-}: {
-  appelOffres: ConsulterAppelOffreReadModel;
-  famille?: string;
-}) => {
-  return famille
-    ? appelOffres.familles.find((f) => f.id === famille)?.soumisAuxGarantiesFinancieres !==
-        'non soumis'
-    : appelOffres.soumisAuxGarantiesFinancieres !== 'non soumis';
-};

--- a/packages/applications/legacy/src/controllers/project/getProjectPage.ts
+++ b/packages/applications/legacy/src/controllers/project/getProjectPage.ts
@@ -266,15 +266,19 @@ const getGarantiesFinancières = async (
       ...(garantiesFinancières.actuelles && {
         actuelles: {
           type: garantiesFinancières.actuelles.type.type,
-          dateÉchéance: garantiesFinancières.actuelles.dateÉchéance?.formatter(),
-          dateConstitution: garantiesFinancières.actuelles.dateConstitution!.formatter(),
+          dateÉchéance:
+            garantiesFinancières.actuelles.dateÉchéance &&
+            garantiesFinancières.actuelles.dateÉchéance.formatter(),
+          dateConstitution:
+            garantiesFinancières.actuelles.dateConstitution &&
+            garantiesFinancières.actuelles.dateConstitution.formatter(),
         },
       }),
       ...(dépôtEnCours && {
         dépôtÀTraiter: {
           type: dépôtEnCours.type.type,
-          dateÉchéance: dépôtEnCours.dateÉchéance?.formatter(),
-          dateConstitution: dépôtEnCours.dateConstitution!.formatter(),
+          dateÉchéance: dépôtEnCours.dateÉchéance && dépôtEnCours.dateÉchéance.formatter(),
+          dateConstitution: dépôtEnCours.dateConstitution.formatter(),
         },
       }),
     };

--- a/packages/applications/legacy/src/modules/modificationRequest/useCases/requestActionnaireModification.spec.ts
+++ b/packages/applications/legacy/src/modules/modificationRequest/useCases/requestActionnaireModification.spec.ts
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, it, jest } from '@jest/globals';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { Readable } from 'stream';
 import { DomainEvent, Repository } from '../../../core/domain';
 import { okAsync } from '../../../core/utils';
@@ -8,21 +8,24 @@ import { fakeTransactionalRepo, makeFakeProject } from '../../../__tests__/fixtu
 import makeFakeUser from '../../../__tests__/fixtures/user';
 import { FileObject } from '../../file';
 import { Project } from '../../project';
-import { EntityNotFoundError, InfraNotAvailableError, UnauthorizedError } from '../../shared';
+import { InfraNotAvailableError, UnauthorizedError } from '../../shared';
 import { ModificationReceived, ModificationRequested } from '../events';
 import { makeRequestActionnaireModification } from './requestActionnaireModification';
-import { HasGarantiesFinancières, IsProjectParticipatif } from '../queries';
 
 describe('requestActionnaireModification use-case', () => {
-  const shouldUserAccessProject = jest.fn(async () => true);
-  const fakeUser = UnwrapForTest(makeUser(makeFakeUser({ role: 'admin' })));
+  const fakeUser = UnwrapForTest(makeUser(makeFakeUser({ role: 'porteur-projet' })));
+
   const fakeProject = {
     ...makeFakeProject(),
     actionnaire: 'initial actionnaire',
     cahierDesCharges: { type: 'initial' },
+    numéroCRE: '123',
   };
+
   const projectRepo = fakeTransactionalRepo(fakeProject as Project);
+
   const fakePublish = jest.fn((event: DomainEvent) => okAsync<null, InfraNotAvailableError>(null));
+
   const eventBus = {
     publish: fakePublish,
     subscribe: jest.fn(),
@@ -32,257 +35,22 @@ describe('requestActionnaireModification use-case', () => {
     load: jest.fn(),
   };
 
-  const getProjectAppelOffreId = jest.fn((projectId: string) =>
-    okAsync<string, EntityNotFoundError | InfraNotAvailableError>('appelOffreId'),
-  );
-  const isProjectParticipatif = jest.fn<IsProjectParticipatif>();
-  const hasGarantiesFinancières = jest.fn<HasGarantiesFinancières>();
-
   const fakeFileContents = Readable.from('test-content');
   const fakeFileName = 'myfilename.pdf';
 
-  describe('when user is allowed', () => {
-    const newActionnaire = 'new actionnaire';
-
-    describe('when project is not Eolien', () => {
-      const requestActionnaireModification = makeRequestActionnaireModification({
-        isProjectParticipatif,
-        hasGarantiesFinancières,
-        getProjectAppelOffreId,
-        projectRepo,
-        eventBus,
-        shouldUserAccessProject,
-        fileRepo: fileRepo as Repository<FileObject>,
-      });
-
-      beforeAll(async () => {
-        fakePublish.mockClear();
-        fakeProject.updateActionnaire.mockClear();
-        fileRepo.save.mockClear();
-
-        const res = await requestActionnaireModification({
-          projectId: fakeProject.id,
-          requestedBy: fakeUser,
-          newActionnaire,
-          file: { contents: fakeFileContents, filename: fakeFileName },
-        });
-
-        expect(res.isOk()).toBe(true);
-
-        expect(shouldUserAccessProject).toHaveBeenCalledWith({
-          user: fakeUser,
-          projectId: fakeProject.id.toString(),
-        });
-      });
-
-      it('should emit a ModificationReceived', async () => {
-        expect(eventBus.publish).toHaveBeenCalledTimes(1);
-        const event = eventBus.publish.mock.calls[0][0];
-        expect(event).toBeInstanceOf(ModificationReceived);
-        expect(event).toMatchObject({
-          payload: {
-            type: 'actionnaire',
-            actionnaire: newActionnaire,
-            cahierDesCharges: 'initial',
-          },
-        });
-      });
-
-      it('should update the Actionnaire', () => {
-        expect(fakeProject.updateActionnaire).toHaveBeenCalledWith(fakeUser, 'new actionnaire');
-      });
-
-      it('should save the file', () => {
-        expect(fileRepo.save).toHaveBeenCalledTimes(1);
-        expect(fileRepo.save.mock.calls[0][0].contents).toEqual(fakeFileContents);
-        expect(fileRepo.save.mock.calls[0][0].filename).toEqual(fakeFileName);
-      });
-    });
-
-    describe('when project is Eolien', () => {
-      const getProjectAppelOffreId = jest.fn((projectId: string) =>
-        okAsync<string, EntityNotFoundError | InfraNotAvailableError>('Eolien'),
-      );
-
-      describe('when project does not have Garantie Financiere', () => {
-        const hasGarantiesFinancières = jest.fn((projectId: string) =>
-          okAsync<boolean, EntityNotFoundError | InfraNotAvailableError>(false),
-        );
-        const isProjectParticipatif = jest.fn((projectId: string) =>
-          okAsync<boolean, EntityNotFoundError | InfraNotAvailableError>(false),
-        );
-
-        const requestActionnaireModification = makeRequestActionnaireModification({
-          isProjectParticipatif,
-          hasGarantiesFinancières,
-          getProjectAppelOffreId,
-          projectRepo,
-          eventBus,
-          shouldUserAccessProject,
-          fileRepo: fileRepo as Repository<FileObject>,
-        });
-
-        beforeAll(async () => {
-          fakePublish.mockClear();
-          fakeProject.updateActionnaire.mockClear();
-          fileRepo.save.mockClear();
-
-          const res = await requestActionnaireModification({
-            projectId: fakeProject.id,
-            requestedBy: fakeUser,
-            newActionnaire,
-            file: { contents: fakeFileContents, filename: fakeFileName },
-          });
-
-          expect(res.isOk()).toBe(true);
-
-          expect(shouldUserAccessProject).toHaveBeenCalledWith({
-            user: fakeUser,
-            projectId: fakeProject.id.toString(),
-          });
-        });
-
-        it('should emit a ModificationRequested', async () => {
-          expect(eventBus.publish).toHaveBeenCalledTimes(1);
-          const event = eventBus.publish.mock.calls[0][0];
-          expect(event).toBeInstanceOf(ModificationRequested);
-          expect(event).toMatchObject({
-            payload: {
-              type: 'actionnaire',
-              actionnaire: newActionnaire,
-              cahierDesCharges: 'initial',
-            },
-          });
-        });
-
-        it('should not update the Actionnaire', () => {
-          expect(fakeProject.updateActionnaire).not.toHaveBeenCalled();
-        });
-      });
-
-      describe('when project is participatif', () => {
-        const hasGarantiesFinancières = jest.fn((projectId: string) =>
-          okAsync<boolean, EntityNotFoundError | InfraNotAvailableError>(true),
-        );
-        const isProjectParticipatif = jest.fn((projectId: string) =>
-          okAsync<boolean, EntityNotFoundError | InfraNotAvailableError>(true),
-        );
-
-        const requestActionnaireModification = makeRequestActionnaireModification({
-          isProjectParticipatif,
-          hasGarantiesFinancières,
-          getProjectAppelOffreId,
-          projectRepo,
-          eventBus,
-          shouldUserAccessProject,
-          fileRepo: fileRepo as Repository<FileObject>,
-        });
-
-        beforeAll(async () => {
-          fakePublish.mockClear();
-          fakeProject.updateActionnaire.mockClear();
-          fileRepo.save.mockClear();
-
-          const res = await requestActionnaireModification({
-            projectId: fakeProject.id,
-            requestedBy: fakeUser,
-            newActionnaire,
-            file: { contents: fakeFileContents, filename: fakeFileName },
-          });
-
-          expect(res.isOk()).toBe(true);
-
-          expect(shouldUserAccessProject).toHaveBeenCalledWith({
-            user: fakeUser,
-            projectId: fakeProject.id.toString(),
-          });
-        });
-
-        it('should emit a ModificationRequested', async () => {
-          expect(eventBus.publish).toHaveBeenCalledTimes(1);
-          const event = eventBus.publish.mock.calls[0][0];
-          expect(event).toBeInstanceOf(ModificationRequested);
-
-          const { type, actionnaire } = event.payload;
-          expect(type).toEqual('actionnaire');
-          expect(actionnaire).toEqual(newActionnaire);
-        });
-
-        it('should not update the Actionnaire', () => {
-          expect(fakeProject.updateActionnaire).not.toHaveBeenCalled();
-        });
-      });
-
-      describe('when project is not participatif and has a GF', () => {
-        const hasGarantiesFinancières = jest.fn((projectId: string) =>
-          okAsync<boolean, EntityNotFoundError | InfraNotAvailableError>(true),
-        );
-        const isProjectParticipatif = jest.fn((projectId: string) =>
-          okAsync<boolean, EntityNotFoundError | InfraNotAvailableError>(false),
-        );
-
-        const requestActionnaireModification = makeRequestActionnaireModification({
-          isProjectParticipatif,
-          hasGarantiesFinancières,
-          getProjectAppelOffreId,
-          projectRepo,
-          eventBus,
-          shouldUserAccessProject,
-          fileRepo: fileRepo as Repository<FileObject>,
-        });
-
-        beforeAll(async () => {
-          fakePublish.mockClear();
-          fakeProject.updateActionnaire.mockClear();
-          fileRepo.save.mockClear();
-
-          const res = await requestActionnaireModification({
-            projectId: fakeProject.id,
-            requestedBy: fakeUser,
-            newActionnaire,
-            file: { contents: fakeFileContents, filename: fakeFileName },
-          });
-
-          expect(res.isOk()).toBe(true);
-
-          expect(shouldUserAccessProject).toHaveBeenCalledWith({
-            user: fakeUser,
-            projectId: fakeProject.id.toString(),
-          });
-        });
-
-        it('should emit a ModificationReceived', async () => {
-          expect(eventBus.publish).toHaveBeenCalledTimes(1);
-          const event = eventBus.publish.mock.calls[0][0];
-          expect(event).toBeInstanceOf(ModificationReceived);
-          expect(event).toMatchObject({
-            payload: {
-              type: 'actionnaire',
-              actionnaire: newActionnaire,
-              cahierDesCharges: 'initial',
-            },
-          });
-        });
-
-        it('should update the Actionnaire', () => {
-          expect(fakeProject.updateActionnaire).toHaveBeenCalledWith(fakeUser, 'new actionnaire');
-        });
-      });
-    });
+  beforeEach(() => {
+    fakePublish.mockClear();
+    fakeProject.updateActionnaire.mockClear();
+    fileRepo.save.mockClear();
   });
 
-  describe('when user is not allowed', () => {
-    it('should return an UnauthorizedError', async () => {
-      fakePublish.mockClear();
-      fakeProject.updateActionnaire.mockClear();
-      fileRepo.save.mockClear();
-
+  describe('Utilisateur non autorisé', () => {
+    it(`Etant donné un projet
+        Lorsqu'un utilisateur qui n'a pas les droits sur ce projet demande un changement d'actionnaire
+        Alors l'utilisateur devrait être informé qu'il n'a pas les droits sur le projet`, async () => {
       const shouldUserAccessProject = jest.fn(async () => false);
 
       const requestActionnaireModification = makeRequestActionnaireModification({
-        isProjectParticipatif,
-        hasGarantiesFinancières,
-        getProjectAppelOffreId,
         projectRepo,
         eventBus,
         shouldUserAccessProject,
@@ -293,10 +61,256 @@ describe('requestActionnaireModification use-case', () => {
         projectId: fakeProject.id,
         requestedBy: fakeUser,
         newActionnaire: 'new actionnaire',
+        file: { contents: fakeFileContents, filename: fakeFileName },
+        soumisAuxGarantiesFinancières: 'à la candidature',
       });
 
       expect(res._unsafeUnwrapErr()).toBeInstanceOf(UnauthorizedError);
       expect(fakePublish).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Utilisateur autorisé', () => {
+    // contexte global
+    const shouldUserAccessProject = jest.fn(async () => true);
+    const newActionnaire = 'new actionnaire';
+
+    describe(`Contexte nécessitant une validation du changement d'actionnaire`, () => {
+      it(`Etant donné un projet dont les garanties financières sont à soumettre après candidature
+          Et dont les garanties financières n'ont pas encore été déposées par le porteur
+          Lorsque le porteur demande un changement d'actionnaire
+          Alors une validation de sa demande est attendue
+          Et l'actionnaire n'est pas modifié automatiquement 
+          `, async () => {
+        const requestActionnaireModification = makeRequestActionnaireModification({
+          projectRepo,
+          eventBus,
+          shouldUserAccessProject,
+          fileRepo: fileRepo as Repository<FileObject>,
+        });
+
+        const res = await requestActionnaireModification({
+          projectId: fakeProject.id,
+          requestedBy: fakeUser,
+          newActionnaire,
+          file: { contents: fakeFileContents, filename: fakeFileName },
+          soumisAuxGarantiesFinancières: 'après candidature',
+        });
+
+        expect(res.isOk()).toBe(true);
+
+        expect(eventBus.publish).toHaveBeenCalledTimes(1);
+        const event = eventBus.publish.mock.calls[0][0];
+        expect(event).toBeInstanceOf(ModificationRequested);
+        expect(event).toMatchObject({
+          payload: {
+            type: 'actionnaire',
+            actionnaire: newActionnaire,
+            cahierDesCharges: 'initial',
+          },
+        });
+
+        expect(fakeProject.updateActionnaire).not.toHaveBeenCalled();
+      });
+
+      it(`Etant donné un projet "participatif"
+          Et dont les garanties financières sont à soumettre après candidature
+          Et dont les garanties financières ont été déposées par le porteur
+          Lorsque le porteur demande un changement d'actionnaire
+          Alors une validation de sa demande est attendue
+          Et l'actionnaire n'est pas modifié automatiquement 
+          `, async () => {
+        const projectFixture = makeFakeProject();
+        const fakeProject = {
+          ...projectFixture,
+          actionnaire: 'initial actionnaire',
+          cahierDesCharges: { type: 'initial' },
+          numéroCRE: '123',
+          data: { ...projectFixture.data, isFinancementParticipatif: true },
+        };
+
+        const projectRepo = fakeTransactionalRepo(fakeProject as Project);
+
+        const requestActionnaireModification = makeRequestActionnaireModification({
+          projectRepo,
+          eventBus,
+          shouldUserAccessProject,
+          fileRepo: fileRepo as Repository<FileObject>,
+        });
+
+        const res = await requestActionnaireModification({
+          projectId: fakeProject.id,
+          requestedBy: fakeUser,
+          newActionnaire,
+          file: { contents: fakeFileContents, filename: fakeFileName },
+          soumisAuxGarantiesFinancières: 'après candidature',
+          garantiesFinancièresConstituées: true,
+        });
+
+        expect(res.isOk()).toBe(true);
+
+        expect(eventBus.publish).toHaveBeenCalledTimes(1);
+        const event = eventBus.publish.mock.calls[0][0];
+        expect(event).toBeInstanceOf(ModificationRequested);
+        expect(event).toMatchObject({
+          payload: {
+            type: 'actionnaire',
+            actionnaire: newActionnaire,
+            cahierDesCharges: 'initial',
+          },
+        });
+
+        expect(fakeProject.updateActionnaire).not.toHaveBeenCalled();
+      });
+    });
+
+    describe(`Contexte permettant un changement automatique d'actionnaire`, () => {
+      it(`Etant donné un projet non "participatif"
+          Et dont les garanties financières sont à soumettre après candidature
+          Et dont les garanties financières ont été déposées par le porteur
+          Lorsque le porteur demande un changement d'actionnaire
+          Alors l'actionnaire est modifié automatiquement 
+          Et aucune validation du changemnet n'est attendue
+          `, async () => {
+        const fakeProject = {
+          ...makeFakeProject(),
+          actionnaire: 'initial actionnaire',
+          cahierDesCharges: { type: 'initial' },
+          isParticipatif: false,
+          numéroCRE: '123',
+        };
+
+        const projectRepo = fakeTransactionalRepo(fakeProject as Project);
+
+        const requestActionnaireModification = makeRequestActionnaireModification({
+          projectRepo,
+          eventBus,
+          shouldUserAccessProject,
+          fileRepo: fileRepo as Repository<FileObject>,
+        });
+
+        const res = await requestActionnaireModification({
+          projectId: fakeProject.id,
+          requestedBy: fakeUser,
+          newActionnaire,
+          file: { contents: fakeFileContents, filename: fakeFileName },
+          soumisAuxGarantiesFinancières: 'après candidature',
+          garantiesFinancièresConstituées: true,
+        });
+
+        expect(res.isOk()).toBe(true);
+
+        expect(shouldUserAccessProject).toHaveBeenCalledWith({
+          user: fakeUser,
+          projectId: fakeProject.id.toString(),
+        });
+
+        expect(eventBus.publish).toHaveBeenCalledTimes(1);
+        const event = eventBus.publish.mock.calls[0][0];
+        expect(event).toBeInstanceOf(ModificationReceived);
+        expect(event).toMatchObject({
+          payload: {
+            type: 'actionnaire',
+            actionnaire: newActionnaire,
+            cahierDesCharges: 'initial',
+          },
+        });
+
+        expect(fakeProject.updateActionnaire).toHaveBeenCalledWith(fakeUser, 'new actionnaire');
+
+        expect(fileRepo.save).toHaveBeenCalledTimes(1);
+        expect(fileRepo.save.mock.calls[0][0].contents).toEqual(fakeFileContents);
+        expect(fileRepo.save.mock.calls[0][0].filename).toEqual(fakeFileName);
+      });
+
+      it(`Etant donné un projet dont les garanties financières sont soumises à la candidature
+          Lorsque le porteur demande un changement d'actionnaire
+          Alors l'actionnaire est modifié automatiquement 
+          Et aucune validation du changemnet n'est attendue
+          `, async () => {
+        const requestActionnaireModification = makeRequestActionnaireModification({
+          projectRepo,
+          eventBus,
+          shouldUserAccessProject,
+          fileRepo: fileRepo as Repository<FileObject>,
+        });
+
+        const res = await requestActionnaireModification({
+          projectId: fakeProject.id,
+          requestedBy: fakeUser,
+          newActionnaire,
+          file: { contents: fakeFileContents, filename: fakeFileName },
+          soumisAuxGarantiesFinancières: 'à la candidature',
+        });
+
+        expect(res.isOk()).toBe(true);
+
+        expect(shouldUserAccessProject).toHaveBeenCalledWith({
+          user: fakeUser,
+          projectId: fakeProject.id.toString(),
+        });
+
+        expect(eventBus.publish).toHaveBeenCalledTimes(1);
+        const event = eventBus.publish.mock.calls[0][0];
+        expect(event).toBeInstanceOf(ModificationReceived);
+        expect(event).toMatchObject({
+          payload: {
+            type: 'actionnaire',
+            actionnaire: newActionnaire,
+            cahierDesCharges: 'initial',
+          },
+        });
+
+        expect(fakeProject.updateActionnaire).toHaveBeenCalledWith(fakeUser, 'new actionnaire');
+
+        expect(fileRepo.save).toHaveBeenCalledTimes(1);
+        expect(fileRepo.save.mock.calls[0][0].contents).toEqual(fakeFileContents);
+        expect(fileRepo.save.mock.calls[0][0].filename).toEqual(fakeFileName);
+      });
+    });
+    it(`Etant donné un projet non soumis à garanties financières
+          Lorsque le porteur demande un changement d'actionnaire
+          Alors l'actionnaire est modifié automatiquement 
+          Et aucune validation du changemnet n'est attendue
+          `, async () => {
+      const requestActionnaireModification = makeRequestActionnaireModification({
+        projectRepo,
+        eventBus,
+        shouldUserAccessProject,
+        fileRepo: fileRepo as Repository<FileObject>,
+      });
+
+      const res = await requestActionnaireModification({
+        projectId: fakeProject.id,
+        requestedBy: fakeUser,
+        newActionnaire,
+        file: { contents: fakeFileContents, filename: fakeFileName },
+        soumisAuxGarantiesFinancières: 'non soumis',
+      });
+
+      expect(res.isOk()).toBe(true);
+
+      expect(shouldUserAccessProject).toHaveBeenCalledWith({
+        user: fakeUser,
+        projectId: fakeProject.id.toString(),
+      });
+
+      expect(eventBus.publish).toHaveBeenCalledTimes(1);
+      const event = eventBus.publish.mock.calls[0][0];
+      expect(event).toBeInstanceOf(ModificationReceived);
+      expect(event).toMatchObject({
+        payload: {
+          type: 'actionnaire',
+          actionnaire: newActionnaire,
+          cahierDesCharges: 'initial',
+        },
+      });
+
+      expect(fakeProject.updateActionnaire).toHaveBeenCalledWith(fakeUser, 'new actionnaire');
+
+      expect(fileRepo.save).toHaveBeenCalledTimes(1);
+      expect(fileRepo.save.mock.calls[0][0].contents).toEqual(fakeFileContents);
+      expect(fileRepo.save.mock.calls[0][0].filename).toEqual(fakeFileName);
     });
   });
 });

--- a/packages/applications/legacy/src/modules/modificationRequest/useCases/requestActionnaireModification.ts
+++ b/packages/applications/legacy/src/modules/modificationRequest/useCases/requestActionnaireModification.ts
@@ -15,25 +15,29 @@ import {
   UnauthorizedError,
 } from '../../shared';
 import { ModificationReceived, ModificationRequested } from '../events';
-import { GetProjectAppelOffreId, HasGarantiesFinancières, IsProjectParticipatif } from '../queries';
 
-interface RequestActionnaireModificationDeps {
+type RequestActionnaireModificationDeps = {
   eventBus: EventBus;
   shouldUserAccessProject: (args: { user: User; projectId: string }) => Promise<boolean>;
   projectRepo: TransactionalRepository<Project>;
   fileRepo: Repository<FileObject>;
-  isProjectParticipatif: IsProjectParticipatif;
-  hasGarantiesFinancières: HasGarantiesFinancières;
-  getProjectAppelOffreId: GetProjectAppelOffreId;
-}
+};
 
-interface RequestActionnaireModificationArgs {
+type RequestActionnaireModificationArgs = {
   projectId: UniqueEntityID;
   requestedBy: User;
   newActionnaire: string;
   justification?: string;
-  file?: { contents: FileContents; filename: string };
-}
+  file: { contents: FileContents; filename: string };
+} & (
+  | {
+      soumisAuxGarantiesFinancières: 'non soumis' | 'à la candidature';
+    }
+  | {
+      soumisAuxGarantiesFinancières: 'après candidature';
+      garantiesFinancièresConstituées?: true;
+    }
+);
 
 export const makeRequestActionnaireModification =
   (deps: RequestActionnaireModificationDeps) =>
@@ -46,7 +50,14 @@ export const makeRequestActionnaireModification =
     | EntityNotFoundError
     | UnauthorizedError
   > => {
-    const { projectId, requestedBy, newActionnaire, justification, file } = args;
+    const {
+      projectId,
+      requestedBy,
+      newActionnaire,
+      justification,
+      file,
+      soumisAuxGarantiesFinancières,
+    } = args;
     const { eventBus, shouldUserAccessProject, projectRepo, fileRepo } = deps;
 
     return wrapInfra(
@@ -54,8 +65,6 @@ export const makeRequestActionnaireModification =
     )
       .andThen((userHasRightsToProject) => {
         if (!userHasRightsToProject) return errAsync(new UnauthorizedError());
-        if (!file) return okAsync(null);
-
         return makeAndSaveFile({
           file: {
             designation: 'modification-request',
@@ -72,39 +81,30 @@ export const makeRequestActionnaireModification =
             return new InfraNotAvailableError();
           });
       })
-      .andThen((fileId: string) =>
-        deps.getProjectAppelOffreId(projectId.toString()).andThen((appelOffreId) => {
-          if (appelOffreId === 'Eolien') {
-            return ResultAsync.combine([
-              deps.hasGarantiesFinancières(projectId.toString()),
-              deps.isProjectParticipatif(projectId.toString()),
-            ]).map(([hasGarantieFinanciere, isProjectParticipatif]) => ({
-              requiresAuthorization: !hasGarantieFinanciere || isProjectParticipatif,
-              fileId,
-            }));
-          }
-
-          return okAsync({ requiresAuthorization: false, fileId });
-        }),
-      )
-      .andThen(({ requiresAuthorization, fileId }) =>
+      .andThen((fileId) =>
         projectRepo.transaction(projectId, (project: Project) => {
-          if (requiresAuthorization) {
-            return eventBus.publish(
-              new ModificationRequested({
-                payload: {
-                  modificationRequestId: new UniqueEntityID().toString(),
-                  projectId: projectId.toString(),
-                  requestedBy: requestedBy.id,
-                  type: 'actionnaire',
-                  actionnaire: newActionnaire,
-                  justification,
-                  fileId,
-                  authority: 'dreal',
-                  cahierDesCharges: formatCahierDesChargesRéférence(project.cahierDesCharges),
-                },
-              }),
-            );
+          if (soumisAuxGarantiesFinancières === 'après candidature') {
+            if (
+              project.data?.isFinancementParticipatif ||
+              project.data?.isInvestissementParticipatif ||
+              !args.garantiesFinancièresConstituées
+            ) {
+              return eventBus.publish(
+                new ModificationRequested({
+                  payload: {
+                    modificationRequestId: new UniqueEntityID().toString(),
+                    projectId: projectId.toString(),
+                    requestedBy: requestedBy.id,
+                    type: 'actionnaire',
+                    actionnaire: newActionnaire,
+                    justification,
+                    fileId,
+                    authority: 'dreal',
+                    cahierDesCharges: formatCahierDesChargesRéférence(project.cahierDesCharges),
+                  },
+                }),
+              );
+            }
           }
 
           project.updateActionnaire(requestedBy, newActionnaire);

--- a/packages/applications/legacy/src/modules/project/eventHandlers/handleProjectRawDataImported.ts
+++ b/packages/applications/legacy/src/modules/project/eventHandlers/handleProjectRawDataImported.ts
@@ -54,7 +54,7 @@ export const handleProjectRawDataImported =
     if (classe === 'Classé' && featureFlags.SHOW_GARANTIES_FINANCIERES) {
       const typeGarantiesFinancières =
         data.garantiesFinancièresType &&
-        convertGarantiesFinancièresType(data.garantiesFinancièresType);
+        convertirGarantiesFinancièresType(data.garantiesFinancièresType);
 
       if (typeGarantiesFinancières) {
         const identifiantProjetValue = IdentifiantProjet.convertirEnValueType(
@@ -85,7 +85,7 @@ export const handleProjectRawDataImported =
     }
   };
 
-const convertGarantiesFinancièresType = (typeImporté: string) => {
+const convertirGarantiesFinancièresType = (typeImporté: string) => {
   switch (typeImporté) {
     case "Garantie financière jusqu'à 6 mois après la date d'achèvement":
       return GarantiesFinancières.TypeGarantiesFinancières.sixMoisAprèsAchèvement.type;

--- a/packages/applications/legacy/src/modules/project/eventHandlers/handleProjectRawDataImported.ts
+++ b/packages/applications/legacy/src/modules/project/eventHandlers/handleProjectRawDataImported.ts
@@ -18,7 +18,7 @@ export const handleProjectRawDataImported =
     const { findProjectByIdentifiers, projectRepo, getProjectAppelOffre } = deps;
 
     const { data, importId } = event.payload;
-    const { appelOffreId, periodeId, familleId, numeroCRE } = data;
+    const { appelOffreId, periodeId, familleId, numeroCRE, classe } = data;
     const appelOffre = getProjectAppelOffre({ appelOffreId, periodeId, familleId });
 
     // PAD: There is a concurrency risk here:
@@ -50,34 +50,36 @@ export const handleProjectRawDataImported =
       console.error('handleProjectRawDataImported error', res.error);
     }
 
-    const typeGarantiesFinancières =
-      data.garantiesFinancièresType &&
-      convertGarantiesFinancièresType(data.garantiesFinancièresType);
+    if (classe === 'Classé') {
+      const typeGarantiesFinancières =
+        data.garantiesFinancièresType &&
+        convertGarantiesFinancièresType(data.garantiesFinancièresType);
 
-    if (typeGarantiesFinancières) {
-      const identifiantProjetValue = IdentifiantProjet.convertirEnValueType(
-        `${appelOffreId}#${periodeId}#${familleId}#${numeroCRE}`,
-      ).formatter();
+      if (typeGarantiesFinancières) {
+        const identifiantProjetValue = IdentifiantProjet.convertirEnValueType(
+          `${appelOffreId}#${periodeId}#${familleId}#${numeroCRE}`,
+        ).formatter();
 
-      try {
-        await mediator.send<GarantiesFinancières.ImporterTypeGarantiesFinancièresUseCase>({
-          type: 'Lauréat.GarantiesFinancières.UseCase.ImporterTypeGarantiesFinancières',
-          data: {
-            identifiantProjetValue,
-            importéLeValue: new Date(event.occurredAt).toISOString(),
-            typeValue: typeGarantiesFinancières,
-            ...(data.garantiesFinancièresDateEchéance &&
-              GarantiesFinancières.TypeGarantiesFinancières.convertirEnValueType(
-                typeGarantiesFinancières,
-              ).estAvecDateÉchéance() && {
-                dateÉchéanceValue: new Date(data.garantiesFinancièresDateEchéance).toISOString(),
-              }),
-          },
-        });
-      } catch (error) {
-        logger.error(
-          `handleProjectRawDataImported : enregistrer le type de garantie financière (projet ${identifiantProjetValue}) : ${error.message}`,
-        );
+        try {
+          await mediator.send<GarantiesFinancières.ImporterTypeGarantiesFinancièresUseCase>({
+            type: 'Lauréat.GarantiesFinancières.UseCase.ImporterTypeGarantiesFinancières',
+            data: {
+              identifiantProjetValue,
+              importéLeValue: new Date(event.occurredAt).toISOString(),
+              typeValue: typeGarantiesFinancières,
+              ...(data.garantiesFinancièresDateEchéance &&
+                GarantiesFinancières.TypeGarantiesFinancières.convertirEnValueType(
+                  typeGarantiesFinancières,
+                ).estAvecDateÉchéance() && {
+                  dateÉchéanceValue: new Date(data.garantiesFinancièresDateEchéance).toISOString(),
+                }),
+            },
+          });
+        } catch (error) {
+          logger.error(
+            `handleProjectRawDataImported : enregistrer le type de garantie financière (projet ${identifiantProjetValue}) : ${error.message}`,
+          );
+        }
       }
     }
   };

--- a/packages/applications/legacy/src/modules/project/eventHandlers/handleProjectRawDataImported.ts
+++ b/packages/applications/legacy/src/modules/project/eventHandlers/handleProjectRawDataImported.ts
@@ -7,6 +7,7 @@ import { Project } from '../Project';
 import { IdentifiantProjet } from '@potentiel-domain/common';
 import { mediator } from 'mediateur';
 import { GarantiesFinancières } from '@potentiel-domain/laureat';
+import { featureFlags } from '@potentiel-applications/feature-flags';
 
 export const handleProjectRawDataImported =
   (deps: {
@@ -50,7 +51,7 @@ export const handleProjectRawDataImported =
       console.error('handleProjectRawDataImported error', res.error);
     }
 
-    if (classe === 'Classé') {
+    if (classe === 'Classé' && featureFlags.SHOW_GARANTIES_FINANCIERES) {
       const typeGarantiesFinancières =
         data.garantiesFinancièresType &&
         convertGarantiesFinancièresType(data.garantiesFinancièresType);

--- a/packages/applications/legacy/src/modules/project/queries/GetProjectDataForProjectPage.ts
+++ b/packages/applications/legacy/src/modules/project/queries/GetProjectDataForProjectPage.ts
@@ -125,12 +125,12 @@ type NotesInnovation = {
 export type GarantiesFinancièresForProjectPage = {
   garantiesFinancièresEnAttente?: true;
   actuelles?: {
-    type: GarantiesFinancières.TypeGarantiesFinancières.RawType;
-    dateConstitution: string;
+    type?: GarantiesFinancières.TypeGarantiesFinancières.RawType;
+    dateConstitution?: string;
     dateÉchéance?: string;
   };
   dépôtÀTraiter?: {
-    type: GarantiesFinancières.TypeGarantiesFinancières.RawType;
+    type?: GarantiesFinancières.TypeGarantiesFinancières.RawType;
     dateConstitution: string;
     dateÉchéance?: string;
   };

--- a/packages/applications/legacy/src/views/pages/projectDetailsPage/sections/InfoGenerales.tsx
+++ b/packages/applications/legacy/src/views/pages/projectDetailsPage/sections/InfoGenerales.tsx
@@ -144,21 +144,38 @@ const GarantiesFinancièresProjet = ({
     )}
 
     {garantiesFinancières.actuelles && (
-      <p className="mt-0 mb-3">
-        Le projet dispose actuellement de{' '}
-        <span className="font-semibold">
-          garanties financières validées {getGFLabel(garantiesFinancières.actuelles.type)}
-        </span>
-        , constituées le {afficherDate(new Date(garantiesFinancières.actuelles.dateConstitution))}
-        {garantiesFinancières.actuelles.dateÉchéance && (
-          <span>
-            {' '}
-            et avec échéance au{' '}
-            {afficherDate(new Date(garantiesFinancières.actuelles.dateÉchéance))}
+      <>
+        <p className="mt-0 mb-3">
+          Le projet dispose actuellement de{' '}
+          <span className="font-semibold">
+            garanties financières validées {getGFLabel(garantiesFinancières.actuelles.type)}
           </span>
+          {garantiesFinancières.actuelles.dateConstitution && (
+            <>
+              , constituées le{' '}
+              {afficherDate(new Date(garantiesFinancières.actuelles.dateConstitution))}
+            </>
+          )}
+          {garantiesFinancières.actuelles.dateÉchéance && (
+            <span>
+              {' '}
+              et avec échéance au{' '}
+              {afficherDate(new Date(garantiesFinancières.actuelles.dateÉchéance))}
+            </span>
+          )}
+          .
+        </p>
+
+        {!garantiesFinancières.actuelles?.dateConstitution && (
+          <AlertMessage>
+            L'attestation de constitution des garanties financières reste à transmettre.
+          </AlertMessage>
         )}
-        .
-      </p>
+
+        {!garantiesFinancières.actuelles?.type && (
+          <AlertMessage>Le type de garanties financières reste à préciser.</AlertMessage>
+        )}
+      </>
     )}
 
     {garantiesFinancières.dépôtÀTraiter && (

--- a/packages/applications/projectors/src/subscribers/lauréat/garantiesFinancières.projector.ts
+++ b/packages/applications/projectors/src/subscribers/lauréat/garantiesFinancières.projector.ts
@@ -290,7 +290,6 @@ export const register = () => {
                 typeImportéLe: payload.importéLe,
                 dernièreMiseÀJour: {
                   date: payload.importéLe,
-                  par: payload.importéPar,
                 },
               },
             },

--- a/packages/applications/projectors/src/subscribers/lauréat/garantiesFinancières.projector.ts
+++ b/packages/applications/projectors/src/subscribers/lauréat/garantiesFinancières.projector.ts
@@ -355,6 +355,16 @@ export const register = () => {
             },
           );
           break;
+
+        case 'HistoriqueGarantiesFinancièresEffacé-V1':
+          await removeProjection<GarantiesFinancières.GarantiesFinancièresEntity>(
+            `garanties-financieres|${identifiantProjet}`,
+          );
+
+          await removeProjection<GarantiesFinancières.DépôtEnCoursGarantiesFinancièresEntity>(
+            `depot-en-cours-garanties-financieres|${identifiantProjet}`,
+          );
+          break;
       }
     }
   };

--- a/packages/applications/projectors/src/subscribers/lauréat/garantiesFinancières.projector.ts
+++ b/packages/applications/projectors/src/subscribers/lauréat/garantiesFinancières.projector.ts
@@ -290,6 +290,7 @@ export const register = () => {
                 typeImportéLe: payload.importéLe,
                 dernièreMiseÀJour: {
                   date: payload.importéLe,
+                  par: '',
                 },
               },
             },

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/garanties-financieres/actuelles:modifier/page.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/garanties-financieres/actuelles:modifier/page.tsx
@@ -72,7 +72,7 @@ export default async function Page({ params: { identifiant } }: IdentifiantParam
         attestation: garantiesFinancières.actuelles.attestation?.formatter(),
         dernièreMiseÀJour: {
           date: garantiesFinancières.actuelles.dernièreMiseÀJour.date.formatter(),
-          par: garantiesFinancières.actuelles.dernièreMiseÀJour.par.formatter(),
+          par: garantiesFinancières.actuelles.dernièreMiseÀJour.par?.formatter(),
         },
       },
     };

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/garanties-financieres/page.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/garanties-financieres/page.tsx
@@ -129,7 +129,7 @@ const mapToProps: MapToProps = ({ projet, utilisateur, garantiesFinancières }) 
           attestation: garantiesFinancières.actuelles.attestation?.formatter(),
           dernièreMiseÀJour: {
             date: garantiesFinancières.actuelles.dernièreMiseÀJour.date.formatter(),
-            par: garantiesFinancières.actuelles.dernièreMiseÀJour.par.formatter(),
+            par: garantiesFinancières.actuelles.dernièreMiseÀJour.par?.formatter(),
           },
           action:
             utilisateur.role.estÉgaleÀ(Role.porteur) &&

--- a/packages/applications/ssr/src/components/pages/garanties-financières/détails/components/GarantiesFinancièresActuelles.tsx
+++ b/packages/applications/ssr/src/components/pages/garanties-financières/détails/components/GarantiesFinancièresActuelles.tsx
@@ -17,7 +17,7 @@ export type GarantiesFinancièresActuelles = {
   soumisLe?: string;
   dernièreMiseÀJour: {
     date: string;
-    par: string;
+    par?: string;
   };
 };
 
@@ -50,8 +50,13 @@ export const GarantiesFinancièresActuelles: FC<GarantiesFinancièresActuellesPr
           <Heading2>Garanties financières actuelles</Heading2>
           <div className="text-xs italic">
             Dernière mise à jour le{' '}
-            <span className="font-semibold">{formatDateForText(dernièreMiseÀJour.date)}</span> par{' '}
-            <span className="font-semibold">{dernièreMiseÀJour.par}</span>
+            <span className="font-semibold">{formatDateForText(dernièreMiseÀJour.date)}</span>
+            {dernièreMiseÀJour.par && (
+              <>
+                {' '}
+                par <span className="font-semibold">{dernièreMiseÀJour.par}</span>
+              </>
+            )}
           </div>
           <div className="mt-5 gap-2 text-base">
             <div>

--- a/packages/domain/lauréat/src/garantiesFinancières/consulter/consulterGarantiesFinancières.query.ts
+++ b/packages/domain/lauréat/src/garantiesFinancières/consulter/consulterGarantiesFinancières.query.ts
@@ -38,7 +38,7 @@ export type ConsulterGarantiesFinancièresReadModel = {
     validéLe?: DateTime.ValueType;
     dernièreMiseÀJour: {
       date: DateTime.ValueType;
-      par: IdentifiantUtilisateur.ValueType;
+      par?: IdentifiantUtilisateur.ValueType;
     };
   };
   dépôts: Array<DépôtGarantiesFinancières>;
@@ -96,7 +96,9 @@ export const registerConsulterGarantiesFinancièresQuery = ({
           : undefined,
       dernièreMiseÀJour: {
         date: DateTime.convertirEnValueType(result.actuelles.dernièreMiseÀJour.date),
-        par: IdentifiantUtilisateur.convertirEnValueType(result.actuelles.dernièreMiseÀJour.par),
+        par: result.actuelles.dernièreMiseÀJour.par
+          ? IdentifiantUtilisateur.convertirEnValueType(result.actuelles.dernièreMiseÀJour.par)
+          : undefined,
       },
     };
 

--- a/packages/domain/lauréat/src/garantiesFinancières/demander/demanderGarantiesFinancières.behavior.ts
+++ b/packages/domain/lauréat/src/garantiesFinancières/demander/demanderGarantiesFinancières.behavior.ts
@@ -2,6 +2,7 @@ import { DateTime, IdentifiantProjet } from '@potentiel-domain/common';
 import { DomainEvent } from '@potentiel-domain/core';
 
 import { GarantiesFinancièresAggregate } from '../garantiesFinancières.aggregate';
+import { MotifDemandeGarantiesFinancières } from '..';
 
 export type GarantiesFinancièresDemandéesEvent = DomainEvent<
   'GarantiesFinancièresDemandées-V1',
@@ -9,6 +10,7 @@ export type GarantiesFinancièresDemandéesEvent = DomainEvent<
     identifiantProjet: IdentifiantProjet.RawType;
     dateLimiteSoumission: DateTime.RawType;
     demandéLe: DateTime.RawType;
+    motif?: MotifDemandeGarantiesFinancières.RawType;
   }
 >;
 
@@ -16,11 +18,12 @@ export type Options = {
   identifiantProjet: IdentifiantProjet.ValueType;
   dateLimiteSoumission: DateTime.ValueType;
   demandéLe: DateTime.ValueType;
+  motif: MotifDemandeGarantiesFinancières.ValueType;
 };
 
 export async function demanderGarantiesFinancières(
   this: GarantiesFinancièresAggregate,
-  { dateLimiteSoumission, identifiantProjet, demandéLe }: Options,
+  { dateLimiteSoumission, identifiantProjet, demandéLe, motif }: Options,
 ) {
   const event: GarantiesFinancièresDemandéesEvent = {
     type: 'GarantiesFinancièresDemandées-V1',
@@ -28,6 +31,7 @@ export async function demanderGarantiesFinancières(
       identifiantProjet: identifiantProjet.formatter(),
       dateLimiteSoumission: dateLimiteSoumission.formatter(),
       demandéLe: demandéLe.formatter(),
+      motif: motif.motif,
     },
   };
 

--- a/packages/domain/lauréat/src/garantiesFinancières/demander/demanderGarantiesFinancières.command.ts
+++ b/packages/domain/lauréat/src/garantiesFinancières/demander/demanderGarantiesFinancières.command.ts
@@ -4,6 +4,7 @@ import { DateTime, IdentifiantProjet } from '@potentiel-domain/common';
 
 import { LoadAggregate } from '@potentiel-domain/core';
 import { loadGarantiesFinancièresFactory } from '../garantiesFinancières.aggregate';
+import { MotifDemandeGarantiesFinancières } from '..';
 
 export type DemanderGarantiesFinancièresCommand = Message<
   'Lauréat.GarantiesFinancières.Command.DemanderGarantiesFinancières',
@@ -11,6 +12,7 @@ export type DemanderGarantiesFinancièresCommand = Message<
     identifiantProjet: IdentifiantProjet.ValueType;
     dateLimiteSoumission: DateTime.ValueType;
     demandéLe: DateTime.ValueType;
+    motif: MotifDemandeGarantiesFinancières.ValueType;
   }
 >;
 
@@ -20,6 +22,7 @@ export const registerDemanderGarantiesFinancièresCommand = (loadAggregate: Load
     identifiantProjet,
     dateLimiteSoumission,
     demandéLe,
+    motif,
   }) => {
     const garantiesFinancières = await loadGarantiesFinancières(identifiantProjet, false);
 
@@ -27,6 +30,7 @@ export const registerDemanderGarantiesFinancièresCommand = (loadAggregate: Load
       identifiantProjet,
       dateLimiteSoumission,
       demandéLe,
+      motif,
     });
   };
   mediator.register('Lauréat.GarantiesFinancières.Command.DemanderGarantiesFinancières', handler);

--- a/packages/domain/lauréat/src/garantiesFinancières/demander/demanderGarantiesFinancières.usecase.ts
+++ b/packages/domain/lauréat/src/garantiesFinancières/demander/demanderGarantiesFinancières.usecase.ts
@@ -1,6 +1,7 @@
 import { Message, MessageHandler, mediator } from 'mediateur';
 import { DateTime, IdentifiantProjet } from '@potentiel-domain/common';
 import { DemanderGarantiesFinancièresCommand } from './demanderGarantiesFinancières.command';
+import { MotifDemandeGarantiesFinancières } from '..';
 
 export type DemanderGarantiesFinancièresUseCase = Message<
   'Lauréat.GarantiesFinancières.UseCase.DemanderGarantiesFinancières',
@@ -8,6 +9,7 @@ export type DemanderGarantiesFinancièresUseCase = Message<
     identifiantProjetValue: string;
     dateLimiteSoumissionValue: string;
     demandéLeValue: string;
+    motifValue: string;
   }
 >;
 
@@ -16,10 +18,12 @@ export const registerDemanderGarantiesFinancièresUseCase = () => {
     identifiantProjetValue,
     dateLimiteSoumissionValue,
     demandéLeValue,
+    motifValue,
   }) => {
     const identifiantProjet = IdentifiantProjet.convertirEnValueType(identifiantProjetValue);
     const dateLimiteSoumission = DateTime.convertirEnValueType(dateLimiteSoumissionValue);
     const demandéLe = DateTime.convertirEnValueType(demandéLeValue);
+    const motif = MotifDemandeGarantiesFinancières.convertirEnValueType(motifValue);
 
     await mediator.send<DemanderGarantiesFinancièresCommand>({
       type: 'Lauréat.GarantiesFinancières.Command.DemanderGarantiesFinancières',
@@ -27,6 +31,7 @@ export const registerDemanderGarantiesFinancièresUseCase = () => {
         dateLimiteSoumission,
         identifiantProjet,
         demandéLe,
+        motif,
       },
     });
   };

--- a/packages/domain/lauréat/src/garantiesFinancières/dépôt/supprimerDépôtEnCours/supprimerDépôtGarantiesFinancièresEnCours.behavior.ts
+++ b/packages/domain/lauréat/src/garantiesFinancières/dépôt/supprimerDépôtEnCours/supprimerDépôtGarantiesFinancièresEnCours.behavior.ts
@@ -24,7 +24,7 @@ export async function supprimerDépôtGarantiesFinancièresEnCours(
   this: GarantiesFinancièresAggregate,
   { suppriméLe, identifiantProjet, suppriméPar }: Options,
 ) {
-  if (!this.dépôtEnCours) {
+  if (!this.dépôts?.some((dépôt) => dépôt.statut.estEnCours())) {
     throw new AucunDépôtEnCoursGarantiesFinancièresPourLeProjetError();
   }
   const event: DépôtGarantiesFinancièresEnCoursSuppriméEvent = {
@@ -40,5 +40,5 @@ export async function supprimerDépôtGarantiesFinancièresEnCours(
 }
 
 export function applyDépôtGarantiesFinancièresEnCoursSupprimé(this: GarantiesFinancièresAggregate) {
-  this.dépôtEnCours = undefined;
+  this.dépôts = this.dépôts?.filter((dépôt) => !dépôt.statut.estEnCours());
 }

--- a/packages/domain/lauréat/src/garantiesFinancières/dépôt/validerDépôtEnCours/validerDépôtGarantiesFinancièresEnCours.behavior.ts
+++ b/packages/domain/lauréat/src/garantiesFinancières/dépôt/validerDépôtEnCours/validerDépôtGarantiesFinancièresEnCours.behavior.ts
@@ -43,14 +43,14 @@ export function applyDépôtGarantiesFinancièresEnCoursValidé(
   this: GarantiesFinancièresAggregate,
   { payload: { validéLe } }: DépôtGarantiesFinancièresEnCoursValidéEvent,
 ) {
-  const dépôtValidé = this.dépôts!.find((dépôt) => dépôt.statut.estEnCours());
+  const dépôtValidé = this.dépôts && this.dépôts.find((dépôt) => dépôt.statut.estEnCours());
 
   this.actuelles = {
-    type: dépôtValidé!.type,
-    ...(dépôtValidé!.dateÉchéance && { dateÉchéance: dépôtValidé!.dateÉchéance }),
-    dateConstitution: dépôtValidé!.dateConstitution,
+    type: dépôtValidé ? dépôtValidé.type : 'type-inconnu',
+    ...(dépôtValidé && dépôtValidé.dateÉchéance && { dateÉchéance: dépôtValidé!.dateÉchéance }),
+    dateConstitution: dépôtValidé && dépôtValidé.dateConstitution,
     validéLe: DateTime.convertirEnValueType(validéLe),
-    attestation: dépôtValidé!.attestation,
+    attestation: dépôtValidé && dépôtValidé.attestation,
   };
-  this.dépôts = this.dépôts!.filter((dépôt) => !dépôt.statut.estEnCours());
+  this.dépôts = this.dépôts && this.dépôts.filter((dépôt) => !dépôt.statut.estEnCours());
 }

--- a/packages/domain/lauréat/src/garantiesFinancières/effacerHistorique/effacerHistoriqueGarantiesFinancières.behavior.ts
+++ b/packages/domain/lauréat/src/garantiesFinancières/effacerHistorique/effacerHistoriqueGarantiesFinancières.behavior.ts
@@ -1,0 +1,51 @@
+import { DateTime, IdentifiantProjet } from '@potentiel-domain/common';
+import { DomainEvent, NotFoundError } from '@potentiel-domain/core';
+
+import { GarantiesFinancièresAggregate } from '../garantiesFinancières.aggregate';
+import { IdentifiantUtilisateur } from '@potentiel-domain/utilisateur';
+
+export type HistoriqueGarantiesFinancièresEffacéEvent = DomainEvent<
+  'HistoriqueGarantiesFinancièresEffacé-V1',
+  {
+    identifiantProjet: IdentifiantProjet.RawType;
+    effacéLe: DateTime.RawType;
+    effacéPar: IdentifiantUtilisateur.RawType;
+  }
+>;
+
+export type Options = {
+  identifiantProjet: IdentifiantProjet.ValueType;
+  effacéLe: DateTime.ValueType;
+  effacéPar: IdentifiantUtilisateur.ValueType;
+};
+
+export async function effacerHistorique(
+  this: GarantiesFinancièresAggregate,
+  { identifiantProjet, effacéLe, effacéPar }: Options,
+) {
+  if (!this.actuelles && !this.dépôts?.length) {
+    throw new AucunHistoriqueÀEffacerError();
+  }
+
+  const event: HistoriqueGarantiesFinancièresEffacéEvent = {
+    type: 'HistoriqueGarantiesFinancièresEffacé-V1',
+    payload: {
+      identifiantProjet: identifiantProjet.formatter(),
+      effacéLe: effacéLe.formatter(),
+      effacéPar: effacéPar.formatter(),
+    },
+  };
+
+  await this.publish(event);
+}
+
+export function applyEffacerHistoriqueGarantiesFinancières(this: GarantiesFinancièresAggregate) {
+  this.actuelles = undefined;
+  this.dépôts = [];
+}
+
+class AucunHistoriqueÀEffacerError extends NotFoundError {
+  constructor() {
+    super(`Il n'y a aucunes garanties financières sur ce projet`);
+  }
+}

--- a/packages/domain/lauréat/src/garantiesFinancières/effacerHistorique/effacerHistoriqueGarantiesFinancières.command.ts
+++ b/packages/domain/lauréat/src/garantiesFinancières/effacerHistorique/effacerHistoriqueGarantiesFinancières.command.ts
@@ -1,0 +1,38 @@
+import { Message, MessageHandler, mediator } from 'mediateur';
+
+import { DateTime, IdentifiantProjet } from '@potentiel-domain/common';
+
+import { LoadAggregate } from '@potentiel-domain/core';
+import { loadGarantiesFinancièresFactory } from '../garantiesFinancières.aggregate';
+import { IdentifiantUtilisateur } from '@potentiel-domain/utilisateur';
+
+export type EffacerHistoriqueGarantiesFinancièresCommand = Message<
+  'Lauréat.GarantiesFinancières.Command.EffacerHistoriqueGarantiesFinancières',
+  {
+    identifiantProjet: IdentifiantProjet.ValueType;
+    effacéPar: IdentifiantUtilisateur.ValueType;
+    effacéLe: DateTime.ValueType;
+  }
+>;
+
+export const registerEffacerHistoriqueGarantiesFinancièresCommand = (
+  loadAggregate: LoadAggregate,
+) => {
+  const loadGarantiesFinancières = loadGarantiesFinancièresFactory(loadAggregate);
+  const handler: MessageHandler<EffacerHistoriqueGarantiesFinancièresCommand> = async ({
+    identifiantProjet,
+    effacéLe,
+    effacéPar,
+  }) => {
+    const garantiesFinancières = await loadGarantiesFinancières(identifiantProjet, false);
+    await garantiesFinancières.effacerHistorique({
+      identifiantProjet,
+      effacéLe,
+      effacéPar,
+    });
+  };
+  mediator.register(
+    'Lauréat.GarantiesFinancières.Command.EffacerHistoriqueGarantiesFinancières',
+    handler,
+  );
+};

--- a/packages/domain/lauréat/src/garantiesFinancières/effacerHistorique/effacerHistoriqueGarantiesFinancières.usecase.ts
+++ b/packages/domain/lauréat/src/garantiesFinancières/effacerHistorique/effacerHistoriqueGarantiesFinancières.usecase.ts
@@ -1,0 +1,38 @@
+import { Message, MessageHandler, mediator } from 'mediateur';
+import { DateTime, IdentifiantProjet } from '@potentiel-domain/common';
+import { EffacerHistoriqueGarantiesFinancièresCommand } from './effacerHistoriqueGarantiesFinancières.command';
+import { IdentifiantUtilisateur } from '@potentiel-domain/utilisateur';
+
+export type EffacerHistoriqueGarantiesFinancièresUseCase = Message<
+  'Lauréat.GarantiesFinancières.UseCase.EffacerHistoriqueGarantiesFinancières',
+  {
+    identifiantProjetValue: string;
+    effacéLeValue: string;
+    effacéParValue: string;
+  }
+>;
+
+export const registerEffacerHistoriqueGarantiesFinancièresUseCase = () => {
+  const runner: MessageHandler<EffacerHistoriqueGarantiesFinancièresUseCase> = async ({
+    identifiantProjetValue,
+    effacéLeValue,
+    effacéParValue,
+  }) => {
+    const identifiantProjet = IdentifiantProjet.convertirEnValueType(identifiantProjetValue);
+    const effacéLe = DateTime.convertirEnValueType(effacéLeValue);
+    const effacéPar = IdentifiantUtilisateur.convertirEnValueType(effacéParValue);
+
+    await mediator.send<EffacerHistoriqueGarantiesFinancièresCommand>({
+      type: 'Lauréat.GarantiesFinancières.Command.EffacerHistoriqueGarantiesFinancières',
+      data: {
+        identifiantProjet,
+        effacéLe,
+        effacéPar,
+      },
+    });
+  };
+  mediator.register(
+    'Lauréat.GarantiesFinancières.UseCase.EffacerHistoriqueGarantiesFinancières',
+    runner,
+  );
+};

--- a/packages/domain/lauréat/src/garantiesFinancières/garantiesFinancières.aggregate.ts
+++ b/packages/domain/lauréat/src/garantiesFinancières/garantiesFinancières.aggregate.ts
@@ -6,7 +6,7 @@ import {
   applyDépôtGarantiesFinancièresSoumis,
   soumettreDépôt,
 } from './dépôt/soumettreDépôt/soumettreDépôtGarantiesFinancières.behavior';
-import { TypeGarantiesFinancières } from '.';
+import { StatutDépôtGarantiesFinancières, TypeGarantiesFinancières } from '.';
 import { AucunesGarantiesFinancièresPourLeProjetError } from './aucunesGarantiesFinancièresPourLeProjet.error';
 import {
   GarantiesFinancièresDemandéesEvent,
@@ -47,6 +47,11 @@ import {
   applyEnregistrerGarantiesFinancières,
   enregistrer,
 } from './enregistrer/enregistrerGarantiesFinancières.behavior';
+import {
+  HistoriqueGarantiesFinancièresEffacéEvent,
+  applyEffacerHistoriqueGarantiesFinancières,
+  effacerHistorique,
+} from './effacerHistorique/effacerHistoriqueGarantiesFinancières.behavior';
 
 export type GarantiesFinancièresEvent =
   | DépôtGarantiesFinancièresSoumisEvent
@@ -57,7 +62,8 @@ export type GarantiesFinancièresEvent =
   | TypeGarantiesFinancièresImportéEvent
   | GarantiesFinancièresModifiéesEvent
   | AttestationGarantiesFinancièresEnregistréeEvent
-  | GarantiesFinancièresEnregistréesEvent;
+  | GarantiesFinancièresEnregistréesEvent
+  | HistoriqueGarantiesFinancièresEffacéEvent;
 
 export type GarantiesFinancièresAggregate = Aggregate<GarantiesFinancièresEvent> & {
   actuelles?: {
@@ -68,13 +74,14 @@ export type GarantiesFinancièresAggregate = Aggregate<GarantiesFinancièresEven
     validéLe?: DateTime.ValueType;
     importéLe?: DateTime.ValueType;
   };
-  dépôtEnCours?: {
+  dépôts?: Array<{
+    statut: StatutDépôtGarantiesFinancières.ValueType;
     type: TypeGarantiesFinancières.ValueType | 'type-inconnu';
     dateÉchéance?: DateTime.ValueType;
     dateConstitution: DateTime.ValueType;
     soumisLe: DateTime.ValueType;
     attestation?: { format: string };
-  };
+  }>;
   readonly soumettreDépôt: typeof soumettreDépôt;
   readonly demanderGarantiesFinancières: typeof demanderGarantiesFinancières;
   readonly supprimerDépôtGarantiesFinancièresEnCours: typeof supprimerDépôtGarantiesFinancièresEnCours;
@@ -84,6 +91,7 @@ export type GarantiesFinancièresAggregate = Aggregate<GarantiesFinancièresEven
   readonly modifier: typeof modifier;
   readonly enregistrerAttestation: typeof enregistrerAttestation;
   readonly enregistrer: typeof enregistrer;
+  readonly effacerHistorique: typeof effacerHistorique;
 };
 
 export const getDefaultGarantiesFinancièresAggregate: GetDefaultAggregateState<
@@ -100,6 +108,7 @@ export const getDefaultGarantiesFinancièresAggregate: GetDefaultAggregateState<
   modifier,
   enregistrerAttestation,
   enregistrer,
+  effacerHistorique,
 });
 
 function apply(this: GarantiesFinancièresAggregate, event: GarantiesFinancièresEvent) {
@@ -127,6 +136,9 @@ function apply(this: GarantiesFinancièresAggregate, event: GarantiesFinancière
       break;
     case 'GarantiesFinancièresEnregistrées-V1':
       applyEnregistrerGarantiesFinancières.bind(this)(event);
+      break;
+    case 'HistoriqueGarantiesFinancièresEffacé-V1':
+      applyEffacerHistoriqueGarantiesFinancières.bind(this)();
       break;
   }
 }

--- a/packages/domain/lauréat/src/garantiesFinancières/garantiesFinancières.entity.ts
+++ b/packages/domain/lauréat/src/garantiesFinancières/garantiesFinancières.entity.ts
@@ -19,7 +19,7 @@ export type GarantiesFinancièresEntity = Entity<
       typeImportéLe?: string;
       dernièreMiseÀJour: {
         date: string;
-        par: string;
+        par?: string;
       };
     };
     dépôts: Array<{

--- a/packages/domain/lauréat/src/garantiesFinancières/garantiesFinancières.entity.ts
+++ b/packages/domain/lauréat/src/garantiesFinancières/garantiesFinancières.entity.ts
@@ -19,7 +19,7 @@ export type GarantiesFinancièresEntity = Entity<
       typeImportéLe?: string;
       dernièreMiseÀJour: {
         date: string;
-        par?: string;
+        par: string;
       };
     };
     dépôts: Array<{

--- a/packages/domain/lauréat/src/garantiesFinancières/garantiesFinancières.register.ts
+++ b/packages/domain/lauréat/src/garantiesFinancières/garantiesFinancières.register.ts
@@ -25,6 +25,8 @@ import {
   ListerDépôtsEnCoursGarantiesFinancièresDependencies,
   registerListerDépôtsEnCoursGarantiesFinancièresQuery,
 } from './dépôt/lister/listerDépôtsEnCoursGarantiesFinancières.query';
+import { registerEffacerHistoriqueGarantiesFinancièresCommand } from './effacerHistorique/effacerHistoriqueGarantiesFinancières.command';
+import { registerEffacerHistoriqueGarantiesFinancièresUseCase } from './effacerHistorique/effacerHistoriqueGarantiesFinancières.usecase';
 
 export type GarantiesFinancièresQueryDependencies = ConsulterGarantiesFinancièresDependencies &
   ListerDépôtsEnCoursGarantiesFinancièresDependencies;
@@ -45,6 +47,7 @@ export const registerGarantiesFinancièresUseCases = ({
   registerModifierGarantiesFinancièresCommand(loadAggregate);
   registerEnregistrerAttestationGarantiesFinancièresCommand(loadAggregate);
   registerEnregistrerGarantiesFinancièresCommand(loadAggregate);
+  registerEffacerHistoriqueGarantiesFinancièresCommand(loadAggregate);
 
   registerSoumettreDépôtGarantiesFinancièresUseCase();
   registerDemanderGarantiesFinancièresUseCase();
@@ -55,6 +58,7 @@ export const registerGarantiesFinancièresUseCases = ({
   registerModifierGarantiesFinancièresUseCase();
   registerEnregistrerAttestationGarantiesFinancièresUseCase();
   registerEnregistrerGarantiesFinancièresUseCase();
+  registerEffacerHistoriqueGarantiesFinancièresUseCase();
 };
 
 export const registerGarantiesFinancièresQueries = (

--- a/packages/domain/lauréat/src/garantiesFinancières/importer/importerTypeGarantiesFinancières.behavior.ts
+++ b/packages/domain/lauréat/src/garantiesFinancières/importer/importerTypeGarantiesFinancières.behavior.ts
@@ -3,7 +3,6 @@ import { DomainEvent } from '@potentiel-domain/core';
 
 import { TypeGarantiesFinancières } from '..';
 import { GarantiesFinancièresAggregate } from '../garantiesFinancières.aggregate';
-import { IdentifiantUtilisateur } from '@potentiel-domain/utilisateur';
 import { DateÉchéanceManquanteError } from '../dateÉchéanceManquante.error';
 import { DateÉchéanceNonAttendueError } from '../dateÉchéanceNonAttendue.error';
 
@@ -14,7 +13,6 @@ export type TypeGarantiesFinancièresImportéEvent = DomainEvent<
     type: TypeGarantiesFinancières.RawType;
     dateÉchéance?: DateTime.RawType;
     importéLe: DateTime.RawType;
-    importéPar: IdentifiantUtilisateur.RawType;
   }
 >;
 
@@ -23,12 +21,11 @@ export type Options = {
   type: TypeGarantiesFinancières.ValueType;
   dateÉchéance?: DateTime.ValueType;
   importéLe: DateTime.ValueType;
-  importéPar: IdentifiantUtilisateur.ValueType;
 };
 
 export async function importerType(
   this: GarantiesFinancièresAggregate,
-  { identifiantProjet, type, dateÉchéance, importéLe, importéPar }: Options,
+  { identifiantProjet, type, dateÉchéance, importéLe }: Options,
 ) {
   if (type.estAvecDateÉchéance() && !dateÉchéance) {
     throw new DateÉchéanceManquanteError();
@@ -43,7 +40,6 @@ export async function importerType(
       type: type.type,
       dateÉchéance: dateÉchéance?.formatter(),
       importéLe: importéLe.formatter(),
-      importéPar: importéPar.formatter(),
     },
   };
 

--- a/packages/domain/lauréat/src/garantiesFinancières/importer/importerTypeGarantiesFinancières.command.ts
+++ b/packages/domain/lauréat/src/garantiesFinancières/importer/importerTypeGarantiesFinancières.command.ts
@@ -5,7 +5,6 @@ import { DateTime, IdentifiantProjet } from '@potentiel-domain/common';
 import { LoadAggregate } from '@potentiel-domain/core';
 import { TypeGarantiesFinancières } from '..';
 import { loadGarantiesFinancièresFactory } from '../garantiesFinancières.aggregate';
-import { IdentifiantUtilisateur } from '@potentiel-domain/utilisateur';
 
 export type ImporterTypeGarantiesFinancièresCommand = Message<
   'Lauréat.GarantiesFinancières.Command.ImporterTypeGarantiesFinancières',
@@ -14,7 +13,6 @@ export type ImporterTypeGarantiesFinancièresCommand = Message<
     type: TypeGarantiesFinancières.ValueType;
     dateÉchéance?: DateTime.ValueType;
     importéLe: DateTime.ValueType;
-    importéPar: IdentifiantUtilisateur.ValueType;
   }
 >;
 
@@ -25,7 +23,6 @@ export const registerImporterTypeGarantiesFinancièresCommand = (loadAggregate: 
     importéLe,
     type,
     dateÉchéance,
-    importéPar,
   }) => {
     const garantiesFinancières = await loadGarantiesFinancières(identifiantProjet, false);
 
@@ -34,7 +31,6 @@ export const registerImporterTypeGarantiesFinancièresCommand = (loadAggregate: 
       importéLe,
       type,
       dateÉchéance,
-      importéPar,
     });
   };
   mediator.register(

--- a/packages/domain/lauréat/src/garantiesFinancières/importer/importerTypeGarantiesFinancières.usecase.ts
+++ b/packages/domain/lauréat/src/garantiesFinancières/importer/importerTypeGarantiesFinancières.usecase.ts
@@ -1,7 +1,6 @@
 import { Message, MessageHandler, mediator } from 'mediateur';
 import { DateTime, IdentifiantProjet } from '@potentiel-domain/common';
 import { TypeGarantiesFinancières } from '..';
-import { IdentifiantUtilisateur } from '@potentiel-domain/utilisateur';
 import { ImporterTypeGarantiesFinancièresCommand } from './importerTypeGarantiesFinancières.command';
 
 export type ImporterTypeGarantiesFinancièresUseCase = Message<
@@ -11,7 +10,6 @@ export type ImporterTypeGarantiesFinancièresUseCase = Message<
     typeValue: string;
     dateÉchéanceValue?: string;
     importéLeValue: string;
-    importéParValue: string;
   }
 >;
 
@@ -21,7 +19,6 @@ export const registerImporterTypeGarantiesFinancièresUseCase = () => {
     typeValue,
     dateÉchéanceValue,
     importéLeValue,
-    importéParValue,
   }) => {
     const identifiantProjet = IdentifiantProjet.convertirEnValueType(identifiantProjetValue);
     const type = TypeGarantiesFinancières.convertirEnValueType(typeValue);
@@ -29,11 +26,10 @@ export const registerImporterTypeGarantiesFinancièresUseCase = () => {
       ? DateTime.convertirEnValueType(dateÉchéanceValue)
       : undefined;
     const importéLe = DateTime.convertirEnValueType(importéLeValue);
-    const importéPar = IdentifiantUtilisateur.convertirEnValueType(importéParValue);
 
     await mediator.send<ImporterTypeGarantiesFinancièresCommand>({
       type: 'Lauréat.GarantiesFinancières.Command.ImporterTypeGarantiesFinancières',
-      data: { identifiantProjet, importéLe, importéPar, type, dateÉchéance },
+      data: { identifiantProjet, importéLe, type, dateÉchéance },
     });
   };
 

--- a/packages/domain/lauréat/src/garantiesFinancières/index.ts
+++ b/packages/domain/lauréat/src/garantiesFinancières/index.ts
@@ -73,6 +73,7 @@ export * as GarantiesFinancières from './garantiesFinancières.valueType';
 export * as TypeGarantiesFinancières from './typeGarantiesFinancières.valueType';
 export * as TypeDocumentGarantiesFinancières from './typeDocumentGarantiesFinancières.valueType';
 export * as StatutDépôtGarantiesFinancières from './statutDépôtGarantiesFinancières.valueType';
+export * as MotifDemandeGarantiesFinancières from './motifDemandeGarantiesFinancières.valueType';
 
 // Projections
 export * from './garantiesFinancières.entity';

--- a/packages/domain/lauréat/src/garantiesFinancières/index.ts
+++ b/packages/domain/lauréat/src/garantiesFinancières/index.ts
@@ -16,6 +16,7 @@ import { ImporterTypeGarantiesFinancièresUseCase } from './importer/importerTyp
 import { ModifierGarantiesFinancièresUseCase } from './modifier/modifierGarantiesFinancières.usecase';
 import { EnregistrerAttestationGarantiesFinancièresUseCase } from './enregistrerAttestation/enregistrerAttestationGarantiesFinancières.usecase';
 import { EnregistrerGarantiesFinancièresUseCase } from './enregistrer/enregistrerGarantiesFinancières.usecase';
+import { EffacerHistoriqueGarantiesFinancièresUseCase } from './effacerHistorique/effacerHistoriqueGarantiesFinancières.usecase';
 
 // Query
 export type GarantiesFinancièresQuery =
@@ -37,7 +38,8 @@ export type GarantiesFinancièresUseCase =
   | ImporterTypeGarantiesFinancièresUseCase
   | ModifierGarantiesFinancièresUseCase
   | EnregistrerAttestationGarantiesFinancièresUseCase
-  | EnregistrerGarantiesFinancièresUseCase;
+  | EnregistrerGarantiesFinancièresUseCase
+  | EffacerHistoriqueGarantiesFinancièresUseCase;
 
 export {
   SoumettreDépôtGarantiesFinancièresUseCase,
@@ -49,6 +51,7 @@ export {
   ModifierGarantiesFinancièresUseCase,
   EnregistrerAttestationGarantiesFinancièresUseCase,
   EnregistrerGarantiesFinancièresUseCase,
+  EffacerHistoriqueGarantiesFinancièresUseCase,
 };
 
 // Event
@@ -61,6 +64,7 @@ export { DépôtGarantiesFinancièresEnCoursModifiéEvent } from './dépôt/modi
 export { TypeGarantiesFinancièresImportéEvent } from './importer/importerTypeGarantiesFinancières.behavior';
 export { GarantiesFinancièresModifiéesEvent } from './modifier/modifierGarantiesFinancières.behavior';
 export { AttestationGarantiesFinancièresEnregistréeEvent } from './enregistrerAttestation/enregistrerAttestationGarantiesFinancières.behavior';
+export { HistoriqueGarantiesFinancièresEffacéEvent } from './effacerHistorique/effacerHistoriqueGarantiesFinancières.behavior';
 
 // Register
 export {

--- a/packages/domain/lauréat/src/garantiesFinancières/motifDemandeGarantiesFinancières.valueType.ts
+++ b/packages/domain/lauréat/src/garantiesFinancières/motifDemandeGarantiesFinancières.valueType.ts
@@ -1,0 +1,68 @@
+import { InvalidOperationError, ReadonlyValueType } from '@potentiel-domain/core';
+
+export const motifs = [
+  'recours-accordé',
+  'changement-producteur',
+  'échéance-garanties-financières-actuelles',
+  'garanties-financières-initiales',
+] as const;
+
+export type RawType = (typeof motifs)[number];
+
+export type ValueType = ReadonlyValueType<{
+  motif: RawType;
+  estRecoursAccordé: () => boolean;
+  estChangementProducteur: () => boolean;
+  estÉchéance: () => boolean;
+  estGarantiesFinancièresInitiales: () => boolean;
+}>;
+
+export const convertirEnValueType = (value: string): ValueType => {
+  estValide(value);
+  return {
+    get motif() {
+      return value;
+    },
+    estÉgaleÀ(valueType) {
+      return this.motif === valueType.motif;
+    },
+    estRecoursAccordé() {
+      return this.motif === 'recours-accordé';
+    },
+    estChangementProducteur() {
+      return this.motif === 'changement-producteur';
+    },
+    estÉchéance() {
+      return this.motif === 'échéance-garanties-financières-actuelles';
+    },
+
+    estGarantiesFinancièresInitiales() {
+      return this.motif === 'garanties-financières-initiales';
+    },
+  };
+};
+
+function estValide(value: string): asserts value is RawType {
+  const isValid = motifs.includes(value as RawType);
+
+  if (!isValid) {
+    throw new MotifDemandeGarantiesFinancièresInvalideError(value);
+  }
+}
+
+export const recoursAccordé = convertirEnValueType('recours-accordé');
+export const changementProducteur = convertirEnValueType('changement-producteur');
+export const échéanceGarantiesFinancièresActuelles = convertirEnValueType(
+  'échéance-garanties-financières-actuelles',
+);
+export const garantiesFinancièresInitiales = convertirEnValueType(
+  'garanties-financières-initiales',
+);
+
+class MotifDemandeGarantiesFinancièresInvalideError extends InvalidOperationError {
+  constructor(value: string) {
+    super(`Le motif ne correspond à aucune valeur connue`, {
+      value,
+    });
+  }
+}

--- a/packages/domain/utilisateur/src/role.valueType.ts
+++ b/packages/domain/utilisateur/src/role.valueType.ts
@@ -133,6 +133,8 @@ const référencielPermissions = {
         modifier: 'Lauréat.GarantiesFinancières.UseCase.ModifierGarantiesFinancières',
         enregistrerAttestation: 'Lauréat.GarantiesFinancières.UseCase.EnregistrerAttestation',
         enregistrer: 'Lauréat.GarantiesFinancières.UseCase.EnregistrerGarantiesFinancières',
+        effacerHistorique:
+          'Lauréat.GarantiesFinancières.UseCase.EffacerHistoriqueGarantiesFinancières',
       },
       command: {
         demander: 'Lauréat.GarantiesFinancières.Command.DemanderGarantiesFinancières',
@@ -146,6 +148,8 @@ const référencielPermissions = {
         modifier: 'Lauréat.GarantiesFinancières.Command.ModifierGarantiesFinancières',
         enregistrerAttestation: 'Lauréat.GarantiesFinancières.Command.EnregistrerAttestation',
         enregistrer: 'Lauréat.GarantiesFinancières.Command.EnregistrerGarantiesFinancières',
+        effacerHistorique:
+          'Lauréat.GarantiesFinancières.Command.EffacerHistoriqueGarantiesFinancières',
       },
     },
   },
@@ -448,6 +452,10 @@ const policies = {
       référencielPermissions.appelOffre.query.consulter,
       référencielPermissions.lauréat.garantiesFinancières.query.consulter,
     ],
+    effacerHistorique: [
+      référencielPermissions.lauréat.garantiesFinancières.usecase.effacerHistorique,
+      référencielPermissions.lauréat.garantiesFinancières.command.effacerHistorique,
+    ],
     dépôt: {
       demander: [
         référencielPermissions.lauréat.garantiesFinancières.usecase.demander,
@@ -545,6 +553,7 @@ const permissionAdmin = [
   ...policies.garantiesFinancières.actuelles.modifier,
   ...policies.garantiesFinancières.actuelles.enregistrerAttestation,
   ...policies.garantiesFinancières.actuelles.enregistrer,
+  ...policies.garantiesFinancières.effacerHistorique,
 ];
 
 const permissionCRE = [
@@ -579,6 +588,7 @@ const permissionDreal = [
   ...policies.garantiesFinancières.actuelles.modifier,
   ...policies.garantiesFinancières.actuelles.enregistrerAttestation,
   ...policies.garantiesFinancières.actuelles.enregistrer,
+  ...policies.garantiesFinancières.effacerHistorique,
 ];
 
 const permissionDgecValidateur = [
@@ -616,6 +626,7 @@ const permissionDgecValidateur = [
   ...policies.garantiesFinancières.actuelles.modifier,
   ...policies.garantiesFinancières.actuelles.enregistrerAttestation,
   ...policies.garantiesFinancières.actuelles.enregistrer,
+  ...policies.garantiesFinancières.effacerHistorique,
 ];
 
 const permissionPorteurProjet = [
@@ -647,6 +658,7 @@ const permissionPorteurProjet = [
   ...policies.garantiesFinancières.dépôt.supprimer,
   ...policies.garantiesFinancières.dépôt.modifier,
   ...policies.garantiesFinancières.actuelles.enregistrerAttestation,
+  ...policies.garantiesFinancières.effacerHistorique,
 ];
 
 const permissionAcheteurObligé = [

--- a/packages/specifications/src/projet/lauréat/garantiesFinancières/effacerHistoriqueGarantiesFinancières.feature
+++ b/packages/specifications/src/projet/lauréat/garantiesFinancières/effacerHistoriqueGarantiesFinancières.feature
@@ -1,0 +1,16 @@
+#Language: fr-FR
+Fonctionnalité: Effacer tout l'historique de garanties financières d'un projet
+    Contexte: 
+        Etant donné le projet lauréat "Centrale PV"
+    
+    Scénario: Un admin supprime l'historique de garanties financières d'un projet
+        Etant donné des garanties financières validées pour le projet "Centrale PV" avec :
+            | type                 | six-mois-après-achèvement |
+        Et des garanties financières à traiter pour le projet "Centrale PV" avec :
+            | type                 | consignation              |
+        Quand un admin efface l'historique des garanties financières pour le projet "Centrale PV"
+        Alors il ne devrait pas y avoir d'historique de garanties financières pour le projet "Centrale PV"                 
+
+    Scénario: Erreur s'il n'y a aucun historique de garanties financières sur le projet
+        Quand un admin efface l'historique des garanties financières pour le projet "Centrale PV"
+        Alors l'utilisateur devrait être informé que "Il n'y a aucunes garanties financières sur ce projet"          

--- a/packages/specifications/src/projet/lauréat/garantiesFinancières/effacerHistoriqueGarantiesFinancières.feature
+++ b/packages/specifications/src/projet/lauréat/garantiesFinancières/effacerHistoriqueGarantiesFinancières.feature
@@ -2,7 +2,6 @@
 Fonctionnalité: Effacer tout l'historique de garanties financières d'un projet
     Contexte: 
         Etant donné le projet lauréat "Centrale PV"
-    
     Scénario: Un admin supprime l'historique de garanties financières d'un projet
         Etant donné des garanties financières validées pour le projet "Centrale PV" avec :
             | type                 | six-mois-après-achèvement |

--- a/packages/specifications/src/projet/lauréat/garantiesFinancières/stepDefinitions/garantiesFinancières.given.ts
+++ b/packages/specifications/src/projet/lauréat/garantiesFinancières/stepDefinitions/garantiesFinancières.given.ts
@@ -121,7 +121,6 @@ EtantDonné(
         typeValue: typeGarantiesFinancières,
         ...(dateÉchéance && { dteÉchéanceValue: new Date(dateÉchéance).toISOString() }),
         importéLeValue: new Date().toISOString(),
-        importéParValue: 'admin@test.test',
       },
     });
 

--- a/packages/specifications/src/projet/lauréat/garantiesFinancières/stepDefinitions/garantiesFinancières.given.ts
+++ b/packages/specifications/src/projet/lauréat/garantiesFinancières/stepDefinitions/garantiesFinancières.given.ts
@@ -21,6 +21,7 @@ EtantDonné(
         identifiantProjetValue: identifiantProjet.formatter(),
         demandéLeValue: new Date(notifiéLe).toISOString(),
         dateLimiteSoumissionValue: new Date(dateLimiteSoumission).toISOString(),
+        motifValue: 'garanties-financières-initiales',
       },
     });
 

--- a/packages/specifications/src/projet/lauréat/garantiesFinancières/stepDefinitions/garantiesFinancières.then.ts
+++ b/packages/specifications/src/projet/lauréat/garantiesFinancières/stepDefinitions/garantiesFinancières.then.ts
@@ -165,9 +165,10 @@ Alors(
             identifiantProjetValue: identifiantProjet.formatter(),
           },
         });
-      } catch (error: any) {
+      } catch (error) {
         résultat = error;
       }
+      expect(résultat).not.to.be.undefined;
       résultat.message.should.be.equal(`Il n'y a aucunes garanties financières sur le projet`);
     });
   },

--- a/packages/specifications/src/projet/lauréat/garantiesFinancières/stepDefinitions/garantiesFinancières.then.ts
+++ b/packages/specifications/src/projet/lauréat/garantiesFinancières/stepDefinitions/garantiesFinancières.then.ts
@@ -150,3 +150,25 @@ Alors(
     });
   },
 );
+
+Alors(
+  `il ne devrait pas y avoir d'historique de garanties financières pour le projet {string}`,
+  async function (this: PotentielWorld, nomProjet: string) {
+    const { identifiantProjet } = this.lauréatWorld.rechercherLauréatFixture(nomProjet);
+
+    await waitForExpect(async () => {
+      let résultat: any;
+      try {
+        await mediator.send<GarantiesFinancières.ConsulterGarantiesFinancièresQuery>({
+          type: 'Lauréat.GarantiesFinancières.Query.ConsulterGarantiesFinancières',
+          data: {
+            identifiantProjetValue: identifiantProjet.formatter(),
+          },
+        });
+      } catch (error: any) {
+        résultat = error;
+      }
+      résultat.message.should.be.equal(`Il n'y a aucunes garanties financières sur le projet`);
+    });
+  },
+);

--- a/packages/specifications/src/projet/lauréat/garantiesFinancières/stepDefinitions/garantiesFinancières.when.ts
+++ b/packages/specifications/src/projet/lauréat/garantiesFinancières/stepDefinitions/garantiesFinancières.when.ts
@@ -137,7 +137,6 @@ Quand(
           identifiantProjetValue: identifiantProjet.formatter(),
           typeValue: typeGarantiesFinancières,
           importéLeValue: new Date(importéLe).toISOString(),
-          importéParValue: 'admin@test.test',
           ...(dateÉchéance && { dateÉchéanceValue: new Date(dateÉchéance).toISOString() }),
         },
       });

--- a/packages/specifications/src/projet/lauréat/garantiesFinancières/stepDefinitions/garantiesFinancières.when.ts
+++ b/packages/specifications/src/projet/lauréat/garantiesFinancières/stepDefinitions/garantiesFinancières.when.ts
@@ -244,3 +244,24 @@ Quand(
     }
   },
 );
+
+Quand(
+  `un admin efface l'historique des garanties financières pour le projet {string}`,
+  async function (this: PotentielWorld, nomProjet: string) {
+    try {
+      const { identifiantProjet } = this.lauréatWorld.rechercherLauréatFixture(nomProjet);
+
+      await mediator.send<GarantiesFinancières.EffacerHistoriqueGarantiesFinancièresUseCase>({
+        type: 'Lauréat.GarantiesFinancières.UseCase.EffacerHistoriqueGarantiesFinancières',
+        data: {
+          identifiantProjetValue: identifiantProjet.formatter(),
+          effacéLeValue: new Date().toISOString(),
+          effacéParValue: 'admin@test.test',
+        },
+      });
+      await sleep(500);
+    } catch (error) {
+      this.error = error as Error;
+    }
+  },
+);


### PR DESCRIPTION
Cas concernés, pour tout projet soumis à GF : 
- import types avec candidature si projet classé > le projet devrait avoir des GF actuelles validées en attente de l'attestation de constitution
- import types avec candidature si projet éliminé > le projet ne devrait pas avoir de GF
- recours accordé > le projet devrait avoir des GF en attente*, et le porteur devrait pouvoir soumettre des GF
- changement de producteur > l'historique des GF du projet (actuelles, dépôts, dépôt en cours) devrait être effacé et le projet devrait avoir des GF en attente*, et le porteur devrait pouvoir soumettre des GF 
- changement d'actionnaire : enregistrer ou envoyer demande selon état GF (voir specs requestActionnaireModification)

*GF en attente : pour le moment il n'y a pas de tâche ou de projection à vérifier, mais on faut s'assurer que l'event "GF demandées" est bien publié dans le store. 