### PR TITLE
🐛 Ne pas permettre de demander la mainlevée si pas de d'attestation de garanties financières

### DIFF
--- a/packages/applications/ssr/src/app/laureats/[identifiant]/achevement/attestation-conformite:transmettre/page.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/achevement/attestation-conformite:transmettre/page.tsx
@@ -42,7 +42,7 @@ export default async function Page({ params: { identifiant } }: IdentifiantParam
         },
       });
 
-    const showDemanderMainlevée =
+    const canDemanderMainlevée =
       Option.isSome(garantiesFinancières) &&
       garantiesFinancières.garantiesFinancières.attestation !== undefined &&
       garantiesFinancières.garantiesFinancières.validéLe !== undefined;
@@ -51,7 +51,7 @@ export default async function Page({ params: { identifiant } }: IdentifiantParam
 
     const props: TransmettreAttestationConformitéPageProps = {
       projet,
-      showDemanderMainlevée,
+      canDemanderMainlevée,
     };
 
     return <TransmettreAttestationConformitéPage {...props} />;

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/achevement/attestation-conformite:transmettre/page.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/achevement/attestation-conformite:transmettre/page.tsx
@@ -42,7 +42,7 @@ export default async function Page({ params: { identifiant } }: IdentifiantParam
         },
       });
 
-    const canDemanderMainlevée =
+    const peutDemanderMainlevée =
       Option.isSome(garantiesFinancières) &&
       garantiesFinancières.garantiesFinancières.attestation !== undefined &&
       garantiesFinancières.garantiesFinancières.validéLe !== undefined;
@@ -51,7 +51,7 @@ export default async function Page({ params: { identifiant } }: IdentifiantParam
 
     const props: TransmettreAttestationConformitéPageProps = {
       projet,
-      canDemanderMainlevée,
+      peutDemanderMainlevée,
     };
 
     return <TransmettreAttestationConformitéPage {...props} />;

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/achevement/attestation-conformite:transmettre/page.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/achevement/attestation-conformite:transmettre/page.tsx
@@ -44,8 +44,8 @@ export default async function Page({ params: { identifiant } }: IdentifiantParam
 
     const showDemanderMainlevée =
       Option.isSome(garantiesFinancières) &&
-      Option.isSome(garantiesFinancières.garantiesFinancières.attestation) &&
-      Option.isSome(garantiesFinancières.garantiesFinancières.validéLe);
+      garantiesFinancières.garantiesFinancières.attestation !== undefined &&
+      garantiesFinancières.garantiesFinancières.validéLe !== undefined;
 
     const projet = { ...candidature, identifiantProjet };
 

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/achevement/attestation-conformite:transmettre/page.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/achevement/attestation-conformite:transmettre/page.tsx
@@ -44,8 +44,7 @@ export default async function Page({ params: { identifiant } }: IdentifiantParam
 
     const peutDemanderMainlevée =
       Option.isSome(garantiesFinancières) &&
-      garantiesFinancières.garantiesFinancières.attestation !== undefined &&
-      garantiesFinancières.garantiesFinancières.validéLe !== undefined;
+      garantiesFinancières.garantiesFinancières.attestation !== undefined;
 
     const projet = { ...candidature, identifiantProjet };
 

--- a/packages/applications/ssr/src/components/pages/attestation-conformité/FormulaireAttestationConformité.tsx
+++ b/packages/applications/ssr/src/components/pages/attestation-conformité/FormulaireAttestationConformité.tsx
@@ -1,5 +1,6 @@
 import { FC, useState } from 'react';
 import { useRouter } from 'next/navigation';
+import Link from 'next/link';
 import Button from '@codegouvfr/react-dsfr/Button';
 import Checkbox from '@codegouvfr/react-dsfr/Checkbox';
 import Alert from '@codegouvfr/react-dsfr/Alert';
@@ -28,7 +29,7 @@ export type FormulaireAttestationConformitéProps = {
     preuveTransmissionAuCocontractant: string;
     dateTransmissionAuCocontractant: Iso8601DateTime;
   };
-  showDemanderMainlevée?: boolean;
+  canDemanderMainlevée?: boolean;
 };
 
 export const FormulaireAttestationConformité: FC<FormulaireAttestationConformitéProps> = ({
@@ -36,7 +37,7 @@ export const FormulaireAttestationConformité: FC<FormulaireAttestationConformit
   action,
   submitButtonLabel,
   donnéesActuelles,
-  showDemanderMainlevée,
+  canDemanderMainlevée,
 }) => {
   const [validationErrors, setValidationErrors] = useState<Array<string>>([]);
   const router = useRouter();
@@ -101,21 +102,43 @@ export const FormulaireAttestationConformité: FC<FormulaireAttestationConformit
           stateRelatedMessage="Date de transmission au co-contractant obligatoire"
         />
 
-        {showDemanderMainlevée && (
-          <Checkbox
-            id="demanderMainlevee"
-            state={validationErrors.includes('demanderMainlevee') ? 'error' : 'default'}
-            options={[
-              {
-                label: `Je souhaite demander une mainlevée de mes garanties financières`,
-                nativeInputProps: {
-                  name: 'demanderMainlevee',
-                  value: 'true',
-                },
-              },
-            ]}
+        {!canDemanderMainlevée && (
+          <Alert
+            severity="warning"
+            small
+            description={
+              <p className="p-3">
+                Vous ne pouvez pas faire une demande de mainlevée automatique de vos garanties
+                financières depuis cette page de transmission de l'attestation de conformité en
+                l'absence de votre attestation de constitution des garanties financières sur
+                Potentiel que vous poouvez transmettre depuis la page pour{' '}
+                <Link
+                  href={Routes.GarantiesFinancières.dépôt.soumettre(identifiantProjet)}
+                  className="font-semibold"
+                >
+                  soumettre de nouvelles garanties financières
+                </Link>
+                .
+              </p>
+            }
           />
         )}
+
+        <Checkbox
+          id="demanderMainlevee"
+          state={validationErrors.includes('demanderMainlevee') ? 'error' : 'default'}
+          options={[
+            {
+              label: `Je souhaite demander une mainlevée de mes garanties financières`,
+
+              nativeInputProps: {
+                disabled: canDemanderMainlevée,
+                name: 'demanderMainlevee',
+                value: 'true',
+              },
+            },
+          ]}
+        />
       </div>
 
       <div className="flex flex-col md:flex-row gap-4 mt-5">

--- a/packages/applications/ssr/src/components/pages/attestation-conformité/FormulaireAttestationConformité.tsx
+++ b/packages/applications/ssr/src/components/pages/attestation-conformité/FormulaireAttestationConformité.tsx
@@ -29,7 +29,11 @@ export type FormulaireAttestationConformitéProps = {
     preuveTransmissionAuCocontractant: string;
     dateTransmissionAuCocontractant: Iso8601DateTime;
   };
-  canDemanderMainlevée?: boolean;
+  demanderMainlevée:
+    | {
+        visible: false;
+      }
+    | { visible: true; canBeDone: boolean };
 };
 
 export const FormulaireAttestationConformité: FC<FormulaireAttestationConformitéProps> = ({
@@ -37,7 +41,7 @@ export const FormulaireAttestationConformité: FC<FormulaireAttestationConformit
   action,
   submitButtonLabel,
   donnéesActuelles,
-  canDemanderMainlevée,
+  demanderMainlevée,
 }) => {
   const [validationErrors, setValidationErrors] = useState<Array<string>>([]);
   const router = useRouter();
@@ -102,43 +106,46 @@ export const FormulaireAttestationConformité: FC<FormulaireAttestationConformit
           stateRelatedMessage="Date de transmission au co-contractant obligatoire"
         />
 
-        {!canDemanderMainlevée && (
-          <Alert
-            severity="warning"
-            small
-            description={
-              <p className="p-3">
-                Vous ne pouvez pas faire une demande de mainlevée automatique de vos garanties
-                financières depuis cette page de transmission de l'attestation de conformité en
-                l'absence de votre attestation de constitution des garanties financières sur
-                Potentiel que vous poouvez transmettre depuis la page pour{' '}
-                <Link
-                  href={Routes.GarantiesFinancières.dépôt.soumettre(identifiantProjet)}
-                  className="font-semibold"
-                >
-                  soumettre de nouvelles garanties financières
-                </Link>
-                .
-              </p>
-            }
-          />
+        {demanderMainlevée.visible && (
+          <>
+            {!demanderMainlevée.canBeDone && (
+              <Alert
+                severity="warning"
+                small
+                description={
+                  <p className="p-3">
+                    Vous ne pouvez pas faire une demande de mainlevée automatique de vos garanties
+                    financières depuis cette page de transmission de l'attestation de conformité en
+                    l'absence de votre attestation de constitution des garanties financières sur
+                    Potentiel que vous pouvez transmettre depuis la page pour{' '}
+                    <Link
+                      href={Routes.GarantiesFinancières.dépôt.soumettre(identifiantProjet)}
+                      className="font-semibold"
+                    >
+                      soumettre de nouvelles garanties financières
+                    </Link>
+                    .
+                  </p>
+                }
+              />
+            )}
+            <Checkbox
+              id="demanderMainlevee"
+              state={validationErrors.includes('demanderMainlevee') ? 'error' : 'default'}
+              options={[
+                {
+                  label: `Je souhaite demander une mainlevée de mes garanties financières`,
+
+                  nativeInputProps: {
+                    disabled: !demanderMainlevée.canBeDone,
+                    name: 'demanderMainlevee',
+                    value: 'true',
+                  },
+                },
+              ]}
+            />
+          </>
         )}
-
-        <Checkbox
-          id="demanderMainlevee"
-          state={validationErrors.includes('demanderMainlevee') ? 'error' : 'default'}
-          options={[
-            {
-              label: `Je souhaite demander une mainlevée de mes garanties financières`,
-
-              nativeInputProps: {
-                disabled: canDemanderMainlevée,
-                name: 'demanderMainlevee',
-                value: 'true',
-              },
-            },
-          ]}
-        />
       </div>
 
       <div className="flex flex-col md:flex-row gap-4 mt-5">

--- a/packages/applications/ssr/src/components/pages/attestation-conformité/FormulaireAttestationConformité.tsx
+++ b/packages/applications/ssr/src/components/pages/attestation-conformité/FormulaireAttestationConformité.tsx
@@ -117,12 +117,12 @@ export const FormulaireAttestationConformité: FC<FormulaireAttestationConformit
                     Vous ne pouvez pas faire une demande de mainlevée automatique de vos garanties
                     financières depuis cette page de transmission de l'attestation de conformité en
                     l'absence de votre attestation de constitution des garanties financières sur
-                    Potentiel que vous pouvez transmettre depuis la page pour{' '}
+                    Potentiel que vous pouvez transmettre depuis{' '}
                     <Link
                       href={Routes.GarantiesFinancières.dépôt.soumettre(identifiantProjet)}
                       className="font-semibold"
                     >
-                      soumettre de nouvelles garanties financières
+                      la page des garanties financières du projet
                     </Link>
                     .
                   </p>

--- a/packages/applications/ssr/src/components/pages/attestation-conformité/modifier/modifierAttestationConformité.page.tsx
+++ b/packages/applications/ssr/src/components/pages/attestation-conformité/modifier/modifierAttestationConformité.page.tsx
@@ -30,6 +30,7 @@ export const ModifierAttestationConformitéPage: FC<ModifierAttestationConformit
       action={modifierAttestationConformitéAction}
       submitButtonLabel="Modifier"
       donnéesActuelles={attestationConformitéActuelle}
+      demanderMainlevée={{ visible: false }}
     />
   </PageTemplate>
 );

--- a/packages/applications/ssr/src/components/pages/attestation-conformité/transmettre/transmettreAttestationConformité.page.tsx
+++ b/packages/applications/ssr/src/components/pages/attestation-conformité/transmettre/transmettreAttestationConformité.page.tsx
@@ -12,12 +12,12 @@ import { transmettreAttestationConformitéAction } from './transmettreAttestatio
 
 export type TransmettreAttestationConformitéPageProps = {
   projet: ProjetBannerProps;
-  canDemanderMainlevée?: boolean;
+  peutDemanderMainlevée: boolean;
 };
 
 export const TransmettreAttestationConformitéPage: FC<
   TransmettreAttestationConformitéPageProps
-> = ({ projet, canDemanderMainlevée }) => (
+> = ({ projet, peutDemanderMainlevée }) => (
   <PageTemplate banner={<ProjetBanner {...projet} />}>
     <TitrePageAttestationConformité title="Transmettre l'attestation de conformité du projet" />
 
@@ -25,7 +25,7 @@ export const TransmettreAttestationConformitéPage: FC<
       identifiantProjet={projet.identifiantProjet}
       action={transmettreAttestationConformitéAction}
       submitButtonLabel="Transmettre"
-      canDemanderMainlevée={canDemanderMainlevée}
+      demanderMainlevée={{ visible: true, canBeDone: peutDemanderMainlevée }}
     />
   </PageTemplate>
 );

--- a/packages/applications/ssr/src/components/pages/attestation-conformité/transmettre/transmettreAttestationConformité.page.tsx
+++ b/packages/applications/ssr/src/components/pages/attestation-conformité/transmettre/transmettreAttestationConformité.page.tsx
@@ -12,12 +12,12 @@ import { transmettreAttestationConformitéAction } from './transmettreAttestatio
 
 export type TransmettreAttestationConformitéPageProps = {
   projet: ProjetBannerProps;
-  showDemanderMainlevée?: boolean;
+  canDemanderMainlevée?: boolean;
 };
 
 export const TransmettreAttestationConformitéPage: FC<
   TransmettreAttestationConformitéPageProps
-> = ({ projet, showDemanderMainlevée }) => (
+> = ({ projet, canDemanderMainlevée }) => (
   <PageTemplate banner={<ProjetBanner {...projet} />}>
     <TitrePageAttestationConformité title="Transmettre l'attestation de conformité du projet" />
 
@@ -25,7 +25,7 @@ export const TransmettreAttestationConformitéPage: FC<
       identifiantProjet={projet.identifiantProjet}
       action={transmettreAttestationConformitéAction}
       submitButtonLabel="Transmettre"
-      showDemanderMainlevée={showDemanderMainlevée}
+      canDemanderMainlevée={canDemanderMainlevée}
     />
   </PageTemplate>
 );

--- a/packages/applications/ssr/src/components/pages/attestation-conformité/transmettre/transmettreAttestationConformité.stories.tsx
+++ b/packages/applications/ssr/src/components/pages/attestation-conformité/transmettre/transmettreAttestationConformité.stories.tsx
@@ -37,5 +37,6 @@ const projet: TransmettreAttestationConformitéPageProps['projet'] = {
 export const Default: Story = {
   args: {
     projet,
+    peutDemanderMainlevée: false,
   },
 };


### PR DESCRIPTION
# Description

Auparavant pour savoir si on affichait la case à cocher pour demander une mainlevée on utilisait des `Option.isSome` or la projection des garanties financières n'utilise pas les `Option` mais encore des propriétés `optional` et donc le check n'était pas ok.
Maintenant pour la page de transmission d'attestation de conformité on affiche un warning s'il n'est pas possible de demander une mainlevée.

![image](https://github.com/MTES-MCT/potentiel/assets/17512486/56d98316-2701-4748-99f9-e07450239cae)

## Type de changement

Veuillez supprimer les options qui ne sont pas pertinentes.

- Correction de bug

# Comment cela a-t-il été testé?

Un peu compliqué mais il faut des garanties financières actuelles incomplètes non validées et aller sur la page de transmission d'attestation de conformité/achèvement. Normalement dans ce cas nous devrions avoir la case à cocher pour demander la mainlevée  `disabled` avec un warning