### PR TITLE
🎨 Utilisation du target blank pour bypasser la preview navigateur

### DIFF
--- a/packages/applications/ssr/src/components/atoms/form/InputDownload.tsx
+++ b/packages/applications/ssr/src/components/atoms/form/InputDownload.tsx
@@ -1,7 +1,9 @@
 import { FC } from 'react';
 import { Download, DownloadProps } from '@codegouvfr/react-dsfr/Download';
 
-type InputDownloadProps = DownloadProps;
+type InputDownloadProps = DownloadProps & {
+  ariaLabel: string;
+};
 
 /**
  * @description Ce composant est une surcouche du composant Download de react-dsfr pour ajouter l'attribut target blan et que le document se télécharge directement dans un nouvel onglet, sans preview
@@ -13,6 +15,7 @@ export const InputDownload: FC<InputDownloadProps> = (props) => (
       ...props,
       linkProps: {
         href: props.linkProps.href,
+        'aria-label': `${props.ariaLabel} (dans un nouvel onglet)`,
         target: '_blank',
       },
     }}

--- a/packages/applications/ssr/src/components/atoms/form/InputDownload.tsx
+++ b/packages/applications/ssr/src/components/atoms/form/InputDownload.tsx
@@ -4,7 +4,7 @@ import { Download, DownloadProps } from '@codegouvfr/react-dsfr/Download';
 type InputDownloadProps = DownloadProps;
 
 /**
- * @description Ce composant est une surcouche du composant Download de react-dsfr pour ajouter l'attribut download et que le document se télécharge directement, sans preview
+ * @description Ce composant est une surcouche du composant Download de react-dsfr pour ajouter l'attribut target blan et que le document se télécharge directement dans un nouvel onglet, sans preview
  * @param props cf https://components.react-dsfr.codegouv.studio/?path=/docs/components-download--default
  */
 export const InputDownload: FC<InputDownloadProps> = (props) => (
@@ -13,7 +13,7 @@ export const InputDownload: FC<InputDownloadProps> = (props) => (
       ...props,
       linkProps: {
         href: props.linkProps.href,
-        download: true,
+        target: '_blank',
       },
     }}
   />

--- a/packages/applications/ssr/src/components/pages/abandon/détails/EtapesAbandon.tsx
+++ b/packages/applications/ssr/src/components/pages/abandon/détails/EtapesAbandon.tsx
@@ -99,6 +99,7 @@ export const EtapesAbandon: FC<EtapesAbandonProps> = ({
           {accord.réponseSignée && (
             <InputDownload
               details=""
+              ariaLabel="Télécharger la pièce justificative pour l'accord de la demande d'abandon"
               label="Télécharger la pièce justificative"
               linkProps={{
                 href: Routes.Document.télécharger(accord.réponseSignée),
@@ -123,6 +124,7 @@ export const EtapesAbandon: FC<EtapesAbandonProps> = ({
           {rejet.réponseSignée && (
             <InputDownload
               details=""
+              ariaLabel="Télécharger la pièce justificative pour le rejet de la demande d'abandon"
               label="Télécharger la pièce justificative"
               linkProps={{
                 href: Routes.Document.télécharger(rejet.réponseSignée),
@@ -160,6 +162,7 @@ export const EtapesAbandon: FC<EtapesAbandonProps> = ({
           {confirmation.réponseSignée && (
             <InputDownload
               details=""
+              ariaLabel="Télécharger la pièce justificative pour la confirmation de la demande d'abandon"
               label="Télécharger la pièce justificative"
               linkProps={{
                 href: Routes.Document.télécharger(confirmation.réponseSignée),
@@ -192,6 +195,7 @@ export const EtapesAbandon: FC<EtapesAbandonProps> = ({
         {justificatifDemande && (
           <InputDownload
             details=""
+            ariaLabel="Télécharger la pièce justificative pour la demande d'abandon"
             label="Télécharger la pièce justificative"
             linkProps={{
               href: Routes.Document.télécharger(justificatifDemande),

--- a/packages/applications/ssr/src/components/pages/abandon/détails/accorder/AccorderAbandonSansRecandidature.tsx
+++ b/packages/applications/ssr/src/components/pages/abandon/détails/accorder/AccorderAbandonSansRecandidature.tsx
@@ -65,6 +65,7 @@ export const AccorderAbandonSansRecandidature = ({
               />
 
               <InputDownload
+                ariaLabel={`Télécharger le modèle de réponse pour l'accord de la demande d'abandon sans recandidature`}
                 linkProps={{
                   href: Routes.Abandon.téléchargerModèleRéponse(identifiantProjet),
                 }}

--- a/packages/applications/ssr/src/components/pages/abandon/détails/demanderConfirmation/DemanderConfirmationAbandon.tsx
+++ b/packages/applications/ssr/src/components/pages/abandon/détails/demanderConfirmation/DemanderConfirmationAbandon.tsx
@@ -65,6 +65,7 @@ export const DemanderConfirmationAbandon = ({
               />
 
               <InputDownload
+                ariaLabel={`Télécharger le modèle de réponse pour demander la confirmation de la demande d'abandon `}
                 linkProps={{
                   href: Routes.Abandon.téléchargerModèleRéponse(identifiantProjet),
                 }}

--- a/packages/applications/ssr/src/components/pages/abandon/détails/rejeter/RejeterAbandon.tsx
+++ b/packages/applications/ssr/src/components/pages/abandon/détails/rejeter/RejeterAbandon.tsx
@@ -62,6 +62,7 @@ export const RejeterAbandon = ({ identifiantProjet }: RejeterAbandonFormProps) =
               />
 
               <InputDownload
+                ariaLabel={`Télécharger le modèle de réponse pour le rejet de la demande d'abandon`}
                 linkProps={{
                   href: Routes.Abandon.téléchargerModèleRéponse(identifiantProjet),
                   target: '_blank',

--- a/packages/applications/ssr/src/components/pages/garanties-financières/détails/components/GarantiesFinancièresActuelles.tsx
+++ b/packages/applications/ssr/src/components/pages/garanties-financières/détails/components/GarantiesFinancièresActuelles.tsx
@@ -115,6 +115,7 @@ export const GarantiesFinancièresActuelles: FC<GarantiesFinancièresActuellesPr
             <div>
               {attestation && (
                 <InputDownload
+                  ariaLabel="Télécharger l'attestation de constitution des garanties financières"
                   details="fichier au format pdf"
                   label="Télécharger l'attestation"
                   linkProps={{

--- a/packages/applications/ssr/src/components/pages/garanties-financières/détails/components/GarantiesFinancièresDépôtEnCours.tsx
+++ b/packages/applications/ssr/src/components/pages/garanties-financières/détails/components/GarantiesFinancièresDépôtEnCours.tsx
@@ -73,6 +73,7 @@ export const GarantiesFinancièresDépôtEnCours: FC<GarantiesFinancièresDépô
             <div>
               {attestation && (
                 <InputDownload
+                  ariaLabel="Télécharger l'attestation de constitution"
                   details="fichier au format pdf"
                   label="Télécharger l'attestation"
                   linkProps={{

--- a/packages/applications/ssr/src/components/pages/garanties-financières/en-attente/lister/ListItemProjetAvecGarantiesFinancièresEnAttente.tsx
+++ b/packages/applications/ssr/src/components/pages/garanties-financières/en-attente/lister/ListItemProjetAvecGarantiesFinancièresEnAttente.tsx
@@ -70,6 +70,7 @@ export const ListItemProjetAvecGarantiesFinancièresEnAttente: FC<
         </div>
         {afficherModèleMiseEnDemeure && (
           <InputDownload
+            ariaLabel={`Télécharger un modèle de mise en demeure pour le projet ${nomProjet}`}
             linkProps={{
               href: Routes.GarantiesFinancières.téléchargerModèleMiseEnDemeure(identifiantProjet),
             }}

--- a/packages/applications/ssr/src/components/pages/réseau/raccordement/détails/components/ÉtapeDemandeComplèteRaccordement.tsx
+++ b/packages/applications/ssr/src/components/pages/réseau/raccordement/détails/components/ÉtapeDemandeComplèteRaccordement.tsx
@@ -65,9 +65,9 @@ export const ÉtapeDemandeComplèteRaccordement: FC<ÉtapeDemandeComplèteRaccor
           {accuséRéception.endsWith('.bin') && <FormatFichierInvalide />}
           <InputDownload
             className="flex items-center"
+            ariaLabel={`Télécharger l'accusé de réception pour le dossier ${référence}`}
             linkProps={{
               href: Routes.Document.télécharger(accuséRéception),
-              'aria-label': `Télécharger l'accusé de réception pour le dossier ${référence}`,
               title: `Télécharger l'accusé de réception pour le dossier ${référence}`,
             }}
             label="Télécharger la pièce justificative"

--- a/packages/applications/ssr/src/components/pages/réseau/raccordement/détails/components/ÉtapePropositionTechniqueEtFinancière.tsx
+++ b/packages/applications/ssr/src/components/pages/réseau/raccordement/détails/components/ÉtapePropositionTechniqueEtFinancière.tsx
@@ -52,9 +52,9 @@ export const ÉtapePropositionTechniqueEtFinancière: FC<
             {propositionTechniqueEtFinancièreSignée.endsWith('.bin') && <FormatFichierInvalide />}
             <InputDownload
               className="flex items-center"
+              ariaLabel={`Télécharger la proposition technique et financière pour le dossier ${référence}`}
               linkProps={{
                 href: Routes.Document.télécharger(propositionTechniqueEtFinancièreSignée),
-                'aria-label': `Télécharger la proposition technique et financière pour le dossier ${référence}`,
                 title: `Télécharger la proposition technique et financière pour le dossier ${référence}`,
               }}
               label="Télécharger la pièce justificative"


### PR DESCRIPTION
# Description

Pour éviter que le navigateur fasse la preview d'un fichier alors qu'on lui a spécifié qu'on voulait uniquement le télécharger (attr download natif au composant dsfr) on ajout target _blank. Afin de garantir l'accessibilité on ajoute un aria-label pour que les lecteurs d'écrans puissent afficher l'information que le téléchargement se fera dans un nouvel onglet