### PR TITLE
🚑️ Erreur lors de la notification d'un changement de statut pour des appels d'offres

### DIFF
--- a/packages/infrastructure/domain-adapters/src/utilisateur/récupérerDrealsParIdentifiantProjet.adapter.ts
+++ b/packages/infrastructure/domain-adapters/src/utilisateur/récupérerDrealsParIdentifiantProjet.adapter.ts
@@ -16,7 +16,7 @@ from
       from "users" u
       inner join "userDreals" ud on u.id = ud."userId"
       inner join "projects" p on p."regionProjet" = ud."dreal"
-      where p."appelOffre" = $1 and p."periodeId" = $2 and p."numeroCRE" = $3 and p."familleId" = $4
+      where p."appelOffreId" = $1 and p."periodeId" = $2 and p."numeroCRE" = $3 and p."familleId" = $4
     ) as "user"; 
 `;
 


### PR DESCRIPTION
# Description

On a remarqué pendant la mise en prod que les notifications ne marchaient pas pour GF. Ca vient du faire que l'adapter `récupérerDrealsParIdentifiantProjet.adapter.ts` cherche une colonne `p."appelOffre"` qui n'existe pas, c'est `p."appelOffreId"`.

## Type de changement

- [x] Hotfix

# Comment cela a-t-il été testé?

J'ai fais la modif et bien vérifié que le log pour l'envoi d'email soit affiché. Exemple de message : 

```
Emailing mode set to logging-only so no email was sent | Service(potentiel-dev) | Metadata({templateId=5740394} {messageSubject=Potentiel - Des garanties financières sont en attente de validation pour le projet Centrale PV 49 dans le département Hauts-de-Seine} {recipients=[object Object]} {variables=[object Object]})
```

## Pré-requis 

- [ ] Ne pas avoir la variable d'env `SEND_EMAIL_MODE` dans `legacy/.env` ou avoir l'avoir avoir comme valeur `'logging-only'`
 
## Scénarios 

- [ ] soumettre / valider dépot gf 
- [ ] attestation gf enregistrée
- [ ] gf actuelles modifiées / enregistrées