### PR TITLE
♻️ Passer la query générerModèleMiseEnDemeure avec Option

### DIFF
--- a/packages/applications/ssr/src/app/global-error/page.tsx
+++ b/packages/applications/ssr/src/app/global-error/page.tsx
@@ -1,0 +1,5 @@
+import { CustomErrorPage } from '@/components/pages/custom-error/CustomError.page';
+
+export default async function Page() {
+  return <CustomErrorPage statusCode="500" type="ServerError" />;
+}

--- a/packages/domain/lauréat/src/garantiesFinancières/générerModèleMiseEnDemeure/générerModèleMiseEnDemeure.query.ts
+++ b/packages/domain/lauréat/src/garantiesFinancières/générerModèleMiseEnDemeure/générerModèleMiseEnDemeure.query.ts
@@ -1,10 +1,9 @@
 import { Message, MessageHandler, mediator } from 'mediateur';
+import { CommonPort } from '@potentiel-domain/common';
+import { Option } from '@potentiel-libraries/monads';
+import { ConsulterUtilisateurQuery } from '@potentiel-domain/utilisateur';
 import { ConsulterCandidatureQuery } from '@potentiel-domain/candidature';
 import { ConsulterAppelOffreQuery } from '@potentiel-domain/appel-offre';
-import { ConsulterUtilisateurQuery } from '@potentiel-domain/utilisateur';
-import { CommonError, CommonPort } from '@potentiel-domain/common';
-import { Option } from '@potentiel-libraries/monads';
-import { PériodeNonIdentifiéError } from '../périodeNonIdentifiéError.error';
 import { ConsulterProjetAvecGarantiesFinancièresEnAttenteQuery } from '../enAttente/consulter/consulterProjetAvecGarantiesFinancièresEnAttente.query';
 
 export type GénérerModèleMiseEnDemeureGarantiesFinancièresReadModel = {
@@ -19,7 +18,7 @@ export type GénérerModèleMiseEnDemeureGarantiesFinancièresQuery = Message<
     identifiantUtilisateurValue: string;
     dateCourrierValue: string;
   },
-  GénérerModèleMiseEnDemeureGarantiesFinancièresReadModel
+  Option.Type<GénérerModèleMiseEnDemeureGarantiesFinancièresReadModel>
 >;
 
 export type BuildModèleMiseEnDemeureGarantiesFinancièresPort = (options: {
@@ -64,7 +63,7 @@ export const registerGénérerModèleMiseEnDemeureGarantiesFinancièresQuery = (
   }) => {
     const régionDreal = await récupérerRégionDreal(identifiantUtilisateurValue);
     if (Option.isNone(régionDreal)) {
-      throw new CommonError.RégionNonTrouvéeError();
+      return Option.none;
     }
 
     const utilisateur = await mediator.send<ConsulterUtilisateurQuery>({
@@ -91,7 +90,7 @@ export const registerGénérerModèleMiseEnDemeureGarantiesFinancièresQuery = (
     );
 
     if (!détailPériode) {
-      throw new PériodeNonIdentifiéError();
+      return Option.none;
     }
 
     const détailFamille = détailPériode?.familles.find((f) => f.id === candidature.famille);


### PR DESCRIPTION
# Description
Utilisation de Option dans la query, conformément aux conventions de code + Ajout d'une page d'erreur générique pour les endpoint routes handlers next 

## Type de changement
- [x] Refacto de code

# Comment cela a-t-il été testé?

- En forçant retour de query à retourner Option.none
- en testant le flow classique fonctionnel (etq dreal depuis la liste des projets en attente de gf je peux générer le document)


# Check-up :

- [x] Mon code [suit les directives de style](../docs/contributing//DEVELOPMENT_FLOW.md) de ce projet
- [x] J'ai effectué une auto-revue de mon code
- [ ] J'ai commenté mon code, en particulier dans les zones difficiles à comprendre
- [ ] J'ai apporté des modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun warning
