### PR TITLE
✨ [Achèvement PR 2]: notification dreal en cas d'attestation de conformité transmise

### DIFF
--- a/packages/applications/bootstrap/src/setupLauréat.ts
+++ b/packages/applications/bootstrap/src/setupLauréat.ts
@@ -7,7 +7,7 @@ import {
 } from '@potentiel-infrastructure/pg-projections';
 import {
   AbandonNotification,
-  AttestationConformitéNotification,
+  AchèvementNotification,
   GarantiesFinancièresNotification,
 } from '@potentiel-applications/notifications';
 import {
@@ -49,7 +49,7 @@ export const setupLauréat = async () => {
   GarantiesFinancièreProjector.register();
   GarantiesFinancièresNotification.register();
   AchèvementProjector.register();
-  AttestationConformitéNotification.register();
+  AchèvementNotification.register();
 
   const unsubscribeAbandonNotification = await subscribe<AbandonNotification.SubscriptionEvent>({
     name: 'notifications',
@@ -149,13 +149,13 @@ export const setupLauréat = async () => {
       },
     });
 
-  const unsubscribeAttestationConformitéNotification =
-    await subscribe<AttestationConformitéNotification.SubscriptionEvent>({
+  const unsubscribeAchèvementNotification =
+    await subscribe<AchèvementNotification.SubscriptionEvent>({
       name: 'notifications',
-      streamCategory: 'attestation-conformite',
+      streamCategory: 'achevement',
       eventType: ['AttestationConformitéTransmise-V1'],
       eventHandler: async (event) => {
-        await mediator.publish<AttestationConformitéNotification.Execute>({
+        await mediator.publish<AchèvementNotification.Execute>({
           type: 'System.Notification.Lauréat.Achèvement.AttestationConformité',
           data: event,
         });
@@ -168,6 +168,6 @@ export const setupLauréat = async () => {
     await unsubscribeGarantiesFinancièresProjector();
     await unsubscribeGarantiesFinancièresNotification();
     await unsubscribeAchèvementProjector();
-    await unsubscribeAttestationConformitéNotification();
+    await unsubscribeAchèvementNotification();
   };
 };

--- a/packages/applications/bootstrap/src/setupLauréat.ts
+++ b/packages/applications/bootstrap/src/setupLauréat.ts
@@ -7,6 +7,7 @@ import {
 } from '@potentiel-infrastructure/pg-projections';
 import {
   AbandonNotification,
+  AttestationConformitéNotification,
   GarantiesFinancièresNotification,
 } from '@potentiel-applications/notifications';
 import {
@@ -48,6 +49,7 @@ export const setupLauréat = async () => {
   GarantiesFinancièreProjector.register();
   GarantiesFinancièresNotification.register();
   AchèvementProjector.register();
+  AttestationConformitéNotification.register();
 
   const unsubscribeAbandonNotification = await subscribe<AbandonNotification.SubscriptionEvent>({
     name: 'notifications',
@@ -147,11 +149,25 @@ export const setupLauréat = async () => {
       },
     });
 
+  const unsubscribeAttestationConformitéNotification =
+    await subscribe<AttestationConformitéNotification.SubscriptionEvent>({
+      name: 'notifications',
+      streamCategory: 'attestation-conformite',
+      eventType: ['AttestationConformitéTransmise-V1'],
+      eventHandler: async (event) => {
+        await mediator.publish<AttestationConformitéNotification.Execute>({
+          type: 'System.Notification.Lauréat.Achèvement.AttestationConformité',
+          data: event,
+        });
+      },
+    });
+
   return async () => {
     await unsubscribeAbandonNotification();
     await unsubscribeAbandonProjector();
     await unsubscribeGarantiesFinancièresProjector();
     await unsubscribeGarantiesFinancièresNotification();
     await unsubscribeAchèvementProjector();
+    await unsubscribeAttestationConformitéNotification();
   };
 };

--- a/packages/applications/notifications/src/index.ts
+++ b/packages/applications/notifications/src/index.ts
@@ -1,3 +1,3 @@
 export * as AbandonNotification from './subscribers/lauréat/abandon.notification';
 export * as GarantiesFinancièresNotification from './subscribers/lauréat/garantiesFinancières.notification';
-export * as AttestationConformitéNotification from './subscribers/lauréat/attestationConformité.notification';
+export * as AchèvementNotification from './subscribers/lauréat/achèvement.notification';

--- a/packages/applications/notifications/src/index.ts
+++ b/packages/applications/notifications/src/index.ts
@@ -1,2 +1,3 @@
 export * as AbandonNotification from './subscribers/lauréat/abandon.notification';
 export * as GarantiesFinancièresNotification from './subscribers/lauréat/garantiesFinancières.notification';
+export * as AttestationConformitéNotification from './subscribers/lauréat/attestationConformité.notification';

--- a/packages/applications/notifications/src/subscribers/lauréat/achèvement.notification.ts
+++ b/packages/applications/notifications/src/subscribers/lauréat/achèvement.notification.ts
@@ -21,7 +21,7 @@ const templateId = {
   attestationConformitéTransmise: 5945568,
 };
 
-const sendEmailAttestationConformité = async ({
+const sendEmailAchèvement = async ({
   identifiantProjet,
   templateId,
   recipients,
@@ -74,7 +74,7 @@ export const register = () => {
 
     switch (event.type) {
       case 'AttestationConformitéTransmise-V1':
-        await sendEmailAttestationConformité({
+        await sendEmailAchèvement({
           subject: `Potentiel - Une attestation de conformité a été transmise pour le projet ${nomProjet} dans le département ${départementProjet}`,
           templateId: templateId.attestationConformitéTransmise,
           recipients: dreals,

--- a/packages/applications/notifications/src/subscribers/lauréat/attestationConformité.notification.ts
+++ b/packages/applications/notifications/src/subscribers/lauréat/attestationConformité.notification.ts
@@ -10,7 +10,7 @@ import { Achèvement } from '@potentiel-domain/laureat';
 import { Routes } from '@potentiel-applications/routes';
 import { sendEmail } from '../../infrastructure/sendEmail';
 
-export type SubscriptionEvent = Achèvement.AttestationConformité.AttestationConformitéEvent & Event;
+export type SubscriptionEvent = Achèvement.AchèvementEvent & Event;
 
 export type Execute = Message<
   'System.Notification.Lauréat.Achèvement.AttestationConformité',

--- a/packages/applications/notifications/src/subscribers/lauréat/attestationConformité.notification.ts
+++ b/packages/applications/notifications/src/subscribers/lauréat/attestationConformité.notification.ts
@@ -1,0 +1,91 @@
+import { Message, MessageHandler, mediator } from 'mediateur';
+import { IdentifiantProjet } from '@potentiel-domain/common';
+import { Option } from '@potentiel-libraries/monads';
+import { Event } from '@potentiel-infrastructure/pg-event-sourcing';
+import {
+  CandidatureAdapter,
+  récupérerDrealsParIdentifiantProjetAdapter,
+} from '@potentiel-infrastructure/domain-adapters';
+import { Achèvement } from '@potentiel-domain/laureat';
+import { Routes } from '@potentiel-applications/routes';
+import { sendEmail } from '../../infrastructure/sendEmail';
+
+export type SubscriptionEvent = Achèvement.AttestationConformité.AttestationConformitéEvent & Event;
+
+export type Execute = Message<
+  'System.Notification.Lauréat.Achèvement.AttestationConformité',
+  SubscriptionEvent
+>;
+
+const templateId = {
+  attestationConformitéTransmise: 5945568,
+};
+
+const sendEmailAttestationConformité = async ({
+  identifiantProjet,
+  templateId,
+  recipients,
+  nomProjet,
+  départementProjet,
+  régionProjet,
+  subject,
+}: {
+  identifiantProjet: IdentifiantProjet.ValueType;
+  subject: string;
+  templateId: number;
+  recipients: Array<{ email: string; fullName: string }>;
+  nomProjet: string;
+  départementProjet: string;
+  régionProjet: string;
+}) => {
+  const { BASE_URL } = process.env;
+
+  await sendEmail({
+    templateId,
+    messageSubject: subject,
+    recipients,
+    variables: {
+      nom_projet: nomProjet,
+      departement_projet: départementProjet,
+      region_projet: régionProjet,
+      url: `${BASE_URL}${Routes.Projet.details(identifiantProjet.formatter())}`,
+    },
+  });
+};
+
+export const register = () => {
+  const handler: MessageHandler<Execute> = async (event) => {
+    const identifiantProjet = IdentifiantProjet.convertirEnValueType(
+      event.payload.identifiantProjet,
+    );
+    const projet = await CandidatureAdapter.récupérerCandidatureAdapter(
+      identifiantProjet.formatter(),
+    );
+
+    if (Option.isNone(projet)) {
+      return;
+    }
+
+    const dreals = await récupérerDrealsParIdentifiantProjetAdapter(identifiantProjet);
+
+    const nomProjet = projet.nom;
+    const départementProjet = projet.localité.département;
+    const régionProjet = projet.localité.région;
+
+    switch (event.type) {
+      case 'AttestationConformitéTransmise-V1':
+        await sendEmailAttestationConformité({
+          subject: `Potentiel - Une attestation de conformité a été transmise pour le projet ${nomProjet} dans le département ${départementProjet}`,
+          templateId: templateId.attestationConformitéTransmise,
+          recipients: dreals,
+          identifiantProjet,
+          nomProjet,
+          départementProjet,
+          régionProjet,
+        });
+        break;
+    }
+  };
+
+  mediator.register('System.Notification.Lauréat.Achèvement.AttestationConformité', handler);
+};


### PR DESCRIPTION
⚠️  À merger après #1768 

# Description

Les utilisateurs "dreal" rattachés à la région d'un projet pour lequel une attestation de conformité a été déposée sont notifiées par mail. 

## Type de changement

Veuillez supprimer les options qui ne sont pas pertinentes.

- [ ] Correction de bug
- [x] Nouvelle fonctionnalité
- [ ] Refacto de code
- [ ] Breaking changes (correction ou fonctionnalité qui ferait en sorte que la fonctionnalité existante ne fonctionne pas comme prévu)
- [ ] Ce changement nécessite une mise à jour de la documentation

# Comment cela a-t-il été testé?

Pas possible à tester en local, on peut juste vérifier que le log est bien trigger (`Emailing mode set to logging-only so no email waq sent`)

## Pré-requis 

- [ ] Pré-requis A   
- [ ] Pré-requis B   
 
## Scénarios 

- [ ] Scénario A
- [ ] Scénario B

# Check-up :

- [ ] Mon code [suit les directives de style](../docs/contributing//DEVELOPMENT_FLOW.md) de ce projet
- [ ] J'ai effectué une auto-revue de mon code
- [ ] J'ai commenté mon code, en particulier dans les zones difficiles à comprendre
- [ ] J'ai apporté des modifications correspondantes à la documentation
- [ ] Mes modifications ne génèrent aucun warning
- [ ] J'ai ajouté des tests qui prouvent l'efficacité de ma correction ou que ma fonctionnalité fonctionne
- [ ] Les nouveaux tests unitaires et les tests existants passent en local / dans la CI avec mes modifications
