### PR TITLE
🎨 Ajout d'une id à l'historique des mainlevée rejetée pour permettre la modification

### DIFF
--- a/packages/applications/projectors/src/subscribers/lauréat/garantiesFinancières.projector.ts
+++ b/packages/applications/projectors/src/subscribers/lauréat/garantiesFinancières.projector.ts
@@ -10,7 +10,6 @@ import { removeProjection } from '../../infrastructure/removeProjection';
 import { upsertProjection } from '../../infrastructure/upsertProjection';
 import { getLogger } from '@potentiel-libraries/monitoring';
 import { IdentifiantProjet } from '@potentiel-domain/common';
-import { v4 as uuid } from 'uuid';
 
 export type SubscriptionEvent =
   | (GarantiesFinancières.GarantiesFinancièresEvent & Event)
@@ -509,7 +508,7 @@ export const register = () => {
               historique: [
                 ...historiqueMainlevéeRejetéeGarantiesFinancièresToUpsert.historique,
                 {
-                  id: uuid(),
+                  id: payload.id,
                   demande: mainlevéeGarantiesFinancièresToUpsert.demande,
                   motif: mainlevéeGarantiesFinancièresToUpsert.motif,
                   rejet: {

--- a/packages/applications/projectors/src/subscribers/lauréat/garantiesFinancières.projector.ts
+++ b/packages/applications/projectors/src/subscribers/lauréat/garantiesFinancières.projector.ts
@@ -10,6 +10,7 @@ import { removeProjection } from '../../infrastructure/removeProjection';
 import { upsertProjection } from '../../infrastructure/upsertProjection';
 import { getLogger } from '@potentiel-libraries/monitoring';
 import { IdentifiantProjet } from '@potentiel-domain/common';
+import { v4 as uuid } from 'uuid';
 
 export type SubscriptionEvent =
   | (GarantiesFinancières.GarantiesFinancièresEvent & Event)
@@ -508,6 +509,7 @@ export const register = () => {
               historique: [
                 ...historiqueMainlevéeRejetéeGarantiesFinancièresToUpsert.historique,
                 {
+                  id: uuid(),
                   demande: mainlevéeGarantiesFinancièresToUpsert.demande,
                   motif: mainlevéeGarantiesFinancièresToUpsert.motif,
                   rejet: {

--- a/packages/domain/lauréat/src/garantiesFinancières/garantiesFinancières.aggregate.ts
+++ b/packages/domain/lauréat/src/garantiesFinancières/garantiesFinancières.aggregate.ts
@@ -125,6 +125,7 @@ export type GarantiesFinancièresAggregate = Aggregate<GarantiesFinancièresEven
   demandeMainlevéeEnCours?: {
     statut: StatutMainlevéeGarantiesFinancières.ValueType;
   };
+  historiqueMainlevéeRejetée?: Array<string>;
   readonly soumettreDépôt: typeof soumettreDépôt;
   readonly demanderGarantiesFinancières: typeof demanderGarantiesFinancières;
   readonly supprimerDépôtGarantiesFinancièresEnCours: typeof supprimerDépôtGarantiesFinancièresEnCours;
@@ -207,7 +208,7 @@ function apply(this: GarantiesFinancièresAggregate, event: GarantiesFinancière
       applyInstructionDemandeMainlevéeGarantiesFinancièresDémarrée.bind(this)();
       break;
     case 'DemandeMainlevéeGarantiesFinancièresRejetée-V1':
-      applyDemandeMainlevéeGarantiesFinancièresRejetée.bind(this)();
+      applyDemandeMainlevéeGarantiesFinancièresRejetée.bind(this)(event);
       break;
     case 'DemandeMainlevéeGarantiesFinancièresAccordée-V1':
       applyDemandeMainlevéeGarantiesFinancièresAccordée.bind(this)();

--- a/packages/domain/lauréat/src/garantiesFinancières/mainlevée/consulter/consulterHistoriqueDemandeMainlevéeRejetéeGarantiesFinancières.query.ts
+++ b/packages/domain/lauréat/src/garantiesFinancières/mainlevée/consulter/consulterHistoriqueDemandeMainlevéeRejetéeGarantiesFinancières.query.ts
@@ -19,6 +19,7 @@ export type ConsulterHistoriqueDemandeMainlevéeRejetéeGarantiesFinancièresRea
   période: string;
   régionProjet: string;
   historique: Array<{
+    id: string;
     motif: MotifDemandeMainlevéeGarantiesFinancières.ValueType;
     demande: { demandéeLe: DateTime.ValueType; demandéePar: Email.ValueType };
     rejet: {
@@ -82,6 +83,7 @@ export const mapToReadModel = ({
   période,
   régionProjet,
   historique: historique.map((demandeRejetée) => ({
+    id: demandeRejetée.id,
     demande: {
       demandéeLe: DateTime.convertirEnValueType(demandeRejetée.demande.demandéeLe),
       demandéePar: Email.convertirEnValueType(demandeRejetée.demande.demandéePar),

--- a/packages/domain/lauréat/src/garantiesFinancières/mainlevée/historiqueMainlevéeRejetéeGarantiesFinancières.entity.ts
+++ b/packages/domain/lauréat/src/garantiesFinancières/mainlevée/historiqueMainlevéeRejetéeGarantiesFinancières.entity.ts
@@ -11,6 +11,7 @@ export type HistoriqueMainlevéeRejetéeGarantiesFinancièresEntity = Entity<
     famille?: string;
 
     historique: Array<{
+      id: string;
       motif: string;
       demande: { demandéeLe: string; demandéePar: string };
       rejet: { rejetéLe: string; rejetéPar: string; courrierRejet: { format: string } };

--- a/packages/domain/lauréat/src/garantiesFinancières/mainlevée/rejeter/rejeterDemandeMainlevéeGarantiesFinancières.behavior.ts
+++ b/packages/domain/lauréat/src/garantiesFinancières/mainlevée/rejeter/rejeterDemandeMainlevéeGarantiesFinancières.behavior.ts
@@ -15,6 +15,7 @@ export type DemandeMainlevéeGarantiesFinancièresRejetéeEvent = DomainEvent<
     réponseSignée: {
       format: string;
     };
+    id: string;
   }
 >;
 
@@ -23,11 +24,12 @@ type Options = {
   rejetéLe: DateTime.ValueType;
   rejetéPar: Email.ValueType;
   réponseSignée: DocumentProjet.ValueType;
+  id: string;
 };
 
 export async function rejeterDemandeMainlevéeGarantiesFinancières(
   this: GarantiesFinancièresAggregate,
-  { identifiantProjet, rejetéLe, rejetéPar, réponseSignée }: Options,
+  { identifiantProjet, rejetéLe, rejetéPar, réponseSignée, id }: Options,
 ) {
   if (!this.demandeMainlevéeEnCours) {
     throw new DemandeMainlevéeNonTrouvéeError();
@@ -46,6 +48,7 @@ export async function rejeterDemandeMainlevéeGarantiesFinancières(
       réponseSignée: {
         format: réponseSignée.format,
       },
+      id,
     },
   };
 
@@ -54,10 +57,17 @@ export async function rejeterDemandeMainlevéeGarantiesFinancières(
 
 export function applyDemandeMainlevéeGarantiesFinancièresRejetée(
   this: GarantiesFinancièresAggregate,
+  { payload: { id } }: DemandeMainlevéeGarantiesFinancièresRejetéeEvent,
 ) {
   if (this.demandeMainlevéeEnCours) {
     this.demandeMainlevéeEnCours.statut = StatutMainlevéeGarantiesFinancières.rejeté;
+    this.historiqueMainlevéeRejetée = this.historiqueMainlevéeRejetée
+      ? [...this.historiqueMainlevéeRejetée, id]
+      : [id];
   } else {
     this.demandeMainlevéeEnCours = { statut: StatutMainlevéeGarantiesFinancières.rejeté };
+    this.historiqueMainlevéeRejetée = this.historiqueMainlevéeRejetée
+      ? [...this.historiqueMainlevéeRejetée, id]
+      : [id];
   }
 }

--- a/packages/domain/lauréat/src/garantiesFinancières/mainlevée/rejeter/rejeterDemandeMainlevéeGarantiesFinancières.command.ts
+++ b/packages/domain/lauréat/src/garantiesFinancières/mainlevée/rejeter/rejeterDemandeMainlevéeGarantiesFinancières.command.ts
@@ -13,6 +13,7 @@ export type RejeterDemandeMainlevéeGarantiesFinancièresCommand = Message<
     rejetéLe: DateTime.ValueType;
     rejetéPar: Email.ValueType;
     réponseSignée: DocumentProjet.ValueType;
+    id: string;
   }
 >;
 
@@ -26,6 +27,7 @@ export const registeRejeterDemandeMainlevéeGarantiesFinancièresCommand = (
     rejetéLe,
     rejetéPar,
     réponseSignée,
+    id,
   }) => {
     const garantiesFinancières = await loadGarantiesFinancières(identifiantProjet, false);
 
@@ -34,6 +36,7 @@ export const registeRejeterDemandeMainlevéeGarantiesFinancièresCommand = (
       rejetéLe,
       rejetéPar,
       réponseSignée,
+      id,
     });
   };
   mediator.register(

--- a/packages/domain/lauréat/src/garantiesFinancières/mainlevée/rejeter/rejeterDemandeMainlevéeGarantiesFinancières.usecase.ts
+++ b/packages/domain/lauréat/src/garantiesFinancières/mainlevée/rejeter/rejeterDemandeMainlevéeGarantiesFinancières.usecase.ts
@@ -3,6 +3,7 @@ import { DateTime, Email, IdentifiantProjet } from '@potentiel-domain/common';
 import { RejeterDemandeMainlevéeGarantiesFinancièresCommand } from './rejeterDemandeMainlevéeGarantiesFinancières.command';
 import { DocumentProjet, EnregistrerDocumentProjetCommand } from '@potentiel-domain/document';
 import { TypeDocumentRéponseDemandeMainlevée } from '../..';
+import { v4 as uuid } from 'uuid';
 
 export type RejeterDemandeMainlevéeGarantiesFinancièresUseCase = Message<
   'Lauréat.GarantiesFinancières.Mainlevée.UseCase.RejeterDemandeMainlevée',
@@ -33,6 +34,7 @@ export const registerRejeterDemandeMainlevéeGarantiesFinancièresUseCase = () =
       rejetéLe.formatter(),
       format,
     );
+    const id = uuid();
 
     await mediator.send<EnregistrerDocumentProjetCommand>({
       type: 'Document.Command.EnregistrerDocumentProjet',
@@ -49,6 +51,7 @@ export const registerRejeterDemandeMainlevéeGarantiesFinancièresUseCase = () =
         rejetéPar,
         identifiantProjet,
         réponseSignée,
+        id,
       },
     });
   };

--- a/packages/specifications/src/projet/lauréat/mainLevéeGarantiesFinancières/rejeterDemandeMainlevéeGarantiesFinancières.feature
+++ b/packages/specifications/src/projet/lauréat/mainLevéeGarantiesFinancières/rejeterDemandeMainlevéeGarantiesFinancières.feature
@@ -3,6 +3,7 @@ Fonctionnalité: Rejeter une demande de mainlevée des garanties financières
     Contexte: 
         Etant donné le projet lauréat "Centrale PV"
 
+@select
     Scénario: Un utilisateur Dreal rejette une demande de mainlevée pour un projet abandonné
         Etant donné un abandon accordé pour le projet lauréat "Centrale PV"
         Et des garanties financières validées pour le projet "Centrale PV"

--- a/packages/specifications/src/projet/lauréat/mainLevéeGarantiesFinancières/stepDefinitions/mainlevéeGarantiesFinancières.then.ts
+++ b/packages/specifications/src/projet/lauréat/mainLevéeGarantiesFinancières/stepDefinitions/mainlevéeGarantiesFinancières.then.ts
@@ -275,7 +275,7 @@ Alors(
           formatFichierRéponse,
         );
 
-        expect(actualReadModel.historique[0].id).to.be.true;
+        expect(actualReadModel.historique[0].id).not.to.be.undefined;
 
         const actualFile = await mediator.send<ConsulterDocumentProjetQuery>({
           type: 'Document.Query.ConsulterDocumentProjet',

--- a/packages/specifications/src/projet/lauréat/mainLevéeGarantiesFinancières/stepDefinitions/mainlevéeGarantiesFinancières.then.ts
+++ b/packages/specifications/src/projet/lauréat/mainLevéeGarantiesFinancières/stepDefinitions/mainlevéeGarantiesFinancières.then.ts
@@ -275,6 +275,8 @@ Alors(
           formatFichierRéponse,
         );
 
+        expect(actualReadModel.historique[0].id).to.be.true;
+
         const actualFile = await mediator.send<ConsulterDocumentProjetQuery>({
           type: 'Document.Query.ConsulterDocumentProjet',
           data: { documentKey: actualReadModel.historique[0].rejet.courrierRejet.formatter() },


### PR DESCRIPTION
# Description

Nous devons être capable d'identifier une mainlevée rejetée dans l'historique des mainlevée rejetée pour pouvoir faire une modification de réponse signée pour un rejet spécifique => https://linear.app/startup-potentiel/issue/POT-356/[dreal]-etq-dreal-je-peux-modifier-le-courrier-de-reponse-dune
J'ai donc :
- ajouté un id pour chaque mainlevée rejetée dans la project historique
- ajouté l'array des id dans l'aggrégat GF
- modifié les tests en fonction

## Type de changement

Veuillez supprimer les options qui ne sont pas pertinentes.

- [ ] Correction de bug
- [ ] Nouvelle fonctionnalité
- [ ] Refacto de code
- [ ] Breaking changes (correction ou fonctionnalité qui ferait en sorte que la fonctionnalité existante ne fonctionne pas comme prévu)
- [ ] Ce changement nécessite une mise à jour de la documentation

# Comment cela a-t-il été testé?

Veuillez décrire les tests que vous avez effectués pour vérifier vos changements. Fournissez des instructions afin que nous puissions les reproduire. Veuillez également lister tous les détails pertinents pour la configuration de votre test.

## Pré-requis 

- [ ] Pré-requis A   
- [ ] Pré-requis B   
 
## Scénarios 

- [ ] Scénario A
- [ ] Scénario B

# Check-up :

- [x] Mon code [suit les directives de style](../docs/contributing//DEVELOPMENT_FLOW.md) de ce projet
- [x] J'ai effectué une auto-revue de mon code
- [ ] J'ai commenté mon code, en particulier dans les zones difficiles à comprendre
- [x] J'ai apporté des modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun warning
- [x] J'ai ajouté des tests qui prouvent l'efficacité de ma correction ou que ma fonctionnalité fonctionne
- [x] Les nouveaux tests unitaires et les tests existants passent en local / dans la CI avec mes modifications
