### PR TITLE
🐛 Remplacer les log d'erreurs dans les projecteurs par des warning lorsqu'un projet n'exsite pas

### DIFF
--- a/packages/applications/projectors/src/subscribers/lauréat/abandon.projector.ts
+++ b/packages/applications/projectors/src/subscribers/lauréat/abandon.projector.ts
@@ -49,7 +49,7 @@ export const register = () => {
           const projet = await CandidatureAdapter.récupérerCandidatureAdapter(identifiantProjet);
 
           if (Option.isNone(projet)) {
-            getLogger().error(new Error(`Projet inconnu !`), { identifiantProjet, message: event });
+            getLogger().warn(`Projet inconnu !`, { identifiantProjet, message: event });
           }
 
           await upsertProjection<Abandon.AbandonEntity>(`abandon|${identifiantProjet}`, {

--- a/packages/applications/projectors/src/subscribers/lauréat/achèvement.projector.ts
+++ b/packages/applications/projectors/src/subscribers/lauréat/achèvement.projector.ts
@@ -45,7 +45,7 @@ export const register = () => {
       const getProjectData = async (identifiantProjet: IdentifiantProjet.RawType) => {
         const projet = await CandidatureAdapter.récupérerCandidatureAdapter(identifiantProjet);
         if (Option.isNone(projet)) {
-          getLogger().error(new Error(`Projet inconnu !`), {
+          getLogger().warn(`Projet inconnu !`, {
             identifiantProjet,
             message: event,
           });

--- a/packages/applications/projectors/src/subscribers/lauréat/garantiesFinancières.projector.ts
+++ b/packages/applications/projectors/src/subscribers/lauréat/garantiesFinancières.projector.ts
@@ -189,10 +189,11 @@ export const register = () => {
       const getProjectData = async (identifiantProjet: IdentifiantProjet.RawType) => {
         const projet = await CandidatureAdapter.récupérerCandidatureAdapter(identifiantProjet);
         if (Option.isNone(projet)) {
-          getLogger().error(new Error(`Projet inconnu !`), {
-            identifiantProjet,
-            message: event,
-          });
+          getLogger().warn(`Projet inconnu !`),
+            {
+              identifiantProjet,
+              message: event,
+            };
           return {
             nomProjet: 'Projet inconnu',
             appelOffre: `N/A`,

--- a/packages/applications/projectors/src/subscribers/réseau/raccordement.projector.ts
+++ b/packages/applications/projectors/src/subscribers/réseau/raccordement.projector.ts
@@ -290,7 +290,7 @@ const getRaccordementToUpsert = async (
   const projet = await CandidatureAdapter.récupérerCandidatureAdapter(identifiantProjet);
 
   if (Option.isNone(projet)) {
-    getLogger().error(new Error(`Projet inconnu !`), { identifiantProjet, message: event });
+    getLogger().warn(`Projet inconnu !`, { identifiantProjet });
   }
 
   const raccordementDefaultValue: Omit<Raccordement.RaccordementEntity, 'type'> = {

--- a/packages/applications/projectors/src/subscribers/tâche/tâche.projector.ts
+++ b/packages/applications/projectors/src/subscribers/tâche/tâche.projector.ts
@@ -31,7 +31,7 @@ export const register = () => {
       ]);
 
       if (!projet) {
-        getLogger().error(new Error(`Projet inconnu !`), { identifiantProjet, event });
+        getLogger().warn(`Projet inconnu !`, { identifiantProjet, event });
       }
 
       switch (type) {

--- a/packages/applications/projectors/src/subscribers/éliminé/recours.projector.ts
+++ b/packages/applications/projectors/src/subscribers/éliminé/recours.projector.ts
@@ -50,7 +50,7 @@ export const register = () => {
           const projet = await CandidatureAdapter.récupérerCandidatureAdapter(identifiantProjet);
 
           if (Option.isNone(projet)) {
-            getLogger().error(new Error(`Projet inconnu !`), { identifiantProjet, message: event });
+            getLogger().warn(`Projet inconnu !`, { identifiantProjet, message: event });
           }
 
           await upsertProjection<Recours.RecoursEntity>(`recours|${identifiantProjet}`, {


### PR DESCRIPTION
# Description

Ce cas était traité comme une erreur mais n'en est pas une. Certains identifiants de projet sont valides sans pour autant permettre de récupérer les données de candidature associé. C'est le cas notament lorsqu'un projet a changé d'appel d'offre.

## Type de changement

- [x] Correction de bug

# Check-up :

- [x] Mon code [suit les directives de style](../docs/contributing//DEVELOPMENT_FLOW.md) de ce projet
- [x] J'ai effectué une auto-revue de mon code
- [x] J'ai commenté mon code, en particulier dans les zones difficiles à comprendre
- [x] J'ai apporté des modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun warning
- [x] J'ai ajouté des tests qui prouvent l'efficacité de ma correction ou que ma fonctionnalité fonctionne
- [x] Les nouveaux tests unitaires et les tests existants passent en local / dans la CI avec mes modifications
