### PR TITLE
♻️ Suppression anciennes variables pour accéder au bucket legacy

### DIFF
--- a/packages/applications/legacy/.env.template
+++ b/packages/applications/legacy/.env.template
@@ -12,10 +12,6 @@ AWS_ACCESS_KEY_ID=minioadmin
 AWS_SECRET_ACCESS_KEY=minioadmin 
 S3_ENDPOINT=http://localhost:9000
 S3_BUCKET=potentiel
-LEGACY_S3_ACCESS_KEY_ID=minioadmin
-LEGACY_S3_SECRET_ACCESS_KEY=minioadmin 
-LEGACY_S3_ENDPOINT=http://localhost:9000
-LEGACY_S3_BUCKET=potentiel
 
 # CRISP
 CRISP_WEBSITE_ID=

--- a/packages/applications/legacy/jest.env.ts
+++ b/packages/applications/legacy/jest.env.ts
@@ -1,5 +1,5 @@
-process.env.LEGACY_S3_BUCKET = 'potentiel';
-process.env.LEGACY_S3_ENDPOINT = 'http://localhost:9001';
-process.env.LEGACY_S3_ACCESS_KEY_ID = 'minioadmin';
-process.env.LEGACY_S3_SECRET_ACCESS_KEY = 'minioadmin';
+process.env.S3_BUCKET = 'potentiel';
+process.env.S3_ENDPOINT = 'http://localhost:9001';
+process.env.AWS_ACCESS_KEY_ID = 'minioadmin';
+process.env.AWS_SECRET_ACCESS_KEY = 'minioadmin';
 process.env.POTENTIEL_IDENTIFIER_SECRET = 'none';

--- a/packages/applications/legacy/src/config/fileStorage.config.ts
+++ b/packages/applications/legacy/src/config/fileStorage.config.ts
@@ -1,17 +1,17 @@
 import { makeS3FileStorageService } from '../infra/file';
 
 const {
-  LEGACY_S3_ACCESS_KEY_ID,
-  LEGACY_S3_SECRET_ACCESS_KEY,
-  LEGACY_S3_ENDPOINT,
-  LEGACY_S3_BUCKET,
+  AWS_ACCESS_KEY_ID,
+  AWS_SECRET_ACCESS_KEY,
+  S3_ENDPOINT,
+  S3_BUCKET,
 } = process.env;
 
 const missingVars = [
-  'LEGACY_S3_BUCKET',
-  'LEGACY_S3_ENDPOINT',
-  'LEGACY_S3_ACCESS_KEY_ID',
-  'LEGACY_S3_SECRET_ACCESS_KEY',
+  'S3_BUCKET',
+  'S3_ENDPOINT',
+  'AWS_ACCESS_KEY_ID',
+  'AWS_SECRET_ACCESS_KEY',
 ].filter((key) => !process.env[key]);
 
 if (missingVars.length) {
@@ -23,12 +23,12 @@ if (missingVars.length) {
 }
 
 const fileStorageService = makeS3FileStorageService({
-  accessKeyId: LEGACY_S3_ACCESS_KEY_ID!,
-  secretAccessKey: LEGACY_S3_SECRET_ACCESS_KEY!,
-  endpoint: LEGACY_S3_ENDPOINT!,
-  bucket: LEGACY_S3_BUCKET!,
+  accessKeyId: AWS_ACCESS_KEY_ID!,
+  secretAccessKey: AWS_SECRET_ACCESS_KEY!,
+  endpoint: S3_ENDPOINT!,
+  bucket: S3_BUCKET!,
 });
 
-console.log(`FileService will be using S3 on bucket ${LEGACY_S3_BUCKET}`);
+console.log(`FileService will be using S3 on bucket ${S3_BUCKET}`);
 
 export { fileStorageService };

--- a/packages/applications/legacy/src/infra/file/S3FileStorageService.integration.ts
+++ b/packages/applications/legacy/src/infra/file/S3FileStorageService.integration.ts
@@ -4,10 +4,10 @@ import { makeS3FileStorageService } from './S3FileStorageService';
 import dotenv from 'dotenv';
 dotenv.config();
 
-const accessKeyId = process.env.LEGACY_S3_ACCESS_KEY_ID!;
-const secretAccessKey = process.env.LEGACY_S3_SECRET_ACCESS_KEY!;
-const bucket = process.env.LEGACY_S3_BUCKET!;
-const endpoint = process.env.LEGACY_S3_ENDPOINT!;
+const accessKeyId = process.env.AWS_ACCESS_KEY_ID!;
+const secretAccessKey = process.env.AWS_SECRET_ACCESS_KEY!;
+const bucket = process.env.S3_BUCKET!;
+const endpoint = process.env.S3_ENDPOINT!;
 
 describe.skip('S3FileStorageService', () => {
   const fakePath = `test/fakeFile-${Date.now()}.txt`;

--- a/packages/applications/scheduled-tasks/s3-backup.sh
+++ b/packages/applications/scheduled-tasks/s3-backup.sh
@@ -28,19 +28,4 @@ echo "Syncing bucket..."
 
 echo "Bucket successfully synced..."
 
-# echo "Syncing legacy bucket..."
-
-# if [ -z $LEGACY_S3_ACCESS_KEY_ID ] || [ -z $LEGACY_S3_SECRET_ACCESS_KEY ] || [ -z $LEGACY_S3_ENDPOINT ] || [ -z $LEGACY_S3_BUCKET ] || [ -z $LEGACY_S3_BACKUP_BUCKET ]
-# then
-#     echo "An environment variable is missing !!"
-#     exit 1
-# fi
-
-
-# ./aws configure set aws_access_key_id $LEGACY_S3_ACCESS_KEY_ID
-# ./aws configure set aws_secret_access_key $LEGACY_S3_SECRET_ACCESS_KEY
-# ./aws s3 sync s3://$LEGACY_S3_BUCKET s3://$LEGACY_S3_BACKUP_BUCKET --endpoint-url $LEGACY_S3_ENDPOINT
-
-# echo "Legacy bucket successfully synced..."
-
 exit 0

--- a/packages/applications/ssr/.env.template
+++ b/packages/applications/ssr/.env.template
@@ -12,10 +12,6 @@ AWS_ACCESS_KEY_ID=minioadmin
 AWS_SECRET_ACCESS_KEY=minioadmin 
 S3_ENDPOINT=http://localhost:9000
 S3_BUCKET=potentiel
-LEGACY_S3_ACCESS_KEY_ID=minioadmin
-LEGACY_S3_SECRET_ACCESS_KEY=minioadmin 
-LEGACY_S3_ENDPOINT=http://localhost:9000
-LEGACY_S3_BUCKET=potentiel
 
 # CRISP
 CRISP_WEBSITE_ID=


### PR DESCRIPTION
# Description

Cette PR supprime l'ensemble des variables d'accés au bucket legacy. Ces variables ne sont plus utilisées en production

## Type de changement

Veuillez supprimer les options qui ne sont pas pertinentes.

- [x] Refacto de code

# Comment cela a-t-il été testé?

Lancer les tests avec le script test

# Check-up :

- [x] Mon code [suit les directives de style](../docs/contributing//DEVELOPMENT_FLOW.md) de ce projet
- [x] J'ai effectué une auto-revue de mon code
- [x] J'ai commenté mon code, en particulier dans les zones difficiles à comprendre
- [x] J'ai apporté des modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun warning
- [x] J'ai ajouté des tests qui prouvent l'efficacité de ma correction ou que ma fonctionnalité fonctionne
- [x] Les nouveaux tests unitaires et les tests existants passent en local / dans la CI avec mes modifications
