### PR TITLE
✨ Ajout d'une méthode `ajouterNombreDeMois` au value type DateTime

### DIFF
--- a/packages/domain/common/src/valueTypes/dateTime.valueType.ts
+++ b/packages/domain/common/src/valueTypes/dateTime.valueType.ts
@@ -10,6 +10,7 @@ export type ValueType = ReadonlyValueType<{
   estAntérieurÀ(dateTime: ValueType): boolean;
   estUltérieureÀ(dateTime: ValueType): boolean;
   nombreJoursÉcartAvec(dateTime: ValueType): number;
+  ajouterNombreDeMois(nombreDeMois: number): Date;
   formatter(): RawType;
 }>;
 
@@ -43,6 +44,9 @@ export const convertirEnValueType = (value: Date | string): ValueType => {
     nombreJoursÉcartAvec(dateTime) {
       const écart = differenceInDays(this.date, dateTime.date);
       return Math.abs(écart); // Peu importe si la date est avant ou aprés, on veut l'écart positif.
+    },
+    ajouterNombreDeMois(nombreDeMois) {
+      return new Date(this.date.setMonth(this.date.getMonth() + nombreDeMois));
     },
   };
 };

--- a/packages/domain/common/src/valueTypes/dateTime.valueType.ts
+++ b/packages/domain/common/src/valueTypes/dateTime.valueType.ts
@@ -10,7 +10,7 @@ export type ValueType = ReadonlyValueType<{
   estAntérieurÀ(dateTime: ValueType): boolean;
   estUltérieureÀ(dateTime: ValueType): boolean;
   nombreJoursÉcartAvec(dateTime: ValueType): number;
-  ajouterNombreDeMois(nombreDeMois: number): Date;
+  ajouterNombreDeMois(nombreDeMois: number): ValueType;
   formatter(): RawType;
 }>;
 
@@ -46,7 +46,8 @@ export const convertirEnValueType = (value: Date | string): ValueType => {
       return Math.abs(écart); // Peu importe si la date est avant ou aprés, on veut l'écart positif.
     },
     ajouterNombreDeMois(nombreDeMois) {
-      return new Date(this.date.setMonth(this.date.getMonth() + nombreDeMois));
+      const nouvelleDate = new Date(this.date.setMonth(this.date.getMonth() + nombreDeMois));
+      return convertirEnValueType(nouvelleDate);
     },
   };
 };

--- a/packages/domain/lauréat/src/garantiesFinancières/générerModèleMiseEnDemeure/générerModèleMiseEnDemeure.query.ts
+++ b/packages/domain/lauréat/src/garantiesFinancières/générerModèleMiseEnDemeure/générerModèleMiseEnDemeure.query.ts
@@ -126,11 +126,11 @@ export const registerGénérerModèleMiseEnDemeureGarantiesFinancièresQuery = (
           détailFamille && détailFamille?.soumisAuxGarantiesFinancieres === 'après candidature'
             ? DateTime.convertirEnValueType(candidature.dateDésignation)
                 .ajouterNombreDeMois(détailFamille.garantieFinanciereEnMois)
-                .toLocaleDateString('fr-FR')
+                .date.toLocaleDateString('fr-FR')
             : appelOffres.soumisAuxGarantiesFinancieres === 'après candidature'
             ? DateTime.convertirEnValueType(candidature.dateDésignation)
                 .ajouterNombreDeMois(appelOffres.garantieFinanciereEnMois)
-                .toLocaleDateString('fr-FR')
+                .date.toLocaleDateString('fr-FR')
             : '!!! dateFinGarantieFinanciere non disponible !!!',
         dateLimiteDepotGF:
           (Option.isSome(projetAvecGarantiesFinancièresEnAttente) &&

--- a/packages/domain/lauréat/src/garantiesFinancières/générerModèleMiseEnDemeure/générerModèleMiseEnDemeure.query.ts
+++ b/packages/domain/lauréat/src/garantiesFinancières/générerModèleMiseEnDemeure/générerModèleMiseEnDemeure.query.ts
@@ -1,5 +1,5 @@
 import { Message, MessageHandler, mediator } from 'mediateur';
-import { CommonPort } from '@potentiel-domain/common';
+import { CommonPort, DateTime } from '@potentiel-domain/common';
 import { Option } from '@potentiel-libraries/monads';
 import { ConsulterUtilisateurQuery } from '@potentiel-domain/utilisateur';
 import { ConsulterCandidatureQuery } from '@potentiel-domain/candidature';
@@ -124,19 +124,13 @@ export const registerGénérerModèleMiseEnDemeureGarantiesFinancièresQuery = (
             : '!!! garantieFinanciereEnMois non disponible !!!',
         dateFinGarantieFinanciere:
           détailFamille && détailFamille?.soumisAuxGarantiesFinancieres === 'après candidature'
-            ? new Date(
-                new Date(candidature.dateDésignation).setMonth(
-                  new Date(candidature.dateDésignation).getMonth() +
-                    détailFamille.garantieFinanciereEnMois,
-                ),
-              ).toLocaleDateString('fr-FR')
+            ? DateTime.convertirEnValueType(candidature.dateDésignation)
+                .ajouterNombreDeMois(détailFamille.garantieFinanciereEnMois)
+                .toLocaleDateString('fr-FR')
             : appelOffres.soumisAuxGarantiesFinancieres === 'après candidature'
-            ? new Date(
-                new Date(candidature.dateDésignation).setMonth(
-                  new Date(candidature.dateDésignation).getMonth() +
-                    appelOffres.garantieFinanciereEnMois,
-                ),
-              ).toLocaleDateString('fr-FR')
+            ? DateTime.convertirEnValueType(candidature.dateDésignation)
+                .ajouterNombreDeMois(appelOffres.garantieFinanciereEnMois)
+                .toLocaleDateString('fr-FR')
             : '!!! dateFinGarantieFinanciere non disponible !!!',
         dateLimiteDepotGF:
           (Option.isSome(projetAvecGarantiesFinancièresEnAttente) &&


### PR DESCRIPTION
# Description

Cette PR ajoute une méthode `ajouterNombreDeMois` au value type existant DateTime afin d'éviter de faire des `new Date().setMonth(...)` dans les query 

## Type de changement

Veuillez supprimer les options qui ne sont pas pertinentes.

- [x] Refacto de code

# Comment cela a-t-il été testé?

Génération du modèle de mise en demeure pour les gfs, en étant connecté en tant que DREAL sur la liste des projets en attente de GF en vérifiant que le calcul de la date est bien fonctionnel (utilisation d'un outil en ligne pour vérifier, par exemple : https://icalendrier.fr/outils/ajouter-retirer-date?startDate=2019-10-07&addOrSub=add&days=0&weeks=0&months=36&years=0)

# Check-up :

- [x] Mon code [suit les directives de style](../docs/contributing//DEVELOPMENT_FLOW.md) de ce projet
- [x] J'ai effectué une auto-revue de mon code
- [x] Mes modifications ne génèrent aucun warning
