### PR TITLE
🧑‍💻 Vérifier l'absence d'erreur dans tous les "Alors", hors test d'erreur

### DIFF
--- a/packages/specifications/package.json
+++ b/packages/specifications/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "build": "tsc",
     "test": "cucumber-js --tags \"not @NotImplemented\"",
-    "test:select": "cucumber-js --tags @select"
+    "test:select": "cucumber-js --tags @select --tags \"not @NotImplemented\""
   },
   "dependencies": {
     "@potentiel-applications/bootstrap": "*",

--- a/packages/specifications/src/potentiel.world.ts
+++ b/packages/specifications/src/potentiel.world.ts
@@ -46,6 +46,13 @@ export class PotentielWorld extends World {
 
   #error!: Error;
 
+  get hasNoError() {
+    if (this.#error) {
+      throw new Error('An error was thrown');
+    }
+    return true;
+  }
+
   get error() {
     if (!this.#error) {
       throw new Error('No error was thrown');

--- a/packages/specifications/src/setup.ts
+++ b/packages/specifications/src/setup.ts
@@ -8,8 +8,9 @@ import {
   BeforeAll,
   setDefaultTimeout,
   AfterAll,
+  AfterStep,
 } from '@cucumber/cucumber';
-import { should } from 'chai';
+import { expect, should } from 'chai';
 import { clear } from 'mediateur';
 import {
   CreateBucketCommand,
@@ -40,6 +41,14 @@ const disableNodeMaxListenerWarning = () => (EventEmitter.defaultMaxListeners = 
 BeforeStep(async () => {
   // As read data are inconsistant, we wait 100ms before each step.
   await sleep(200);
+});
+
+AfterStep(async function (this: PotentielWorld, { pickleStep, result }) {
+  if (pickleStep.type === 'Outcome' && result.status === 'PASSED') {
+    if (!pickleStep.text.includes('devrait être informé que')) {
+      expect(this.hasNoError).to.be.true;
+    }
+  }
 });
 
 BeforeAll(async () => {


### PR DESCRIPTION
Fix du script `spec:select` qui n'ignorait pas les `@NotImplemented` 

Ajout d'une vérification pour tous les tests que l'erreur n'est pas set, sauf s'il s'agit du test `devrait être informé que`