### PR TITLE
✨ Demander la main levée lors de la transmission de l'attestation de conformité

### DIFF
--- a/packages/applications/ssr/src/app/laureats/[identifiant]/achevement/attestation-conformite:transmettre/page.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/achevement/attestation-conformite:transmettre/page.tsx
@@ -3,6 +3,8 @@ import { mediator } from 'mediateur';
 
 import { ConsulterCandidatureQuery } from '@potentiel-domain/candidature';
 import { InvalidOperationError } from '@potentiel-domain/core';
+import { GarantiesFinancières } from '@potentiel-domain/laureat';
+import { Option } from '@potentiel-libraries/monads';
 
 import { PageWithErrorHandling } from '@/utils/PageWithErrorHandling';
 import { decodeParameter } from '@/utils/decodeParameter';
@@ -32,10 +34,24 @@ export default async function Page({ params: { identifiant } }: IdentifiantParam
       );
     }
 
+    const garantiesFinancières =
+      await mediator.send<GarantiesFinancières.ConsulterGarantiesFinancièresQuery>({
+        type: 'Lauréat.GarantiesFinancières.Query.ConsulterGarantiesFinancières',
+        data: {
+          identifiantProjetValue: identifiantProjet,
+        },
+      });
+
+    const showDemanderMainLevée =
+      Option.isSome(garantiesFinancières) &&
+      Option.isSome(garantiesFinancières.garantiesFinancières.attestation) &&
+      Option.isSome(garantiesFinancières.garantiesFinancières.validéLe);
+
     const projet = { ...candidature, identifiantProjet };
 
     const props: TransmettreAttestationConformitéPageProps = {
       projet,
+      showDemanderMainLevée,
     };
 
     return <TransmettreAttestationConformitéPage {...props} />;

--- a/packages/applications/ssr/src/components/pages/attestation-conformité/FormulaireAttestationConformité.tsx
+++ b/packages/applications/ssr/src/components/pages/attestation-conformité/FormulaireAttestationConformité.tsx
@@ -1,6 +1,7 @@
 import { FC, useState } from 'react';
 import { Upload } from '@codegouvfr/react-dsfr/Upload';
 import Button from '@codegouvfr/react-dsfr/Button';
+import Checkbox from '@codegouvfr/react-dsfr/Checkbox';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 
@@ -27,6 +28,7 @@ export type FormulaireAttestationConformitéProps = {
     preuveTransmissionAuCocontractant: string;
     dateTransmissionAuCocontractant: Iso8601DateTime;
   };
+  showDemanderMainLevée?: true;
 };
 
 export const FormulaireAttestationConformité: FC<FormulaireAttestationConformitéProps> = ({
@@ -34,6 +36,7 @@ export const FormulaireAttestationConformité: FC<FormulaireAttestationConformit
   action,
   submitButtonLabel,
   donnéesActuelles,
+  showDemanderMainLevée,
 }) => {
   const [validationErrors, setValidationErrors] = useState<Array<string>>([]);
   const router = useRouter();
@@ -129,6 +132,20 @@ export const FormulaireAttestationConformité: FC<FormulaireAttestationConformit
           state={validationErrors.includes('dateTransmissionAuCocontractant') ? 'error' : 'default'}
           stateRelatedMessage="Date de transmission au co-contractant obligatoire"
         />
+
+        {showDemanderMainLevée && (
+          <Checkbox
+            options={[
+              {
+                label: `Je souhaite demander une mainlevée de mes garanties financières`,
+                nativeInputProps: {
+                  name: 'demanderMainLevee',
+                  value: 'true',
+                },
+              },
+            ]}
+          />
+        )}
       </div>
 
       <div className="flex flex-col md:flex-row gap-4 mt-5">

--- a/packages/applications/ssr/src/components/pages/attestation-conformité/FormulaireAttestationConformité.tsx
+++ b/packages/applications/ssr/src/components/pages/attestation-conformité/FormulaireAttestationConformité.tsx
@@ -137,7 +137,7 @@ export const FormulaireAttestationConformité: FC<FormulaireAttestationConformit
           <Checkbox
             options={[
               {
-                label: `Je souhaite demander une mainlevée de mes garanties financières`,
+                label: `Je souhaite demander une main-levée de mes garanties financières`,
                 nativeInputProps: {
                   name: 'demanderMainLevee',
                   value: 'true',

--- a/packages/applications/ssr/src/components/pages/attestation-conformité/FormulaireAttestationConformité.tsx
+++ b/packages/applications/ssr/src/components/pages/attestation-conformité/FormulaireAttestationConformité.tsx
@@ -28,7 +28,7 @@ export type FormulaireAttestationConformitéProps = {
     preuveTransmissionAuCocontractant: string;
     dateTransmissionAuCocontractant: Iso8601DateTime;
   };
-  showDemanderMainLevée?: true;
+  showDemanderMainLevée?: boolean;
 };
 
 export const FormulaireAttestationConformité: FC<FormulaireAttestationConformitéProps> = ({

--- a/packages/applications/ssr/src/components/pages/attestation-conformité/transmettre/transmettreAttestationConformité.page.tsx
+++ b/packages/applications/ssr/src/components/pages/attestation-conformité/transmettre/transmettreAttestationConformité.page.tsx
@@ -12,11 +12,12 @@ import { transmettreAttestationConformitéAction } from './transmettreAttestatio
 
 export type TransmettreAttestationConformitéPageProps = {
   projet: ProjetBannerProps;
+  showDemanderMainLevée?: boolean;
 };
 
 export const TransmettreAttestationConformitéPage: FC<
   TransmettreAttestationConformitéPageProps
-> = ({ projet }) => (
+> = ({ projet, showDemanderMainLevée }) => (
   <PageTemplate banner={<ProjetBanner {...projet} />}>
     <TitrePageAttestationConformité title="Transmettre l'attestation de conformité du projet" />
 
@@ -24,7 +25,7 @@ export const TransmettreAttestationConformitéPage: FC<
       identifiantProjet={projet.identifiantProjet}
       action={transmettreAttestationConformitéAction}
       submitButtonLabel="Transmettre"
-      showDemanderMainLevée
+      showDemanderMainLevée={showDemanderMainLevée}
     />
   </PageTemplate>
 );

--- a/packages/applications/ssr/src/components/pages/attestation-conformité/transmettre/transmettreAttestationConformité.page.tsx
+++ b/packages/applications/ssr/src/components/pages/attestation-conformité/transmettre/transmettreAttestationConformité.page.tsx
@@ -24,6 +24,7 @@ export const TransmettreAttestationConformitéPage: FC<
       identifiantProjet={projet.identifiantProjet}
       action={transmettreAttestationConformitéAction}
       submitButtonLabel="Transmettre"
+      showDemanderMainLevée
     />
   </PageTemplate>
 );


### PR DESCRIPTION
# Description

En tant que PP, je peux faire une demande automatique de mainlevée de mes GF quand je transmets mon attestation de conformité

## Type de changement

- [x] Nouvelle fonctionnalité

# Comment cela a-t-il été testé?

Sur le formulaire de transmission de mon attestation de conformité + preuve de transmission au contractant, j'ai une case à cocher qui indique "Je souhaite demander une mainlevée de mes garanties financières"

Si la transmission est complète et donc validée, l'action demande de mainlevée se déclenche automatiquement 
- si le projet a des garanties financières actuelles validées 
- Il ne dispose pas de demande de renouvellement ou de modifications de garanties financières en cours. 
- Sinon, un message d'erreur s'affiche "Vous devez avoir des garanties financières actuelles validées sur Potentiel pour pouvoir faire cette demande de mainlevée"

# Check-up :

- [x] Mon code [suit les directives de style](../docs/contributing//DEVELOPMENT_FLOW.md) de ce projet
- [x] J'ai effectué une auto-revue de mon code
- [x] J'ai commenté mon code, en particulier dans les zones difficiles à comprendre
- [x] J'ai apporté des modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun warning
- [x] J'ai ajouté des tests qui prouvent l'efficacité de ma correction ou que ma fonctionnalité fonctionne
- [x] Les nouveaux tests unitaires et les tests existants passent en local / dans la CI avec mes modifications
