### PR TITLE
🐛 (legacy): demandes de changement de producteur et actionnaire dans la frise

### DIFF
--- a/packages/applications/legacy/src/infra/sequelize/projectionsNext/projectEvents/events/ModificationRequestEvents.ts
+++ b/packages/applications/legacy/src/infra/sequelize/projectionsNext/projectEvents/events/ModificationRequestEvents.ts
@@ -20,6 +20,14 @@ export type ModificationRequestEvents = ProjectEvent &
               modificationType: 'puissance';
               puissance: number;
             }
+          | {
+              modificationType: 'producteur';
+              producteur: string;
+            }
+          | {
+              modificationType: 'actionnaire';
+              actionnaire: string;
+            }
         );
       }
     | {

--- a/packages/applications/legacy/src/infra/sequelize/projectionsNext/projectEvents/updates/onModificationRequested.ts
+++ b/packages/applications/legacy/src/infra/sequelize/projectionsNext/projectEvents/updates/onModificationRequested.ts
@@ -8,7 +8,7 @@ export default ProjectEventProjector.on(
   async ({ payload, occurredAt }, transaction) => {
     const { projectId, type, modificationRequestId, authority, requestedBy } = payload;
 
-    if (!['delai', 'recours', 'puissance'].includes(type)) {
+    if (!['delai', 'recours', 'puissance', 'actionnaire', 'producteur'].includes(type)) {
       return;
     }
 
@@ -52,6 +52,8 @@ export default ProjectEventProjector.on(
           modificationRequestId,
           authority,
           ...(type === 'puissance' && { puissance: payload.puissance }),
+          ...(type === 'actionnaire' && { actionnaire: payload.actionnaire }),
+          ...(type === 'producteur' && { producteur: payload.producteur }),
         },
       },
       { transaction },

--- a/packages/applications/legacy/src/infra/sequelize/queries/frise/getProjectEvents.ts
+++ b/packages/applications/legacy/src/infra/sequelize/queries/frise/getProjectEvents.ts
@@ -212,6 +212,28 @@ export const getProjectEvents: GetProjectEvents = ({ projectId, user }) => {
                         authority: payload.authority,
                       });
                       break;
+                    case 'actionnaire':
+                      events.push({
+                        type,
+                        date: valueDate,
+                        variant: user.role,
+                        modificationType: payload.modificationType,
+                        modificationRequestId: payload.modificationRequestId,
+                        actionnaire: payload.actionnaire,
+                        authority: payload.authority,
+                      });
+                      break;
+                    case 'producteur':
+                      events.push({
+                        type,
+                        date: valueDate,
+                        variant: user.role,
+                        modificationType: payload.modificationType,
+                        modificationRequestId: payload.modificationRequestId,
+                        producteur: payload.producteur,
+                        authority: payload.authority,
+                      });
+                      break;
                   }
                 }
                 break;

--- a/packages/applications/legacy/src/modules/frise/dtos/ProjectEventListDTO.ts
+++ b/packages/applications/legacy/src/modules/frise/dtos/ProjectEventListDTO.ts
@@ -159,6 +159,8 @@ export type ModificationRequestedDTO = {
       unitePuissance?: string;
     }
   | { modificationType: 'recours' }
+  | { modificationType: 'actionnaire'; actionnaire: string }
+  | { modificationType: 'producteur'; producteur: string }
 );
 
 export type ModificationRequestAcceptedDTO = {

--- a/packages/applications/legacy/src/views/components/timeline/components/ModificationRequestItem.tsx
+++ b/packages/applications/legacy/src/views/components/timeline/components/ModificationRequestItem.tsx
@@ -141,6 +141,8 @@ const Details = (
     | { modificationType: 'delai'; delayInMonths: number }
     | { modificationType: 'puissance'; puissance: number; unitePuissance: string }
     | { modificationType: 'recours' }
+    | { modificationType: 'actionnaire'; actionnaire: string }
+    | { modificationType: 'producteur'; producteur: string }
   ),
 ) => {
   const { status, modificationType, detailsUrl, authority = undefined, role } = props;
@@ -150,6 +152,8 @@ const Details = (
       delai: `délai supplémentaire`,
       recours: `recours`,
       puissance: `changement de puissance installée`,
+      actionnaire: `changement de l'actionnariat`,
+      producteur: `changement de producteur`,
     };
 
   const libelleStatus: { [key in ModificationRequestItemProps['status']]: string } = {
@@ -172,6 +176,12 @@ const Details = (
         <p className="p-0 m-0">
           Puissance demandée : {props.puissance} {props.unitePuissance}
         </p>
+      )}
+      {modificationType === 'actionnaire' && (
+        <p className="p-0 m-0">Actionnaire : {props.actionnaire}</p>
+      )}
+      {modificationType === 'producteur' && (
+        <p className="p-0 m-0">Producteur : {props.producteur}</p>
       )}
       {['admin', 'dgec-validateur', 'porteur-projet', 'cre', 'acheteur-obligé', 'dreal'].includes(
         role,

--- a/packages/applications/legacy/src/views/components/timeline/helpers/extractModificationRequestsItemProps.ts
+++ b/packages/applications/legacy/src/views/components/timeline/helpers/extractModificationRequestsItemProps.ts
@@ -25,6 +25,8 @@ export type ModificationRequestItemProps = {
   | {
       modificationType: 'recours';
     }
+  | { modificationType: 'actionnaire'; actionnaire: string }
+  | { modificationType: 'producteur'; producteur: string }
 );
 
 export const extractModificationRequestsItemProps = (
@@ -91,6 +93,32 @@ export const extractModificationRequestsItemProps = (
             role,
             responseUrl,
             detailsUrl,
+          };
+
+        case 'actionnaire':
+          return {
+            type: 'demande-de-modification',
+            date,
+            authority,
+            modificationType,
+            status,
+            role,
+            responseUrl,
+            detailsUrl,
+            actionnaire: requestEvent.actionnaire,
+          };
+
+        case 'producteur':
+          return {
+            type: 'demande-de-modification',
+            date,
+            authority,
+            modificationType,
+            status,
+            role,
+            responseUrl,
+            detailsUrl,
+            producteur: requestEvent.producteur,
           };
       }
     });


### PR DESCRIPTION
# Description

**En lien avec cette issue : https://linear.app/startup-potentiel/issue/POT-199/les-demandes-de-changement-dactionnaire-et-de-producteur-ne-sont-pas
Et priorisé dans le sprint 31 (24 juin - 8 juillet 2024).**

Les demandes de changement d'actionnaire et de producteur ne sont pas affichées dans la frise. 

A noter qu'il n'y a plus de demande de changement de producteur, actuellement elles sont toutes en "information enregistrées". Cependant il reste des demandes faites par le passé non traitées à ce jour. 

La plupart des changements d'actionnaire sont également en "information enregistrée", [mais dans certains cas une validation Dreal est nécessaire](https://github.com/MTES-MCT/potentiel/blob/master/packages/applications/legacy/src/modules/modificationRequest/useCases/requestActionnaireModification.spec.ts). 

Cette correction permet d'avoir les bonnes informations dans la frise en cas de changement d'actionnaire nécessitant une validation Dreal ou en cas de rebuild de la projection project_events. 
**Elle sera accompagnée d'une opération de mise à jour de project_events pour les demandes passées.** 

## Type de changement

Veuillez supprimer les options qui ne sont pas pertinentes.

- [x] Correction de bug
- [ ] Nouvelle fonctionnalité
- [ ] Refacto de code
- [ ] Breaking changes (correction ou fonctionnalité qui ferait en sorte que la fonctionnalité existante ne fonctionne pas comme prévu)
- [ ] Ce changement nécessite une mise à jour de la documentation
 
## Scénarios 

Scenario testable : cas d'un projet donc les changements d'actionnaires sont soumis à validation par la Dreal : projet soumis à GF "après candidature" (donc CRE4), si le projet est participatif (IP ou FP) le changement d'actionnaire est une "demande envoyée" et cette demande soit être affichée dans la frise. 

# Check-up :

- [ ] Mon code [suit les directives de style](../docs/contributing//DEVELOPMENT_FLOW.md) de ce projet
- [ ] J'ai effectué une auto-revue de mon code
- [ ] J'ai commenté mon code, en particulier dans les zones difficiles à comprendre
- [ ] J'ai apporté des modifications correspondantes à la documentation
- [ ] Mes modifications ne génèrent aucun warning
- [ ] J'ai ajouté des tests qui prouvent l'efficacité de ma correction ou que ma fonctionnalité fonctionne
- [ ] Les nouveaux tests unitaires et les tests existants passent en local / dans la CI avec mes modifications
