### PR TITLE
✨ (Main-levée demandée): notifier les DREALs

### DIFF
--- a/packages/applications/bootstrap/src/setupLauréat.ts
+++ b/packages/applications/bootstrap/src/setupLauréat.ts
@@ -145,6 +145,7 @@ export const setupLauréat = async () => {
         'AttestationGarantiesFinancièresEnregistrée-V1',
         'GarantiesFinancièresModifiées-V1',
         'GarantiesFinancièresEnregistrées-V1',
+        'MainLevéeGarantiesFinancièresDemandée-V1',
       ],
       eventHandler: async (event) => {
         await mediator.publish<GarantiesFinancièresNotification.Execute>({


### PR DESCRIPTION
Lorsqu'un porteur dépose une demande de main-levée de GF dans Potentiel, nous devons envoyer un email de notification aux utilisateurs Dreal de la région du projet. 