### PR TITLE
💬 Le formulaire de saisie des gf doit avoir un bouton cancel qui retourne sur le détail des gfs du  projet

### DIFF
--- a/packages/applications/ssr/src/components/pages/garanties-financières/FormulaireGarantiesFinancières.tsx
+++ b/packages/applications/ssr/src/components/pages/garanties-financières/FormulaireGarantiesFinancières.tsx
@@ -115,11 +115,11 @@ export const FormulaireGarantiesFinancières: FC<FormulaireGarantiesFinancières
         <Button
           priority="secondary"
           linkProps={{
-            href: Routes.Projet.details(identifiantProjet),
+            href: Routes.GarantiesFinancières.détail(identifiantProjet),
           }}
           iconId="fr-icon-arrow-left-line"
         >
-          Retour au détail du projet
+          Retour au détail des garanties financières
         </Button>
         <SubmitButton>{submitButtonLabel}</SubmitButton>
       </div>


### PR DESCRIPTION
# Description

Juste un changement de route ciblée quand on cancel le formulaire de saisi d'une GF. On redirige sur le détail des GFs du projet, non pas le projet en lui même

## Type de changement

- [x] Refacto de code

# Comment cela a-t-il été testé?

Se rendre sur les formulaire pour : 
- soumettre des GFs
- modifer un dépot
- Enregistrer des gfs


# Check-up :

- [x] Mon code [suit les directives de style](../docs/contributing//DEVELOPMENT_FLOW.md) de ce projet
- [x] J'ai effectué une auto-revue de mon code
- [x] Mes modifications ne génèrent aucun warning