### PR TITLE
:sparkles: [GF] Filtrer listes par cycle d'AO (PPE2 ou CRE4)

### DIFF
--- a/packages/applications/ssr/src/app/garanties-financieres/depots-en-cours/page.tsx
+++ b/packages/applications/ssr/src/app/garanties-financieres/depots-en-cours/page.tsx
@@ -28,6 +28,7 @@ export default async function Page({ searchParams }: PageProps) {
     withUtilisateur(async (utilisateur) => {
       const page = searchParams?.page ? parseInt(searchParams.page) : 1;
       const appelOffre = searchParams?.appelOffre;
+      const cycle = searchParams?.cycle;
 
       const dépôtsEnCoursGarantiesFinancières =
         await mediator.send<GarantiesFinancières.ListerDépôtsEnCoursGarantiesFinancièresQuery>({
@@ -38,6 +39,7 @@ export default async function Page({ searchParams }: PageProps) {
               rôle: utilisateur.role.nom,
             },
             ...(appelOffre && { appelOffre }),
+            cycle,
             range: mapToRangeOptions({
               currentPage: page,
               itemsPerPage: 10,
@@ -51,6 +53,15 @@ export default async function Page({ searchParams }: PageProps) {
       });
 
       const filters = [
+        {
+          label: "Cycle d'appels d'offres",
+          searchParamKey: 'cycle',
+          defaultValue: cycle,
+          options: [
+            { label: 'PPE2', value: 'PPE2' },
+            { label: 'CRE4', value: 'CRE4' },
+          ],
+        },
         {
           label: `Appel d'offres`,
           searchParamKey: 'appelOffre',

--- a/packages/applications/ssr/src/app/garanties-financieres/projets-en-attente/page.tsx
+++ b/packages/applications/ssr/src/app/garanties-financieres/projets-en-attente/page.tsx
@@ -23,8 +23,8 @@ type PageProps = {
 };
 
 export const metadata: Metadata = {
-  title: 'Garanties financières en attente - Potentiel',
-  description: 'Liste des garanties financières en attente',
+  title: 'Projets en attente de garanties financières - Potentiel',
+  description: 'Liste des projets pour lesquels de nouvelles garanties financières sont attendues',
 };
 
 export default async function Page({ searchParams }: PageProps) {
@@ -33,6 +33,7 @@ export default async function Page({ searchParams }: PageProps) {
       const page = searchParams?.page ? parseInt(searchParams.page) : 1;
       const appelOffre = searchParams?.appelOffre;
       const motif = searchParams?.motif;
+      const cycle = searchParams?.cycle;
 
       const projetsAvecGarantiesFinancièresEnAttente =
         await mediator.send<GarantiesFinancières.ListerProjetsAvecGarantiesFinancièresEnAttenteQuery>(
@@ -45,6 +46,7 @@ export default async function Page({ searchParams }: PageProps) {
               },
               appelOffre,
               motif,
+              cycle,
               range: mapToRangeOptions({ currentPage: page, itemsPerPage: 10 }),
             },
           },
@@ -57,6 +59,15 @@ export default async function Page({ searchParams }: PageProps) {
 
       const filters: ListPageTemplateProps<ListItemProjetAvecGarantiesFinancièresEnAttenteProps>['filters'] =
         [
+          {
+            label: "Cycle d'appels d'offres",
+            searchParamKey: 'cycle',
+            defaultValue: cycle,
+            options: [
+              { label: 'PPE2', value: 'PPE2' },
+              { label: 'CRE4', value: 'CRE4' },
+            ],
+          },
           {
             label: `Appel d'offres`,
             searchParamKey: 'appelOffre',

--- a/packages/applications/ssr/src/components/pages/garanties-financières/dépôt/lister/ListerDépôtsEnCoursGarantiesFinancières.page.tsx
+++ b/packages/applications/ssr/src/components/pages/garanties-financières/dépôt/lister/ListerDépôtsEnCoursGarantiesFinancières.page.tsx
@@ -25,17 +25,24 @@ export const ListDépôtsEnCoursGarantiesFinancièresPage: FC<
 > = ({ list: { items: garantiesFinancières, currentPage, totalItems, itemsPerPage }, filters }) => {
   const searchParams = useSearchParams();
   const appelOffre = searchParams.get('appelOffre') ?? undefined;
+  const cycle = searchParams.get('cycle') ?? undefined;
 
-  const tagFilters = [
-    ...(appelOffre
-      ? [
-          {
-            label: `appel d'offres : ${appelOffre}`,
-            searchParamKey: 'appelOffre',
-          },
-        ]
-      : []),
-  ];
+  const tagFilters: ListPageTemplateProps<ListItemDépôtEnCoursGarantiesFinancièresProps>['tagFilters'] =
+    [];
+
+  if (cycle) {
+    tagFilters.push({
+      label: `cycle d'appels d'offres : ${cycle}`,
+      searchParamKey: 'cycle',
+    });
+  }
+
+  if (appelOffre) {
+    tagFilters.push({
+      label: `appel d'offres : ${appelOffre}`,
+      searchParamKey: 'appelOffre',
+    });
+  }
 
   return (
     <ListPageTemplate

--- a/packages/applications/ssr/src/components/pages/garanties-financières/en-attente/lister/ListerProjetsAvecGarantiesFinancièresEnAttente.page.tsx
+++ b/packages/applications/ssr/src/components/pages/garanties-financières/en-attente/lister/ListerProjetsAvecGarantiesFinancièresEnAttente.page.tsx
@@ -26,9 +26,17 @@ export const ListProjetsAvecGarantiesFinancièresEnAttentePage: FC<
   const searchParams = useSearchParams();
   const appelOffre = searchParams.get('appelOffre') ?? undefined;
   const motif = searchParams.get('motif') ?? undefined;
+  const cycle = searchParams.get('cycle') ?? undefined;
 
   const tagFilters: ListPageTemplateProps<ListItemProjetAvecGarantiesFinancièresEnAttenteProps>['tagFilters'] =
     [];
+
+  if (cycle) {
+    tagFilters.push({
+      label: `cycle d'appels d'offres : ${cycle}`,
+      searchParamKey: 'cycle',
+    });
+  }
 
   if (appelOffre) {
     tagFilters.push({
@@ -46,7 +54,7 @@ export const ListProjetsAvecGarantiesFinancièresEnAttentePage: FC<
 
   return (
     <ListPageTemplate
-      heading="Projets avec des garanties financières en attente"
+      heading="Projets en attente de garanties financières"
       actions={[]}
       items={garantiesFinancières.map((gf) => ({
         ...gf,

--- a/packages/domain/lauréat/src/garantiesFinancières/dépôt/lister/listerDépôtsEnCoursGarantiesFinancières.query.ts
+++ b/packages/domain/lauréat/src/garantiesFinancières/dépôt/lister/listerDépôtsEnCoursGarantiesFinancières.query.ts
@@ -42,6 +42,7 @@ export type ListerDépôtsEnCoursGarantiesFinancièresQuery = Message<
   'Lauréat.GarantiesFinancières.Query.ListerDépôtsEnCoursGarantiesFinancières',
   {
     appelOffre?: string;
+    cycle?: string;
     utilisateur: {
       rôle: string;
       email: string;
@@ -64,6 +65,7 @@ export const registerListerDépôtsEnCoursGarantiesFinancièresQuery = ({
     appelOffre,
     utilisateur: { email, rôle },
     range,
+    cycle,
   }) => {
     let région: string | undefined = undefined;
 
@@ -94,6 +96,9 @@ export const registerListerDépôtsEnCoursGarantiesFinancièresQuery = ({
           }),
           ...(région && {
             régionProjet: { operator: 'equal', value: région },
+          }),
+          ...(cycle && {
+            appelOffre: { operator: cycle === 'PPE2' ? 'like' : 'notLike', value: '%PPE2%' },
           }),
         },
       },

--- a/packages/domain/lauréat/src/garantiesFinancières/enAttente/lister/listerProjetsAvecGarantiesFinancièresEnAttente.query.ts
+++ b/packages/domain/lauréat/src/garantiesFinancières/enAttente/lister/listerProjetsAvecGarantiesFinancièresEnAttente.query.ts
@@ -33,6 +33,7 @@ export type ListerProjetsAvecGarantiesFinancièresEnAttenteQuery = Message<
   {
     appelOffre?: string;
     motif?: string;
+    cycle?: string;
     utilisateur: {
       rôle: string;
       email: string;
@@ -56,6 +57,7 @@ export const registerListerProjetsAvecGarantiesFinancièresEnAttenteQuery = ({
     motif,
     utilisateur: { email, rôle },
     range,
+    cycle,
   }) => {
     let région: string | undefined = undefined;
 
@@ -89,6 +91,9 @@ export const registerListerProjetsAvecGarantiesFinancièresEnAttenteQuery = ({
           }),
           ...(région && {
             régionProjet: { operator: 'equal', value: région },
+          }),
+          ...(cycle && {
+            appelOffre: { operator: cycle === 'PPE2' ? 'like' : 'notLike', value: '%PPE2%' },
           }),
         },
       },


### PR DESCRIPTION
# Description

Afin de faciliter l'instruction des GF, les DREALs et DGEC souhaitent pouvoir filtrer les listes de GF en attente et à traiter par cycle d'AO (PPE2 ou CRE4). 

## Type de changement

Veuillez supprimer les options qui ne sont pas pertinentes.

- [ ] Correction de bug
- [x] Nouvelle fonctionnalité
- [ ] Refacto de code
- [ ] Breaking changes (correction ou fonctionnalité qui ferait en sorte que la fonctionnalité existante ne fonctionne pas comme prévu)
- [ ] Ce changement nécessite une mise à jour de la documentation

# Comment cela a-t-il été testé?

ETQ admin, ou dreal, il est possible de filtrer les listes de GF en attente et à traiter par cycle d'AO. 

![image](https://github.com/MTES-MCT/potentiel/assets/72154904/5c2ecedf-a633-4aec-b4a1-b20981381860)

![image](https://github.com/MTES-MCT/potentiel/assets/72154904/340f6790-26df-4540-ac16-eaa02d814070)


# Check-up :

- [ ] Mon code [suit les directives de style](../docs/contributing//DEVELOPMENT_FLOW.md) de ce projet
- [ ] J'ai effectué une auto-revue de mon code
- [ ] J'ai commenté mon code, en particulier dans les zones difficiles à comprendre
- [ ] J'ai apporté des modifications correspondantes à la documentation
- [ ] Mes modifications ne génèrent aucun warning
- [ ] J'ai ajouté des tests qui prouvent l'efficacité de ma correction ou que ma fonctionnalité fonctionne
- [ ] Les nouveaux tests unitaires et les tests existants passent en local / dans la CI avec mes modifications
