### PR TITLE
✨ Attribuer GRD inconnu

### DIFF
--- a/packages/applications/ssr/src/app/laureats/[identifiant]/raccordements/gestionnaire:modifier/page.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/raccordements/gestionnaire:modifier/page.tsx
@@ -1,6 +1,5 @@
 import { mediator } from 'mediateur';
 import { Metadata } from 'next';
-import { notFound } from 'next/navigation';
 
 import {
   ConsulterCandidatureQuery,
@@ -43,10 +42,6 @@ export default async function Page({ params: { identifiant } }: IdentifiantParam
         data: { identifiantProjetValue: identifiantProjet },
       });
 
-    if (Option.isNone(gestionnaireRéseau)) {
-      return notFound();
-    }
-
     const props = mapToProps({
       gestionnairesRéseau,
       candidature,
@@ -61,7 +56,7 @@ export default async function Page({ params: { identifiant } }: IdentifiantParam
 type MapToProps = (args: {
   gestionnairesRéseau: GestionnaireRéseau.ListerGestionnaireRéseauReadModel;
   candidature: ConsulterCandidatureReadModel;
-  gestionnaireRéseau: Raccordement.ConsulterGestionnaireRéseauRaccordementReadModel;
+  gestionnaireRéseau: Option.Type<Raccordement.ConsulterGestionnaireRéseauRaccordementReadModel>;
   identifiantProjet: string;
 }) => ModifierGestionnaireRéseauRaccordementPageProps;
 
@@ -72,8 +67,9 @@ const mapToProps: MapToProps = ({
   identifiantProjet,
 }) => {
   return {
-    identifiantGestionnaireRéseauActuel:
-      gestionnaireRéseau.identifiantGestionnaireRéseau.formatter(),
+    identifiantGestionnaireRéseauActuel: Option.match(gestionnaireRéseau)
+      .some((gestionnaireRéseau) => gestionnaireRéseau.identifiantGestionnaireRéseau.formatter())
+      .none(() => ''),
     listeGestionnairesRéseau: gestionnairesRéseau.items.map((gestionnaire) => ({
       identifiantGestionnaireRéseau: gestionnaire.identifiantGestionnaireRéseau.formatter(),
       raisonSociale: gestionnaire.raisonSociale,

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/raccordements/page.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/raccordements/page.tsx
@@ -49,7 +49,8 @@ export default async function Page({ params: { identifiant } }: PageProps) {
         await mediator.send<GestionnaireRéseau.ConsulterGestionnaireRéseauQuery>({
           type: 'Réseau.Gestionnaire.Query.ConsulterGestionnaireRéseau',
           data: {
-            identifiantGestionnaireRéseau: raccordement.identifiantGestionnaireRéseau.formatter(),
+            identifiantGestionnaireRéseau:
+              raccordement.identifiantGestionnaireRéseau?.formatter() || '',
           },
         });
 

--- a/packages/applications/ssr/src/components/pages/réseau/gestionnaire/modifier/ModifierGestionnaireRéseau.page.tsx
+++ b/packages/applications/ssr/src/components/pages/réseau/gestionnaire/modifier/ModifierGestionnaireRéseau.page.tsx
@@ -5,10 +5,10 @@ import { useRouter } from 'next/navigation';
 import { FC, useState } from 'react';
 
 import { Routes } from '@potentiel-applications/routes';
-import { GestionnaireRéseau } from '@potentiel-domain/reseau';
 import { PlainType } from '@potentiel-domain/core';
 import { ExpressionRegulière, Email } from '@potentiel-domain/common';
 import { Option } from '@potentiel-libraries/monads';
+import { GestionnaireRéseau } from '@potentiel-domain/reseau';
 
 import { Form } from '@/components/atoms/form/Form';
 import { SubmitButton } from '@/components/atoms/form/SubmitButton';

--- a/packages/applications/ssr/src/components/pages/réseau/raccordement/détails/DétailsRaccordement.page.tsx
+++ b/packages/applications/ssr/src/components/pages/réseau/raccordement/détails/DétailsRaccordement.page.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 import { FC } from 'react';
 
 import { Routes } from '@potentiel-applications/routes';
+import { GestionnaireRéseau } from '@potentiel-domain/reseau';
 
 import { ProjetBanner, ProjetBannerProps } from '@/components/molecules/projet/ProjetBanner';
 import { Tile } from '@/components/organisms/Tile';
@@ -15,11 +16,11 @@ import { TitrePageRaccordement } from '../TitrePageRaccordement';
 
 import { DossierRaccordement, DossierRaccordementProps } from './components/DossierRaccordement';
 import { ModifierGestionnaireRéseauDuRaccordement } from './components/ModifierGestionnaireRéseauDuRaccordement';
-import { GestionnaireRéseau } from './type';
+import { GestionnaireRéseau as GestionnaireRéseauProps } from './type';
 
 export type DétailsRaccordementPageProps = {
   projet: ProjetBannerProps;
-  gestionnaireRéseau?: GestionnaireRéseau;
+  gestionnaireRéseau?: GestionnaireRéseauProps;
   dossiers: ReadonlyArray<DossierRaccordementProps>;
 };
 
@@ -27,53 +28,61 @@ export const DétailsRaccordementPage: FC<DétailsRaccordementPageProps> = ({
   projet,
   gestionnaireRéseau,
   dossiers,
-}) => (
-  <PageTemplate banner={<ProjetBanner {...projet} />}>
-    <TitrePageRaccordement />
-    <div className="my-2 md:my-4">
-      {gestionnaireRéseau && (
-        <ModifierGestionnaireRéseauDuRaccordement
-          gestionnaireRéseau={gestionnaireRéseau}
-          identifiantProjet={projet.identifiantProjet}
-        />
-      )}
-      {dossiers.length === 1 ? (
-        <DossierRaccordement {...dossiers[0]} />
-      ) : (
-        dossiers.map((dossier) => (
-          <Tile key={dossier.référence} className="mb-3">
-            <DossierRaccordement {...dossier} />
-          </Tile>
-        ))
-      )}
-    </div>
+}) => {
+  const isGestionnaireInconnu = gestionnaireRéseau
+    ? GestionnaireRéseau.IdentifiantGestionnaireRéseau.convertirEnValueType(
+        gestionnaireRéseau.identifiantGestionnaireRéseau,
+      ).estÉgaleÀ(GestionnaireRéseau.IdentifiantGestionnaireRéseau.inconnu)
+    : false;
+  return (
+    <PageTemplate banner={<ProjetBanner {...projet} />}>
+      <TitrePageRaccordement />
+      <div className="my-2 md:my-4">
+        {gestionnaireRéseau && (
+          <ModifierGestionnaireRéseauDuRaccordement
+            gestionnaireRéseau={gestionnaireRéseau}
+            identifiantProjet={projet.identifiantProjet}
+            isGestionnaireInconnu={isGestionnaireInconnu}
+          />
+        )}
+        {dossiers.length === 1 ? (
+          <DossierRaccordement {...dossiers[0]} isGestionnaireInconnu={isGestionnaireInconnu} />
+        ) : (
+          dossiers.map((dossier) => (
+            <Tile key={dossier.référence} className="mb-3">
+              <DossierRaccordement {...dossier} isGestionnaireInconnu={isGestionnaireInconnu} />
+            </Tile>
+          ))
+        )}
+      </div>
 
-    <Alert
-      severity="info"
-      small
-      description={
-        <div className="p-3">
-          Si le raccordement comporte plusieurs points d'injection, vous pouvez{' '}
-          <Link
-            href={Routes.Raccordement.transmettreDemandeComplèteRaccordement(
-              projet.identifiantProjet,
-            )}
-            className="font-semibold"
-          >
-            transmettre une autre demande complète de raccordement
-          </Link>
-          .
-        </div>
-      }
-    />
+      <Alert
+        severity="info"
+        small
+        description={
+          <div className="p-3">
+            Si le raccordement comporte plusieurs points d'injection, vous pouvez{' '}
+            <Link
+              href={Routes.Raccordement.transmettreDemandeComplèteRaccordement(
+                projet.identifiantProjet,
+              )}
+              className="font-semibold"
+            >
+              transmettre une autre demande complète de raccordement
+            </Link>
+            .
+          </div>
+        }
+      />
 
-    <Button
-      priority="secondary"
-      linkProps={{ href: Routes.Projet.details(projet.identifiantProjet) }}
-      className="mt-4"
-      iconId="fr-icon-arrow-left-line"
-    >
-      Retour vers le projet
-    </Button>
-  </PageTemplate>
-);
+      <Button
+        priority="secondary"
+        linkProps={{ href: Routes.Projet.details(projet.identifiantProjet) }}
+        className="mt-4"
+        iconId="fr-icon-arrow-left-line"
+      >
+        Retour vers le projet
+      </Button>
+    </PageTemplate>
+  );
+};

--- a/packages/applications/ssr/src/components/pages/réseau/raccordement/détails/DétailsRaccordement.stories.tsx
+++ b/packages/applications/ssr/src/components/pages/réseau/raccordement/détails/DétailsRaccordement.stories.tsx
@@ -95,3 +95,14 @@ export const Incomplet: Story = {
     ],
   },
 };
+
+export const GestionnaireInconnu: Story = {
+  args: {
+    projet,
+    gestionnaireRéseau: {
+      ...gestionnaireRéseau,
+      identifiantGestionnaireRéseau: 'inconnu',
+    },
+    dossiers: Complet.args.dossiers,
+  },
+};

--- a/packages/applications/ssr/src/components/pages/réseau/raccordement/détails/components/DossierRaccordement.tsx
+++ b/packages/applications/ssr/src/components/pages/réseau/raccordement/détails/components/DossierRaccordement.tsx
@@ -24,6 +24,7 @@ export type DossierRaccordementProps = {
     dateMiseEnService?: Iso8601DateTime;
     canEdit: boolean;
   };
+  isGestionnaireInconnu?: boolean;
 };
 
 export const DossierRaccordement: FC<DossierRaccordementProps> = ({
@@ -32,6 +33,7 @@ export const DossierRaccordement: FC<DossierRaccordementProps> = ({
   demandeComplèteRaccordement,
   propositionTechniqueEtFinancière,
   miseEnService,
+  isGestionnaireInconnu,
 }) => (
   <div className="flex flex-col md:flex-row justify-items-stretch">
     <ÉtapeDemandeComplèteRaccordement
@@ -39,7 +41,7 @@ export const DossierRaccordement: FC<DossierRaccordementProps> = ({
       référence={référence}
       dateQualification={demandeComplèteRaccordement.dateQualification}
       accuséRéception={demandeComplèteRaccordement.accuséRéception}
-      canEdit={demandeComplèteRaccordement.canEdit}
+      canEdit={demandeComplèteRaccordement.canEdit && !isGestionnaireInconnu}
     />
 
     <Separateur />
@@ -51,7 +53,7 @@ export const DossierRaccordement: FC<DossierRaccordementProps> = ({
       propositionTechniqueEtFinancièreSignée={
         propositionTechniqueEtFinancière.propositionTechniqueEtFinancièreSignée
       }
-      canEdit={propositionTechniqueEtFinancière.canEdit}
+      canEdit={propositionTechniqueEtFinancière.canEdit && !isGestionnaireInconnu}
     />
 
     <Separateur />
@@ -60,7 +62,7 @@ export const DossierRaccordement: FC<DossierRaccordementProps> = ({
       identifiantProjet={identifiantProjet}
       référence={référence}
       dateMiseEnService={miseEnService.dateMiseEnService}
-      canEdit={miseEnService.canEdit}
+      canEdit={miseEnService.canEdit && !isGestionnaireInconnu}
     />
   </div>
 );

--- a/packages/applications/ssr/src/components/pages/réseau/raccordement/détails/components/ModifierGestionnaireRéseauDuRaccordement.tsx
+++ b/packages/applications/ssr/src/components/pages/réseau/raccordement/détails/components/ModifierGestionnaireRéseauDuRaccordement.tsx
@@ -1,34 +1,59 @@
 import { FC } from 'react';
+import Alert from '@codegouvfr/react-dsfr/Alert';
 
 import { Routes } from '@potentiel-applications/routes';
+import { GestionnaireRéseau } from '@potentiel-domain/reseau';
 
 import { Icon } from '@/components/atoms/Icon';
 
 import { ProjetBannerProps } from '../../../../../molecules/projet/ProjetBanner';
-import { GestionnaireRéseau } from '../type';
+import { GestionnaireRéseau as GestionnaireRéseauProps } from '../type';
 
 type ModifierGestionnaireRéseauDuRaccordementProps = {
-  gestionnaireRéseau: GestionnaireRéseau;
+  gestionnaireRéseau: GestionnaireRéseauProps;
   identifiantProjet: ProjetBannerProps['identifiantProjet'];
 };
 
 export const ModifierGestionnaireRéseauDuRaccordement: FC<
   ModifierGestionnaireRéseauDuRaccordementProps
 > = ({ gestionnaireRéseau, identifiantProjet }: ModifierGestionnaireRéseauDuRaccordementProps) => {
+  const isGestionnaireInconnu =
+    GestionnaireRéseau.IdentifiantGestionnaireRéseau.convertirEnValueType(
+      gestionnaireRéseau.identifiantGestionnaireRéseau,
+    ).estÉgaleÀ(GestionnaireRéseau.IdentifiantGestionnaireRéseau.inconnu);
+
+  const lienModifier = gestionnaireRéseau.canEdit ? (
+    <a
+      className="ml-1"
+      href={Routes.Raccordement.modifierGestionnaireDeRéseau(identifiantProjet)}
+      aria-label={`Modifier le gestionnaire (actuel : ${gestionnaireRéseau.raisonSociale})`}
+    >
+      <Icon id="fr-icon-pencil-fill" size="xs" className="mr-1" />
+      Modifier
+    </a>
+  ) : undefined;
+
+  if (isGestionnaireInconnu) {
+    return (
+      <Alert
+        severity="warning"
+        title="Gestionnaire de réseau inconnu"
+        className="mb-6"
+        description={
+          <div className="flex flex-col">
+            Vous devez spécifier un gestionnaire de réseau
+            {lienModifier && <div>{lienModifier}</div>}
+          </div>
+        }
+      />
+    );
+  }
+
   return (
     <div className="mt-2 mb-4 p-0">
       <div>
         Gestionnaire de réseau : {gestionnaireRéseau.raisonSociale}{' '}
-        {gestionnaireRéseau.canEdit && (
-          <a
-            className="ml-1"
-            href={Routes.Raccordement.modifierGestionnaireDeRéseau(identifiantProjet)}
-            aria-label={`Modifier le gestionnaire (actuel : ${gestionnaireRéseau.raisonSociale})`}
-          >
-            (<Icon id="fr-icon-pencil-fill" size="xs" className="mr-1" />
-            Modifier)
-          </a>
-        )}
+        {lienModifier && <>({lienModifier})</>}
       </div>
       {gestionnaireRéseau.contactEmail && (
         <div>

--- a/packages/applications/ssr/src/components/pages/réseau/raccordement/détails/components/ModifierGestionnaireRéseauDuRaccordement.tsx
+++ b/packages/applications/ssr/src/components/pages/réseau/raccordement/détails/components/ModifierGestionnaireRéseauDuRaccordement.tsx
@@ -2,7 +2,6 @@ import { FC } from 'react';
 import Alert from '@codegouvfr/react-dsfr/Alert';
 
 import { Routes } from '@potentiel-applications/routes';
-import { GestionnaireRéseau } from '@potentiel-domain/reseau';
 
 import { Icon } from '@/components/atoms/Icon';
 
@@ -12,16 +11,16 @@ import { GestionnaireRéseau as GestionnaireRéseauProps } from '../type';
 type ModifierGestionnaireRéseauDuRaccordementProps = {
   gestionnaireRéseau: GestionnaireRéseauProps;
   identifiantProjet: ProjetBannerProps['identifiantProjet'];
+  isGestionnaireInconnu?: boolean;
 };
 
 export const ModifierGestionnaireRéseauDuRaccordement: FC<
   ModifierGestionnaireRéseauDuRaccordementProps
-> = ({ gestionnaireRéseau, identifiantProjet }: ModifierGestionnaireRéseauDuRaccordementProps) => {
-  const isGestionnaireInconnu =
-    GestionnaireRéseau.IdentifiantGestionnaireRéseau.convertirEnValueType(
-      gestionnaireRéseau.identifiantGestionnaireRéseau,
-    ).estÉgaleÀ(GestionnaireRéseau.IdentifiantGestionnaireRéseau.inconnu);
-
+> = ({
+  gestionnaireRéseau,
+  identifiantProjet,
+  isGestionnaireInconnu,
+}: ModifierGestionnaireRéseauDuRaccordementProps) => {
   const lienModifier = gestionnaireRéseau.canEdit ? (
     <a
       className="ml-1"

--- a/packages/applications/ssr/src/components/pages/réseau/raccordement/modifier/modifierDemandeComplèteRaccordement/ModifierDemandeComplèteRaccordement.page.tsx
+++ b/packages/applications/ssr/src/components/pages/réseau/raccordement/modifier/modifierDemandeComplèteRaccordement/ModifierDemandeComplèteRaccordement.page.tsx
@@ -102,12 +102,12 @@ export const ModifierDemandeComplèteRaccordementPage: FC<
                   <>
                     {aideSaisieRéférenceDossierRaccordement.format !== '' && (
                       <div className="m-0">
-                        Format attendu : {aideSaisieRéférenceDossierRaccordement.légende}
+                        Format attendu : {aideSaisieRéférenceDossierRaccordement.format}
                       </div>
                     )}
                     {aideSaisieRéférenceDossierRaccordement.légende !== '' && (
                       <div className="m-0 italic">
-                        Exemple : {aideSaisieRéférenceDossierRaccordement.format}
+                        Exemple : {aideSaisieRéférenceDossierRaccordement.légende}
                       </div>
                     )}
                   </>

--- a/packages/domain/réseau/src/gestionnaire/consulter/consulterGestionnaireRéseau.query.ts
+++ b/packages/domain/réseau/src/gestionnaire/consulter/consulterGestionnaireRéseau.query.ts
@@ -37,6 +37,23 @@ export const registerConsulterGestionnaireRéseauQuery = ({
   const handler: MessageHandler<ConsulterGestionnaireRéseauQuery> = async ({
     identifiantGestionnaireRéseau,
   }) => {
+    if (
+      identifiantGestionnaireRéseau &&
+      IdentifiantGestionnaireRéseau.convertirEnValueType(identifiantGestionnaireRéseau).estÉgaleÀ(
+        IdentifiantGestionnaireRéseau.inconnu,
+      )
+    ) {
+      return {
+        identifiantGestionnaireRéseau: IdentifiantGestionnaireRéseau.inconnu,
+        aideSaisieRéférenceDossierRaccordement: {
+          expressionReguliere: ExpressionRegulière.accepteTout,
+          format: '',
+          légende: '',
+        },
+        raisonSociale: 'Inconnu',
+        contactEmail: Option.none,
+      };
+    }
     const result = await find<GestionnaireRéseauEntity>(
       `gestionnaire-réseau|${identifiantGestionnaireRéseau}`,
     );

--- a/packages/domain/réseau/src/gestionnaire/gestionnaireRéseau.aggregate.ts
+++ b/packages/domain/réseau/src/gestionnaire/gestionnaireRéseau.aggregate.ts
@@ -61,7 +61,9 @@ export const loadGestionnaireRéseauFactory =
       getDefaultAggregate: getDefaultGestionnaireRéseauAggregate,
       onNone: throwOnNone
         ? () => {
-            throw new GestionnaireRéseauInconnuError();
+            if (!identifiantGestionnaireRéseau.estÉgaleÀ(IdentifiantGestionnaireRéseau.inconnu)) {
+              throw new GestionnaireRéseauInconnuError();
+            }
           }
         : undefined,
     });

--- a/packages/domain/réseau/src/raccordement/attribuer/attribuerGestionnaireRéseau.behavior.ts
+++ b/packages/domain/réseau/src/raccordement/attribuer/attribuerGestionnaireRéseau.behavior.ts
@@ -14,27 +14,25 @@ export type GestionnaireRéseauAttribuéEvent = DomainEvent<
 >;
 
 export type AttribuerGestionnaireRéseauOptions = {
-  identifiantGestionnaireRéseau: IdentifiantGestionnaireRéseau.RawType;
-  identifiantProjet: IdentifiantProjet.RawType;
+  identifiantGestionnaireRéseau: IdentifiantGestionnaireRéseau.ValueType;
+  identifiantProjet: IdentifiantProjet.ValueType;
 };
 
 export async function attribuerGestionnaireRéseau(
   this: RaccordementAggregate,
   { identifiantGestionnaireRéseau, identifiantProjet }: AttribuerGestionnaireRéseauOptions,
 ) {
-  const raccordementDéjàExistantPourLeProjet = this.identifiantProjet.estÉgaleÀ(
-    IdentifiantProjet.convertirEnValueType(identifiantProjet),
-  );
+  const raccordementDéjàExistantPourLeProjet = this.identifiantProjet.estÉgaleÀ(identifiantProjet);
 
   if (raccordementDéjàExistantPourLeProjet) {
-    throw new RaccordementDéjàExistantError(identifiantProjet);
+    throw new RaccordementDéjàExistantError(identifiantProjet.formatter());
   }
 
   const event: GestionnaireRéseauAttribuéEvent = {
     type: 'GestionnaireRéseauAttribué-V1',
     payload: {
-      identifiantGestionnaireRéseau,
-      identifiantProjet,
+      identifiantGestionnaireRéseau: identifiantGestionnaireRéseau.formatter(),
+      identifiantProjet: identifiantProjet.formatter(),
     },
   };
 

--- a/packages/domain/réseau/src/raccordement/attribuer/attribuerGestionnaireRéseau.command.ts
+++ b/packages/domain/réseau/src/raccordement/attribuer/attribuerGestionnaireRéseau.command.ts
@@ -5,6 +5,7 @@ import { LoadAggregate } from '@potentiel-domain/core';
 
 import * as IdentifiantGestionnaireRéseau from '../../gestionnaire/identifiantGestionnaireRéseau.valueType';
 import { loadRaccordementAggregateFactory } from '../raccordement.aggregate';
+import { loadGestionnaireRéseauFactory } from '../../gestionnaire/gestionnaireRéseau.aggregate';
 
 export type AttribuerGestionnaireRéseauCommand = Message<
   'Réseau.Raccordement.Command.AttribuerGestionnaireRéseau',
@@ -16,16 +17,18 @@ export type AttribuerGestionnaireRéseauCommand = Message<
 
 export const registerAttribuerGestionnaireCommand = (loadAggregate: LoadAggregate) => {
   const loadRaccordement = loadRaccordementAggregateFactory(loadAggregate);
+  const loadGestionnaire = loadGestionnaireRéseauFactory(loadAggregate);
 
   const handler: MessageHandler<AttribuerGestionnaireRéseauCommand> = async ({
     identifiantGestionnaireRéseau,
     identifiantProjet,
   }) => {
+    const gestionnaire = await loadGestionnaire(identifiantGestionnaireRéseau);
     const raccordement = await loadRaccordement(identifiantProjet, false);
 
     await raccordement.attribuerGestionnaireRéseau({
-      identifiantGestionnaireRéseau: identifiantGestionnaireRéseau.formatter(),
-      identifiantProjet: identifiantProjet.formatter(),
+      identifiantGestionnaireRéseau: gestionnaire.identifiantGestionnaireRéseau,
+      identifiantProjet: identifiantProjet,
     });
   };
 

--- a/packages/domain/réseau/src/raccordement/attribuer/attribuerGestionnaireRéseau.command.ts
+++ b/packages/domain/réseau/src/raccordement/attribuer/attribuerGestionnaireRéseau.command.ts
@@ -17,18 +17,18 @@ export type AttribuerGestionnaireRéseauCommand = Message<
 
 export const registerAttribuerGestionnaireCommand = (loadAggregate: LoadAggregate) => {
   const loadRaccordement = loadRaccordementAggregateFactory(loadAggregate);
-  const loadGestionnaire = loadGestionnaireRéseauFactory(loadAggregate);
+  const loadGestionnaireRéseau = loadGestionnaireRéseauFactory(loadAggregate);
 
   const handler: MessageHandler<AttribuerGestionnaireRéseauCommand> = async ({
-    identifiantGestionnaireRéseau,
     identifiantProjet,
+    identifiantGestionnaireRéseau,
   }) => {
-    const gestionnaire = await loadGestionnaire(identifiantGestionnaireRéseau);
+    const gestionnaireRéseau = await loadGestionnaireRéseau(identifiantGestionnaireRéseau);
     const raccordement = await loadRaccordement(identifiantProjet, false);
 
     await raccordement.attribuerGestionnaireRéseau({
-      identifiantGestionnaireRéseau: gestionnaire.identifiantGestionnaireRéseau,
-      identifiantProjet: identifiantProjet,
+      identifiantProjet,
+      identifiantGestionnaireRéseau: gestionnaireRéseau.identifiantGestionnaireRéseau,
     });
   };
 

--- a/packages/domain/réseau/src/raccordement/consulter/consulterRaccordement.query.ts
+++ b/packages/domain/réseau/src/raccordement/consulter/consulterRaccordement.query.ts
@@ -9,11 +9,10 @@ import * as RéférenceDossierRaccordement from '../référenceDossierRaccordeme
 import * as TypeDocumentRaccordement from '../typeDocumentRaccordement.valueType';
 import { RaccordementEntity } from '../raccordement.entity';
 import { IdentifiantGestionnaireRéseau } from '../../gestionnaire';
-import { GestionnaireRéseau } from '../..';
 
 export type ConsulterRaccordementReadModel = {
   identifiantProjet: IdentifiantProjet.ValueType;
-  identifiantGestionnaireRéseau: IdentifiantGestionnaireRéseau.ValueType;
+  identifiantGestionnaireRéseau?: IdentifiantGestionnaireRéseau.ValueType;
   dossiers: Array<{
     référence: RéférenceDossierRaccordement.ValueType;
     demandeComplèteRaccordement: {
@@ -54,7 +53,6 @@ export const registerConsulterRaccordementQuery = ({ find }: ConsulterRaccordeme
     if (Option.isNone(result)) {
       return {
         identifiantProjet,
-        identifiantGestionnaireRéseau: GestionnaireRéseau.IdentifiantGestionnaireRéseau.inconnu,
         dossiers: [],
       };
     }

--- a/packages/domain/réseau/src/raccordement/modifier/modifierGestionnaireRéseauRaccordement.command.ts
+++ b/packages/domain/réseau/src/raccordement/modifier/modifierGestionnaireRéseauRaccordement.command.ts
@@ -16,14 +16,15 @@ export type ModifierGestionnaireRéseauRaccordementCommand = Message<
 >;
 
 export const registerModifierGestionnaireRéseauProjetCommand = (loadAggregate: LoadAggregate) => {
-  const loadRaccordementAggregate = loadRaccordementAggregateFactory(loadAggregate);
   const loadGestionnaireRéseau = loadGestionnaireRéseauFactory(loadAggregate);
+  const loadRaccordement = loadRaccordementAggregateFactory(loadAggregate);
+
   const handler: MessageHandler<ModifierGestionnaireRéseauRaccordementCommand> = async ({
     identifiantProjet,
     identifiantGestionnaireRéseau,
   }) => {
-    const raccordement = await loadRaccordementAggregate(identifiantProjet);
     const gestionnaireRéseau = await loadGestionnaireRéseau(identifiantGestionnaireRéseau);
+    const raccordement = await loadRaccordement(identifiantProjet);
 
     await raccordement.modifierGestionnaireRéseau({
       identifiantProjet,

--- a/packages/specifications/src/raccordement/attribuerGestionnaireRéseau.feature
+++ b/packages/specifications/src/raccordement/attribuerGestionnaireRéseau.feature
@@ -9,6 +9,14 @@ Fonctionnalité: Attribuer un gestionnaire de réseau au raccordement d'un proje
         Quand le gestionnaire de réseau "EDF Corse" est attribué au raccordement du projet lauréat "Du boulodrome de Marseille"
         Alors le projet "Du boulodrome de Marseille" devrait avoir un raccordement attribué au gestionnaire de réseau "EDF Corse"
 
+    Scénario: Un gestionnaire de réseau inconnu est attribué au raccordement d'un projet lauréat
+        Quand le gestionnaire de réseau inconnu est attribué au raccordement du projet lauréat "Du boulodrome de Marseille"
+        Alors le projet "Du boulodrome de Marseille" devrait avoir un raccordement attribué au gestionnaire de réseau inconnu
+
+    Scénario: Impossible d'attribuer un gestionnaire de réseau non référencé
+        Quand un gestionnaire de réseau non référencé est attribué au raccordement du projet lauréat "Du boulodrome de Marseille"
+        Alors on devrait être informé que "Le gestionnaire de réseau n'est pas référencé"
+
     Scénario: Impossible d'attribuer un gestionnaire de réseau au raccordement d'un projet lauréat si celui-ci a déjà un raccordement attribué à un gestionnaire
         Etant donné le gestionnaire de réseau "Enedis"
         Et le gestionnaire de réseau "Enedis" attribué au raccordement du projet lauréat "Du boulodrome de Marseille"

--- a/packages/specifications/src/raccordement/modifierGestionnaireRéseauRaccordement.feature
+++ b/packages/specifications/src/raccordement/modifierGestionnaireRéseauRaccordement.feature
@@ -24,6 +24,15 @@ Fonctionnalité: Modifier le gestionnaire de réseau d'un raccordement
         Quand un porteur modifie le gestionnaire de réseau du projet "Du boulodrome de Marseille" avec un gestionnaire non référencé
         Alors le porteur devrait être informé que "Le gestionnaire de réseau n'est pas référencé"
 
+    Scénario: Le système modifie le gestionnaire de réseau d'un raccordement avec un gestionnaire inconnu
+        Etant donné une demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" transmise auprès du gestionnaire de réseau "Enedis" avec :
+            | La date de qualification                | 2022-10-28                                                                                            |
+            | La référence du dossier de raccordement | OUE-RP-2022-000033                                                                                    |
+            | Le format de l'accusé de réception      | application/pdf                                                                                       |
+            | Le contenu de l'accusé de réception     | Accusé de réception ayant pour référence OUE-RP-2022-000033 et la date de qualification au 2022-10-28 |
+        Quand le système modifie le gestionnaire de réseau du projet "Du boulodrome de Marseille" avec un gestionnaire inconnu
+        Alors le projet "Du boulodrome de Marseille" devrait avoir un raccordement attribué au gestionnaire de réseau inconnu
+
     Scénario: Un porteur de projet peut transmettre une demande compléte de raccordemnent pour son nouveau gestionnaire de projet
         Etant donné une demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" transmise auprès du gestionnaire de réseau "Enedis" avec :
             | La date de qualification                | 2022-10-28                                                                                            |

--- a/packages/specifications/src/raccordement/stepDefinitions/raccordement.then.ts
+++ b/packages/specifications/src/raccordement/stepDefinitions/raccordement.then.ts
@@ -90,7 +90,7 @@ Alors(
     });
 
     expect(
-      résultat.identifiantGestionnaireRéseau.estÉgaleÀ(
+      résultat.identifiantGestionnaireRéseau?.estÉgaleÀ(
         GestionnaireRéseau.IdentifiantGestionnaireRéseau.convertirEnValueType(codeEIC),
       ),
     ).to.be.true;
@@ -111,7 +111,7 @@ Alors(
     });
 
     expect(
-      résultat.identifiantGestionnaireRéseau.estÉgaleÀ(
+      résultat.identifiantGestionnaireRéseau?.estÉgaleÀ(
         GestionnaireRéseau.IdentifiantGestionnaireRéseau.inconnu,
       ),
     ).to.be.true;

--- a/packages/specifications/src/raccordement/stepDefinitions/raccordement.then.ts
+++ b/packages/specifications/src/raccordement/stepDefinitions/raccordement.then.ts
@@ -96,6 +96,28 @@ Alors(
     ).to.be.true;
   },
 );
+
+Alors(
+  `le projet {string} devrait avoir un raccordement attribué au gestionnaire de réseau inconnu`,
+  async function (this: PotentielWorld, nomProjet: string) {
+    const { identifiantProjet } = this.lauréatWorld.rechercherLauréatFixture(nomProjet);
+
+    // Assert on read model
+    const résultat = await mediator.send<Raccordement.ConsulterRaccordementQuery>({
+      type: 'Réseau.Raccordement.Query.ConsulterRaccordement',
+      data: {
+        identifiantProjetValue: identifiantProjet.formatter(),
+      },
+    });
+
+    expect(
+      résultat.identifiantGestionnaireRéseau.estÉgaleÀ(
+        GestionnaireRéseau.IdentifiantGestionnaireRéseau.inconnu,
+      ),
+    ).to.be.true;
+  },
+);
+
 Alors(
   'le projet lauréat {string} devrait avoir {int} dossiers de raccordement pour le gestionnaire de réseau {string}',
   async function (

--- a/packages/specifications/src/raccordement/stepDefinitions/raccordement.when.ts
+++ b/packages/specifications/src/raccordement/stepDefinitions/raccordement.when.ts
@@ -339,3 +339,47 @@ Quand(
     }
   },
 );
+
+Quand(
+  `un gestionnaire de réseau non référencé est attribué au raccordement du projet {lauréat-éliminé} {string}`,
+  async function (this: PotentielWorld, statutProjet: 'lauréat' | 'éliminé', nomProjet: string) {
+    const { identifiantProjet } =
+      statutProjet === 'lauréat'
+        ? this.lauréatWorld.rechercherLauréatFixture(nomProjet)
+        : this.eliminéWorld.rechercherEliminéFixture(nomProjet);
+
+    try {
+      await mediator.send<Raccordement.RaccordementUseCase>({
+        type: 'Réseau.Raccordement.UseCase.AttribuerGestionnaireRéseau',
+        data: {
+          identifiantGestionnaireRéseauValue: 'GESTIONNAIRE NON RÉFÉRENCÉ',
+          identifiantProjetValue: identifiantProjet.formatter(),
+        },
+      });
+    } catch (e) {
+      this.error = e as Error;
+    }
+  },
+);
+
+Quand(
+  `le gestionnaire de réseau inconnu est attribué au raccordement du projet {lauréat-éliminé} {string}`,
+  async function (this: PotentielWorld, statutProjet: 'lauréat' | 'éliminé', nomProjet: string) {
+    const { identifiantProjet } =
+      statutProjet === 'lauréat'
+        ? this.lauréatWorld.rechercherLauréatFixture(nomProjet)
+        : this.eliminéWorld.rechercherEliminéFixture(nomProjet);
+
+    try {
+      await mediator.send<Raccordement.RaccordementUseCase>({
+        type: 'Réseau.Raccordement.UseCase.AttribuerGestionnaireRéseau',
+        data: {
+          identifiantGestionnaireRéseauValue: 'inconnu',
+          identifiantProjetValue: identifiantProjet.formatter(),
+        },
+      });
+    } catch (e) {
+      this.error = e as Error;
+    }
+  },
+);

--- a/packages/specifications/src/raccordement/stepDefinitions/raccordement.when.ts
+++ b/packages/specifications/src/raccordement/stepDefinitions/raccordement.when.ts
@@ -254,6 +254,25 @@ Quand(
 );
 
 Quand(
+  `le système modifie le gestionnaire de réseau du projet {string} avec un gestionnaire inconnu`,
+  async function (this: PotentielWorld, nomProjet: string) {
+    const { identifiantProjet } = this.lauréatWorld.rechercherLauréatFixture(nomProjet);
+
+    try {
+      await mediator.send<Raccordement.ModifierGestionnaireRéseauRaccordementUseCase>({
+        type: 'Réseau.Raccordement.UseCase.ModifierGestionnaireRéseauRaccordement',
+        data: {
+          identifiantProjetValue: identifiantProjet.formatter(),
+          identifiantGestionnaireRéseauValue: 'inconnu',
+        },
+      });
+    } catch (e) {
+      this.error = e as Error;
+    }
+  },
+);
+
+Quand(
   `un porteur modifie le gestionnaire de réseau du projet {string} avec le gestionnaire {string}`,
   async function (this: PotentielWorld, nomProjet: string, raisonSocialGestionnaireRéseau: string) {
     const { identifiantProjet } = this.lauréatWorld.rechercherLauréatFixture(nomProjet);


### PR DESCRIPTION
Dans l'optique d'automatiser l'import de la date de Mise en service du raccordement, ainsi que la correction du code EIC, nous devons d'abord flagger comme `inconnu` tous les GRD qu'on ne peut vérifier dû aux mauvaises données, qui nous empêche un mapping correct avec les data ORE (principalement des typos dans les villes ou les codes postaux)


Cette PR introduit la capabilité d'attribuer un GRD "inconnu" à un raccordement, et les modifications du front pour qu'un projet avec GRD "inconnu" puisse être mis à jour


Cas testés: 
- un projet sans raccordement n'a pas de message d'erreur 
- un projet avec raccordement mais un gestionnaire inconnu a un message d'erreur 
![image](https://github.com/MTES-MCT/potentiel/assets/14175665/d79d61d8-8749-486e-9c51-de1f7c992f2f)
- un projet avec raccordement mais un gestionnaire inconnu peut modifier ce gestionnaire (pas de 404)

Cas limite:
- un projet avec raccordement mais un gestionnaire inconnu NE PEUT PAS modifier le raccordement (404), il doit d'abord modifier le gestionnaire. J'ai préféré laisser ce cas là plutot que de rajouter des conditions bancales
