### PR TITLE
:children_crossing: Déplacer les boutons d'action sur le détails du dépôt de GF 

### DIFF
--- a/packages/applications/ssr/src/app/laureats/[identifiant]/garanties-financieres/depot:modifier/page.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/garanties-financieres/depot:modifier/page.tsx
@@ -73,11 +73,6 @@ export default async function Page({ params: { identifiant } }: IdentifiantParam
           },
         },
         showWarning: utilisateur.role.estÉgaleÀ(Role.porteur) ? true : undefined,
-        actions: utilisateur.role.estÉgaleÀ(Role.porteur)
-          ? ['supprimer']
-          : utilisateur.role.estÉgaleÀ(Role.dreal)
-          ? ['valider']
-          : [],
       };
 
       return <ModifierDépôtEnCoursGarantiesFinancièresPage {...props} />;

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/garanties-financieres/page.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/garanties-financieres/page.tsx
@@ -113,11 +113,14 @@ const mapToProps: MapToProps = ({ projet, utilisateur, garantiesFinancières }) 
 
   const dépôtEnCours = garantiesFinancières.dépôts.find((dépôt) => dépôt.statut.estEnCours());
   let dépôtEnCoursActions: GarantiesFinancièresDépôtEnCoursProps['dépôt']['actions'] = [];
-  if (utilisateur.role.estÉgaleÀ(Role.porteur) || utilisateur.role.estÉgaleÀ(Role.admin)) {
+  if (utilisateur.role.estÉgaleÀ(Role.admin)) {
     dépôtEnCoursActions = ['modifier'];
   }
   if (utilisateur.role.estÉgaleÀ(Role.dreal)) {
     dépôtEnCoursActions = ['instruire', 'modifier'];
+  }
+  if (utilisateur.role.estÉgaleÀ(Role.porteur)) {
+    dépôtEnCoursActions = ['modifier', 'supprimer'];
   }
 
   return {

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/garanties-financieres/page.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/garanties-financieres/page.tsx
@@ -20,6 +20,7 @@ import {
 import { projetSoumisAuxGarantiesFinancières } from '@/utils/garanties-financières/vérifierAppelOffreSoumisAuxGarantiesFinancières';
 import { ProjetNonSoumisAuxGarantiesFinancièresPage } from '@/components/pages/garanties-financières/ProjetNonSoumisAuxGarantiesFinancières.page';
 import { tryToGetResource } from '@/utils/tryToGetRessource';
+import { GarantiesFinancièresDépôtEnCoursProps } from '@/components/pages/garanties-financières/détails/components/GarantiesFinancièresDépôtEnCours';
 
 export const metadata: Metadata = {
   title: 'Détail des garanties financières - Potentiel',
@@ -111,6 +112,13 @@ const mapToProps: MapToProps = ({ projet, utilisateur, garantiesFinancières }) 
   }
 
   const dépôtEnCours = garantiesFinancières.dépôts.find((dépôt) => dépôt.statut.estEnCours());
+  let dépôtEnCoursActions: GarantiesFinancièresDépôtEnCoursProps['dépôt']['actions'] = [];
+  if (utilisateur.role.estÉgaleÀ(Role.porteur) || utilisateur.role.estÉgaleÀ(Role.admin)) {
+    dépôtEnCoursActions = ['modifier'];
+  }
+  if (utilisateur.role.estÉgaleÀ(Role.dreal)) {
+    dépôtEnCoursActions = ['instruire', 'modifier'];
+  }
 
   return {
     projet,
@@ -150,12 +158,7 @@ const mapToProps: MapToProps = ({ projet, utilisateur, garantiesFinancières }) 
             par: dépôtEnCours.dernièreMiseÀJour.par.formatter(),
           },
           attestation: dépôtEnCours.attestation.formatter(),
-          action:
-            utilisateur.role.estÉgaleÀ(Role.porteur) || utilisateur.role.estÉgaleÀ(Role.admin)
-              ? 'modifier'
-              : utilisateur.role.estÉgaleÀ(Role.dreal)
-              ? 'instruire'
-              : undefined,
+          actions: dépôtEnCoursActions,
         }
       : undefined,
     historiqueDépôts: garantiesFinancières.dépôts

--- a/packages/applications/ssr/src/components/pages/garanties-financières/dépôt/modifier/ModifierDépôtEnCoursGarantiesFinancières.page.tsx
+++ b/packages/applications/ssr/src/components/pages/garanties-financières/dépôt/modifier/ModifierDépôtEnCoursGarantiesFinancières.page.tsx
@@ -14,24 +14,18 @@ import {
   FormulaireGarantiesFinancièresProps,
 } from '../../FormulaireGarantiesFinancières';
 
-import { ValiderDépôtEnCoursGarantiesFinancières } from './valider/validerDépôtEnCoursGarantiesFinancières';
-import { RejeterDépôtEnCoursGarantiesFinancières } from './rejeter/RejeterDépôtEnCoursGarantiesFinancières';
-import { SupprimerDépôtEnCoursGarantiesFinancières } from './supprimer/SupprimerDépôtEnCoursGarantiesFinancières';
 import { modifierDépôtEnCoursGarantiesFinancièresAction } from './modifierDépôtEnCoursGarantiesFinancières.action';
-
-type AvailableActions = Array<'valider' | 'rejeter' | 'supprimer'>;
 
 export type ModifierDépôtEnCoursGarantiesFinancièresProps = {
   projet: ProjetBannerProps;
   typesGarantiesFinancières: FormulaireGarantiesFinancièresProps['typesGarantiesFinancières'];
   dépôtEnCours: DépôtGarantiesFinancières;
   showWarning?: true;
-  actions: AvailableActions;
 };
 
 export const ModifierDépôtEnCoursGarantiesFinancièresPage: FC<
   ModifierDépôtEnCoursGarantiesFinancièresProps
-> = ({ projet, typesGarantiesFinancières, dépôtEnCours, showWarning, actions }) => (
+> = ({ projet, typesGarantiesFinancières, dépôtEnCours, showWarning }) => (
   <ColumnPageTemplate
     banner={<ProjetBanner {...projet} />}
     heading={
@@ -40,19 +34,6 @@ export const ModifierDépôtEnCoursGarantiesFinancièresPage: FC<
     leftColumn={{
       children: (
         <>
-          {showWarning && (
-            <Alert
-              severity="warning"
-              className="mb-3"
-              title=""
-              description={
-                <>
-                  Vous pouvez modifier ou supprimer cette soumission de garanties financières
-                  jusqu'à la validation par la DREAL concernée.
-                </>
-              }
-            />
-          )}
           <FormulaireGarantiesFinancières
             identifiantProjet={projet.identifiantProjet}
             action={modifierDépôtEnCoursGarantiesFinancièresAction}
@@ -72,30 +53,23 @@ export const ModifierDépôtEnCoursGarantiesFinancièresPage: FC<
     }}
     rightColumn={{
       className: 'flex flex-col w-full md:w-1/4 gap-4',
-      children: mapToActionComponents({
-        actions,
-        identifiantProjet: projet.identifiantProjet,
-      }),
+      children: (
+        <>
+          {showWarning ? (
+            <Alert
+              severity="warning"
+              className="mb-3"
+              title=""
+              description={
+                <>
+                  Vous pouvez modifier ce dépôt de garanties financières jusqu'à sa validation par
+                  la DREAL.
+                </>
+              }
+            />
+          ) : null}
+        </>
+      ),
     }}
   />
 );
-
-type MapToActionsComponentsProps = {
-  actions: AvailableActions;
-  identifiantProjet: string;
-};
-const mapToActionComponents = ({ actions, identifiantProjet }: MapToActionsComponentsProps) => {
-  return actions.length ? (
-    <>
-      {actions.includes('valider') && (
-        <ValiderDépôtEnCoursGarantiesFinancières identifiantProjet={identifiantProjet} />
-      )}
-      {actions.includes('rejeter') && (
-        <RejeterDépôtEnCoursGarantiesFinancières identifiantProjet={identifiantProjet} />
-      )}
-      {actions.includes('supprimer') && (
-        <SupprimerDépôtEnCoursGarantiesFinancières identifiantProjet={identifiantProjet} />
-      )}
-    </>
-  ) : null;
-};

--- a/packages/applications/ssr/src/components/pages/garanties-financières/dépôt/modifier/ModifierDépôtEnCoursGarantiesFinancières.stories.tsx
+++ b/packages/applications/ssr/src/components/pages/garanties-financières/dépôt/modifier/ModifierDépôtEnCoursGarantiesFinancières.stories.tsx
@@ -53,7 +53,6 @@ export const EnTantQueDreal: Story = {
         par: 'PORTEUR#1',
       },
     },
-    actions: ['valider', 'rejeter'],
     typesGarantiesFinancières,
   },
 };
@@ -73,7 +72,6 @@ export const EnTantQuePorteur: Story = {
         par: 'DREAL#1',
       },
     },
-    actions: ['supprimer'],
     showWarning: true,
     typesGarantiesFinancières,
   },

--- a/packages/applications/ssr/src/components/pages/garanties-financières/dépôt/modifier/supprimer/SupprimerDépôtEnCoursGarantiesFinancières.tsx
+++ b/packages/applications/ssr/src/components/pages/garanties-financières/dépôt/modifier/supprimer/SupprimerDépôtEnCoursGarantiesFinancières.tsx
@@ -1,10 +1,13 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import { createModal } from '@codegouvfr/react-dsfr/Modal';
+import Button from '@codegouvfr/react-dsfr/Button';
 
 import { Routes } from '@potentiel-applications/routes';
 
-import { ButtonWithFormInModal } from '@/components/molecules/ButtonWithFormInModal';
+import { Form } from '@/components/atoms/form/Form';
 
 import { supprimerDépôtEnCoursGarantiesFinancièresAction } from './supprimerDépôtEnCoursGarantiesFinancières.action';
 
@@ -17,25 +20,56 @@ export const SupprimerDépôtEnCoursGarantiesFinancières = ({
 }: SupprimerDépôtEnCoursGarantiesFinancièresProps) => {
   const router = useRouter();
 
+  const [modal, _] = useState(
+    createModal({
+      id: `action-modal-Supprimer`,
+      isOpenedByDefault: false,
+    }),
+  );
+
   return (
-    <ButtonWithFormInModal
-      name="Supprimer"
-      yesNo
-      description="Supprimer les garanties financières en attente de validation"
-      form={{
-        id: 'supprimer-garanties-financieres-a-traiter-form',
-        action: supprimerDépôtEnCoursGarantiesFinancièresAction,
-        method: 'post',
-        encType: 'multipart/form-data',
-        omitMandatoryFieldsLegend: true,
-        onSuccess: () => router.push(Routes.Projet.details(identifiantProjet)),
-        children: (
-          <>
-            <p className="mt-3">Êtes-vous sûr de vouloir supprimer ces garanties financières ?</p>
-            <input type={'hidden'} value={identifiantProjet} name="identifiantProjet" />
-          </>
-        ),
-      }}
-    />
+    <>
+      <Button priority="primary" onClick={() => modal.open()}>
+        <span className="mx-auto">Supprimer</span>
+      </Button>
+
+      <modal.Component
+        title="Supprimer les garanties financières en attente de validation"
+        buttons={[
+          {
+            type: 'button',
+            children: 'Non',
+          },
+          {
+            type: 'submit',
+            nativeButtonProps: {
+              className: 'text-theme-white bg-theme-blueFrance',
+              form: 'supprimer-garanties-financieres-a-traiter-form',
+            },
+            children: 'Oui',
+            doClosesModal: false,
+          },
+        ]}
+      >
+        <Form
+          {...{
+            id: 'supprimer-garanties-financieres-a-traiter-form',
+            action: supprimerDépôtEnCoursGarantiesFinancièresAction,
+            method: 'post',
+            encType: 'multipart/form-data',
+            omitMandatoryFieldsLegend: true,
+            onSuccess: () => router.push(Routes.GarantiesFinancières.détail(identifiantProjet)),
+            children: (
+              <>
+                <p className="mt-3">
+                  Êtes-vous sûr de vouloir supprimer ces garanties financières ?
+                </p>
+                <input type={'hidden'} value={identifiantProjet} name="identifiantProjet" />
+              </>
+            ),
+          }}
+        />
+      </modal.Component>
+    </>
   );
 };

--- a/packages/applications/ssr/src/components/pages/garanties-financières/dépôt/modifier/valider/validerDépôtEnCoursGarantiesFinancières.tsx
+++ b/packages/applications/ssr/src/components/pages/garanties-financières/dépôt/modifier/valider/validerDépôtEnCoursGarantiesFinancières.tsx
@@ -1,10 +1,13 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
+import Button from '@codegouvfr/react-dsfr/Button';
+import { useState } from 'react';
+import { createModal } from '@codegouvfr/react-dsfr/Modal';
 
 import { Routes } from '@potentiel-applications/routes';
 
-import { ButtonWithFormInModal } from '@/components/molecules/ButtonWithFormInModal';
+import { Form } from '@/components/atoms/form/Form';
 
 import { validerDépôtEnCoursGarantiesFinancièresAction } from './validerDépôtEnCoursGarantiesFinancières.action';
 
@@ -17,25 +20,54 @@ export const ValiderDépôtEnCoursGarantiesFinancières = ({
 }: ValiderDépôtEnCoursGarantiesFinancièresProps) => {
   const router = useRouter();
 
+  const [modal, _] = useState(
+    createModal({
+      id: `action-modal-Valider`,
+      isOpenedByDefault: false,
+    }),
+  );
+
   return (
-    <ButtonWithFormInModal
-      name="Valider"
-      yesNo
-      description="Valider les garanties financières"
-      form={{
-        id: 'valider-garanties-financieres-a-traiter-form',
-        action: validerDépôtEnCoursGarantiesFinancièresAction,
-        method: 'post',
-        encType: 'multipart/form-data',
-        omitMandatoryFieldsLegend: true,
-        onSuccess: () => router.push(Routes.GarantiesFinancières.détail(identifiantProjet)),
-        children: (
-          <>
-            <p className="mt-3">Êtes-vous sûr de vouloir valider ces garanties financières ?</p>
-            <input type={'hidden'} value={identifiantProjet} name="identifiantProjet" />
-          </>
-        ),
-      }}
-    />
+    <>
+      <Button priority="primary" onClick={() => modal.open()}>
+        <span className="mx-auto">Valider</span>
+      </Button>
+
+      <modal.Component
+        title="Valider les garanties financières"
+        buttons={[
+          {
+            type: 'button',
+            children: 'Non',
+          },
+          {
+            type: 'submit',
+            nativeButtonProps: {
+              className: 'text-theme-white bg-theme-blueFrance',
+              form: 'valider-garanties-financieres-a-traiter-form',
+            },
+            children: 'Oui',
+            doClosesModal: false,
+          },
+        ]}
+      >
+        <Form
+          {...{
+            id: 'valider-garanties-financieres-a-traiter-form',
+            action: validerDépôtEnCoursGarantiesFinancièresAction,
+            method: 'post',
+            encType: 'multipart/form-data',
+            omitMandatoryFieldsLegend: true,
+            onSuccess: () => router.push(Routes.GarantiesFinancières.détail(identifiantProjet)),
+            children: (
+              <>
+                <p className="mt-3">Êtes-vous sûr de vouloir valider ces garanties financières ?</p>
+                <input type={'hidden'} value={identifiantProjet} name="identifiantProjet" />
+              </>
+            ),
+          }}
+        />
+      </modal.Component>
+    </>
   );
 };

--- a/packages/applications/ssr/src/components/pages/garanties-financières/détails/DétailsGarantiesFinancières.page.tsx
+++ b/packages/applications/ssr/src/components/pages/garanties-financières/détails/DétailsGarantiesFinancières.page.tsx
@@ -27,7 +27,7 @@ export type DétailsGarantiesFinancièresPageProps = {
   projet: ProjetBannerProps;
   actuelles?: GarantiesFinancièresActuellesProps['actuelles'];
   dépôtEnCours?: DépôtGarantiesFinancières & {
-    action?: 'modifier' | 'instruire';
+    actions: Array<'modifier' | 'instruire' | 'supprimer'>;
   };
   dateLimiteSoummission?: Iso8601DateTime;
   historiqueDépôts: GarantiesFinancièresHistoriqueDépôtsProps['dépôts'];

--- a/packages/applications/ssr/src/components/pages/garanties-financières/détails/DétailsGarantiesFinancières.stories.tsx
+++ b/packages/applications/ssr/src/components/pages/garanties-financières/détails/DétailsGarantiesFinancières.stories.tsx
@@ -107,7 +107,7 @@ export const GarantiesFinancieresActuellesComplètesAvecDépôtEnCours: Story = 
         date: new Date('2024-01-01').toISOString() as Iso8601DateTime,
         par: 'PORTEUR#1',
       },
-      action: 'modifier',
+      actions: ['modifier'],
     },
     historiqueDépôts: [
       {
@@ -169,7 +169,7 @@ export const GarantiesFinancieresVideAvecUnDépôtEnCours: Story = {
         date: new Date('2024-01-01').toISOString() as Iso8601DateTime,
         par: 'PORTEUR#1',
       },
-      action: 'modifier',
+      actions: ['modifier'],
     },
     historiqueDépôts: [],
   },

--- a/packages/applications/ssr/src/components/pages/garanties-financières/détails/components/GarantiesFinancièresDépôtEnCours.tsx
+++ b/packages/applications/ssr/src/components/pages/garanties-financières/détails/components/GarantiesFinancièresDépôtEnCours.tsx
@@ -8,16 +8,18 @@ import { CallOut } from '@/components/atoms/CallOut';
 import { Heading2 } from '@/components/atoms/headings';
 import { FormattedDate } from '@/components/atoms/FormattedDate';
 
+import { ValiderDépôtEnCoursGarantiesFinancières } from '../../dépôt/modifier/valider/validerDépôtEnCoursGarantiesFinancières';
+
 import { DépôtGarantiesFinancières } from './GarantiesFinancièresHistoriqueDépôts';
 
-type GarantiesFinancièresDépôtEnCoursProps = {
-  dépôt: DépôtGarantiesFinancières & { action?: 'modifier' | 'instruire' };
+export type GarantiesFinancièresDépôtEnCoursProps = {
+  dépôt: DépôtGarantiesFinancières & { actions?: Array<'modifier' | 'instruire'> };
   identifiantProjet: string;
 };
 
 export const GarantiesFinancièresDépôtEnCours: FC<GarantiesFinancièresDépôtEnCoursProps> = ({
   identifiantProjet,
-  dépôt: { type, dateÉchéance, dateConstitution, attestation, action, dernièreMiseÀJour },
+  dépôt: { type, dateÉchéance, dateConstitution, attestation, actions, dernièreMiseÀJour },
 }) => (
   <>
     <CallOut
@@ -36,7 +38,7 @@ export const GarantiesFinancièresDépôtEnCours: FC<GarantiesFinancièresDépô
               <>
                 Type : <span className="font-semibold">{type}</span>
               </>
-            ) : action === 'modifier' || action === 'instruire' ? (
+            ) : actions?.includes('modifier') ? (
               <>
                 Type de garanties financières manquant (
                 <a href={Routes.GarantiesFinancières.dépôt.modifier(identifiantProjet)}>
@@ -71,16 +73,21 @@ export const GarantiesFinancièresDépôtEnCours: FC<GarantiesFinancièresDépô
               )}
             </div>
           </div>
-          {action && (
-            <Button
-              className="mt-auto w-fit"
-              linkProps={{
-                href: Routes.GarantiesFinancières.dépôt.modifier(identifiantProjet),
-              }}
-            >
-              {action.charAt(0).toUpperCase() + action.slice(1)}
-            </Button>
-          )}
+          <div className="flex md:flex-row flex-col gap-4">
+            {actions?.includes('modifier') && (
+              <Button
+                priority="secondary"
+                linkProps={{
+                  href: Routes.GarantiesFinancières.dépôt.modifier(identifiantProjet),
+                }}
+              >
+                Modifier
+              </Button>
+            )}
+            {actions?.includes('instruire') && (
+              <ValiderDépôtEnCoursGarantiesFinancières identifiantProjet={identifiantProjet} />
+            )}
+          </div>
         </div>
       }
     />

--- a/packages/applications/ssr/src/components/pages/garanties-financières/détails/components/GarantiesFinancièresDépôtEnCours.tsx
+++ b/packages/applications/ssr/src/components/pages/garanties-financières/détails/components/GarantiesFinancièresDépôtEnCours.tsx
@@ -39,7 +39,7 @@ export const GarantiesFinancièresDépôtEnCours: FC<GarantiesFinancièresDépô
               <>
                 Type : <span className="font-semibold">{type}</span>
               </>
-            ) : actions?.includes('modifier') ? (
+            ) : actions.includes('modifier') ? (
               <>
                 Type de garanties financières manquant (
                 <a href={Routes.GarantiesFinancières.dépôt.modifier(identifiantProjet)}>

--- a/packages/applications/ssr/src/components/pages/garanties-financières/détails/components/GarantiesFinancièresDépôtEnCours.tsx
+++ b/packages/applications/ssr/src/components/pages/garanties-financières/détails/components/GarantiesFinancièresDépôtEnCours.tsx
@@ -14,7 +14,7 @@ import { SupprimerDépôtEnCoursGarantiesFinancières } from '../../dépôt/modi
 import { DépôtGarantiesFinancières } from './GarantiesFinancièresHistoriqueDépôts';
 
 export type GarantiesFinancièresDépôtEnCoursProps = {
-  dépôt: DépôtGarantiesFinancières & { actions?: Array<'modifier' | 'instruire' | 'supprimer'> };
+  dépôt: DépôtGarantiesFinancières & { actions: Array<'modifier' | 'instruire' | 'supprimer'> };
   identifiantProjet: string;
 };
 

--- a/packages/applications/ssr/src/components/pages/garanties-financières/détails/components/GarantiesFinancièresDépôtEnCours.tsx
+++ b/packages/applications/ssr/src/components/pages/garanties-financières/détails/components/GarantiesFinancièresDépôtEnCours.tsx
@@ -9,11 +9,12 @@ import { Heading2 } from '@/components/atoms/headings';
 import { FormattedDate } from '@/components/atoms/FormattedDate';
 
 import { ValiderDépôtEnCoursGarantiesFinancières } from '../../dépôt/modifier/valider/validerDépôtEnCoursGarantiesFinancières';
+import { SupprimerDépôtEnCoursGarantiesFinancières } from '../../dépôt/modifier/supprimer/SupprimerDépôtEnCoursGarantiesFinancières';
 
 import { DépôtGarantiesFinancières } from './GarantiesFinancièresHistoriqueDépôts';
 
 export type GarantiesFinancièresDépôtEnCoursProps = {
-  dépôt: DépôtGarantiesFinancières & { actions?: Array<'modifier' | 'instruire'> };
+  dépôt: DépôtGarantiesFinancières & { actions?: Array<'modifier' | 'instruire' | 'supprimer'> };
   identifiantProjet: string;
 };
 
@@ -86,6 +87,9 @@ export const GarantiesFinancièresDépôtEnCours: FC<GarantiesFinancièresDépô
             )}
             {actions?.includes('instruire') && (
               <ValiderDépôtEnCoursGarantiesFinancières identifiantProjet={identifiantProjet} />
+            )}
+            {actions?.includes('supprimer') && (
+              <SupprimerDépôtEnCoursGarantiesFinancières identifiantProjet={identifiantProjet} />
             )}
           </div>
         </div>

--- a/packages/applications/ssr/src/components/pages/garanties-financières/détails/components/GarantiesFinancièresDépôtEnCours.tsx
+++ b/packages/applications/ssr/src/components/pages/garanties-financières/détails/components/GarantiesFinancièresDépôtEnCours.tsx
@@ -74,24 +74,28 @@ export const GarantiesFinancièresDépôtEnCours: FC<GarantiesFinancièresDépô
               )}
             </div>
           </div>
-          <div className="flex md:flex-row flex-col gap-4">
-            {actions?.includes('modifier') && (
-              <Button
-                priority="secondary"
-                linkProps={{
-                  href: Routes.GarantiesFinancières.dépôt.modifier(identifiantProjet),
-                }}
-              >
-                Modifier
-              </Button>
-            )}
-            {actions?.includes('instruire') && (
-              <ValiderDépôtEnCoursGarantiesFinancières identifiantProjet={identifiantProjet} />
-            )}
-            {actions?.includes('supprimer') && (
-              <SupprimerDépôtEnCoursGarantiesFinancières identifiantProjet={identifiantProjet} />
-            )}
-          </div>
+         {
+          actions.length > 0 ? (
+            <div className="flex md:flex-row flex-col gap-4">
+              {actions.includes('modifier') && (
+                <Button
+                  priority="secondary"
+                  linkProps={{
+                    href: Routes.GarantiesFinancières.dépôt.modifier(identifiantProjet),
+                  }}
+                >
+                  Modifier
+                </Button>
+              )}
+              {actions.includes('instruire') && (
+                <ValiderDépôtEnCoursGarantiesFinancières identifiantProjet={identifiantProjet} />
+              )}
+              {actions.includes('supprimer') && (
+                <SupprimerDépôtEnCoursGarantiesFinancières identifiantProjet={identifiantProjet} />
+              )}
+            </div>
+         ) : null
+       }
         </div>
       }
     />


### PR DESCRIPTION
Les boutons "supprimer" et "valider" étaient accessibles depuis la page de modification du dépôt de GF. On les déplace sur la page du détail du dépôt.