### PR TITLE
🚸 Composant Download - ouvrir les liens de téléchargement dans un nouvel onglet 

### DIFF
--- a/packages/applications/ssr/src/components/pages/abandon/détails/accorder/AccorderAbandonSansRecandidature.tsx
+++ b/packages/applications/ssr/src/components/pages/abandon/détails/accorder/AccorderAbandonSansRecandidature.tsx
@@ -67,6 +67,7 @@ export const AccorderAbandonSansRecandidature = ({
               <Download
                 linkProps={{
                   href: Routes.Abandon.téléchargerModèleRéponse(identifiantProjet),
+                  target: '_blank',
                 }}
                 details="docx"
                 label="Télécharger le modèle de réponse"

--- a/packages/applications/ssr/src/components/pages/abandon/détails/demanderConfirmation/DemanderConfirmationAbandon.tsx
+++ b/packages/applications/ssr/src/components/pages/abandon/détails/demanderConfirmation/DemanderConfirmationAbandon.tsx
@@ -67,6 +67,7 @@ export const DemanderConfirmationAbandon = ({
               <Download
                 linkProps={{
                   href: Routes.Abandon.téléchargerModèleRéponse(identifiantProjet),
+                  target: '_blank',
                 }}
                 details="docx"
                 label="Télécharger le modèle de réponse"

--- a/packages/applications/ssr/src/components/pages/abandon/détails/rejeter/RejeterAbandon.tsx
+++ b/packages/applications/ssr/src/components/pages/abandon/détails/rejeter/RejeterAbandon.tsx
@@ -64,6 +64,7 @@ export const RejeterAbandon = ({ identifiantProjet }: RejeterAbandonFormProps) =
               <Download
                 linkProps={{
                   href: Routes.Abandon.téléchargerModèleRéponse(identifiantProjet),
+                  target: '_blank',
                 }}
                 details="docx"
                 label="Télécharger le modèle de réponse"

--- a/packages/applications/ssr/src/components/pages/garanties-financières/en-attente/lister/ListItemProjetAvecGarantiesFinancièresEnAttente.tsx
+++ b/packages/applications/ssr/src/components/pages/garanties-financières/en-attente/lister/ListItemProjetAvecGarantiesFinancièresEnAttente.tsx
@@ -72,6 +72,7 @@ export const ListItemProjetAvecGarantiesFinancièresEnAttente: FC<
           <Download
             linkProps={{
               href: Routes.GarantiesFinancières.téléchargerModèleMiseEnDemeure(identifiantProjet),
+              target: '_blank',
             }}
             details="docx"
             label="Télécharger un modèle de mise en demeure"

--- a/packages/applications/ssr/src/components/pages/réseau/raccordement/détails/components/ÉtapeDemandeComplèteRaccordement.tsx
+++ b/packages/applications/ssr/src/components/pages/réseau/raccordement/détails/components/ÉtapeDemandeComplèteRaccordement.tsx
@@ -69,6 +69,7 @@ export const ÉtapeDemandeComplèteRaccordement: FC<ÉtapeDemandeComplèteRaccor
               href: Routes.Document.télécharger(accuséRéception),
               'aria-label': `Télécharger l'accusé de réception pour le dossier ${référence}`,
               title: `Télécharger l'accusé de réception pour le dossier ${référence}`,
+              target: '_blank',
             }}
             label="Télécharger la pièce justificative"
             details=""

--- a/packages/applications/ssr/src/components/pages/réseau/raccordement/détails/components/ÉtapePropositionTechniqueEtFinancière.tsx
+++ b/packages/applications/ssr/src/components/pages/réseau/raccordement/détails/components/ÉtapePropositionTechniqueEtFinancière.tsx
@@ -56,6 +56,7 @@ export const ÉtapePropositionTechniqueEtFinancière: FC<
                 href: Routes.Document.télécharger(propositionTechniqueEtFinancièreSignée),
                 'aria-label': `Télécharger la proposition technique et financière pour le dossier ${référence}`,
                 title: `Télécharger la proposition technique et financière pour le dossier ${référence}`,
+                target: '_blank',
               }}
               label="Télécharger la pièce justificative"
               details=""


### PR DESCRIPTION
Cette PR ajoute le fait d'ouvrir les liens de téléchargement dans un nouvel onglet  pour enregistrer automatiquement sur le disque de l'utilisateur qui fait l'action + éviter de perdre la page courante (avant on avait une preview du fichier qui remplacait la page Potentiel) 

# Comment cela a-t-il été testé?

En parcourant les fichiers aux endroits où il y a des modifications