### PR TITLE
♻️ Retirer le paramètre inutile pour ModifierRéférenceDossierRaccordement

### DIFF
--- a/packages/applications/ssr/src/components/pages/réseau/raccordement/modifier/modifierDemandeComplèteRaccordement/modifierDemandeComplèteRaccordement.action.ts
+++ b/packages/applications/ssr/src/components/pages/réseau/raccordement/modifier/modifierDemandeComplèteRaccordement/modifierDemandeComplèteRaccordement.action.ts
@@ -36,7 +36,6 @@ const action: FormAction<FormState, typeof schema> = async (
       await mediator.send<Raccordement.ModifierRéférenceDossierRaccordementUseCase>({
         type: 'Réseau.Raccordement.UseCase.ModifierRéférenceDossierRaccordement',
         data: {
-          identifiantGestionnaireRéseauValue: identifiantGestionnaireReseau,
           identifiantProjetValue: identifiantProjet,
           référenceDossierRaccordementActuelleValue: referenceDossierRaccordementActuelle,
           nouvelleRéférenceDossierRaccordementValue: referenceDossierRaccordement,

--- a/packages/domain/réseau/src/raccordement/modifier/modifierRéférenceDossierRaccordement.command.ts
+++ b/packages/domain/réseau/src/raccordement/modifier/modifierRéférenceDossierRaccordement.command.ts
@@ -6,14 +6,12 @@ import { IdentifiantProjet } from '@potentiel-domain/common';
 
 import { loadRaccordementAggregateFactory } from '../raccordement.aggregate';
 import { loadGestionnaireRéseauFactory } from '../../gestionnaire/gestionnaireRéseau.aggregate';
-import { IdentifiantGestionnaireRéseau } from '../../gestionnaire';
 import * as RéférenceDossierRaccordement from '../référenceDossierRaccordement.valueType';
 
 export type ModifierRéférenceDossierRaccordementCommand = Message<
   'Réseau.Raccordement.Command.ModifierRéférenceDossierRaccordement',
   {
     identifiantProjet: IdentifiantProjet.ValueType;
-    identifiantGestionnaireRéseau: IdentifiantGestionnaireRéseau.ValueType;
     référenceDossierRaccordementActuelle: RéférenceDossierRaccordement.ValueType;
     nouvelleRéférenceDossierRaccordement: RéférenceDossierRaccordement.ValueType;
     rôle: Role.ValueType;
@@ -28,13 +26,12 @@ export const registerModifierRéférenceDossierRaccordementCommand = (
 
   const handler: MessageHandler<ModifierRéférenceDossierRaccordementCommand> = async ({
     identifiantProjet,
-    identifiantGestionnaireRéseau,
     référenceDossierRaccordementActuelle,
     nouvelleRéférenceDossierRaccordement,
     rôle,
   }) => {
     const raccordement = await loadRaccordement(identifiantProjet);
-    const gestionnaireRéseau = loadGestionnaireRéseau(identifiantGestionnaireRéseau);
+    const gestionnaireRéseau = loadGestionnaireRéseau(raccordement.identifiantGestionnaireRéseau);
 
     await raccordement.modifierRéférenceDossierRacordement({
       identifiantProjet,

--- a/packages/domain/réseau/src/raccordement/modifier/modifierRéférenceDossierRaccordement.command.ts
+++ b/packages/domain/réseau/src/raccordement/modifier/modifierRéférenceDossierRaccordement.command.ts
@@ -31,13 +31,15 @@ export const registerModifierRéférenceDossierRaccordementCommand = (
     rôle,
   }) => {
     const raccordement = await loadRaccordement(identifiantProjet);
-    const gestionnaireRéseau = loadGestionnaireRéseau(raccordement.identifiantGestionnaireRéseau);
+    const gestionnaireRéseau = await loadGestionnaireRéseau(
+      raccordement.identifiantGestionnaireRéseau,
+    );
 
     await raccordement.modifierRéférenceDossierRacordement({
       identifiantProjet,
       nouvelleRéférenceDossierRaccordement,
-      référenceDossierExpressionRegulière: (await gestionnaireRéseau)
-        .référenceDossierRaccordementExpressionRegulière,
+      référenceDossierExpressionRegulière:
+        gestionnaireRéseau.référenceDossierRaccordementExpressionRegulière,
       référenceDossierRaccordementActuelle,
       rôle,
     });

--- a/packages/domain/réseau/src/raccordement/modifier/modifierRéférenceDossierRaccordement.usecase.ts
+++ b/packages/domain/réseau/src/raccordement/modifier/modifierRéférenceDossierRaccordement.usecase.ts
@@ -5,7 +5,6 @@ import { Role } from '@potentiel-domain/utilisateur';
 import { DossierProjet, DéplacerDocumentProjetCommand } from '@potentiel-domain/document';
 
 import * as RéférenceDossierRaccordement from '../référenceDossierRaccordement.valueType';
-import { IdentifiantGestionnaireRéseau } from '../../gestionnaire';
 import * as TypeDocumentRaccordement from '../typeDocumentRaccordement.valueType';
 
 import { ModifierRéférenceDossierRaccordementCommand } from './modifierRéférenceDossierRaccordement.command';
@@ -14,7 +13,6 @@ export type ModifierRéférenceDossierRaccordementUseCase = Message<
   'Réseau.Raccordement.UseCase.ModifierRéférenceDossierRaccordement',
   {
     identifiantProjetValue: string;
-    identifiantGestionnaireRéseauValue: string;
     référenceDossierRaccordementActuelleValue: string;
     nouvelleRéférenceDossierRaccordementValue: string;
     rôleValue: string;
@@ -23,15 +21,11 @@ export type ModifierRéférenceDossierRaccordementUseCase = Message<
 
 export const registerModifierRéférenceDossierRaccordementUseCase = () => {
   const runner: MessageHandler<ModifierRéférenceDossierRaccordementUseCase> = async ({
-    identifiantGestionnaireRéseauValue,
     identifiantProjetValue,
     nouvelleRéférenceDossierRaccordementValue,
     référenceDossierRaccordementActuelleValue,
     rôleValue,
   }) => {
-    const identifiantGestionnaireRéseau = IdentifiantGestionnaireRéseau.convertirEnValueType(
-      identifiantGestionnaireRéseauValue,
-    );
     const identifiantProjet = IdentifiantProjet.convertirEnValueType(identifiantProjetValue);
     const nouvelleRéférenceDossierRaccordement = RéférenceDossierRaccordement.convertirEnValueType(
       nouvelleRéférenceDossierRaccordementValue,
@@ -89,7 +83,6 @@ export const registerModifierRéférenceDossierRaccordementUseCase = () => {
     await mediator.send<ModifierRéférenceDossierRaccordementCommand>({
       type: 'Réseau.Raccordement.Command.ModifierRéférenceDossierRaccordement',
       data: {
-        identifiantGestionnaireRéseau,
         identifiantProjet,
         nouvelleRéférenceDossierRaccordement,
         référenceDossierRaccordementActuelle,

--- a/packages/specifications/src/raccordement/modifierRéférenceDemandeComplèteDeRaccordement.feature
+++ b/packages/specifications/src/raccordement/modifierRéférenceDemandeComplèteDeRaccordement.feature
@@ -49,7 +49,7 @@ Fonctionnalité: Modifier la référence d'une demande complète de raccordement
             | Le format de l'accusé de réception      | application/pdf                                                                                         |
             | Le contenu de l'accusé de réception     | Accusé de réception ayant pour référence <Référence actuelle> et la date de qualification au 2022-10-28 |
         Quand l'utilisateur avec le rôle "porteur-projet" modifie la demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" ayant pour référence "<Référence actuelle>" avec la référence "OUE-RP-2022-000034"
-        Et le porteur modifie la demande complète de raccordement pour le dossier de raccordement du projet lauréat "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000034" avec :
+        Et le porteur modifie la demande complète de raccordement pour le dossier de raccordement du projet lauréat "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000034" auprès du gestionnaire de réseau "Enedis" avec :
             | La date de qualification            | 2022-10-29                                                                                                      |
             | Le format de l'accusé de réception  | text/plain                                                                                                      |
             | Le contenu de l'accusé de réception | Une autre accusé de réception ayant pour référence OUE-RP-2022-000034 et la date de qualification au 2022-10-29 |
@@ -95,7 +95,7 @@ Fonctionnalité: Modifier la référence d'une demande complète de raccordement
             | La référence du dossier de raccordement | ABC                                                                                    |
             | Le format de l'accusé de réception      | application/pdf                                                                        |
             | Le contenu de l'accusé de réception     | Accusé de réception ayant pour référence ABC et la date de qualification au 2022-10-28 |
-        Quand l'utilisateur avec le rôle "porteur-projet" modifie la demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" ayant pour référence "ABC" avec la référence "UneRéférenceAvecUnFormatInvalide" auprès du gestionnaire de réseau "RTE"
+        Quand l'utilisateur avec le rôle "porteur-projet" modifie la demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" ayant pour référence "ABC" avec la référence "UneRéférenceAvecUnFormatInvalide"
         Alors le porteur devrait être informé que "Le format de la référence du dossier de raccordement est invalide"
 
     Scénario: Impossible de modifier la référence pour un projet sans dossier de raccordement

--- a/packages/specifications/src/raccordement/modifierRéférenceDemandeComplèteDeRaccordement.feature
+++ b/packages/specifications/src/raccordement/modifierRéférenceDemandeComplèteDeRaccordement.feature
@@ -11,36 +11,36 @@ Fonctionnalité: Modifier la référence d'une demande complète de raccordement
             | La référence du dossier de raccordement | <Référence actuelle>                                                                                    |
             | Le format de l'accusé de réception      | application/pdf                                                                                         |
             | Le contenu de l'accusé de réception     | Accusé de réception ayant pour référence <Référence actuelle> et la date de qualification au 2022-10-28 |
-        Quand l'utilisateur avec le rôle "porteur-projet" modifie la demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" ayant pour référence "<Référence actuelle>" avec la référence "OUE-RP-2022-000034" auprès du gestionnaire de réseau "Enedis"
+        Quand l'utilisateur avec le rôle "porteur-projet" modifie la demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" ayant pour référence "<Référence actuelle>" avec la référence "OUE-RP-2022-000034"
         Alors le dossier est consultable dans la liste des dossiers de raccordement du projet lauréat "Du boulodrome de Marseille"
         Et la demande complète de raccordement devrait être consultable dans le dossier de raccordement du projet lauréat "Du boulodrome de Marseille"
-    
-    Exemples:
-        | Référence actuelle        |
-        | Référence non transmise   |
-        | Enedis                    |
-        | Enedis OUE-RP-2022-000033 |
-        | Enedis DDD                |
-        | OUE-RP-2022-000033        |
-    
-    Plan du Scénario: Modifier en tant qu'administrateur la référence d'une demande complète de raccordement pour un dossier ayant déjà une date de mise en service 
+
+        Exemples:
+            | Référence actuelle        |
+            | Référence non transmise   |
+            | Enedis                    |
+            | Enedis OUE-RP-2022-000033 |
+            | Enedis DDD                |
+            | OUE-RP-2022-000033        |
+
+    Plan du Scénario: Modifier en tant qu'administrateur la référence d'une demande complète de raccordement pour un dossier ayant déjà une date de mise en service
         Etant donné une demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" transmise auprès du gestionnaire de réseau "Enedis" avec :
             | La date de qualification                | 2022-10-28                                                                                              |
             | La référence du dossier de raccordement | <Référence actuelle>                                                                                    |
             | Le format de l'accusé de réception      | application/pdf                                                                                         |
             | Le contenu de l'accusé de réception     | Accusé de réception ayant pour référence <Référence actuelle> et la date de qualification au 2022-10-28 |
         Et une date de mise en service "2022-01-12" pour le dossier de raccordement pour le projet lauréat "Du boulodrome de Marseille" ayant pour référence "<Référence actuelle>"
-        Quand l'utilisateur avec le rôle "admin" modifie la demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" ayant pour référence "<Référence actuelle>" avec la référence "OUE-RP-2022-000034" auprès du gestionnaire de réseau "Enedis"
+        Quand l'utilisateur avec le rôle "admin" modifie la demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" ayant pour référence "<Référence actuelle>" avec la référence "OUE-RP-2022-000034"
         Alors le dossier est consultable dans la liste des dossiers de raccordement du projet lauréat "Du boulodrome de Marseille"
         Et la demande complète de raccordement devrait être consultable dans le dossier de raccordement du projet lauréat "Du boulodrome de Marseille"
-    
-    Exemples:
-        | Référence actuelle        |
-        | Référence non transmise   |
-        | Enedis                    |
-        | Enedis OUE-RP-2022-000033 |
-        | Enedis DDD                |
-        | OUE-RP-2022-000033        |
+
+        Exemples:
+            | Référence actuelle        |
+            | Référence non transmise   |
+            | Enedis                    |
+            | Enedis OUE-RP-2022-000033 |
+            | Enedis DDD                |
+            | OUE-RP-2022-000033        |
 
     Plan du Scénario: Modifier un dossier de raccordement suite à la modification de la référence
         Etant donné une demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" transmise auprès du gestionnaire de réseau "Enedis" avec :
@@ -48,21 +48,21 @@ Fonctionnalité: Modifier la référence d'une demande complète de raccordement
             | La référence du dossier de raccordement | <Référence actuelle>                                                                                    |
             | Le format de l'accusé de réception      | application/pdf                                                                                         |
             | Le contenu de l'accusé de réception     | Accusé de réception ayant pour référence <Référence actuelle> et la date de qualification au 2022-10-28 |
-        Quand l'utilisateur avec le rôle "porteur-projet" modifie la demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" ayant pour référence "<Référence actuelle>" avec la référence "OUE-RP-2022-000034" auprès du gestionnaire de réseau "Enedis"
-        Et le porteur modifie la demande complète de raccordement pour le dossier de raccordement du projet lauréat "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000034" auprès du gestionnaire de réseau "Enedis" avec :
+        Quand l'utilisateur avec le rôle "porteur-projet" modifie la demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" ayant pour référence "<Référence actuelle>" avec la référence "OUE-RP-2022-000034"
+        Et le porteur modifie la demande complète de raccordement pour le dossier de raccordement du projet lauréat "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000034" avec :
             | La date de qualification            | 2022-10-29                                                                                                      |
             | Le format de l'accusé de réception  | text/plain                                                                                                      |
             | Le contenu de l'accusé de réception | Une autre accusé de réception ayant pour référence OUE-RP-2022-000034 et la date de qualification au 2022-10-29 |
         Alors le dossier est consultable dans la liste des dossiers de raccordement du projet lauréat "Du boulodrome de Marseille"
         Et la demande complète de raccordement devrait être consultable dans le dossier de raccordement du projet lauréat "Du boulodrome de Marseille"
 
-    Exemples:
-        | Référence actuelle        |
-        | Référence non transmise   |
-        | Enedis                    |
-        | Enedis OUE-RP-2022-000033 |
-        | Enedis DDD                |
-        | OUE-RP-2022-000033        |
+        Exemples:
+            | Référence actuelle        |
+            | Référence non transmise   |
+            | Enedis                    |
+            | Enedis OUE-RP-2022-000033 |
+            | Enedis DDD                |
+            | OUE-RP-2022-000033        |
 
     Plan du Scénario: Modifier la référence d'une demande complète de raccordement ayant une PTF
         Etant donné une demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" transmise auprès du gestionnaire de réseau "Enedis" avec :
@@ -74,16 +74,16 @@ Fonctionnalité: Modifier la référence d'une demande complète de raccordement
             | La date de signature                                | 2023-01-10                                                                                                        |
             | Le format de la proposition technique et financière | application/pdf                                                                                                   |
             | Le contenu de proposition technique et financière   | Proposition technique et financière pour la référence OUE-RP-2022-000033 avec une date de signature au 2023-01-10 |
-        Quand l'utilisateur avec le rôle "porteur-projet" modifie la demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" ayant pour référence "<Référence actuelle>" avec la référence "OUE-RP-2022-000034" auprès du gestionnaire de réseau "Enedis"
+        Quand l'utilisateur avec le rôle "porteur-projet" modifie la demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" ayant pour référence "<Référence actuelle>" avec la référence "OUE-RP-2022-000034"
         Alors la proposition technique et financière signée devrait être consultable dans le dossier de raccordement du projet lauréat "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000034"
 
-    Exemples:
-        | Référence actuelle        |
-        | Référence non transmise   |
-        | Enedis                    |
-        | Enedis OUE-RP-2022-000033 |
-        | Enedis DDD                |
-        | OUE-RP-2022-000033        |
+        Exemples:
+            | Référence actuelle        |
+            | Référence non transmise   |
+            | Enedis                    |
+            | Enedis OUE-RP-2022-000033 |
+            | Enedis DDD                |
+            | OUE-RP-2022-000033        |
 
     Scénario: Impossible de modifier une demande complète de raccordement avec une référence ne correspondant pas au format défini par le gestionnaire de réseau
         Etant donné un gestionnaire de réseau
@@ -99,7 +99,7 @@ Fonctionnalité: Modifier la référence d'une demande complète de raccordement
         Alors le porteur devrait être informé que "Le format de la référence du dossier de raccordement est invalide"
 
     Scénario: Impossible de modifier la référence pour un projet sans dossier de raccordement
-        Quand l'utilisateur avec le rôle "porteur-projet" modifie la demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000033" avec la référence "OUE-RP-2022-000034" auprès du gestionnaire de réseau "Enedis"
+        Quand l'utilisateur avec le rôle "porteur-projet" modifie la demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000033" avec la référence "OUE-RP-2022-000034"
         Alors le porteur devrait être informé que "Raccordement inconnu"
 
     Scénario: Impossible de modifier la référence pour un dossier de raccordement non référencé
@@ -108,7 +108,7 @@ Fonctionnalité: Modifier la référence d'une demande complète de raccordement
             | La référence du dossier de raccordement | OUE-RP-2022-000033                                                                                    |
             | Le format de l'accusé de réception      | application/pdf                                                                                       |
             | Le contenu de l'accusé de réception     | Accusé de réception ayant pour référence OUE-RP-2022-000033 et la date de qualification au 2022-10-28 |
-        Quand l'utilisateur avec le rôle "porteur-projet" modifie la demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000034" avec la référence "OUE-RP-2022-000035" auprès du gestionnaire de réseau "Enedis"
+        Quand l'utilisateur avec le rôle "porteur-projet" modifie la demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000034" avec la référence "OUE-RP-2022-000035"
         Alors le porteur devrait être informé que "Le dossier de raccordement n'est pas référencé"
 
     Scénario: Impossible pour un porteur de modifier la référence pour un dossier de raccordement ayant déjà une date de mise en service
@@ -118,5 +118,5 @@ Fonctionnalité: Modifier la référence d'une demande complète de raccordement
             | Le format de l'accusé de réception      | application/pdf                                                                                       |
             | Le contenu de l'accusé de réception     | Accusé de réception ayant pour référence OUE-RP-2022-000033 et la date de qualification au 2022-10-28 |
         Et une date de mise en service "2022-01-12" pour le dossier de raccordement pour le projet lauréat "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000033"
-        Quand l'utilisateur avec le rôle "porteur-projet" modifie la demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000033" avec la référence "OUE-RP-2022-000034" auprès du gestionnaire de réseau "Enedis"
+        Quand l'utilisateur avec le rôle "porteur-projet" modifie la demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000033" avec la référence "OUE-RP-2022-000034"
         Alors le porteur devrait être informé que "La référence du dossier de raccordement ne peut pas être modifiée car le dossier dispose déjà d'une date de mise en service"

--- a/packages/specifications/src/raccordement/stepDefinitions/raccordement.when.ts
+++ b/packages/specifications/src/raccordement/stepDefinitions/raccordement.when.ts
@@ -283,11 +283,8 @@ Quand(
     nomProjet: string,
     référenceDossierRaccordementActuelle: string,
     nouvelleRéférenceDossierRaccordement: string,
-    raisonSocialeGestionnaire: string,
   ) {
     const { identifiantProjet } = this.lauréatWorld.rechercherLauréatFixture(nomProjet);
-    const { codeEIC } =
-      this.gestionnaireRéseauWorld.rechercherGestionnaireRéseauFixture(raisonSocialeGestionnaire);
 
     try {
       this.raccordementWorld.référenceDossierRaccordement =
@@ -297,7 +294,6 @@ Quand(
       await mediator.send<Raccordement.RaccordementUseCase>({
         type: 'Réseau.Raccordement.UseCase.ModifierRéférenceDossierRaccordement',
         data: {
-          identifiantGestionnaireRéseauValue: codeEIC,
           identifiantProjetValue: identifiantProjet.formatter(),
           nouvelleRéférenceDossierRaccordementValue: nouvelleRéférenceDossierRaccordement,
           référenceDossierRaccordementActuelleValue: référenceDossierRaccordementActuelle,

--- a/packages/specifications/src/raccordement/stepDefinitions/raccordement.when.ts
+++ b/packages/specifications/src/raccordement/stepDefinitions/raccordement.when.ts
@@ -276,7 +276,7 @@ Quand(
 );
 
 Quand(
-  `l'utilisateur avec le rôle {string} modifie la demande complète de raccordement pour le projet lauréat {string} ayant pour référence {string} avec la référence {string} auprès du gestionnaire de réseau {string}`,
+  `l'utilisateur avec le rôle {string} modifie la demande complète de raccordement pour le projet lauréat {string} ayant pour référence {string} avec la référence {string}`,
   async function (
     this: PotentielWorld,
     rôleUtilisateur: string,


### PR DESCRIPTION
Le gestionnaire réseau est passé en input du use case, pour moi il s'agit d'une erreur:
- l'info est déjà disponible sur le raccordement
- c'est source d'erreur car on ne vérifie pas que le gestionnaire est le même que le raccordement