### PR TITLE
🐛 Redéfinir la notion de validateur par défaut

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4864,6 +4864,66 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.0.4.tgz",
+      "integrity": "sha512-mF05E/5uPthWzyYDyptcwHptucf/jj09i2SXBPwNzbgBNc+XnwzrL0U6BmPjQeOL+FiB+iG1gwBeq7mlDjSRPg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.0.4.tgz",
+      "integrity": "sha512-IZQ3C7Bx0k2rYtrZZxKKiusMTM9WWcK5ajyhOZkYYTCc8xytmwSzR1skU7qLgVT/EY9xtXDG0WhY6fyujnI3rw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.0.4.tgz",
+      "integrity": "sha512-VwwZKrBQo/MGb1VOrxJ6LrKvbpo7UbROuyMRvQKTFKhNaXjUmKTu7wxVkIuCARAfiI8JpaWAnKR+D6tzpCcM4w==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.0.4.tgz",
+      "integrity": "sha512-8QftwPEW37XxXoAwsn+nXlodKWHfpMaSvt81W43Wh8dv0gkheD+30ezWMcFGHLI71KiWmHK5PSQbTQGUiidvLQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@next/swc-linux-x64-gnu": {
       "version": "14.0.4",
       "cpu": [
@@ -4887,6 +4947,51 @@
       "optional": true,
       "os": [
         "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.0.4.tgz",
+      "integrity": "sha512-7Wv4PRiWIAWbm5XrGz3D8HUkCVDMMz9igffZG4NB1p4u1KoItwx9qjATHz88kwCEal/HXmbShucaslXCQXUM5w==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.0.4.tgz",
+      "integrity": "sha512-zLeNEAPULsl0phfGb4kdzF/cAVIfaC7hY+kt0/d+y9mzcZHsMS3hAS829WbJ31DkSlVKQeHEjZHIdhN+Pg7Gyg==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.0.4.tgz",
+      "integrity": "sha512-yEh2+R8qDlDCjxVpzOTEpBLQTEFAcP2A8fUFLaWNap9GitYKkKv1//y2S6XY6zsR4rCOPRpU7plYDR+az2n30A==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">= 10"
@@ -28659,111 +28764,6 @@
         "@potentiel-config/tsconfig": "*",
         "@types/chai": "^4.3.5",
         "chai": "^4.3.8"
-      }
-    },
-    "node_modules/@next/swc-darwin-arm64": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.0.4.tgz",
-      "integrity": "sha512-mF05E/5uPthWzyYDyptcwHptucf/jj09i2SXBPwNzbgBNc+XnwzrL0U6BmPjQeOL+FiB+iG1gwBeq7mlDjSRPg==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-darwin-x64": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.0.4.tgz",
-      "integrity": "sha512-IZQ3C7Bx0k2rYtrZZxKKiusMTM9WWcK5ajyhOZkYYTCc8xytmwSzR1skU7qLgVT/EY9xtXDG0WhY6fyujnI3rw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.0.4.tgz",
-      "integrity": "sha512-VwwZKrBQo/MGb1VOrxJ6LrKvbpo7UbROuyMRvQKTFKhNaXjUmKTu7wxVkIuCARAfiI8JpaWAnKR+D6tzpCcM4w==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.0.4.tgz",
-      "integrity": "sha512-8QftwPEW37XxXoAwsn+nXlodKWHfpMaSvt81W43Wh8dv0gkheD+30ezWMcFGHLI71KiWmHK5PSQbTQGUiidvLQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.0.4.tgz",
-      "integrity": "sha512-7Wv4PRiWIAWbm5XrGz3D8HUkCVDMMz9igffZG4NB1p4u1KoItwx9qjATHz88kwCEal/HXmbShucaslXCQXUM5w==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.0.4.tgz",
-      "integrity": "sha512-zLeNEAPULsl0phfGb4kdzF/cAVIfaC7hY+kt0/d+y9mzcZHsMS3hAS829WbJ31DkSlVKQeHEjZHIdhN+Pg7Gyg==",
-      "cpu": [
-        "ia32"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.0.4.tgz",
-      "integrity": "sha512-yEh2+R8qDlDCjxVpzOTEpBLQTEFAcP2A8fUFLaWNap9GitYKkKv1//y2S6XY6zsR4rCOPRpU7plYDR+az2n30A==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
       }
     }
   }

--- a/packages/applications/legacy/src/config/useCases.config.ts
+++ b/packages/applications/legacy/src/config/useCases.config.ts
@@ -92,6 +92,7 @@ export const shouldUserAccessProject = new BaseShouldUserAccessProject(
 export const generateCertificate = makeGenerateCertificate({
   fileRepo,
   projectRepo,
+  findAppelOffreById: oldAppelOffreRepo.findById,
   buildCertificate,
   getUserById,
 });

--- a/packages/applications/legacy/src/modules/project/useCases/generateCertificate.spec.ts
+++ b/packages/applications/legacy/src/modules/project/useCases/generateCertificate.spec.ts
@@ -2,7 +2,7 @@ import { beforeAll, describe, expect, it, jest } from '@jest/globals';
 import { Readable } from 'stream';
 import { Repository, UniqueEntityID } from '../../../core/domain';
 import { ok, okAsync } from '../../../core/utils';
-import { CertificateTemplate } from '@potentiel-domain/appel-offre';
+import { AppelOffre, CertificateTemplate, Validateur } from '@potentiel-domain/appel-offre';
 import { fakeRepo, makeFakeProject } from '../../../__tests__/fixtures/aggregates';
 import { FileObject } from '../../file';
 import { OtherError, InfraNotAvailableError } from '../../shared';
@@ -11,8 +11,8 @@ import makeFakeUser from '../../../__tests__/fixtures/user';
 import { ProjectDataForCertificate } from '../dtos';
 import { Project } from '../Project';
 import { makeGenerateCertificate } from './generateCertificate';
-import { Validateur } from '../../../views/certificates';
 import { User } from '../../../infra/sequelize/projectionsNext';
+import { AppelOffreRepo } from '../../../dataAccess';
 
 const projectId = 'project1';
 
@@ -44,6 +44,13 @@ describe('useCase generateCertificate', () => {
     load: jest.fn(),
   };
 
+  const findAppelOffreById: AppelOffreRepo['findById'] = async () =>
+    ({
+      id: 'appelOffreId',
+      periodes: [{ id: 'periodeId', type: 'notified', choisirNouveauCahierDesCharges: true }],
+      familles: [{ id: 'familleId' }],
+    } as AppelOffre);
+
   const user = makeFakeUser({ id: validateurId, fonction: 'directeur' });
   const getUserById = jest.fn((id: string) => okAsync<User | null, InfraNotAvailableError>(user));
 
@@ -51,6 +58,7 @@ describe('useCase generateCertificate', () => {
     fileRepo: fileRepo as Repository<FileObject>,
     projectRepo,
     buildCertificate,
+    findAppelOffreById,
     getUserById,
   });
 

--- a/packages/applications/legacy/src/modules/project/useCases/generateCertificate.ts
+++ b/packages/applications/legacy/src/modules/project/useCases/generateCertificate.ts
@@ -75,8 +75,8 @@ export const makeGenerateCertificate =
           const validateurParDéfaut =
             certificateData.template === 'ppe2.v2'
               ? {
-                  fullName: 'Nicolas CLAUSSET',
-                  fonction: `Le sous-directeur du système électrique et des énergies renouvelables`,
+                  fullName: 'Hermine Durand',
+                  fonction: `Sous-directrice du système électrique et des énergies renouvelables`,
                 }
               : {
                   fullName: 'Ghislain FERRAN',

--- a/packages/applications/legacy/src/modules/project/useCases/generateCertificate.ts
+++ b/packages/applications/legacy/src/modules/project/useCases/generateCertificate.ts
@@ -70,6 +70,7 @@ export const makeGenerateCertificate =
       .andThen((project) => projectRepo.save(project));
 
     function _buildCertificateForProject(project: Project, validateur?: User | null) {
+      console.log('🙊🙊🙊🙊🙊 projet', project);
       return project.certificateData
         .asyncAndThen((certificateData) => {
           const validateurParDéfaut =

--- a/packages/applications/legacy/src/views/certificates/cre4.v0.tsx
+++ b/packages/applications/legacy/src/views/certificates/cre4.v0.tsx
@@ -8,7 +8,7 @@ import { ProjectDataForCertificate } from '../../modules/project/dtos';
 import { IllegalProjectStateError } from '../../modules/project/errors';
 import { OtherError } from '../../modules/shared';
 import { formatNumber, getNoteThreshold } from './helpers';
-import { Validateur } from '.';
+import { Validateur } from '@potentiel-domain/appel-offre';
 
 dotenv.config();
 

--- a/packages/applications/legacy/src/views/certificates/cre4.v1.tsx
+++ b/packages/applications/legacy/src/views/certificates/cre4.v1.tsx
@@ -8,7 +8,7 @@ import { ProjectDataForCertificate } from '../../modules/project/dtos';
 import { IllegalProjectStateError } from '../../modules/project/errors';
 import { OtherError } from '../../modules/shared';
 import { formatNumber, getNoteThreshold } from './helpers';
-import { Validateur } from '.';
+import { Validateur } from '@potentiel-domain/appel-offre';
 
 dotenv.config();
 

--- a/packages/applications/legacy/src/views/certificates/index.ts
+++ b/packages/applications/legacy/src/views/certificates/index.ts
@@ -1,13 +1,11 @@
 import { ResultAsync } from '../../core/utils';
 import { ProjectDataForCertificate, IllegalProjectStateError } from '../../modules/project';
 import { OtherError } from '../../modules/shared';
-import { CertificateTemplate } from '@potentiel-domain/appel-offre';
+import { CertificateTemplate, Validateur } from '@potentiel-domain/appel-offre';
 import { makeCertificate as makeCre4V0Certificate } from './cre4.v0';
 import { makeCertificate as makeCre4V1Certificate } from './cre4.v1';
 import { makeCertificate as makePpe2V1Certificate } from './ppe2.v1';
 import { makeCertificate as makePpe2V2Certificate } from './ppe2.v2';
-
-export type Validateur = { fullName: string; fonction?: string | null };
 
 export const buildCertificate = ({
   template,

--- a/packages/applications/legacy/src/views/certificates/ppe2.v1/Certificate.tsx
+++ b/packages/applications/legacy/src/views/certificates/ppe2.v1/Certificate.tsx
@@ -7,7 +7,7 @@ import { Introduction } from './components/Introduction';
 import { Signature } from './components/Signature';
 import { PageFooter } from './components/PageFooter';
 import { Footnote, FootnoteProps } from './components/Footnote';
-import { Validateur } from '..';
+import { Validateur } from '@potentiel-domain/appel-offre';
 
 export type CertificateProps = {
   project: ProjectDataForCertificate;

--- a/packages/applications/legacy/src/views/certificates/ppe2.v1/components/Signature.tsx
+++ b/packages/applications/legacy/src/views/certificates/ppe2.v1/components/Signature.tsx
@@ -1,6 +1,6 @@
+import { Validateur } from '@potentiel-domain/appel-offre';
 import { Text, View } from '@react-pdf/renderer';
 import React from 'react';
-import { Validateur } from '../..';
 
 type SignatureProps = {
   validateur: Validateur;

--- a/packages/applications/legacy/src/views/certificates/ppe2.v1/makeCertificate.ts
+++ b/packages/applications/legacy/src/views/certificates/ppe2.v1/makeCertificate.ts
@@ -7,7 +7,7 @@ import { OtherError } from '../../../modules/shared';
 import { Certificate, CertificateProps } from './Certificate';
 import { makeLaureat } from './components/Laureat';
 import { Elimine } from './components/elimine';
-import { Validateur } from '..';
+import { Validateur } from '@potentiel-domain/appel-offre';
 
 dotenv.config();
 

--- a/packages/applications/legacy/src/views/certificates/ppe2.v2/Certificate.tsx
+++ b/packages/applications/legacy/src/views/certificates/ppe2.v2/Certificate.tsx
@@ -7,7 +7,7 @@ import { Introduction } from './components/Introduction';
 import { Signature } from './components/Signature';
 import { PageFooter } from './components/PageFooter';
 import { Footnote, FootnoteProps } from './components/Footnote';
-import { Validateur } from '..';
+import { Validateur } from '@potentiel-domain/appel-offre';
 
 export type CertificateProps = {
   project: ProjectDataForCertificate;

--- a/packages/applications/legacy/src/views/certificates/ppe2.v2/components/Signature.tsx
+++ b/packages/applications/legacy/src/views/certificates/ppe2.v2/components/Signature.tsx
@@ -1,6 +1,6 @@
+import { Validateur } from '@potentiel-domain/appel-offre';
 import { Text, View } from '@react-pdf/renderer';
 import React from 'react';
-import { Validateur } from '../..';
 
 type SignatureProps = {
   validateur: Validateur;

--- a/packages/applications/legacy/src/views/certificates/ppe2.v2/makeCertificate.ts
+++ b/packages/applications/legacy/src/views/certificates/ppe2.v2/makeCertificate.ts
@@ -7,7 +7,7 @@ import { OtherError } from '../../../modules/shared';
 import { Certificate, CertificateProps } from './Certificate';
 import { makeLaureat } from './components/Laureat';
 import { Elimine } from './components/elimine';
-import { Validateur } from '..';
+import { Validateur } from '@potentiel-domain/appel-offre';
 
 dotenv.config();
 

--- a/packages/domain-inmemory-referential/src/appelOffre/CRE4/autoconsommationMetropole.ts
+++ b/packages/domain-inmemory-referential/src/appelOffre/CRE4/autoconsommationMetropole.ts
@@ -1,4 +1,5 @@
 import { AppelOffre, CahierDesChargesModifié } from '@potentiel-domain/appel-offre';
+import { validateurParDéfaut } from '../../validateurParDéfaut';
 
 const CDCModifié30072021: CahierDesChargesModifié = {
   type: 'modifié',
@@ -284,6 +285,7 @@ Ils doivent faire l’objet d’une information au Préfet dans un délai d’un
       title: 'septième',
       noteThreshold: 20.04,
       certificateTemplate: 'cre4.v0',
+      validateurParDéfaut: validateurParDéfaut.ghislain,
       cahierDesCharges: {
         référence: '2017/S 054-100223',
       },
@@ -320,6 +322,7 @@ Ils doivent faire l’objet d’une information au Préfet dans un délai d’un
       title: 'huitième',
       noteThreshold: 32.04,
       certificateTemplate: 'cre4.v1',
+      validateurParDéfaut: validateurParDéfaut.ghislain,
       cahierDesCharges: {
         référence: '2017/S 054-100223',
       },
@@ -356,6 +359,7 @@ Ils doivent faire l’objet d’une information au Préfet dans un délai d’un
       title: 'neuvième',
       noteThreshold: 9.9,
       certificateTemplate: 'cre4.v1',
+      validateurParDéfaut: validateurParDéfaut.ghislain,
       cahierDesCharges: {
         référence: '2017/S 054-100223',
       },
@@ -392,6 +396,7 @@ Ils doivent faire l’objet d’une information au Préfet dans un délai d’un
       title: 'dixième',
       noteThreshold: 44.9,
       certificateTemplate: 'cre4.v1',
+      validateurParDéfaut: validateurParDéfaut.ghislain,
       cahierDesCharges: {
         référence: '2017/S 054-100223',
       },

--- a/packages/domain-inmemory-referential/src/appelOffre/CRE4/autoconsommationZNI.ts
+++ b/packages/domain-inmemory-referential/src/appelOffre/CRE4/autoconsommationZNI.ts
@@ -1,4 +1,5 @@
 import { AppelOffre, CahierDesChargesModifié } from '@potentiel-domain/appel-offre';
+import { validateurParDéfaut } from '../../validateurParDéfaut';
 
 const CDCModifié30072021: CahierDesChargesModifié = {
   paruLe: '30/07/2021',
@@ -127,6 +128,7 @@ Ces retards sont réputés autorisés sous réserve de pouvoir les justifier aup
     {
       id: '2',
       title: 'deuxième',
+      validateurParDéfaut: validateurParDéfaut.ghislain,
       certificateTemplate: 'cre4.v1',
       noteThreshold: 32.9,
       cahierDesCharges: {

--- a/packages/domain-inmemory-referential/src/appelOffre/CRE4/batiment.ts
+++ b/packages/domain-inmemory-referential/src/appelOffre/CRE4/batiment.ts
@@ -1,4 +1,5 @@
 import { AppelOffre, CahierDesChargesModifié } from '@potentiel-domain/appel-offre';
+import { validateurParDéfaut } from '../../validateurParDéfaut';
 
 const garantieFinanciereEnMois = 36;
 
@@ -459,6 +460,7 @@ Ces retards sont réputés autorisés sous réserve de pouvoir les justifier aup
         { familleId: '2', noteThreshold: 25.62 },
       ],
       certificateTemplate: 'cre4.v0',
+      validateurParDéfaut: validateurParDéfaut.ghislain,
       cahierDesCharges: {
         référence: '2016/S 174-312851',
       },
@@ -501,6 +503,7 @@ Ces retards sont réputés autorisés sous réserve de pouvoir les justifier aup
         { familleId: '2', noteThreshold: 29.85 },
       ],
       certificateTemplate: 'cre4.v1',
+      validateurParDéfaut: validateurParDéfaut.ghislain,
       cahierDesCharges: {
         référence: '2016/S 174-312851',
       },
@@ -543,6 +546,7 @@ Ces retards sont réputés autorisés sous réserve de pouvoir les justifier aup
         { familleId: '2', noteThreshold: 32.8 },
       ],
       certificateTemplate: 'cre4.v1',
+      validateurParDéfaut: validateurParDéfaut.ghislain,
       cahierDesCharges: {
         référence: '2016/S 174-312851',
       },
@@ -585,6 +589,7 @@ Ces retards sont réputés autorisés sous réserve de pouvoir les justifier aup
         { familleId: '2', noteThreshold: 26.91 },
       ],
       certificateTemplate: 'cre4.v1',
+      validateurParDéfaut: validateurParDéfaut.ghislain,
       cahierDesCharges: {
         référence: '2016/S 174-312851',
       },

--- a/packages/domain-inmemory-referential/src/appelOffre/CRE4/eolien.ts
+++ b/packages/domain-inmemory-referential/src/appelOffre/CRE4/eolien.ts
@@ -1,4 +1,5 @@
 import { AppelOffre, CahierDesChargesModifié } from '@potentiel-domain/appel-offre';
+import { validateurParDéfaut } from '../../validateurParDéfaut';
 
 const CDCModifié30082022: CahierDesChargesModifié = {
   type: 'modifié',
@@ -349,6 +350,7 @@ Dans tous les cas, l’attribution des délais supplémentaires est conditionné
       id: '6',
       title: 'sixième',
       certificateTemplate: 'cre4.v1',
+      validateurParDéfaut: validateurParDéfaut.ghislain,
       noteThreshold: 10.19,
       cahierDesCharges: {
         référence: '2017/S 083-161855',
@@ -399,6 +401,7 @@ Dans tous les cas, l’attribution des délais supplémentaires est conditionné
       id: '7',
       title: 'septième',
       certificateTemplate: 'cre4.v1',
+      validateurParDéfaut: validateurParDéfaut.ghislain,
       noteThreshold: 13,
       cahierDesCharges: {
         référence: '2017/S 083-161855',
@@ -449,6 +452,7 @@ Dans tous les cas, l’attribution des délais supplémentaires est conditionné
       id: '8',
       title: 'huitième',
       certificateTemplate: 'cre4.v1',
+      validateurParDéfaut: validateurParDéfaut.ghislain,
       noteThreshold: 9.8,
       cahierDesCharges: {
         référence: '2017/S 083-161855',

--- a/packages/domain-inmemory-referential/src/appelOffre/CRE4/fessenheim.ts
+++ b/packages/domain-inmemory-referential/src/appelOffre/CRE4/fessenheim.ts
@@ -1,4 +1,5 @@
 import { AppelOffre, CahierDesChargesModifié } from '@potentiel-domain/appel-offre';
+import { validateurParDéfaut } from '../../validateurParDéfaut';
 
 const garantieFinanciereEnMois = 42;
 
@@ -161,6 +162,7 @@ Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent 
         { familleId: '3', noteThreshold: 1.52 },
       ],
       certificateTemplate: 'cre4.v0',
+      validateurParDéfaut: validateurParDéfaut.ghislain,
       cahierDesCharges: {
         référence: '2019/S 019-040037',
       },
@@ -185,6 +187,7 @@ Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent 
         { familleId: '3', noteThreshold: 18.43 },
       ],
       certificateTemplate: 'cre4.v0',
+      validateurParDéfaut: validateurParDéfaut.ghislain,
       cahierDesCharges: {
         référence: '2019/S 019-040037',
       },

--- a/packages/domain-inmemory-referential/src/appelOffre/CRE4/innovation.ts
+++ b/packages/domain-inmemory-referential/src/appelOffre/CRE4/innovation.ts
@@ -1,4 +1,5 @@
 import { AppelOffre, CahierDesChargesModifié } from '@potentiel-domain/appel-offre';
+import { validateurParDéfaut } from '../../validateurParDéfaut';
 
 const CDCModifié30072021: CahierDesChargesModifié = {
   type: 'modifié',
@@ -162,6 +163,7 @@ Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent 
         { familleId: '2', noteThreshold: 45.49 },
       ],
       certificateTemplate: 'cre4.v0',
+      validateurParDéfaut: validateurParDéfaut.ghislain,
       cahierDesCharges: {
         référence: '2017/S 051-094731',
       },
@@ -185,6 +187,7 @@ Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent 
         { familleId: '2', noteThreshold: 59.32 },
       ],
       certificateTemplate: 'cre4.v1',
+      validateurParDéfaut: validateurParDéfaut.ghislain,
       cahierDesCharges: {
         référence: '2017/S 051-094731',
       },

--- a/packages/domain-inmemory-referential/src/appelOffre/CRE4/sol.ts
+++ b/packages/domain-inmemory-referential/src/appelOffre/CRE4/sol.ts
@@ -1,4 +1,5 @@
 import { AppelOffre, CahierDesChargesModifié } from '@potentiel-domain/appel-offre';
+import { validateurParDéfaut } from '../../validateurParDéfaut';
 
 const garantieFinanciereEnMois = 42;
 
@@ -360,6 +361,7 @@ Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent 
         { familleId: '3', noteThreshold: 54.15 },
       ],
       certificateTemplate: 'cre4.v0',
+      validateurParDéfaut: validateurParDéfaut.ghislain,
       cahierDesCharges: {
         référence: '2016/S 148-268152',
       },
@@ -404,6 +406,7 @@ Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent 
         { familleId: '3', noteThreshold: 54.35 },
       ],
       certificateTemplate: 'cre4.v1',
+      validateurParDéfaut: validateurParDéfaut.ghislain,
       cahierDesCharges: {
         référence: '2016/S 148-268152',
       },
@@ -448,6 +451,7 @@ Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent 
         { familleId: '3', noteThreshold: 36.02 },
       ],
       certificateTemplate: 'cre4.v1',
+      validateurParDéfaut: validateurParDéfaut.ghislain,
       cahierDesCharges: {
         référence: '2016/S 148-268152',
       },
@@ -492,6 +496,7 @@ Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent 
         { familleId: '3', noteThreshold: 23.94 },
       ],
       certificateTemplate: 'cre4.v1',
+      validateurParDéfaut: validateurParDéfaut.ghislain,
       cahierDesCharges: {
         référence: '2016/S 148-268152',
       },

--- a/packages/domain-inmemory-referential/src/appelOffre/CRE4/zni.ts
+++ b/packages/domain-inmemory-referential/src/appelOffre/CRE4/zni.ts
@@ -1,4 +1,5 @@
 import { AppelOffre, CahierDesChargesModifié } from '@potentiel-domain/appel-offre';
+import { validateurParDéfaut } from '../../validateurParDéfaut';
 
 const garantieFinanciereEnMois = 36;
 
@@ -157,6 +158,7 @@ Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent 
       id: '1',
       title: 'première',
       certificateTemplate: 'cre4.v0',
+      validateurParDéfaut: validateurParDéfaut.ghislain,
       cahierDesCharges: {
         référence: '2019/S 113-276264',
       },
@@ -194,6 +196,7 @@ Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent 
       id: '2',
       title: 'deuxième',
       certificateTemplate: 'cre4.v0',
+      validateurParDéfaut: validateurParDéfaut.ghislain,
       cahierDesCharges: {
         référence: '2019/S 113-276264',
       },
@@ -230,6 +233,7 @@ Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent 
       id: '3',
       title: 'troisième',
       certificateTemplate: 'cre4.v1',
+      validateurParDéfaut: validateurParDéfaut.ghislain,
       cahierDesCharges: {
         référence: '2019/S 113-276264',
       },
@@ -264,6 +268,7 @@ Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent 
       id: '4',
       title: 'quatrième',
       certificateTemplate: 'cre4.v1',
+      validateurParDéfaut: validateurParDéfaut.ghislain,
       cahierDesCharges: {
         référence: '2019/S 113-276264',
       },
@@ -300,6 +305,7 @@ Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent 
       id: '5',
       title: 'cinquième',
       certificateTemplate: 'cre4.v1',
+      validateurParDéfaut: validateurParDéfaut.ghislain,
       cahierDesCharges: {
         référence: '2019/S 113-276264',
       },
@@ -329,6 +335,7 @@ Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent 
       id: '6',
       title: 'sixième',
       certificateTemplate: 'cre4.v1',
+      validateurParDéfaut: validateurParDéfaut.nicolas,
       cahierDesCharges: {
         référence: '2020/S 202-487521',
       },

--- a/packages/domain-inmemory-referential/src/appelOffre/PPE2/ppe2.autoconsommationMetropole.ts
+++ b/packages/domain-inmemory-referential/src/appelOffre/PPE2/ppe2.autoconsommationMetropole.ts
@@ -1,4 +1,5 @@
 import { AppelOffre, CahierDesChargesModifié } from '@potentiel-domain/appel-offre';
+import { validateurParDéfaut } from '../../validateurParDéfaut';
 
 const CDCModifié30082022: CahierDesChargesModifié = {
   type: 'modifié',
@@ -155,6 +156,7 @@ Des délais supplémentaires peuvent être accordés par le Préfet, à son appr
       id: '1',
       title: 'première',
       certificateTemplate: 'ppe2.v1',
+      validateurParDéfaut: validateurParDéfaut.ghislain,
       noteThreshold: 62.5,
       cahierDesCharges: {
         référence: '2021 S 176-457526',
@@ -167,6 +169,7 @@ Des délais supplémentaires peuvent être accordés par le Préfet, à son appr
       id: '2',
       title: 'deuxième',
       certificateTemplate: 'ppe2.v1',
+      validateurParDéfaut: validateurParDéfaut.ghislain,
       noteThreshold: 66.95,
       cahierDesCharges: {
         référence: '2022 S 038 098159',
@@ -179,6 +182,7 @@ Des délais supplémentaires peuvent être accordés par le Préfet, à son appr
       id: '3',
       title: 'troisième',
       certificateTemplate: 'ppe2.v2',
+      validateurParDéfaut: validateurParDéfaut.nicolas,
       noteThreshold: 72.13,
       cahierDesCharges: {
         référence: '2022 S 150-427955',
@@ -190,6 +194,7 @@ Des délais supplémentaires peuvent être accordés par le Préfet, à son appr
     {
       id: '4',
       title: 'quatrième',
+      validateurParDéfaut: validateurParDéfaut.hermine,
       certificateTemplate: 'ppe2.v2',
       noteThreshold: 76.25,
       cahierDesCharges: {

--- a/packages/domain-inmemory-referential/src/appelOffre/PPE2/ppe2.batiment.ts
+++ b/packages/domain-inmemory-referential/src/appelOffre/PPE2/ppe2.batiment.ts
@@ -1,5 +1,5 @@
 import { AppelOffre, CahierDesChargesModifié } from '@potentiel-domain/appel-offre';
-
+import { validateurParDéfaut } from '../../validateurParDéfaut';
 const CDCModifié30082022: CahierDesChargesModifié = {
   type: 'modifié',
   paruLe: '30/08/2022',
@@ -100,6 +100,7 @@ Des délais supplémentaires peuvent être accordés par le Préfet, à son appr
       id: '1',
       title: 'première',
       certificateTemplate: 'ppe2.v1',
+      validateurParDéfaut: validateurParDéfaut.ghislain,
       cahierDesCharges: {
         référence: '2021 S 176-457518',
       },
@@ -139,6 +140,7 @@ Des délais supplémentaires peuvent être accordés par le Préfet, à son appr
       id: '2',
       title: 'deuxième',
       certificateTemplate: 'ppe2.v1',
+      validateurParDéfaut: validateurParDéfaut.ghislain,
       cahierDesCharges: {
         référence: '2022 S 020-047803',
       },
@@ -178,6 +180,7 @@ Des délais supplémentaires peuvent être accordés par le Préfet, à son appr
       id: '3',
       title: 'troisième',
       certificateTemplate: 'ppe2.v2',
+      validateurParDéfaut: validateurParDéfaut.nicolas,
       cahierDesCharges: {
         référence: '2022 S 093-254888',
       },
@@ -210,6 +213,7 @@ Des délais supplémentaires peuvent être accordés par le Préfet, à son appr
       id: '4',
       title: 'quatrième',
       certificateTemplate: 'ppe2.v2',
+      validateurParDéfaut: validateurParDéfaut.nicolas,
       cahierDesCharges: {
         référence: '2022 S 216-620968',
       },
@@ -230,6 +234,7 @@ Des délais supplémentaires peuvent être accordés par le Préfet, à son appr
       id: '5',
       title: 'cinquième',
       certificateTemplate: 'ppe2.v2',
+      validateurParDéfaut: validateurParDéfaut.nicolas,
       cahierDesCharges: {
         référence: '2023 S 071-217458',
       },
@@ -261,6 +266,7 @@ Des délais supplémentaires peuvent être accordés par le Préfet, à son appr
       id: '6',
       title: 'sixième',
       certificateTemplate: 'ppe2.v2',
+      validateurParDéfaut: validateurParDéfaut.hermine,
       cahierDesCharges: {
         référence: '2023/S 217-683937',
       },

--- a/packages/domain-inmemory-referential/src/appelOffre/PPE2/ppe2.biométhane.ts
+++ b/packages/domain-inmemory-referential/src/appelOffre/PPE2/ppe2.biométhane.ts
@@ -1,37 +1,37 @@
-import { AppelOffre } from "@potentiel-domain/appel-offre";
+import { AppelOffre } from '@potentiel-domain/appel-offre';
+import { validateurParDéfaut } from '../../validateurParDéfaut';
 
 export const biométhanePPE2: AppelOffre = {
-  id: "PPE2 - Biométhane",
-  typeAppelOffre: "biométhane",
+  id: 'PPE2 - Biométhane',
+  typeAppelOffre: 'biométhane',
   title:
-    "portant sur la réalisation et l’exploitation d’Installations de production de biométhane injecté dans un réseau de gaz naturel.",
-  shortTitle: "PPE2 - Biométhane",
-  launchDate: "février 2024 ",
+    'portant sur la réalisation et l’exploitation d’Installations de production de biométhane injecté dans un réseau de gaz naturel.',
+  shortTitle: 'PPE2 - Biométhane',
+  launchDate: 'février 2024 ',
   cahiersDesChargesUrl:
-    "https://www.cre.fr/documents/Appels-d-offres/appel-d-offres-portant-sur-la-realisation-et-l-exploitation-d-installations-de-production-de-biomethane-injecte-dans-un-reseau-de-gaz-naturel",
-  unitePuissance: "GWh PCS/an",
+    'https://www.cre.fr/documents/Appels-d-offres/appel-d-offres-portant-sur-la-realisation-et-l-exploitation-d-installations-de-production-de-biomethane-injecte-dans-un-reseau-de-gaz-naturel',
+  unitePuissance: 'GWh PCS/an',
   delaiRealisationEnMois: 36,
-  delaiRealisationTexte: "trente six (36) mois",
-  autoritéCompétenteDemandesDélai: "dreal", // Pas de demandes de délais ?
+  delaiRealisationTexte: 'trente six (36) mois',
+  autoritéCompétenteDemandesDélai: 'dreal', // Pas de demandes de délais ?
   decoupageParTechnologie: false,
-  paragraphePrixReference: "7",
-  paragrapheDelaiDerogatoire: "6.2", // Pas de demandes de délais ?
-  paragrapheAttestationConformite: "6.4",
-  paragrapheEngagementIPFPGPFC: "3.3.10, 4.3 et 6.5",
+  paragraphePrixReference: '7',
+  paragrapheDelaiDerogatoire: '6.2', // Pas de demandes de délais ?
+  paragrapheAttestationConformite: '6.4',
+  paragrapheEngagementIPFPGPFC: '3.3.10, 4.3 et 6.5',
   afficherParagrapheInstallationMiseEnServiceModification: true,
-  renvoiModification: "5.2",
+  renvoiModification: '5.2',
   affichageParagrapheECS: false,
-  renvoiDemandeCompleteRaccordement: "",
-  renvoiRetraitDesignationGarantieFinancieres: "6.1",
-  soumisAuxGarantiesFinancieres: "à la candidature",
-  renvoiEngagementIPFPGPFC: "3.3.10, 4.3 et 6.5",
-  paragrapheClauseCompetitivite: "2.13",
-  tarifOuPrimeRetenue: "le tarif",
-  tarifOuPrimeRetenueAlt: "ce prix de référence",
+  renvoiDemandeCompleteRaccordement: '',
+  renvoiRetraitDesignationGarantieFinancieres: '6.1',
+  soumisAuxGarantiesFinancieres: 'à la candidature',
+  renvoiEngagementIPFPGPFC: '3.3.10, 4.3 et 6.5',
+  paragrapheClauseCompetitivite: '2.13',
+  tarifOuPrimeRetenue: 'le tarif',
+  tarifOuPrimeRetenueAlt: 'ce prix de référence',
   afficherValeurEvaluationCarbone: false,
   afficherPhraseRegionImplantation: false,
-  dossierSuiviPar:
-    "gaz-renouvelables-et-bas-carbone@developpement-durable.gouv.fr",
+  dossierSuiviPar: 'gaz-renouvelables-et-bas-carbone@developpement-durable.gouv.fr',
   changementPuissance: {
     ratios: {
       min: 0.8,
@@ -41,11 +41,11 @@ export const biométhanePPE2: AppelOffre = {
   changementProducteurPossibleAvantAchèvement: true,
   donnéesCourriersRéponse: {
     texteEngagementRéalisationEtModalitésAbandon: {
-      référenceParagraphe: "6.1",
+      référenceParagraphe: '6.1',
       dispositions: `Le Candidat dont l’offre a été retenue réalise l’Installation dans les conditions du présent cahier des charges et conformément aux éléments du dossier de candidature (les possibilités et modalités de modification sont indiquées au 5.2). (...) Le Candidat peut également être délié de cette obligation selon l’appréciation du ministre chargé de l’énergie à la suite d’une demande dûment justifiée. Le Ministre peut accompagner son accord de conditions ou du prélèvement d’une part de la garantie financière. Ni l’accord du Ministre, ni les conditions imposées, ni le prélèvement de la garantie financière ne limitent la possibilité de recours de l’Etat aux sanctions du 7.8.`,
     },
     texteChangementDePuissance: {
-      référenceParagraphe: "5.7",
+      référenceParagraphe: '5.7',
       dispositions: `Les modifications de la Production annuelle prévisionnelle de l’Installation sont autorisées, sous réserve que la Production annuelle prévisionnelle de l’Installation modifiée soit comprise entre quatre-vingts pourcents (80 %) et cent vingt pourcents (120 %) de la Production annuelle prévisionnelle indiquée dans l’offre, dans la limite du plafond de Production annuelle prévisionnelle de 50 GWh PCS/an spécifié au paragraphe 1.2.2 pour le cas d'une offre entrant dans le volume réservé. Elles doivent faire l’objet d’une information au Préfet.`,
     },
     // Pas de demandes de délais ???
@@ -56,14 +56,18 @@ export const biométhanePPE2: AppelOffre = {
   },
   periodes: [
     {
-      id: "1",
-      title: "première",
-      certificateTemplate: "ppe2.v2",
+      id: '1',
+      title: 'première',
+      certificateTemplate: 'ppe2.v2',
+      /**
+       * @todo Penser à ajouter le validateur du bureau SD2 quand on aura le contact (cf @potentiel-domain-inmemory-referential/src/validateurParDéfaut/index.ts)
+       */
+      validateurParDéfaut: validateurParDéfaut.sd2,
       cahierDesCharges: {
-        référence: "2023/S 249-790242",
+        référence: '2023/S 249-790242',
       },
-      delaiDcrEnMois: { valeur: 3, texte: "trois" },
-      noteThresholdBy: "category",
+      delaiDcrEnMois: { valeur: 3, texte: 'trois' },
+      noteThresholdBy: 'category',
       noteThreshold: {
         volumeReserve: {
           noteThreshold: 11,

--- a/packages/domain-inmemory-referential/src/appelOffre/PPE2/ppe2.eolien.ts
+++ b/packages/domain-inmemory-referential/src/appelOffre/PPE2/ppe2.eolien.ts
@@ -1,4 +1,5 @@
 import { AppelOffre, CahierDesChargesModifié } from '@potentiel-domain/appel-offre';
+import { validateurParDéfaut } from '../../validateurParDéfaut';
 
 const CDCModifié30082022: CahierDesChargesModifié = {
   type: 'modifié',
@@ -100,6 +101,7 @@ Des délais supplémentaires peuvent être accordés par le Préfet, à son appr
       id: '1',
       title: 'première',
       certificateTemplate: 'ppe2.v1',
+      validateurParDéfaut: validateurParDéfaut.ghislain,
       noteThreshold: 0.68,
       cahierDesCharges: {
         référence: '2021/S 146-386083',
@@ -131,6 +133,7 @@ Des délais supplémentaires peuvent être accordés par le Préfet, à son appr
       id: '2',
       title: 'deuxième',
       certificateTemplate: 'ppe2.v2',
+      validateurParDéfaut: validateurParDéfaut.nicolas,
       noteThreshold: 0.692142857142864,
       cahierDesCharges: {
         référence: '2022/S 035-088651',
@@ -166,6 +169,7 @@ Le Candidat peut également être délié de cette obligation selon l’appréci
       id: '3',
       title: 'troisième',
       certificateTemplate: 'ppe2.v2',
+      validateurParDéfaut: validateurParDéfaut.nicolas,
       noteThreshold: 1.2,
       cahierDesCharges: {
         référence: '2022/S 214-614410',
@@ -189,6 +193,7 @@ Le Candidat peut également être délié de cette obligation selon l’appréci
       id: '4',
       title: 'quatrième',
       certificateTemplate: 'ppe2.v2',
+      validateurParDéfaut: validateurParDéfaut.nicolas,
       noteThreshold: 13.8,
       cahierDesCharges: {
         référence: '2023/S 063-187148',
@@ -211,6 +216,7 @@ Le Candidat peut également être délié de cette obligation selon l’appréci
       id: '5',
       title: 'cinquième',
       certificateTemplate: 'ppe2.v2',
+      validateurParDéfaut: validateurParDéfaut.hermine,
       noteThreshold: 14.22,
       cahierDesCharges: {
         référence: '2023/S 183-570186',
@@ -222,6 +228,7 @@ Le Candidat peut également être délié de cette obligation selon l’appréci
       id: '6',
       title: 'sixième',
       certificateTemplate: 'ppe2.v2',
+      validateurParDéfaut: validateurParDéfaut.hermine,
       noteThreshold: 16.85,
       cahierDesCharges: {
         référence: '2023/S 215-677967',

--- a/packages/domain-inmemory-referential/src/appelOffre/PPE2/ppe2.innovation.ts
+++ b/packages/domain-inmemory-referential/src/appelOffre/PPE2/ppe2.innovation.ts
@@ -1,4 +1,5 @@
 import { AppelOffre, CahierDesChargesModifié } from '@potentiel-domain/appel-offre';
+import { validateurParDéfaut } from '../../validateurParDéfaut';
 
 const CDCModifié30082022: CahierDesChargesModifié = {
   type: 'modifié',
@@ -118,6 +119,7 @@ Des délais supplémentaires peuvent être accordés par le Préfet, à son appr
       title: 'première',
       type: 'notified',
       certificateTemplate: 'ppe2.v2',
+      validateurParDéfaut: validateurParDéfaut.nicolas,
       cahierDesCharges: {
         référence: '2021 S 203-530267',
       },

--- a/packages/domain-inmemory-referential/src/appelOffre/PPE2/ppe2.neutre.ts
+++ b/packages/domain-inmemory-referential/src/appelOffre/PPE2/ppe2.neutre.ts
@@ -1,4 +1,5 @@
 import { AppelOffre } from '@potentiel-domain/appel-offre';
+import { validateurParDéfaut } from '../../validateurParDéfaut';
 
 export const neutrePPE2: AppelOffre = {
   id: 'PPE2 - Neutre',
@@ -74,6 +75,7 @@ Des délais supplémentaires peuvent être accordés par le Préfet, à son appr
       title: 'première',
       type: 'notified',
       certificateTemplate: 'ppe2.v2',
+      validateurParDéfaut: validateurParDéfaut.nicolas,
       noteThreshold: 26.89,
       cahierDesCharges: {
         référence: '2022 S 100-276861',
@@ -98,6 +100,7 @@ Le Candidat peut également être délié de cette obligation selon l’appréci
       title: 'deuxième',
       type: 'notified',
       certificateTemplate: 'ppe2.v2',
+      validateurParDéfaut: validateurParDéfaut.hermine,
       noteThreshold: 26.87,
       cahierDesCharges: {
         référence: '2023 S 147-469153',

--- a/packages/domain-inmemory-referential/src/appelOffre/PPE2/ppe2.sol.ts
+++ b/packages/domain-inmemory-referential/src/appelOffre/PPE2/ppe2.sol.ts
@@ -1,4 +1,5 @@
 import { AppelOffre, CahierDesChargesModifié } from '@potentiel-domain/appel-offre';
+import { validateurParDéfaut } from '../../validateurParDéfaut';
 
 const CDCModifié30082022: CahierDesChargesModifié = {
   type: 'modifié',
@@ -101,6 +102,7 @@ Des délais supplémentaires peuvent être accordés par le Préfet, à son appr
       id: '1',
       title: 'première',
       certificateTemplate: 'ppe2.v1',
+      validateurParDéfaut: validateurParDéfaut.ghislain,
       cahierDesCharges: {
         référence: '2021 S 211-553136',
       },
@@ -143,6 +145,7 @@ Des délais supplémentaires peuvent être accordés par le Préfet, à son appr
       id: '2',
       title: 'deuxième',
       certificateTemplate: 'ppe2.v1',
+      validateurParDéfaut: validateurParDéfaut.ghislain,
       cahierDesCharges: {
         référence: '2022/S 061-160516',
       },
@@ -178,6 +181,7 @@ Des délais supplémentaires peuvent être accordés par le Préfet, à son appr
       id: '3',
       title: 'troisième',
       certificateTemplate: 'ppe2.v2',
+      validateurParDéfaut: validateurParDéfaut.nicolas,
       cahierDesCharges: {
         référence: '2022 S 214-614411',
       },
@@ -198,6 +202,7 @@ Des délais supplémentaires peuvent être accordés par le Préfet, à son appr
       id: '4',
       title: 'quatrième',
       certificateTemplate: 'ppe2.v2',
+      validateurParDéfaut: validateurParDéfaut.hermine,
       cahierDesCharges: {
         référence: '2023 S 063-187860',
       },
@@ -229,6 +234,7 @@ Le Candidat peut également être délié de cette obligation selon l’appréci
       id: '5',
       title: 'cinquième',
       certificateTemplate: 'ppe2.v2',
+      validateurParDéfaut: validateurParDéfaut.hermine,
       cahierDesCharges: {
         référence: '2023/S 217-681379',
       },

--- a/packages/domain-inmemory-referential/src/appelOffre/PPE2/ppe2.zni.ts
+++ b/packages/domain-inmemory-referential/src/appelOffre/PPE2/ppe2.zni.ts
@@ -1,4 +1,5 @@
 import { AppelOffre } from '@potentiel-domain/appel-offre';
+import { validateurParDéfaut } from '../../validateurParDéfaut';
 
 export const zniPPE2: AppelOffre = {
   id: 'PPE2 - ZNI',
@@ -73,6 +74,7 @@ export const zniPPE2: AppelOffre = {
       id: '1',
       title: 'première',
       certificateTemplate: 'ppe2.v2',
+      validateurParDéfaut: validateurParDéfaut.hermine,
       cahierDesCharges: {
         référence: '2023/S 183-570186',
       },

--- a/packages/domain-inmemory-referential/src/index.ts
+++ b/packages/domain-inmemory-referential/src/index.ts
@@ -1,1 +1,2 @@
 export * from './appelOffre';
+export * from './validateurParDéfaut';

--- a/packages/domain-inmemory-referential/src/validateurParDéfaut/index.ts
+++ b/packages/domain-inmemory-referential/src/validateurParDéfaut/index.ts
@@ -1,20 +1,20 @@
-import { ValidateurParDéfaut } from '@potentiel-domain/appel-offre';
+import { Validateur } from '@potentiel-domain/appel-offre';
 
 export const validateurParDéfaut = {
   sd2: {
-    name: 'Sous-directeur bureau SD2',
+    fullName: 'Sous-directeur bureau SD2',
     fonction: 'Sous-directrice du système électrique et des énergies renouvelables',
-  } satisfies ValidateurParDéfaut,
+  } satisfies Validateur,
   hermine: {
-    name: 'Hermine DURAND',
+    fullName: 'Hermine DURAND',
     fonction: `Sous-directrice du système électrique et des énergies renouvelables`,
-  } satisfies ValidateurParDéfaut,
+  } satisfies Validateur,
   nicolas: {
-    name: 'Nicolas CLAUSSET',
+    fullName: 'Nicolas CLAUSSET',
     fonction: `Le sous-directeur du système électrique et des énergies renouvelables`,
-  } satisfies ValidateurParDéfaut,
+  } satisfies Validateur,
   ghislain: {
-    name: 'Ghislain FERRAN',
+    fullName: 'Ghislain FERRAN',
     fonction: `L’adjoint au sous-directeur du système électrique et des énergies renouvelables`,
-  } satisfies ValidateurParDéfaut,
+  } satisfies Validateur,
 };

--- a/packages/domain-inmemory-referential/src/validateurParDéfaut/index.ts
+++ b/packages/domain-inmemory-referential/src/validateurParDéfaut/index.ts
@@ -1,0 +1,20 @@
+import { ValidateurParDéfaut } from '@potentiel-domain/appel-offre';
+
+export const validateurParDéfaut = {
+  sd2: {
+    name: 'Sous-directeur bureau SD2',
+    fonction: 'Sous-directrice du système électrique et des énergies renouvelables',
+  } satisfies ValidateurParDéfaut,
+  hermine: {
+    name: 'Hermine DURAND',
+    fonction: `Sous-directrice du système électrique et des énergies renouvelables`,
+  } satisfies ValidateurParDéfaut,
+  nicolas: {
+    name: 'Nicolas CLAUSSET',
+    fonction: `Le sous-directeur du système électrique et des énergies renouvelables`,
+  } satisfies ValidateurParDéfaut,
+  ghislain: {
+    name: 'Ghislain FERRAN',
+    fonction: `L’adjoint au sous-directeur du système électrique et des énergies renouvelables`,
+  } satisfies ValidateurParDéfaut,
+};

--- a/packages/domain/appel-offre/src/appelOffre.entity.ts
+++ b/packages/domain/appel-offre/src/appelOffre.entity.ts
@@ -1,15 +1,15 @@
-import { Entity } from "@potentiel-domain/core";
+import { Entity } from '@potentiel-domain/core';
 
 type AppelOffreTypes =
-  | "autoconso"
-  | "batiment"
-  | "eolien"
-  | "innovation"
-  | "neutre"
-  | "sol"
-  | "zni"
-  | "biométhane"
-  | "autre";
+  | 'autoconso'
+  | 'batiment'
+  | 'eolien'
+  | 'innovation'
+  | 'neutre'
+  | 'sol'
+  | 'zni'
+  | 'biométhane'
+  | 'autre';
 
 type Ratios = {
   min: number;
@@ -23,7 +23,7 @@ type ChangementPuissance = { paragrapheAlerte?: string } & (
     }
   | {
       changementByTechnologie: true;
-      ratios: { [key in Exclude<Technologie, "N/A">]: Ratios };
+      ratios: { [key in Exclude<Technologie, 'N/A'>]: Ratios };
     }
 );
 
@@ -34,7 +34,7 @@ type DelaiRealisation =
     }
   | {
       delaiRealisationEnMoisParTechnologie: {
-        [key in Exclude<Technologie, "N/A">]: number;
+        [key in Exclude<Technologie, 'N/A'>]: number;
       };
       decoupageParTechnologie: true;
     };
@@ -48,12 +48,12 @@ type GarantiesFinancièresAppelOffre =
 
 // Courriers
 export type DonnéesCourriersRéponse = Record<
-  | "texteEngagementRéalisationEtModalitésAbandon"
-  | "texteChangementDActionnariat"
-  | "texteChangementDePuissance"
-  | "texteIdentitéDuProducteur"
-  | "texteChangementDeProducteur"
-  | "texteDélaisDAchèvement",
+  | 'texteEngagementRéalisationEtModalitésAbandon'
+  | 'texteChangementDActionnariat'
+  | 'texteChangementDePuissance'
+  | 'texteIdentitéDuProducteur'
+  | 'texteChangementDeProducteur'
+  | 'texteDélaisDAchèvement',
   {
     référenceParagraphe: string;
     dispositions: string;
@@ -71,28 +71,23 @@ export type DélaiApplicable = {
 };
 
 export const cahiersDesChargesRéférences = [
-  "initial",
-  "30/07/2021",
-  "30/08/2022",
-  "30/08/2022-alternatif",
-  "07/02/2023",
-  "07/02/2023-alternatif",
+  'initial',
+  '30/07/2021',
+  '30/08/2022',
+  '30/08/2022-alternatif',
+  '07/02/2023',
+  '07/02/2023-alternatif',
 ] as const;
 
-export type CahierDesChargesRéférence =
-  (typeof cahiersDesChargesRéférences)[number];
+export type CahierDesChargesRéférence = (typeof cahiersDesChargesRéférences)[number];
 
-const datesParutionCahiersDesChargesModifiés = [
-  "30/07/2021",
-  "30/08/2022",
-  "07/02/2023",
-] as const;
+const datesParutionCahiersDesChargesModifiés = ['30/07/2021', '30/08/2022', '07/02/2023'] as const;
 
 export type DateParutionCahierDesChargesModifié =
   (typeof datesParutionCahiersDesChargesModifiés)[number];
 
 export type CahierDesChargesModifié = {
-  type: "modifié";
+  type: 'modifié';
   paruLe: DateParutionCahierDesChargesModifié;
   alternatif?: true;
   numéroGestionnaireRequis?: true;
@@ -103,17 +98,17 @@ export type CahierDesChargesModifié = {
 };
 
 // Technologies
-export const technologies = ["pv", "eolien", "hydraulique", "N/A"] as const;
+export const technologies = ['pv', 'eolien', 'hydraulique', 'N/A'] as const;
 export type Technologie = (typeof technologies)[number];
 
 // Famille
 export type GarantiesFinancièresFamille =
   | {
-      soumisAuxGarantiesFinancieres: "après candidature";
+      soumisAuxGarantiesFinancieres: 'après candidature';
       garantieFinanciereEnMois: number;
     }
   | {
-      soumisAuxGarantiesFinancieres: "à la candidature" | "non soumis";
+      soumisAuxGarantiesFinancieres: 'à la candidature' | 'non soumis';
     };
 
 export type Famille = {
@@ -138,16 +133,21 @@ type NoteThresholdByCategory = {
   };
 };
 
+export type ValidateurParDéfaut = {
+  name: string;
+  fonction: string;
+};
 export type NotifiedPeriode = {
-  type?: "notified";
+  type?: 'notified';
   certificateTemplate: CertificateTemplate;
+  validateurParDéfaut: ValidateurParDéfaut;
 } & (
   | {
-      noteThresholdBy: "family";
+      noteThresholdBy: 'family';
       noteThreshold: NoteThresholdByFamily[];
     }
   | {
-      noteThresholdBy: "category";
+      noteThresholdBy: 'category';
       noteThreshold: NoteThresholdByCategory;
     }
   | {
@@ -157,20 +157,21 @@ export type NotifiedPeriode = {
 );
 
 type NotYetNotifiedPeriode = {
-  type: "not-yet-notified";
+  type: 'not-yet-notified';
   certificateTemplate: CertificateTemplate;
+  validateurParDéfaut: ValidateurParDéfaut;
   noteThresholdBy?: undefined;
   noteThreshold?: undefined;
 };
 
 type LegacyPeriode = {
-  type: "legacy";
+  type: 'legacy';
   certificateTemplate?: undefined;
   noteThresholdBy?: undefined;
   noteThreshold?: undefined;
 };
 
-export type CertificateTemplate = "cre4.v0" | "cre4.v1" | "ppe2.v1" | "ppe2.v2";
+export type CertificateTemplate = 'cre4.v0' | 'cre4.v1' | 'ppe2.v1' | 'ppe2.v2';
 
 export type Periode = {
   id: string;
@@ -190,12 +191,12 @@ export type Periode = {
 
 // Territoire
 export const territoires = [
-  "Corse",
-  "Guadeloupe",
-  "Guyane",
-  "La Réunion",
-  "Mayotte",
-  "Martinique",
+  'Corse',
+  'Guadeloupe',
+  'Guyane',
+  'La Réunion',
+  'Mayotte',
+  'Martinique',
 ] as const;
 export type Territoire = (typeof territoires)[number];
 
@@ -232,8 +233,8 @@ export type AppelOffre = {
   changementProducteurPossibleAvantAchèvement: boolean;
   donnéesCourriersRéponse: Partial<DonnéesCourriersRéponse>;
   doitPouvoirChoisirCDCInitial?: true;
-  autoritéCompétenteDemandesDélai: "dgec" | "dreal";
+  autoritéCompétenteDemandesDélai: 'dgec' | 'dreal';
 } & DelaiRealisation &
   GarantiesFinancièresAppelOffre;
 
-export type AppelOffreEntity = Entity<"appel-offre", AppelOffre>;
+export type AppelOffreEntity = Entity<'appel-offre', AppelOffre>;

--- a/packages/domain/appel-offre/src/appelOffre.entity.ts
+++ b/packages/domain/appel-offre/src/appelOffre.entity.ts
@@ -133,14 +133,14 @@ type NoteThresholdByCategory = {
   };
 };
 
-export type ValidateurParDéfaut = {
-  name: string;
-  fonction: string;
+export type Validateur = {
+  fullName: string;
+  fonction?: string;
 };
 export type NotifiedPeriode = {
   type?: 'notified';
   certificateTemplate: CertificateTemplate;
-  validateurParDéfaut: ValidateurParDéfaut;
+  validateurParDéfaut: Validateur;
 } & (
   | {
       noteThresholdBy: 'family';
@@ -159,7 +159,7 @@ export type NotifiedPeriode = {
 type NotYetNotifiedPeriode = {
   type: 'not-yet-notified';
   certificateTemplate: CertificateTemplate;
-  validateurParDéfaut: ValidateurParDéfaut;
+  validateurParDéfaut: Validateur;
   noteThresholdBy?: undefined;
   noteThreshold?: undefined;
 };


### PR DESCRIPTION
Actuellement on avait en dur deux validateurs par défaut, utilisé en fonction du template de certificat.
Cette PR retravaille le choix du validateur par défaut en allant le chercher directement dans la période de l'appel d'offre du projet.

Comme ça on va venir signer avec le validateur qui avait été à l'origine de la notification