### PR TITLE
♻️ Mise à plat des données d'Abandon

### DIFF
--- a/packages/domain/lauréat/src/abandon/abandon.entity.ts
+++ b/packages/domain/lauréat/src/abandon/abandon.entity.ts
@@ -4,40 +4,65 @@ export type AbandonEntity = Entity<
   'abandon',
   {
     identifiantProjet: string;
-    nomProjet: string;
-    régionProjet: Array<string>;
 
-    appelOffre: string;
-    période: string;
-    famille?: string;
+    projet?: {
+      nom: string;
+      appelOffre: string;
+      période: string;
+      famille?: string;
+      numéroCRE: string;
+      région: string;
+    };
+
+    demande: {
+      demandéPar: string;
+      demandéLe: string;
+      raison: string;
+      pièceJustificative?: {
+        format: string;
+      };
+
+      recandidature?: {
+        statut: string;
+        preuve?: {
+          demandéeLe: string;
+          identifiantProjet?: string;
+          transmiseLe?: string;
+          transmisePar?: string;
+        };
+      };
+
+      confirmation?: {
+        demandéePar: string;
+        demandéeLe: string;
+
+        réponseSignée: {
+          format: string;
+        };
+
+        confirméLe?: string;
+        confirméPar?: string;
+      };
+
+      accord?: {
+        réponseSignée: {
+          format: string;
+        };
+        accordéPar: string;
+        accordéLe: string;
+      };
+
+      rejet?: {
+        réponseSignée: {
+          format: string;
+        };
+        rejetéPar: string;
+        rejetéLe: string;
+      };
+    };
 
     statut: string;
     misÀJourLe: string;
-
-    demandeDemandéPar: string;
-    demandeDemandéLe: string;
-    demandeRaison: string;
-    demandePièceJustificativeFormat?: string;
-    demandeRecandidature: boolean;
-    preuveRecandidatureStatut: string;
-    preuveRecandidature?: string;
-    preuveRecandidatureDemandéeLe?: string;
-    preuveRecandidatureTransmiseLe?: string;
-    preuveRecandidatureTransmisePar?: string;
-
-    accordRéponseSignéeFormat?: string;
-    accordAccordéPar?: string;
-    accordAccordéLe?: string;
-
-    rejetRéponseSignéeFormat?: string;
-    rejetRejetéPar?: string;
-    rejetRejetéLe?: string;
-
-    confirmationDemandéePar?: string;
-    confirmationDemandéeLe?: string;
-    confirmationDemandéeRéponseSignéeFormat?: string;
-    confirmationConfirméLe?: string;
-    confirmationConfirméPar?: string;
   }
 >;
 

--- a/packages/domain/lauréat/src/abandon/consulter/consulterAbandon.query.ts
+++ b/packages/domain/lauréat/src/abandon/consulter/consulterAbandon.query.ts
@@ -1,7 +1,7 @@
 import { Message, MessageHandler, mediator } from 'mediateur';
 
 import { Option } from '@potentiel-libraries/monads';
-import { IdentifiantProjet, DateTime } from '@potentiel-domain/common';
+import { IdentifiantProjet, DateTime, Email } from '@potentiel-domain/common';
 import { IdentifiantUtilisateur } from '@potentiel-domain/utilisateur';
 
 import { AucunAbandonEnCours } from '../aucunAbandonEnCours.error';
@@ -68,77 +68,77 @@ export const registerConsulterAbandonQuery = ({ find }: ConsulterAbandonDependen
     }
 
     const demande: ConsulterAbandonReadModel['demande'] = {
-      demandéLe: DateTime.convertirEnValueType(result.demandeDemandéLe),
-      demandéPar: IdentifiantUtilisateur.convertirEnValueType(result.demandeDemandéPar),
-      raison: result.demandeRaison,
-      recandidature: result.demandeRecandidature,
-      preuveRecandidature: result.preuveRecandidature
-        ? IdentifiantProjet.convertirEnValueType(result.preuveRecandidature)
+      demandéLe: DateTime.convertirEnValueType(result.demande.demandéLe),
+      demandéPar: Email.convertirEnValueType(result.demande.demandéPar),
+      raison: result.demande.raison,
+      recandidature: !!result.demande.recandidature,
+      preuveRecandidature: result.demande.recandidature?.preuve?.identifiantProjet
+        ? IdentifiantProjet.convertirEnValueType(
+            result.demande.recandidature.preuve.identifiantProjet,
+          )
         : undefined,
-      preuveRecandidatureTransmiseLe: result.preuveRecandidatureTransmiseLe
-        ? DateTime.convertirEnValueType(result.preuveRecandidatureTransmiseLe)
+      preuveRecandidatureTransmiseLe: result.demande.recandidature?.preuve?.transmiseLe
+        ? DateTime.convertirEnValueType(result.demande.recandidature?.preuve?.transmiseLe)
         : undefined,
-      preuveRecandidatureTransmisePar: result.preuveRecandidatureTransmisePar
-        ? IdentifiantUtilisateur.convertirEnValueType(result.preuveRecandidatureTransmisePar)
+      preuveRecandidatureTransmisePar: result.demande.recandidature?.preuve?.transmisePar
+        ? Email.convertirEnValueType(result.demande.recandidature?.preuve?.transmisePar)
         : undefined,
-      preuveRecandidatureDemandéeLe: result.preuveRecandidatureDemandéeLe
-        ? DateTime.convertirEnValueType(result.preuveRecandidatureDemandéeLe)
+      preuveRecandidatureDemandéeLe: result.demande.recandidature?.preuve?.demandéeLe
+        ? DateTime.convertirEnValueType(result.demande.recandidature?.preuve?.demandéeLe)
         : undefined,
-      preuveRecandidatureStatut: StatutPreuveRecandidature.convertirEnValueType(
-        result.preuveRecandidatureStatut,
-      ),
-      piéceJustificative: result.demandePièceJustificativeFormat
+      preuveRecandidatureStatut: result.demande.recandidature?.statut
+        ? StatutPreuveRecandidature.convertirEnValueType(result.demande.recandidature.statut)
+        : StatutPreuveRecandidature.nonApplicable,
+      piéceJustificative: result.demande.pièceJustificative?.format
         ? DocumentProjet.convertirEnValueType(
             identifiantProjet.formatter(),
             TypeDocumentAbandon.pièceJustificative.formatter(),
-            DateTime.convertirEnValueType(result.demandeDemandéLe).formatter(),
-            result.demandePièceJustificativeFormat,
+            DateTime.convertirEnValueType(result.demande.demandéLe).formatter(),
+            result.demande.pièceJustificative?.format,
           )
         : undefined,
-      confirmation: result.confirmationDemandéeLe
+      confirmation: result.demande.confirmation
         ? {
-            demandéLe: DateTime.convertirEnValueType(result.confirmationDemandéeLe!),
-            demandéPar: IdentifiantUtilisateur.convertirEnValueType(
-              result.confirmationDemandéePar!,
-            ),
+            demandéLe: DateTime.convertirEnValueType(result.demande.confirmation.demandéeLe),
+            demandéPar: Email.convertirEnValueType(result.demande.confirmation.demandéePar),
             réponseSignée: DocumentProjet.convertirEnValueType(
               identifiantProjet.formatter(),
               TypeDocumentAbandon.abandonÀConfirmer.formatter(),
-              DateTime.convertirEnValueType(result.confirmationDemandéeLe!).formatter(),
-              result.confirmationDemandéeRéponseSignéeFormat!,
+              DateTime.convertirEnValueType(result.demande.confirmation.demandéeLe).formatter(),
+              result.demande.confirmation.réponseSignée.format,
             ),
-            confirméLe: result.confirmationConfirméLe
-              ? DateTime.convertirEnValueType(result.confirmationConfirméLe)
+            confirméLe: result.demande.confirmation.confirméLe
+              ? DateTime.convertirEnValueType(result.demande.confirmation.confirméLe)
               : undefined,
-            confirméPar: result.confirmationConfirméPar
-              ? IdentifiantUtilisateur.convertirEnValueType(result.confirmationConfirméPar)
+            confirméPar: result.demande.confirmation.confirméPar
+              ? Email.convertirEnValueType(result.demande.confirmation.confirméPar)
               : undefined,
           }
         : undefined,
     };
 
-    const accord: ConsulterAbandonReadModel['accord'] = result.accordAccordéLe
+    const accord: ConsulterAbandonReadModel['accord'] = result.demande.accord
       ? {
-          accordéLe: DateTime.convertirEnValueType(result.accordAccordéLe!),
-          accordéPar: IdentifiantUtilisateur.convertirEnValueType(result.accordAccordéPar!),
+          accordéLe: DateTime.convertirEnValueType(result.demande.accord.accordéLe),
+          accordéPar: Email.convertirEnValueType(result.demande.accord.accordéPar),
           réponseSignée: DocumentProjet.convertirEnValueType(
             identifiantProjet.formatter(),
             TypeDocumentAbandon.abandonAccordé.formatter(),
-            DateTime.convertirEnValueType(result.accordAccordéLe!).formatter(),
-            result.accordRéponseSignéeFormat!,
+            DateTime.convertirEnValueType(result.demande.accord.accordéLe).formatter(),
+            result.demande.accord.réponseSignée.format,
           ),
         }
       : undefined;
 
-    const rejet: ConsulterAbandonReadModel['rejet'] = result.rejetRejetéLe
+    const rejet: ConsulterAbandonReadModel['rejet'] = result.demande.rejet
       ? {
-          rejetéLe: DateTime.convertirEnValueType(result.rejetRejetéLe!),
-          rejetéPar: IdentifiantUtilisateur.convertirEnValueType(result.rejetRejetéPar!),
+          rejetéLe: DateTime.convertirEnValueType(result.demande.rejet.rejetéLe),
+          rejetéPar: Email.convertirEnValueType(result.demande.rejet.rejetéPar),
           réponseSignée: DocumentProjet.convertirEnValueType(
             identifiantProjet.formatter(),
             TypeDocumentAbandon.abandonRejeté.formatter(),
-            DateTime.convertirEnValueType(result.rejetRejetéLe!).formatter(),
-            result.rejetRéponseSignéeFormat!,
+            DateTime.convertirEnValueType(result.demande.rejet.rejetéLe).formatter(),
+            result.demande.rejet.réponseSignée.format,
           ),
         }
       : undefined;

--- a/packages/domain/lauréat/src/abandon/lister/listerAbandon.query.ts
+++ b/packages/domain/lauréat/src/abandon/lister/listerAbandon.query.ts
@@ -156,15 +156,18 @@ export const registerListerAbandonQuery = ({
   mediator.register('Lauréat.Abandon.Query.ListerAbandons', handler);
 };
 
-const mapToReadModel = (projection: AbandonEntity): AbandonListItemReadModel => {
+const mapToReadModel = (entity: AbandonEntity): AbandonListItemReadModel => {
   return {
-    ...projection,
-    statut: StatutAbandon.convertirEnValueType(projection.statut),
-    recandidature: projection.demandeRecandidature,
-    misÀJourLe: DateTime.convertirEnValueType(projection.misÀJourLe),
-    identifiantProjet: IdentifiantProjet.convertirEnValueType(projection.identifiantProjet),
-    preuveRecandidatureStatut: StatutPreuveRecandidature.convertirEnValueType(
-      projection.preuveRecandidatureStatut,
-    ),
+    appelOffre: entity.projet?.appelOffre || 'N/A',
+    nomProjet: entity.projet?.nom || 'Projet inconnu',
+    période: entity.projet?.période || 'N/A',
+    famille: entity.projet?.famille,
+    statut: StatutAbandon.convertirEnValueType(entity.statut),
+    recandidature: !!entity.demande.recandidature,
+    misÀJourLe: DateTime.convertirEnValueType(entity.misÀJourLe),
+    identifiantProjet: IdentifiantProjet.convertirEnValueType(entity.identifiantProjet),
+    preuveRecandidatureStatut: entity.demande.recandidature
+      ? StatutPreuveRecandidature.convertirEnValueType(entity.demande.recandidature.statut)
+      : StatutPreuveRecandidature.nonApplicable,
   };
 };


### PR DESCRIPTION
# Description

Fait partie de ce ticket : https://linear.app/startup-potentiel/issue/POT-191/switch-domain-abandon-sur-listprojection-v2.

Nécessite un rebuild d'abandon

## Type de changement

Veuillez supprimer les options qui ne sont pas pertinentes.

- [x] Refacto de code

# Comment cela a-t-il été testé?

Il faut lancer les specs pour valider le bon fonctionnement du domain en lecture

# Check-up :

- [x] Mon code [suit les directives de style](../docs/contributing//DEVELOPMENT_FLOW.md) de ce projet
- [x] J'ai effectué une auto-revue de mon code
- [x] J'ai commenté mon code, en particulier dans les zones difficiles à comprendre
- [x] J'ai apporté des modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun warning
- [x] J'ai ajouté des tests qui prouvent l'efficacité de ma correction ou que ma fonctionnalité fonctionne
- [x] Les nouveaux tests unitaires et les tests existants passent en local / dans la CI avec mes modifications
