### PR TITLE
✨ Notifier les porteurs quand la demande de mainlevée change de statut

### DIFF
--- a/packages/applications/bootstrap/src/setupLauréat.ts
+++ b/packages/applications/bootstrap/src/setupLauréat.ts
@@ -150,6 +150,9 @@ export const setupLauréat = async () => {
         'GarantiesFinancièresModifiées-V1',
         'GarantiesFinancièresEnregistrées-V1',
         'MainlevéeGarantiesFinancièresDemandée-V1',
+        'InstructionDemandeMainlevéeGarantiesFinancièresDémarrée-V1',
+        'DemandeMainlevéeGarantiesFinancièresAccordée-V1',
+        'DemandeMainlevéeGarantiesFinancièresRejetée-V1',
       ],
       eventHandler: async (event) => {
         await mediator.publish<GarantiesFinancièresNotification.Execute>({

--- a/packages/applications/notifications/src/subscribers/lauréat/garantiesFinancières.notification.ts
+++ b/packages/applications/notifications/src/subscribers/lauréat/garantiesFinancières.notification.ts
@@ -177,7 +177,7 @@ export const register = () => {
       case 'DemandeMainlevéeGarantiesFinancièresAccordée-V1':
       case 'DemandeMainlevéeGarantiesFinancièresRejetée-V1':
         await sendEmailGarantiesFinancières({
-          subject: `Potentiel - Le statut de la demande de main-levée des garanties financière a été modifié ${nomProjet}`,
+          subject: `Potentiel - Le statut de la demande de mainlevée des garanties financières a été modifié ${nomProjet}`,
           templateId: templateId.mainlevéeGFStatutModifiéPourPorteur,
           recipients: porteurs,
           identifiantProjet,

--- a/packages/applications/notifications/src/subscribers/lauréat/garantiesFinancières.notification.ts
+++ b/packages/applications/notifications/src/subscribers/lauréat/garantiesFinancières.notification.ts
@@ -26,6 +26,7 @@ const templateId = {
   GFActuellesModifiéesPourPorteur: 5765519,
   GFActuellesModifiéesPourDreal: 5765536,
   mainlevéeGFDemandéePourDreal: 6025932,
+  mainlevéeGFStatutModifiéPourPorteur: 6051452,
 };
 
 const sendEmailGarantiesFinancières = async ({
@@ -165,6 +166,20 @@ export const register = () => {
           subject: `Potentiel - Demande de mainlevée des garanties financières pour le projet ${nomProjet} dans le département ${départementProjet}`,
           templateId: templateId.mainlevéeGFDemandéePourDreal,
           recipients: dreals,
+          identifiantProjet,
+          nomProjet,
+          départementProjet,
+          régionProjet,
+        });
+        break;
+
+      case 'InstructionDemandeMainlevéeGarantiesFinancièresDémarrée-V1':
+      case 'DemandeMainlevéeGarantiesFinancièresAccordée-V1':
+      case 'DemandeMainlevéeGarantiesFinancièresRejetée-V1':
+        await sendEmailGarantiesFinancières({
+          subject: `Potentiel - Le statut de la demande de main-levée des garanties financière a été modifié ${nomProjet}`,
+          templateId: templateId.mainlevéeGFStatutModifiéPourPorteur,
+          recipients: porteurs,
           identifiantProjet,
           nomProjet,
           départementProjet,


### PR DESCRIPTION
# Description

Lors de la modification du statut de sa demande de GF (en instruction, validé, ou refusé),

Le PP est notifié par email 

Objet : Le statut de la demande de main-levée des garanties financière a été modifié [Nom du projet]

Contenu : Le statut de votre demande de main-levée des garanties financières pour le projet X a été modifié + Vous pouvez consulter cette demande sur Potentiel :  lien vers la page de la garantie financière

## Type de changement

- Nouvelle fonctionnalité