### PR TITLE
👔 Afficher info box a dreal en cas de changement de puissance non prévue

### DIFF
--- a/packages/applications/legacy/src/views/pages/modificationRequestPage/ModificationRequest.tsx
+++ b/packages/applications/legacy/src/views/pages/modificationRequestPage/ModificationRequest.tsx
@@ -22,6 +22,7 @@ import {
   ProducteurForm,
   PuissanceForm,
   RecoursForm,
+  PuissanceALaHausseInfoBox,
 } from './components';
 
 moment.locale('fr');
@@ -37,14 +38,21 @@ export const ModificationRequest = ({ request, modificationRequest }: Modificati
   const { type, id, status } = modificationRequest;
 
   const userIsDgec = userIs(['admin', 'dgec-validateur'])(user);
-  const userIsDrealWithAuthority =
-    userIs(['dreal'])(user) && modificationRequest.authority === 'dreal';
-
-  const showFormulaireAdministrateur =
-    (userIsDgec || userIsDrealWithAuthority) &&
+  const userIsDreal = userIs(['dreal'])(user);
+  const isPendingModificationRequest =
     !modificationRequest.respondedOn &&
     !modificationRequest.cancelledOn &&
     status !== 'information validée';
+
+  const showPuissanceInfoBox =
+    type === 'puissance' &&
+    userIsDreal &&
+    modificationRequest.authority !== 'dreal' &&
+    isPendingModificationRequest;
+
+  const showFormulaireAdministrateur =
+    (userIsDgec || (userIsDreal && modificationRequest.authority === 'dreal')) &&
+    isPendingModificationRequest;
 
   return (
     <LegacyPageTemplate user={request.user} currentPage="list-requests">
@@ -62,6 +70,8 @@ export const ModificationRequest = ({ request, modificationRequest }: Modificati
 
         <DemandeDetails modificationRequest={modificationRequest} className="mb-5" />
         <DemandeStatus role={user.role} modificationRequest={modificationRequest} />
+
+        {showPuissanceInfoBox && <PuissanceALaHausseInfoBox />}
 
         {showFormulaireAdministrateur && (
           <div>

--- a/packages/applications/legacy/src/views/pages/modificationRequestPage/components/PuissanceALaHausseInfoBox.tsx
+++ b/packages/applications/legacy/src/views/pages/modificationRequestPage/components/PuissanceALaHausseInfoBox.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { InfoBox } from '../../../components';
+
+export const PuissanceALaHausseInfoBox = () => {
+  return (
+    <InfoBox className="mb-4">
+      Cette demande de changement de puissance à la hausse et en dehors de la fourchette prévue aux
+      cahiers des charges est une demande dérogatoire qui n’est pas prévue par les cahiers des
+      charges. Par conséquent, elle fait l’objet d’une instruction par la DGEC.
+    </InfoBox>
+  );
+};

--- a/packages/applications/legacy/src/views/pages/modificationRequestPage/components/index.ts
+++ b/packages/applications/legacy/src/views/pages/modificationRequestPage/components/index.ts
@@ -8,3 +8,4 @@ export * from './ProducteurForm';
 export * from './PuissanceForm';
 export * from './RecoursForm';
 export * from './UploadResponseFile';
+export * from './PuissanceALaHausseInfoBox';


### PR DESCRIPTION
# Description

Ajout d'une info box si certaines conditions sont respectées
Legacy => j'ai fait au plus simple

https://linear.app/startup-potentiel/issue/POT-285/info-box-a-destination-des-dreal-dans-le-cas-dun-changement-de

## Type de changement

Veuillez supprimer les options qui ne sont pas pertinentes.

- [ ] Correction de bug
- [x] Nouvelle fonctionnalité
- [ ] Refacto de code
- [ ] Breaking changes (correction ou fonctionnalité qui ferait en sorte que la fonctionnalité existante ne fonctionne pas comme prévu)
- [ ] Ce changement nécessite une mise à jour de la documentation

# Comment cela a-t-il été testé?

Test visuel des cas

<img width="1178" alt="Capture d’écran 2024-06-05 à 12 02 35" src="https://github.com/MTES-MCT/potentiel/assets/27735540/77feb469-b3d8-4273-9131-cadad52089df">

# Check-up :

- [ ] Mon code [suit les directives de style](../docs/contributing//DEVELOPMENT_FLOW.md) de ce projet
- [ ] J'ai effectué une auto-revue de mon code
- [ ] J'ai commenté mon code, en particulier dans les zones difficiles à comprendre
- [ ] J'ai apporté des modifications correspondantes à la documentation
- [ ] Mes modifications ne génèrent aucun warning
- [ ] J'ai ajouté des tests qui prouvent l'efficacité de ma correction ou que ma fonctionnalité fonctionne
- [ ] Les nouveaux tests unitaires et les tests existants passent en local / dans la CI avec mes modifications
