### PR TITLE
🐛 Display gf links on project page

### DIFF
--- a/packages/applications/legacy/src/controllers/project/getProjectPage.ts
+++ b/packages/applications/legacy/src/controllers/project/getProjectPage.ts
@@ -160,7 +160,7 @@ v1Router.get(
           request,
           project: {
             ...projet,
-            ...garantiesFinancières,
+            ...(garantiesFinancières && { garantiesFinancières }),
           },
           projectEventList: {
             ...rawProjectEventList.value,


### PR DESCRIPTION
# Description

Sur la page projet on n'avait plus accès à l'encart "Garanties financières" des informations générales.

## Type de changement

Veuillez supprimer les options qui ne sont pas pertinentes.

- [x] Correction de bug

# Comment cela a-t-il été testé?

Avant le fix : 
<img width="1345" alt="bug" src="https://github.com/MTES-MCT/potentiel/assets/13203242/a8db0553-0943-4676-953c-74544d65e9c0">

Après le fix : 
<img width="1408" alt="work" src="https://github.com/MTES-MCT/potentiel/assets/13203242/bfaaa9d2-78d0-46da-954d-197634bfcff8">

