### PR TITLE
🎨 Pouvoir filtrer la liste des projets en attente de gf par motif

### DIFF
--- a/packages/applications/legacy/src/views/pages/projectDetailsPage/sections/InfoGenerales.tsx
+++ b/packages/applications/legacy/src/views/pages/projectDetailsPage/sections/InfoGenerales.tsx
@@ -253,8 +253,6 @@ const getMotifGFEnAttente = (
       return 'recours accordé';
     case 'changement-producteur':
       return 'changement de producteur';
-    case 'garanties-financières-initiales':
-      return 'garanties financières initiales';
     case 'échéance-garanties-financières-actuelles':
       return 'garanties financières arrivant à échéance';
     default:

--- a/packages/applications/ssr/src/app/garanties-financieres/projets-en-attente/page.tsx
+++ b/packages/applications/ssr/src/app/garanties-financieres/projets-en-attente/page.tsx
@@ -15,6 +15,8 @@ import {
 import { getGarantiesFinancièresMotifLabel } from '@/components/pages/garanties-financières/getGarantiesFinancièresMotifLabel';
 import { mapToRangeOptions } from '@/utils/mapToRangeOptions';
 import { mapToPagination } from '@/utils/mapToPagination';
+import { ListPageTemplateProps } from '@/components/templates/ListPage.template';
+import { ListItemProjetAvecGarantiesFinancièresEnAttenteProps } from '@/components/pages/garanties-financières/en-attente/lister/ListItemProjetAvecGarantiesFinancièresEnAttente';
 
 type PageProps = {
   searchParams?: Record<string, string>;
@@ -30,6 +32,7 @@ export default async function Page({ searchParams }: PageProps) {
     withUtilisateur(async (utilisateur) => {
       const page = searchParams?.page ? parseInt(searchParams.page) : 1;
       const appelOffre = searchParams?.appelOffre;
+      const motif = searchParams?.motif;
 
       const projetsAvecGarantiesFinancièresEnAttente =
         await mediator.send<GarantiesFinancières.ListerProjetsAvecGarantiesFinancièresEnAttenteQuery>(
@@ -40,7 +43,8 @@ export default async function Page({ searchParams }: PageProps) {
                 email: utilisateur.identifiantUtilisateur.email,
                 rôle: utilisateur.role.nom,
               },
-              ...(appelOffre && { appelOffre }),
+              appelOffre,
+              motif,
               range: mapToRangeOptions({ currentPage: page, itemsPerPage: 10 }),
             },
           },
@@ -51,17 +55,27 @@ export default async function Page({ searchParams }: PageProps) {
         data: {},
       });
 
-      const filters = [
-        {
-          label: `Appel d'offres`,
-          searchParamKey: 'appelOffre',
-          defaultValue: appelOffre,
-          options: appelOffres.items.map((appelOffre) => ({
-            label: appelOffre.id,
-            value: appelOffre.id,
-          })),
-        },
-      ];
+      const filters: ListPageTemplateProps<ListItemProjetAvecGarantiesFinancièresEnAttenteProps>['filters'] =
+        [
+          {
+            label: `Appel d'offres`,
+            searchParamKey: 'appelOffre',
+            defaultValue: appelOffre,
+            options: appelOffres.items.map((appelOffre) => ({
+              label: appelOffre.id,
+              value: appelOffre.id,
+            })),
+          },
+          {
+            label: 'Motif',
+            searchParamKey: 'motif',
+            defaultValue: motif,
+            options: GarantiesFinancières.MotifDemandeGarantiesFinancières.motifs.map((motif) => ({
+              label: getGarantiesFinancièresMotifLabel(motif),
+              value: motif,
+            })),
+          },
+        ];
 
       return (
         <ListProjetsAvecGarantiesFinancièresEnAttentePage

--- a/packages/applications/ssr/src/components/pages/garanties-financières/en-attente/lister/ListerProjetsAvecGarantiesFinancièresEnAttente.page.tsx
+++ b/packages/applications/ssr/src/components/pages/garanties-financières/en-attente/lister/ListerProjetsAvecGarantiesFinancièresEnAttente.page.tsx
@@ -25,17 +25,24 @@ export const ListProjetsAvecGarantiesFinancièresEnAttentePage: FC<
 > = ({ list: { items: garantiesFinancières, currentPage, totalItems, itemsPerPage }, filters }) => {
   const searchParams = useSearchParams();
   const appelOffre = searchParams.get('appelOffre') ?? undefined;
+  const motif = searchParams.get('motif') ?? undefined;
 
-  const tagFilters = [
-    ...(appelOffre
-      ? [
-          {
-            label: `appel d'offres : ${appelOffre}`,
-            searchParamKey: 'appelOffre',
-          },
-        ]
-      : []),
-  ];
+  const tagFilters: ListPageTemplateProps<ListItemProjetAvecGarantiesFinancièresEnAttenteProps>['tagFilters'] =
+    [];
+
+  if (appelOffre) {
+    tagFilters.push({
+      label: `appel d'offres : ${appelOffre}`,
+      searchParamKey: 'appelOffre',
+    });
+  }
+
+  if (motif) {
+    tagFilters.push({
+      label: `motif : ${motif}`,
+      searchParamKey: 'motif',
+    });
+  }
 
   return (
     <ListPageTemplate

--- a/packages/applications/ssr/src/components/pages/garanties-financières/en-attente/lister/ListerProjetsAvecGarantiesFinancièresEnAttente.stories.tsx
+++ b/packages/applications/ssr/src/components/pages/garanties-financières/en-attente/lister/ListerProjetsAvecGarantiesFinancièresEnAttente.stories.tsx
@@ -21,7 +21,7 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-const filters = [
+const filters: ListProjetsAvecGarantiesFinancièresEnAttenteProps['filters'] = [
   {
     label: `Appel d'offres`,
     searchParamKey: 'appelOffre',
@@ -34,6 +34,21 @@ const filters = [
       {
         label: 'Appel offre 2',
         value: 'appel-offre-2',
+      },
+    ],
+  },
+  {
+    label: 'Motifs',
+    searchParamKey: 'motif',
+    defaultValue: undefined,
+    options: [
+      {
+        label: 'Inconnu',
+        value: 'inconnu',
+      },
+      {
+        label: 'Recours accordé',
+        value: 'recours-accordé',
       },
     ],
   },

--- a/packages/applications/ssr/src/components/pages/garanties-financières/en-attente/lister/ListerProjetsAvecGarantiesFinancièresEnAttente.stories.tsx
+++ b/packages/applications/ssr/src/components/pages/garanties-financières/en-attente/lister/ListerProjetsAvecGarantiesFinancièresEnAttente.stories.tsx
@@ -1,6 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { Iso8601DateTime } from '@potentiel-libraries/iso8601-datetime';
+import { GarantiesFinancières } from '@potentiel-domain/laureat';
+
+import { getGarantiesFinancièresMotifLabel } from '../../getGarantiesFinancièresMotifLabel';
 
 import {
   ListProjetsAvecGarantiesFinancièresEnAttentePage,
@@ -32,7 +35,7 @@ const filters: ListProjetsAvecGarantiesFinancièresEnAttenteProps['filters'] = [
         value: 'appel-offre-1',
       },
       {
-        label: 'Appel offre 2',
+        label: 'App`el offre 2',
         value: 'appel-offre-2',
       },
     ],
@@ -41,16 +44,10 @@ const filters: ListProjetsAvecGarantiesFinancièresEnAttenteProps['filters'] = [
     label: 'Motifs',
     searchParamKey: 'motif',
     defaultValue: undefined,
-    options: [
-      {
-        label: 'Inconnu',
-        value: 'inconnu',
-      },
-      {
-        label: 'Recours accordé',
-        value: 'recours-accordé',
-      },
-    ],
+    options: GarantiesFinancières.MotifDemandeGarantiesFinancières.motifs.map((motif) => ({
+      label: getGarantiesFinancièresMotifLabel(motif),
+      value: motif,
+    })),
   },
 ];
 

--- a/packages/applications/ssr/src/components/pages/garanties-financières/getGarantiesFinancièresMotifLabel.ts
+++ b/packages/applications/ssr/src/components/pages/garanties-financières/getGarantiesFinancièresMotifLabel.ts
@@ -6,8 +6,6 @@ export const getGarantiesFinancièresMotifLabel = (
   switch (type) {
     case 'changement-producteur':
       return 'Changement de producteur';
-    case 'garanties-financières-initiales':
-      return 'Garanties financières initiales';
     case 'recours-accordé':
       return 'Recours accordé';
     case 'échéance-garanties-financières-actuelles':

--- a/packages/domain/lauréat/src/garantiesFinancières/enAttente/lister/listerProjetsAvecGarantiesFinancièresEnAttente.query.ts
+++ b/packages/domain/lauréat/src/garantiesFinancières/enAttente/lister/listerProjetsAvecGarantiesFinancièresEnAttente.query.ts
@@ -32,6 +32,7 @@ export type ListerProjetsAvecGarantiesFinancièresEnAttenteQuery = Message<
   'Lauréat.GarantiesFinancières.Query.ListerProjetsAvecGarantiesFinancièresEnAttente',
   {
     appelOffre?: string;
+    motif?: string;
     utilisateur: {
       rôle: string;
       email: string;
@@ -52,6 +53,7 @@ export const registerListerProjetsAvecGarantiesFinancièresEnAttenteQuery = ({
 }: ListerProjetsAvecGarantiesFinancièresEnAttenteDependencies) => {
   const handler: MessageHandler<ListerProjetsAvecGarantiesFinancièresEnAttenteQuery> = async ({
     appelOffre,
+    motif,
     utilisateur: { email, rôle },
     range,
   }) => {
@@ -81,6 +83,9 @@ export const registerListerProjetsAvecGarantiesFinancièresEnAttenteQuery = ({
         where: {
           ...(appelOffre && {
             appelOffre: { operator: 'equal', value: appelOffre },
+          }),
+          ...(motif && {
+            motif: { operator: 'equal', value: motif },
           }),
           ...(région && {
             régionProjet: { operator: 'equal', value: région },

--- a/packages/domain/lauréat/src/garantiesFinancières/motifDemandeGarantiesFinancières.valueType.ts
+++ b/packages/domain/lauréat/src/garantiesFinancières/motifDemandeGarantiesFinancières.valueType.ts
@@ -4,7 +4,6 @@ export const motifs = [
   'recours-accordé',
   'changement-producteur',
   'échéance-garanties-financières-actuelles',
-  'garanties-financières-initiales',
   'motif-inconnu',
 ] as const;
 
@@ -15,7 +14,6 @@ export type ValueType = ReadonlyValueType<{
   estRecoursAccordé: () => boolean;
   estChangementProducteur: () => boolean;
   estÉchéance: () => boolean;
-  estGarantiesFinancièresInitiales: () => boolean;
 }>;
 
 export const convertirEnValueType = (value: string): ValueType => {
@@ -36,9 +34,6 @@ export const convertirEnValueType = (value: string): ValueType => {
     estÉchéance() {
       return this.motif === 'échéance-garanties-financières-actuelles';
     },
-    estGarantiesFinancièresInitiales() {
-      return this.motif === 'garanties-financières-initiales';
-    },
   };
 };
 
@@ -54,9 +49,6 @@ export const recoursAccordé = convertirEnValueType('recours-accordé');
 export const changementProducteur = convertirEnValueType('changement-producteur');
 export const échéanceGarantiesFinancièresActuelles = convertirEnValueType(
   'échéance-garanties-financières-actuelles',
-);
-export const garantiesFinancièresInitiales = convertirEnValueType(
-  'garanties-financières-initiales',
 );
 export const motifInconnu = convertirEnValueType('motif-inconnu');
 class MotifDemandeGarantiesFinancièresInvalideError extends InvalidOperationError {

--- a/packages/specifications/src/projet/lauréat/garantiesFinancières/enregistrerGarantiesFinancières.feature
+++ b/packages/specifications/src/projet/lauréat/garantiesFinancières/enregistrerGarantiesFinancières.feature
@@ -4,6 +4,7 @@ Fonctionnalité: Enregistrer des garanties financières validées
     Contexte: 
         Etant donné le projet lauréat "Centrale PV"
 
+    @select
     Plan du Scénario: Un admin enregistre des garanties financières validées pour un projet ayant des garanties financières en attente
         Etant donné des garanties financières en attente pour le projet "Centrale PV" avec :
             | date limite de soumission | 2023-11-01                      |
@@ -27,11 +28,10 @@ Fonctionnalité: Enregistrer des garanties financières validées
         Et les garanties financières en attente du projet "Centrale PV" ne devraient plus être consultable dans la liste des garanties financières en attente    
     Exemples:
             | type                      | date d'échéance | motif                                    |
-            | avec-date-échéance        | 2027-12-01      | garanties-financières-initiales          |
+            | avec-date-échéance        | 2027-12-01      | motif-inconnu                            |
             | consignation              |                 | recours-accordé                          |
             | six-mois-après-achèvement |                 | changement-producteur                    |
             | consignation              |                 | échéance-garanties-financières-actuelles |
-            | consignation              |                 | motif-inconnu                            |
     
     Plan du Scénario: Un admin enregistre des garanties financières validées
         Quand un admin enregistre les garanties financières validées pour le projet "Centrale PV" avec : 

--- a/packages/specifications/src/projet/lauréat/garantiesFinancières/soumettreGarantiesFinancières.feature
+++ b/packages/specifications/src/projet/lauréat/garantiesFinancières/soumettreGarantiesFinancières.feature
@@ -7,7 +7,7 @@ Fonctionnalité: Soumettre de nouvelles garanties financières
         Etant donné des garanties financières en attente pour le projet "Centrale PV" avec :
             | date limite de soumission | 2023-11-01                      |
             | date de notification      | 2023-09-01                      |
-            | motif                     | garanties-financières-initiales |
+            | motif                     | motif-inconnu                   |
         Quand le porteur soumet des garanties financières pour le projet "Centrale PV" avec :
             | type                 | <type>                 |
             | date d'échéance      | <date d'échéance>      |

--- a/packages/specifications/src/projet/lauréat/garantiesFinancières/supprimerGarantiesFinancièresÀTraiter.feature
+++ b/packages/specifications/src/projet/lauréat/garantiesFinancières/supprimerGarantiesFinancièresÀTraiter.feature
@@ -4,6 +4,7 @@ Fonctionnalité: Supprimer des garanties financières en attente de validation
     Contexte:
         Etant donné le projet lauréat "Centrale PV"
 
+    @select
     Plan du Scénario: Un porteur supprime des garanties financières avec une date limite de soumission après les avoir soumises
         Etant donné des garanties financières en attente pour le projet "Centrale PV" avec :
             | date limite de soumission | 2023-11-01 |
@@ -25,11 +26,10 @@ Fonctionnalité: Supprimer des garanties financières en attente de validation
             | motif                     | <motif>    |
     Exemples:
             | type                      | date d'échéance | format du fichier | contenu du fichier    | date de constitution | motif                                    |
-            | avec-date-échéance        | 2027-12-01      | application/pdf   | le contenu du fichier | 2023-06-01           | garanties-financières-initiales          |
+            | avec-date-échéance        | 2027-12-01      | application/pdf   | le contenu du fichier | 2023-06-01           | motif-inconnu                            |
             | consignation              |                 | application/pdf   | le contenu du fichier | 2023-06-01           | recours-accordé                          |
             | six-mois-après-achèvement |                 | application/pdf   | le contenu du fichier | 2023-06-01           | changement-producteur                    |
             | consignation              |                 | application/pdf   | le contenu du fichier | 2023-06-01           | échéance-garanties-financières-actuelles |
-            | consignation              |                 | application/pdf   | le contenu du fichier | 2023-06-01           | motif-inconnu                            |
 
     Plan du Scénario: Un porteur supprime des garanties financières sans une date limite de soumission après les avoir soumises
         Etant donné des garanties financières à traiter pour le projet "Centrale PV" avec :
@@ -54,7 +54,7 @@ Fonctionnalité: Supprimer des garanties financières en attente de validation
         Etant donné des garanties financières en attente pour le projet "Centrale PV" avec :
             | date limite de soumission | 2023-11-01                      |
             | date de notification      | 2023-09-01                      |
-            | motif                     | garanties-financières-initiales |
+            | motif                     | motif-inconnu                   |
         Quand le porteur supprime les garanties financières à traiter pour le projet "Centrale PV"
         Alors l'utilisateur devrait être informé que "Il n'y a aucun dépôt de garanties financières en cours pour ce projet"
 

--- a/packages/specifications/src/projet/lauréat/garantiesFinancières/validerGarantiesFinancièresÀTraiter.feature
+++ b/packages/specifications/src/projet/lauréat/garantiesFinancières/validerGarantiesFinancièresÀTraiter.feature
@@ -8,7 +8,7 @@ Fonctionnalité: Valider des garanties financières en attente de validation
         Etant donné des garanties financières en attente pour le projet "Centrale PV" avec :
             | date limite de soumission | 2023-11-01                      |
             | date de notification      | 2023-09-01                      |
-            | motif                     | garanties-financières-initiales |
+            | motif                     | motif-inconnu                   |
         Et des garanties financières à traiter pour le projet "Centrale PV" avec :
             | type                 | <type>                 |
             | date d'échéance      | <date d'échéance>      |
@@ -38,7 +38,7 @@ Fonctionnalité: Valider des garanties financières en attente de validation
         Etant donné des garanties financières en attente pour le projet "Centrale PV" avec :
             | date limite de soumission | 2023-11-01                      |
             | date de notification      | 2023-09-01                      |
-            | motif                     | garanties-financières-initiales |
+            | motif                     | motif-inconnu                   |
         Quand l'utilisateur dreal valide les garanties financières à traiter pour le projet "Centrale PV" avec :
             | date de validation | 2023-09-02 |
         Alors l'utilisateur devrait être informé que "Il n'y a aucun dépôt de garanties financières en cours pour ce projet"


### PR DESCRIPTION
# Description

Ajout d'un filtre supplémentaire pour retrouver des projets en attente de transmission de gf par motif d'attente.

## Type de changement

- [x] Nouvelle fonctionnalité

# Comment cela a-t-il été testé?

En local j'avais une base avec l'event stream des gfs déjà à jour.

 
## Scénarios 

Pour pouvoir bien tester le filtre par motif il faut : 

- test avec changement de producteur
- test avec recours accordé
- on peut pas tester gf arrivées à échéance pour le moment


# Check-up :

- [ ] Mon code [suit les directives de style](../docs/contributing//DEVELOPMENT_FLOW.md) de ce projet
- [ ] J'ai effectué une auto-revue de mon code
- [ ] J'ai commenté mon code, en particulier dans les zones difficiles à comprendre
- [ ] J'ai apporté des modifications correspondantes à la documentation
- [ ] Mes modifications ne génèrent aucun warning
- [ ] J'ai ajouté des tests qui prouvent l'efficacité de ma correction ou que ma fonctionnalité fonctionne
- [ ] Les nouveaux tests unitaires et les tests existants passent en local / dans la CI avec mes modifications
