### PR TITLE
🚑️ Fix validation qui bloque le chargement de certaines référence actuel

### DIFF
--- a/packages/domain/réseau/src/raccordement/référenceDossierRaccordement.valueType.ts
+++ b/packages/domain/réseau/src/raccordement/référenceDossierRaccordement.valueType.ts
@@ -20,7 +20,7 @@ export const convertirEnValueType = (value: string): ValueType => {
 };
 
 function estValide(value: string): asserts value is RawType {
-  const isValid = value === value.trim().replace(/\s/g, '');
+  const isValid = !!value;
 
   if (!isValid) {
     throw new FormatRéférenceDossierRaccordementInvalideError(value);

--- a/packages/specifications/src/gestionnaireRéseau/validerRéférenceDossierRaccordement.feature
+++ b/packages/specifications/src/gestionnaireRéseau/validerRéférenceDossierRaccordement.feature
@@ -13,6 +13,14 @@ Fonctionnalité: Valider une référence de dossier de raccordement
             | [a-zA-Z]{3}                       | "123"                       | invalide         |
             | [a-zA-Z]{3}-RP-2[0-9]{3}-[0-9]{6} | "OUE-RP-2022-000034"        | valide           |
             | [a-zA-Z]{3}-RP-2[0-9]{3}-[0-9]{6} | "ENEDIS OUE-RP-2022-000034" | invalide         |
+            | [a-zA-Z]{3}-RP-2[0-9]{3}-[0-9]{6} | "ENEDIS OUE-RP-2022-000034" | invalide         |
+            | ^[^\s\t]*$                        | "Référence non transmise"   | invalide         |
+            | ^[^\s\t]*$                        | "Enedis OUE-RP-2022-000033" | invalide         |
+            | ^[^\s\t]*$                        | "Enedis DDD"                | invalide         |
+            | ^[^\s\t]*$                        | "OUE-RP-2022-000033 "       | invalide         |
+            | ^[^\s\t]*$                        | " OUE-RP-2022-000033"       | invalide         |
+            | ^[^\s\t]*$                        | "OUE-RP-2022-000033"        | valide           |
+            | ^[^\s\t]*$                        | "ENEDIS"                    | valide           |
 
     Plan du Scénario: Valider/Invalider une référence de dossier de raccordement après modification du gestionnaire de réseau
         Etant donné un gestionnaire de réseau
@@ -29,4 +37,10 @@ Fonctionnalité: Valider une référence de dossier de raccordement
             | [a-zA-Z]{3}                       | "123"                       | invalide         |
             | [a-zA-Z]{3}-RP-2[0-9]{3}-[0-9]{6} | "OUE-RP-2022-000034"        | valide           |
             | [a-zA-Z]{3}-RP-2[0-9]{3}-[0-9]{6} | "ENEDIS OUE-RP-2022-000034" | invalide         |
-
+            | ^[^\s\t]*$                        | "Référence non transmise"   | invalide         |
+            | ^[^\s\t]*$                        | "Enedis OUE-RP-2022-000033" | invalide         |
+            | ^[^\s\t]*$                        | "Enedis DDD"                | invalide         |
+            | ^[^\s\t]*$                        | "OUE-RP-2022-000033 "       | invalide         |
+            | ^[^\s\t]*$                        | " OUE-RP-2022-000033"       | invalide         |
+            | ^[^\s\t]*$                        | "OUE-RP-2022-000033"        | valide           |
+            | ^[^\s\t]*$                        | "ENEDIS"                    | valide           |

--- a/packages/specifications/src/raccordement/modifierRéférenceDemandeComplèteDeRaccordement.feature
+++ b/packages/specifications/src/raccordement/modifierRéférenceDemandeComplèteDeRaccordement.feature
@@ -4,34 +4,50 @@ Fonctionnalité: Modifier la référence d'une demande complète de raccordement
         Etant donné le gestionnaire de réseau "Enedis"
         Et le projet lauréat "Du boulodrome de Marseille"
 
-    Scénario: Modifier la référence d'une demande complète de raccordement
+    Plan du Scénario: Modifier la référence d'une demande complète de raccordement
         Etant donné une demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" transmise auprès du gestionnaire de réseau "Enedis" avec :
-            | La date de qualification                | 2022-10-28                                                                                            |
-            | La référence du dossier de raccordement | OUE-RP-2022-000033                                                                                    |
-            | Le format de l'accusé de réception      | application/pdf                                                                                       |
-            | Le contenu de l'accusé de réception     | Accusé de réception ayant pour référence OUE-RP-2022-000033 et la date de qualification au 2022-10-28 |
-        Quand l'utilisateur avec le rôle "porteur-projet" modifie la demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000033" avec la référence "OUE-RP-2022-000034" auprès du gestionnaire de réseau "Enedis"
+            | La date de qualification                | 2022-10-28                                                                                              |
+            | La référence du dossier de raccordement | <Référence actuelle>                                                                                    |
+            | Le format de l'accusé de réception      | application/pdf                                                                                         |
+            | Le contenu de l'accusé de réception     | Accusé de réception ayant pour référence <Référence actuelle> et la date de qualification au 2022-10-28 |
+        Quand l'utilisateur avec le rôle "porteur-projet" modifie la demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" ayant pour référence "<Référence actuelle>" avec la référence "OUE-RP-2022-000034" auprès du gestionnaire de réseau "Enedis"
         Alors le dossier est consultable dans la liste des dossiers de raccordement du projet lauréat "Du boulodrome de Marseille"
         Et la demande complète de raccordement devrait être consultable dans le dossier de raccordement du projet lauréat "Du boulodrome de Marseille"
     
-    Scénario: Modifier en tant qu'administrateur la référence d'une demande complète de raccordement pour un dossier ayant déjà une date de mise en service 
+    Exemples:
+        | Référence actuelle        |
+        | Référence non transmise   |
+        | Enedis                    |
+        | Enedis OUE-RP-2022-000033 |
+        | Enedis DDD                |
+        | OUE-RP-2022-000033        |
+    
+    Plan du Scénario: Modifier en tant qu'administrateur la référence d'une demande complète de raccordement pour un dossier ayant déjà une date de mise en service 
         Etant donné une demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" transmise auprès du gestionnaire de réseau "Enedis" avec :
-            | La date de qualification                | 2022-10-28                                                                                            |
-            | La référence du dossier de raccordement | OUE-RP-2022-000033                                                                                    |
-            | Le format de l'accusé de réception      | application/pdf                                                                                       |
-            | Le contenu de l'accusé de réception     | Accusé de réception ayant pour référence OUE-RP-2022-000033 et la date de qualification au 2022-10-28 |
-        Et une date de mise en service "2022-01-12" pour le dossier de raccordement pour le projet lauréat "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000033"
-        Quand l'utilisateur avec le rôle "admin" modifie la demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000033" avec la référence "OUE-RP-2022-000034" auprès du gestionnaire de réseau "Enedis"
+            | La date de qualification                | 2022-10-28                                                                                              |
+            | La référence du dossier de raccordement | <Référence actuelle>                                                                                    |
+            | Le format de l'accusé de réception      | application/pdf                                                                                         |
+            | Le contenu de l'accusé de réception     | Accusé de réception ayant pour référence <Référence actuelle> et la date de qualification au 2022-10-28 |
+        Et une date de mise en service "2022-01-12" pour le dossier de raccordement pour le projet lauréat "Du boulodrome de Marseille" ayant pour référence "<Référence actuelle>"
+        Quand l'utilisateur avec le rôle "admin" modifie la demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" ayant pour référence "<Référence actuelle>" avec la référence "OUE-RP-2022-000034" auprès du gestionnaire de réseau "Enedis"
         Alors le dossier est consultable dans la liste des dossiers de raccordement du projet lauréat "Du boulodrome de Marseille"
         Et la demande complète de raccordement devrait être consultable dans le dossier de raccordement du projet lauréat "Du boulodrome de Marseille"
     
-    Scénario: Modifier un dossier de raccordement suite à la modification de la référence
+    Exemples:
+        | Référence actuelle        |
+        | Référence non transmise   |
+        | Enedis                    |
+        | Enedis OUE-RP-2022-000033 |
+        | Enedis DDD                |
+        | OUE-RP-2022-000033        |
+
+    Plan du Scénario: Modifier un dossier de raccordement suite à la modification de la référence
         Etant donné une demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" transmise auprès du gestionnaire de réseau "Enedis" avec :
-            | La date de qualification                | 2022-10-28                                                                                            |
-            | La référence du dossier de raccordement | OUE-RP-2022-000033                                                                                    |
-            | Le format de l'accusé de réception      | application/pdf                                                                                       |
-            | Le contenu de l'accusé de réception     | Accusé de réception ayant pour référence OUE-RP-2022-000033 et la date de qualification au 2022-10-28 |
-        Quand l'utilisateur avec le rôle "porteur-projet" modifie la demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000033" avec la référence "OUE-RP-2022-000034" auprès du gestionnaire de réseau "Enedis"
+            | La date de qualification                | 2022-10-28                                                                                              |
+            | La référence du dossier de raccordement | <Référence actuelle>                                                                                    |
+            | Le format de l'accusé de réception      | application/pdf                                                                                         |
+            | Le contenu de l'accusé de réception     | Accusé de réception ayant pour référence <Référence actuelle> et la date de qualification au 2022-10-28 |
+        Quand l'utilisateur avec le rôle "porteur-projet" modifie la demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" ayant pour référence "<Référence actuelle>" avec la référence "OUE-RP-2022-000034" auprès du gestionnaire de réseau "Enedis"
         Et le porteur modifie la demande complète de raccordement pour le dossier de raccordement du projet lauréat "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000034" auprès du gestionnaire de réseau "Enedis" avec :
             | La date de qualification            | 2022-10-29                                                                                                      |
             | Le format de l'accusé de réception  | text/plain                                                                                                      |
@@ -39,18 +55,34 @@ Fonctionnalité: Modifier la référence d'une demande complète de raccordement
         Alors le dossier est consultable dans la liste des dossiers de raccordement du projet lauréat "Du boulodrome de Marseille"
         Et la demande complète de raccordement devrait être consultable dans le dossier de raccordement du projet lauréat "Du boulodrome de Marseille"
 
-    Scénario: Modifier la référence d'une demande complète de raccordement ayant une PTF
+    Exemples:
+        | Référence actuelle        |
+        | Référence non transmise   |
+        | Enedis                    |
+        | Enedis OUE-RP-2022-000033 |
+        | Enedis DDD                |
+        | OUE-RP-2022-000033        |
+
+    Plan du Scénario: Modifier la référence d'une demande complète de raccordement ayant une PTF
         Etant donné une demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" transmise auprès du gestionnaire de réseau "Enedis" avec :
-            | La date de qualification                | 2022-10-28                                                                                            |
-            | La référence du dossier de raccordement | OUE-RP-2022-000033                                                                                    |
-            | Le format de l'accusé de réception      | application/pdf                                                                                       |
-            | Le contenu de l'accusé de réception     | Accusé de réception ayant pour référence OUE-RP-2022-000033 et la date de qualification au 2022-10-28 |
-        Et une propositon technique et financière pour le dossier de raccordement pour le projet lauréat "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000033" avec :
+            | La date de qualification                | 2022-10-28                                                                                              |
+            | La référence du dossier de raccordement | <Référence actuelle>                                                                                    |
+            | Le format de l'accusé de réception      | application/pdf                                                                                         |
+            | Le contenu de l'accusé de réception     | Accusé de réception ayant pour référence <Référence actuelle> et la date de qualification au 2022-10-28 |
+        Et une propositon technique et financière pour le dossier de raccordement pour le projet lauréat "Du boulodrome de Marseille" ayant pour référence "<Référence actuelle>" avec :
             | La date de signature                                | 2023-01-10                                                                                                        |
             | Le format de la proposition technique et financière | application/pdf                                                                                                   |
             | Le contenu de proposition technique et financière   | Proposition technique et financière pour la référence OUE-RP-2022-000033 avec une date de signature au 2023-01-10 |
-        Quand l'utilisateur avec le rôle "porteur-projet" modifie la demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000033" avec la référence "OUE-RP-2022-000034" auprès du gestionnaire de réseau "Enedis"
+        Quand l'utilisateur avec le rôle "porteur-projet" modifie la demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" ayant pour référence "<Référence actuelle>" avec la référence "OUE-RP-2022-000034" auprès du gestionnaire de réseau "Enedis"
         Alors la proposition technique et financière signée devrait être consultable dans le dossier de raccordement du projet lauréat "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000034"
+
+    Exemples:
+        | Référence actuelle        |
+        | Référence non transmise   |
+        | Enedis                    |
+        | Enedis OUE-RP-2022-000033 |
+        | Enedis DDD                |
+        | OUE-RP-2022-000033        |
 
     Scénario: Impossible de modifier une demande complète de raccordement avec une référence ne correspondant pas au format défini par le gestionnaire de réseau
         Etant donné un gestionnaire de réseau
@@ -87,12 +119,3 @@ Fonctionnalité: Modifier la référence d'une demande complète de raccordement
         Et une date de mise en service "2022-01-12" pour le dossier de raccordement pour le projet lauréat "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000033"
         Quand l'utilisateur avec le rôle "porteur-projet" modifie la demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000033" avec la référence "OUE-RP-2022-000034" auprès du gestionnaire de réseau "Enedis"
         Alors le porteur devrait être informé que "La référence du dossier de raccordement ne peut pas être modifiée car le dossier dispose déjà d'une date de mise en service"
-
-    Scénario: Impossible de modifier la référence pour un dossier de raccordement avec une nouvelle référence qui comporte des espaces ou tabulations
-        Etant donné une demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" transmise auprès du gestionnaire de réseau "Enedis" avec :
-            | La date de qualification                | 2022-10-28                                                                                            |
-            | La référence du dossier de raccordement | OUE-RP-2022-000033                                                                                    |
-            | Le format de l'accusé de réception      | application/pdf                                                                                       |
-            | Le contenu de l'accusé de réception     | Accusé de réception ayant pour référence OUE-RP-2022-000033 et la date de qualification au 2022-10-28 |
-        Quand l'utilisateur avec le rôle "porteur-projet" modifie la demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000033" avec la référence " OUE-RP-2022-000034 " auprès du gestionnaire de réseau "Enedis"
-        Alors le porteur devrait être informé que "La référence du dossier de raccordement ne doit pas comporter d'espace ou de tabulation extérieur"    


### PR DESCRIPTION
# Description

Fix de la validation des références qui bloquent la majeur partie des dossiers de raccordement en production

## Type de changement

- [x] hotfix

# Comment cela a-t-il été testé?

Rajout dans les specs de plan de scénario avec des valeurs non fonctionnelles actuellement en prod

# Check-up :

- [x] Mon code [suit les directives de style](../docs/contributing//DEVELOPMENT_FLOW.md) de ce projet
- [x] J'ai effectué une auto-revue de mon code
- [x] J'ai commenté mon code, en particulier dans les zones difficiles à comprendre
- [x] J'ai apporté des modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun warning
- [x] J'ai ajouté des tests qui prouvent l'efficacité de ma correction ou que ma fonctionnalité fonctionne
- [x] Les nouveaux tests unitaires et les tests existants passent en local / dans la CI avec mes modifications
