### PR TITLE
✨ MAJ de la référence dossier dans l'import date de MES

### DIFF
--- a/packages/applications/ssr/src/components/pages/réseau/raccordement/importerDatesMiseEnService/ImporterDatesMiseEnService.page.tsx
+++ b/packages/applications/ssr/src/components/pages/réseau/raccordement/importerDatesMiseEnService/ImporterDatesMiseEnService.page.tsx
@@ -61,6 +61,7 @@ export const ImporterDatesMiseEnServicePage = () => {
                   data={[
                     ['referenceDossier', 'chaîne de caractères'],
                     ['dateMiseEnService', 'date au format JJ/MM/AAAA'],
+                    ['referenceDossierCorrigee', 'chaîne de caractères (optionnel)'],
                   ]}
                 />
               </div>

--- a/packages/applications/ssr/src/components/pages/réseau/raccordement/importerDatesMiseEnService/importDatesMiseEnService.action.ts
+++ b/packages/applications/ssr/src/components/pages/réseau/raccordement/importerDatesMiseEnService/importDatesMiseEnService.action.ts
@@ -24,10 +24,7 @@ const csvSchema = zod.object({
   dateMiseEnService: zod.string().regex(/^\d{2}\/\d{2}\/\d{4}$/, {
     message: "Le format de la date n'est pas respecté (format attendu : JJ/MM/AAAA)",
   }),
-  referenceDossierCorrigee: zod
-    .string()
-    .regex(/[a-zA-Z]{3}/)
-    .optional(),
+  referenceDossierCorrigee: zod.string().optional(),
 });
 
 const convertDateToCommonFormat = (date: string) => {

--- a/packages/applications/ssr/src/components/pages/réseau/raccordement/importerDatesMiseEnService/importDatesMiseEnService.action.ts
+++ b/packages/applications/ssr/src/components/pages/réseau/raccordement/importerDatesMiseEnService/importDatesMiseEnService.action.ts
@@ -24,7 +24,7 @@ const csvSchema = zod.object({
   dateMiseEnService: zod.string().regex(/^\d{2}\/\d{2}\/\d{4}$/, {
     message: "Le format de la date n'est pas respecté (format attendu : JJ/MM/AAAA)",
   }),
-  referenceDossierEnedis: zod
+  referenceDossierCorrigee: zod
     .string()
     .regex(/[a-zA-Z]{3}/)
     .optional(),
@@ -49,7 +49,7 @@ const action: FormAction<FormState, typeof schema> = async (_, { fichierDatesMis
     let success: number = 0;
     const errors: ActionResult['errors'] = [];
 
-    for (const { referenceDossier, dateMiseEnService, referenceDossierEnedis } of lines) {
+    for (const { referenceDossier, dateMiseEnService, referenceDossierCorrigee } of lines) {
       const dossiers = await mediator.send<Raccordement.RechercherDossierRaccordementQuery>({
         type: 'Réseau.Raccordement.Query.RechercherDossierRaccordement',
         data: {
@@ -93,8 +93,10 @@ const action: FormAction<FormState, typeof schema> = async (_, { fichierDatesMis
           /**
            * Mise à jour de la référence dossier raccordement, si différente
            **/
-          const réferenceDossierRaccordementCorrigée = referenceDossierEnedis
-            ? Raccordement.RéférenceDossierRaccordement.convertirEnValueType(referenceDossierEnedis)
+          const réferenceDossierRaccordementCorrigée = referenceDossierCorrigee
+            ? Raccordement.RéférenceDossierRaccordement.convertirEnValueType(
+                referenceDossierCorrigee,
+              )
             : undefined;
 
           if (

--- a/packages/domain/utilisateur/src/role.valueType.ts
+++ b/packages/domain/utilisateur/src/role.valueType.ts
@@ -23,7 +23,7 @@ const roles: Array<RawType> = [
 
 export type ValueType = ReadonlyValueType<{
   nom: RawType;
-  libellé(): string;
+  formatter(): string;
   vérifierLaPermission(value: string): void;
 }>;
 
@@ -34,7 +34,7 @@ export const convertirEnValueType = (value: string): ValueType => {
     estÉgaleÀ(valueType) {
       return valueType.nom === this.nom;
     },
-    libellé() {
+    formatter() {
       return this.nom.replace('-', ' ').toLocaleUpperCase();
     },
     vérifierLaPermission(permission) {


### PR DESCRIPTION
Lors de l'import des dates de mise en service, on rajoute la mise à jour du dossier de raccordement si fourni par Enedis.

ℹ️ ignorer le premier commit lors de la review, et regarder directement le second pour éviter le diff de formattage dû à l'ajout de `withUtilisateur`