### PR TITLE
🗑️ Mark NotFoundError as deprecated

### DIFF
--- a/packages/domain/core/src/domainError.ts
+++ b/packages/domain/core/src/domainError.ts
@@ -7,7 +7,13 @@ export abstract class DomainError extends Error {
   }
 }
 
+/**
+ * @deprecated not found are only throw for Aggregate when executing a command.
+ * Use AggregateNotFoundError instead, or return an Option if your operation is a query
+ */
 export class NotFoundError extends DomainError {}
+
+export class AggregateNotFoundError extends DomainError {}
 
 export class InvalidOperationError extends DomainError {}
 


### PR DESCRIPTION
# Description

NotFoundError ne devrait plus être utilisé par les queries, il y a Option.none de dispo en retour pour ça. Du coup je propose de renommer NotFoundError en AggregateNotFound erreur pour ne plus créer de confusion et lever cette erreur uniquement si l'aggregate n'a pas pu être chargé.

La nouvelle erreur pourra être utilisée lors des prochains refacto lié à Option en retour de query.

## Type de changement

Veuillez supprimer les options qui ne sont pas pertinentes.

- [x] Refacto de code

# Comment cela a-t-il été testé?

N/A

# Check-up :

- [x] Mon code [suit les directives de style](../docs/contributing//DEVELOPMENT_FLOW.md) de ce projet
- [x] J'ai effectué une auto-revue de mon code
- [x] J'ai commenté mon code, en particulier dans les zones difficiles à comprendre
- [x] J'ai apporté des modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun warning
- [x] J'ai ajouté des tests qui prouvent l'efficacité de ma correction ou que ma fonctionnalité fonctionne
- [x] Les nouveaux tests unitaires et les tests existants passent en local / dans la CI avec mes modifications
