### PR TITLE
🐛 Correction raccordement avec référence par défault

### DIFF
--- a/packages/applications/legacy/src/controllers/project/getProjectPage.ts
+++ b/packages/applications/legacy/src/controllers/project/getProjectPage.ts
@@ -264,7 +264,8 @@ const getAlertesRaccordement = async ({
 
     if (
       CDC2022Choisi &&
-      dossiersRaccordement.dossiers[0].référence.formatter() === 'Référence non transmise'
+      dossiersRaccordement.dossiers[0].référence.formatter() ===
+        Raccordement.RéférenceDossierRaccordement.defaultRéférenceDossierRaccordement
     ) {
       alertes.push('référenceDossierManquantePourDélaiCDC2022');
     }

--- a/packages/applications/legacy/src/controllers/project/getProjectPage.ts
+++ b/packages/applications/legacy/src/controllers/project/getProjectPage.ts
@@ -264,8 +264,9 @@ const getAlertesRaccordement = async ({
 
     if (
       CDC2022Choisi &&
-      dossiersRaccordement.dossiers[0].référence.formatter() ===
-        Raccordement.RéférenceDossierRaccordement.defaultRéférenceDossierRaccordement
+      dossiersRaccordement.dossiers[0].référence.estÉgaleÀ(
+        Raccordement.RéférenceDossierRaccordement.référenceNonTransmise,
+      )
     ) {
       alertes.push('référenceDossierManquantePourDélaiCDC2022');
     }

--- a/packages/applications/ssr/src/components/pages/tâche/TâcheListItem.tsx
+++ b/packages/applications/ssr/src/components/pages/tâche/TâcheListItem.tsx
@@ -6,6 +6,7 @@ import { PlainType } from '@potentiel-domain/core';
 import { ListerTâchesReadModel, TypeTâche } from '@potentiel-domain/tache';
 import { DateTime, IdentifiantProjet } from '@potentiel-domain/common';
 import { Option } from '@potentiel-libraries/monads';
+import { Raccordement } from '@potentiel-domain/reseau';
 
 import { FormattedDate } from '@/components/atoms/FormattedDate';
 
@@ -94,7 +95,7 @@ const getDescriptionTâche = (
       };
     case 'raccordement.référence-non-transmise':
       return {
-        titre: 'Référence non transmise',
+        titre: Raccordement.RéférenceDossierRaccordement.defaultRéférenceDossierRaccordement,
         description: `La référence de votre dossier de raccordement n'a pas été transmise pour le projet ${nomProjet}`,
         lien: Routes.Raccordement.détail(identifiant),
         action: 'Voir le raccordement',

--- a/packages/applications/ssr/src/components/pages/tâche/TâcheListItem.tsx
+++ b/packages/applications/ssr/src/components/pages/tâche/TâcheListItem.tsx
@@ -95,7 +95,7 @@ const getDescriptionTâche = (
       };
     case 'raccordement.référence-non-transmise':
       return {
-        titre: Raccordement.RéférenceDossierRaccordement.defaultRéférenceDossierRaccordement,
+        titre: Raccordement.RéférenceDossierRaccordement.référenceNonTransmise.formatter(),
         description: `La référence de votre dossier de raccordement n'a pas été transmise pour le projet ${nomProjet}`,
         lien: Routes.Raccordement.détail(identifiant),
         action: 'Voir le raccordement',

--- a/packages/domain/common/src/valueTypes/expressionRegulière.valueType.ts
+++ b/packages/domain/common/src/valueTypes/expressionRegulière.valueType.ts
@@ -17,7 +17,7 @@ export const bind = ({ expression }: PlainType<ValueType>): ValueType => {
       return this.expression === valueType.expression;
     },
     valider(value) {
-      return new RegExp(`^${this.expression}$`).test(value);
+      return new RegExp(`^${this.expression}$`).test(value) || value === 'Référence non transmise';
     },
     formatter() {
       return this.expression;

--- a/packages/domain/common/src/valueTypes/expressionRegulière.valueType.ts
+++ b/packages/domain/common/src/valueTypes/expressionRegulière.valueType.ts
@@ -17,7 +17,7 @@ export const bind = ({ expression }: PlainType<ValueType>): ValueType => {
       return this.expression === valueType.expression;
     },
     valider(value) {
-      return new RegExp(`^${this.expression}$`).test(value) || value === 'Référence non transmise';
+      return new RegExp(`^${this.expression}$`).test(value);
     },
     formatter() {
       return this.expression;

--- a/packages/domain/réseau/src/raccordement/référenceDossierRaccordement.valueType.ts
+++ b/packages/domain/réseau/src/raccordement/référenceDossierRaccordement.valueType.ts
@@ -2,7 +2,7 @@ import { InvalidOperationError, ReadonlyValueType } from '@potentiel-domain/core
 
 export type RawType = string;
 
-export const defaultRéférenceDossierRaccordement = 'Référence non transmise';
+const defaultRéférenceDossierRaccordement = 'Référence non transmise';
 
 export type ValueType = ReadonlyValueType<{
   référence: string;
@@ -30,6 +30,8 @@ function estValide(value: string): asserts value is RawType {
     throw new FormatRéférenceDossierRaccordementInvalideError(value);
   }
 }
+
+export const référenceNonTransmise = convertirEnValueType(defaultRéférenceDossierRaccordement);
 
 class FormatRéférenceDossierRaccordementInvalideError extends InvalidOperationError {
   constructor(value: string) {

--- a/packages/domain/réseau/src/raccordement/référenceDossierRaccordement.valueType.ts
+++ b/packages/domain/réseau/src/raccordement/référenceDossierRaccordement.valueType.ts
@@ -2,10 +2,13 @@ import { InvalidOperationError, ReadonlyValueType } from '@potentiel-domain/core
 
 export type RawType = string;
 
+export const defaultRéférenceDossierRaccordement = 'Référence non transmise';
+
 export type ValueType = ReadonlyValueType<{
   référence: string;
   formatter(): RawType;
 }>;
+
 export const convertirEnValueType = (value: string): ValueType => {
   estValide(value);
   return {
@@ -20,7 +23,8 @@ export const convertirEnValueType = (value: string): ValueType => {
 };
 
 function estValide(value: string): asserts value is RawType {
-  const isValid = value === value.trim().replace(/\s/g, '');
+  const isValid =
+    value === value.trim().replace(/\s/g, '') || value === defaultRéférenceDossierRaccordement;
 
   if (!isValid) {
     throw new FormatRéférenceDossierRaccordementInvalideError(value);

--- a/packages/specifications/src/gestionnaireRéseau/validerRéférenceDossierRaccordement.feature
+++ b/packages/specifications/src/gestionnaireRéseau/validerRéférenceDossierRaccordement.feature
@@ -11,8 +11,10 @@ Fonctionnalité: Valider une référence de dossier de raccordement
             | Expression régulière              | Référence à valider         | Résultat attendu |
             | [a-zA-Z]{3}                       | "ABC"                       | valide           |
             | [a-zA-Z]{3}                       | "123"                       | invalide         |
+            | [a-zA-Z]{3}                       | "Référence non transmise"   | valide           |
             | [a-zA-Z]{3}-RP-2[0-9]{3}-[0-9]{6} | "OUE-RP-2022-000034"        | valide           |
             | [a-zA-Z]{3}-RP-2[0-9]{3}-[0-9]{6} | "ENEDIS OUE-RP-2022-000034" | invalide         |
+            | [a-zA-Z]{3}-RP-2[0-9]{3}-[0-9]{6} | "Référence non transmise"   | valide           |
 
     Plan du Scénario: Valider/Invalider une référence de dossier de raccordement après modification du gestionnaire de réseau
         Etant donné un gestionnaire de réseau
@@ -27,6 +29,7 @@ Fonctionnalité: Valider une référence de dossier de raccordement
             | Expression régulière              | Référence à valider         | Résultat attendu |
             | [a-zA-Z]{3}                       | "ABC"                       | valide           |
             | [a-zA-Z]{3}                       | "123"                       | invalide         |
+            | [a-zA-Z]{3}                       | "Référence non transmise"   | valide           |
             | [a-zA-Z]{3}-RP-2[0-9]{3}-[0-9]{6} | "OUE-RP-2022-000034"        | valide           |
             | [a-zA-Z]{3}-RP-2[0-9]{3}-[0-9]{6} | "ENEDIS OUE-RP-2022-000034" | invalide         |
-
+            | [a-zA-Z]{3}-RP-2[0-9]{3}-[0-9]{6} | "Référence non transmise"   | valide           |

--- a/packages/specifications/src/gestionnaireRéseau/validerRéférenceDossierRaccordement.feature
+++ b/packages/specifications/src/gestionnaireRéseau/validerRéférenceDossierRaccordement.feature
@@ -11,10 +11,8 @@ Fonctionnalité: Valider une référence de dossier de raccordement
             | Expression régulière              | Référence à valider         | Résultat attendu |
             | [a-zA-Z]{3}                       | "ABC"                       | valide           |
             | [a-zA-Z]{3}                       | "123"                       | invalide         |
-            | [a-zA-Z]{3}                       | "Référence non transmise"   | valide           |
             | [a-zA-Z]{3}-RP-2[0-9]{3}-[0-9]{6} | "OUE-RP-2022-000034"        | valide           |
             | [a-zA-Z]{3}-RP-2[0-9]{3}-[0-9]{6} | "ENEDIS OUE-RP-2022-000034" | invalide         |
-            | [a-zA-Z]{3}-RP-2[0-9]{3}-[0-9]{6} | "Référence non transmise"   | valide           |
 
     Plan du Scénario: Valider/Invalider une référence de dossier de raccordement après modification du gestionnaire de réseau
         Etant donné un gestionnaire de réseau
@@ -29,7 +27,5 @@ Fonctionnalité: Valider une référence de dossier de raccordement
             | Expression régulière              | Référence à valider         | Résultat attendu |
             | [a-zA-Z]{3}                       | "ABC"                       | valide           |
             | [a-zA-Z]{3}                       | "123"                       | invalide         |
-            | [a-zA-Z]{3}                       | "Référence non transmise"   | valide           |
             | [a-zA-Z]{3}-RP-2[0-9]{3}-[0-9]{6} | "OUE-RP-2022-000034"        | valide           |
             | [a-zA-Z]{3}-RP-2[0-9]{3}-[0-9]{6} | "ENEDIS OUE-RP-2022-000034" | invalide         |
-            | [a-zA-Z]{3}-RP-2[0-9]{3}-[0-9]{6} | "Référence non transmise"   | valide           |

--- a/packages/specifications/src/raccordement/transmettreDemandeComplèteDeRaccordement.feature
+++ b/packages/specifications/src/raccordement/transmettreDemandeComplèteDeRaccordement.feature
@@ -13,6 +13,16 @@ Fonctionnalité: Transmettre une demande complète de raccordement
         Alors le dossier est consultable dans la liste des dossiers de raccordement du projet lauréat "Du boulodrome de Marseille"
         Et la demande complète de raccordement devrait être consultable dans le dossier de raccordement du projet lauréat "Du boulodrome de Marseille"
         Et le projet "Du boulodrome de Marseille" devrait avoir un raccordement attribué au gestionnaire de réseau "Enedis"
+
+    Scénario: Un porteur de projet transmet une demande complète de raccordement pour son projet avec la valeur de référence par défault
+        Quand le porteur transmet une demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" auprès du gestionnaire de réseau "Enedis" avec :
+            | La date de qualification                | 2022-10-28                                                                                            |
+            | La référence du dossier de raccordement | Référence non transmise                                                                                             |
+            | Le format de l'accusé de réception      | application/pdf                                                                                       |
+            | Le contenu de l'accusé de réception     | Accusé de réception ayant pour référence OUE-RP-2022-000033 et la date de qualification au 2022-10-28 |
+        Alors le dossier est consultable dans la liste des dossiers de raccordement du projet lauréat "Du boulodrome de Marseille"
+        Et la demande complète de raccordement devrait être consultable dans le dossier de raccordement du projet lauréat "Du boulodrome de Marseille"
+        Et le projet "Du boulodrome de Marseille" devrait avoir un raccordement attribué au gestionnaire de réseau "Enedis"
     
     Scénario: Un porteur de projet transmet plusieurs demandes complètes de raccordement pour son projet
         Quand le porteur transmet une demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" auprès du gestionnaire de réseau "Enedis" avec :


### PR DESCRIPTION
# Description

Raccordement avec la référence par défault "Référence non transmise" n'étaient pas validées dans la valueType

## Type de changement

Veuillez supprimer les options qui ne sont pas pertinentes.

- [ ] Correction de bug
- [ ] Nouvelle fonctionnalité
- [ ] Refacto de code
- [ ] Breaking changes (correction ou fonctionnalité qui ferait en sorte que la fonctionnalité existante ne fonctionne pas comme prévu)
- [ ] Ce changement nécessite une mise à jour de la documentation

# Comment cela a-t-il été testé?

Veuillez décrire les tests que vous avez effectués pour vérifier vos changements. Fournissez des instructions afin que nous puissions les reproduire. Veuillez également lister tous les détails pertinents pour la configuration de votre test.

## Pré-requis 

- [ ] Pré-requis A   
- [ ] Pré-requis B   
 
## Scénarios 

- [ ] Scénario A
- [ ] Scénario B

# Check-up :

- [ ] Mon code [suit les directives de style](../docs/contributing//DEVELOPMENT_FLOW.md) de ce projet
- [ ] J'ai effectué une auto-revue de mon code
- [ ] J'ai commenté mon code, en particulier dans les zones difficiles à comprendre
- [ ] J'ai apporté des modifications correspondantes à la documentation
- [ ] Mes modifications ne génèrent aucun warning
- [ ] J'ai ajouté des tests qui prouvent l'efficacité de ma correction ou que ma fonctionnalité fonctionne
- [ ] Les nouveaux tests unitaires et les tests existants passent en local / dans la CI avec mes modifications
