### PR TITLE
:children_crossing: Formatage id potentiel courriers réponse

### DIFF
--- a/packages/infrastructure/document-builder/src/abandon/accordAbandonAvecRecandidature/Header.tsx
+++ b/packages/infrastructure/document-builder/src/abandon/accordAbandonAvecRecandidature/Header.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from 'react';
 import { Image, Text, View } from '@react-pdf/renderer';
 import { format } from 'date-fns';
+import { formatIdentifiantProjetForDocument } from '../../formatIdentifiantProjetForDocument';
 
 type HeaderProps = {
   dateCourrier: string;
@@ -70,7 +71,7 @@ export const Header: FC<HeaderProps> = ({
 
       <View style={{ marginTop: 10 }}>
         <View style={{ fontSize: 8 }}>
-          <Text>Code Potentiel: {identifiantProjet}</Text>
+          <Text>Code Potentiel: {formatIdentifiantProjetForDocument(identifiantProjet)}</Text>
           <Text>Dossier suivi par : aopv.dgec@developpement-durable.gouv.fr</Text>
         </View>
       </View>

--- a/packages/infrastructure/document-builder/src/abandon/modèlesRéponseDocx/buildDocument.ts
+++ b/packages/infrastructure/document-builder/src/abandon/modèlesRéponseDocx/buildDocument.ts
@@ -5,6 +5,7 @@ import Docxtemplater from 'docxtemplater';
 import { Abandon } from '@potentiel-domain/laureat';
 
 import { formatDatesFromDataToFrFormat } from '../../formatDatesFromDataToFrFormat';
+import { formatIdentifiantProjetForDocument } from '../../formatIdentifiantProjetForDocument';
 
 export const getModèleRéponseAbandon: Abandon.BuildModèleRéponseAbandonPort = async ({
   aprèsConfirmation,
@@ -27,7 +28,10 @@ export const getModèleRéponseAbandon: Abandon.BuildModèleRéponseAbandonPort 
 
   doc.render(
     formatDatesFromDataToFrFormat({
-      data,
+      data: {
+        ...data,
+        refPotentiel: formatIdentifiantProjetForDocument(data.refPotentiel),
+      },
       keys: ['dateDemande', 'dateDemandeConfirmation', 'dateConfirmation', 'dateNotification'],
     }),
   );

--- a/packages/infrastructure/document-builder/src/formatIdentifiantProjetForDocument.ts
+++ b/packages/infrastructure/document-builder/src/formatIdentifiantProjetForDocument.ts
@@ -1,0 +1,8 @@
+import { IdentifiantProjet } from '@potentiel-domain/common';
+
+export const formatIdentifiantProjetForDocument = (projectId: string): string => {
+  const { appelOffre, période, famille, numéroCRE } =
+    IdentifiantProjet.convertirEnValueType(projectId);
+
+  return `${appelOffre}-P${période}${famille ? `-F${famille}` : ''}-${numéroCRE}`;
+};

--- a/packages/infrastructure/document-builder/src/garantiesFinancières/modèleMiseEnDemeureDocx/buildDocument.ts
+++ b/packages/infrastructure/document-builder/src/garantiesFinancières/modèleMiseEnDemeureDocx/buildDocument.ts
@@ -5,6 +5,7 @@ import Docxtemplater from 'docxtemplater';
 import { GarantiesFinancières } from '@potentiel-domain/laureat';
 import { getLogger } from '@potentiel-libraries/monitoring';
 import { formatDatesFromDataToFrFormat } from '../../formatDatesFromDataToFrFormat';
+import { formatIdentifiantProjetForDocument } from '../../formatIdentifiantProjetForDocument';
 
 export const getModèleMiseEnDemeureGarantiesFinancières: GarantiesFinancières.BuildModèleMiseEnDemeureGarantiesFinancièresPort =
   async ({ data }) => {
@@ -22,7 +23,10 @@ export const getModèleMiseEnDemeureGarantiesFinancières: GarantiesFinancières
     });
     doc.render(
       formatDatesFromDataToFrFormat({
-        data,
+        data: {
+          ...data,
+          referenceProjet: formatIdentifiantProjetForDocument(data.referenceProjet),
+        },
         keys: [
           'dateMiseEnDemeure',
           'dateLancementAppelOffre',


### PR DESCRIPTION
# Description

Sur les modèles de réponse aux demandes d'abandon, demandes d'abandon avec recandidature et de mise en demeure (GF), le "**code Potentiel**" affiché est formaté avec des "#" en séparateur. Il faut les remplacer par des "-", et placer un "P" devant la période, et un "F" devant la famille afin de faciliter la compréhension des informations. 

ex : 

- `PPE2 - Eolien#1##24` devient `PPE2 - Eolien-P1-24`
- `CRE4 - Sol#1#2#25 `devient `CRE4 - Sol-P1-F2-25`

## Type de changement

Veuillez supprimer les options qui ne sont pas pertinentes.

- [ ] Correction de bug
- [ ] Nouvelle fonctionnalité
- [ ] Refacto de code
- [ ] Breaking changes (correction ou fonctionnalité qui ferait en sorte que la fonctionnalité existante ne fonctionne pas comme prévu)
- [ ] Ce changement nécessite une mise à jour de la documentation

# Comment cela a-t-il été testé?

- en tant que PP, demander un abandon avec recandidature > en tant que dgec-validateur choisir l'option "accorder" > vérifier le courrier de réponse généré : le "code potentiel"  des références du courrier devrait être correctement formaté
- en tant que PP, demander un abandon (classique) > en tant que dgec-validateur  ou admin choisir l'option "accorder" ou "rejeter" ou "demander conformation" > vérifier le courrier de réponse généré : le "code potentiel" des références du courrier devrait être correctement formaté
- en tant que dreal, depuis la liste des projets en attente de GF, télécharger le modèle de mise en demeure pour des GF en retard  > vérifier le courrier de réponse généré : le "code potentiel" des références du courrier devrait être correctement formaté

![Capture d’écran du 2024-05-16 15-17-19](https://github.com/MTES-MCT/potentiel/assets/72154904/c7b37847-ca7c-425d-a6f6-2b218531d519)

# Check-up :

- [ ] Mon code [suit les directives de style](../docs/contributing//DEVELOPMENT_FLOW.md) de ce projet
- [ ] J'ai effectué une auto-revue de mon code
- [ ] J'ai commenté mon code, en particulier dans les zones difficiles à comprendre
- [ ] J'ai apporté des modifications correspondantes à la documentation
- [ ] Mes modifications ne génèrent aucun warning
- [ ] J'ai ajouté des tests qui prouvent l'efficacité de ma correction ou que ma fonctionnalité fonctionne
- [ ] Les nouveaux tests unitaires et les tests existants passent en local / dans la CI avec mes modifications
