### PR TITLE
🎨 Ajout barre recherche sur liste abandons

### DIFF
--- a/packages/applications/ssr/src/app/abandons/page.tsx
+++ b/packages/applications/ssr/src/app/abandons/page.tsx
@@ -43,6 +43,8 @@ export default async function Page({ searchParams }: PageProps) {
           ).statut
         : undefined;
 
+      const nomProjet = searchParams ? searchParams['nomProjet'] : '';
+
       const abandons = await mediator.send<Abandon.ListerAbandonsQuery>({
         type: 'Lauréat.Abandon.Query.ListerAbandons',
         data: {
@@ -58,6 +60,7 @@ export default async function Page({ searchParams }: PageProps) {
           statut,
           appelOffre,
           preuveRecandidatureStatut,
+          nomProjet,
         },
       });
 

--- a/packages/applications/ssr/src/components/molecules/Search.tsx
+++ b/packages/applications/ssr/src/components/molecules/Search.tsx
@@ -1,7 +1,7 @@
 import assert from 'assert';
 
 import SearchBar from '@codegouvfr/react-dsfr/SearchBar';
-import { usePathname, useRouter } from 'next/navigation';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
 
 export type SearchProps = {
@@ -11,7 +11,8 @@ export type SearchProps = {
 
 export const Search = ({ params, label }: SearchProps) => {
   const pathname = usePathname();
-  const [searchParams, setSearchParams] = useState<string>('');
+  const currentParams = useSearchParams();
+  const [searchParams, setSearchParams] = useState<string>(() => currentParams.get(params) ?? '');
   const [inputElement, setInputElement] = useState<HTMLInputElement | null>(null);
 
   const url = buildUrl(

--- a/packages/applications/ssr/src/components/molecules/Search.tsx
+++ b/packages/applications/ssr/src/components/molecules/Search.tsx
@@ -22,6 +22,7 @@ export const Search = ({ params, label }: SearchProps) => {
       onButtonClick={() => router.push(url)}
       label={label}
       allowEmptySearch
+      className="mb-4"
       renderInput={({ className, id, placeholder, type }) => (
         <input
           ref={setInputElement}

--- a/packages/applications/ssr/src/components/molecules/Search.tsx
+++ b/packages/applications/ssr/src/components/molecules/Search.tsx
@@ -2,7 +2,7 @@ import assert from 'assert';
 
 import SearchBar from '@codegouvfr/react-dsfr/SearchBar';
 import { usePathname, useRouter } from 'next/navigation';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 export type SearchProps = {
   label: string;
@@ -19,7 +19,15 @@ export const Search = ({ params, label }: SearchProps) => {
     new URLSearchParams({ [params]: searchParams.trim() }),
     searchParams,
   );
+
   const router = useRouter();
+
+  // Cela permet de refresh automatiquement la page sans filtre quand on retire sa recherche (au clavier ou en utilisant le bouton "x" du composant)
+  useEffect(() => {
+    if (searchParams === '') {
+      router.push(url);
+    }
+  }, [searchParams]);
 
   return (
     <SearchBar

--- a/packages/applications/ssr/src/components/molecules/Search.tsx
+++ b/packages/applications/ssr/src/components/molecules/Search.tsx
@@ -14,7 +14,11 @@ export const Search = ({ params, label }: SearchProps) => {
   const [searchParams, setSearchParams] = useState<string>('');
   const [inputElement, setInputElement] = useState<HTMLInputElement | null>(null);
 
-  const url = buildUrl(pathname, new URLSearchParams({ [params]: searchParams }), searchParams);
+  const url = buildUrl(
+    pathname,
+    new URLSearchParams({ [params]: searchParams.trim() }),
+    searchParams,
+  );
   const router = useRouter();
 
   return (

--- a/packages/applications/ssr/src/components/organisms/ListFilters.tsx
+++ b/packages/applications/ssr/src/components/organisms/ListFilters.tsx
@@ -3,7 +3,6 @@ import Button from '@codegouvfr/react-dsfr/Button';
 import { usePathname } from 'next/navigation';
 import { FC, useState } from 'react';
 
-import { Heading2 } from '../atoms/headings';
 import { Filter } from '../molecules/Filter';
 
 export type ListFiltersProps = {
@@ -25,7 +24,6 @@ export const ListFilters: FC<ListFiltersProps> = ({ filters }) => {
 
   return (
     <>
-      <Heading2 className="mt-1 mb-6">Affiner la recherche</Heading2>
       {filters.map(({ label, searchParamKey, options, defaultValue }) => (
         <Filter
           key={`filter-${searchParamKey}`}

--- a/packages/applications/ssr/src/components/organisms/ListFilters.tsx
+++ b/packages/applications/ssr/src/components/organisms/ListFilters.tsx
@@ -23,7 +23,7 @@ export const ListFilters: FC<ListFiltersProps> = ({ filters }) => {
   const [url, setUrl] = useState(buildUrl(pathname, searchParams));
 
   return (
-    <>
+    <div className="flex flex-col gap-2">
       {filters.map(({ label, searchParamKey, options, defaultValue }) => (
         <Filter
           key={`filter-${searchParamKey}`}
@@ -48,7 +48,7 @@ export const ListFilters: FC<ListFiltersProps> = ({ filters }) => {
       <Button className="mb-4" linkProps={{ href: url }}>
         Filtrer
       </Button>
-    </>
+    </div>
   );
 };
 

--- a/packages/applications/ssr/src/components/pages/abandon/détails/EtapesAbandon.tsx
+++ b/packages/applications/ssr/src/components/pages/abandon/détails/EtapesAbandon.tsx
@@ -98,7 +98,7 @@ export const EtapesAbandon: FC<EtapesAbandonProps> = ({
         <>
           {accord.réponseSignée && (
             <DownloadDocument
-              className="mb-0 pb-0"
+              className="mb-0"
               label="Télécharger la pièce justificative"
               format="pdf"
               url={Routes.Document.télécharger(accord.réponseSignée)}
@@ -120,7 +120,7 @@ export const EtapesAbandon: FC<EtapesAbandonProps> = ({
         <>
           {rejet.réponseSignée && (
             <DownloadDocument
-              className="mb-0 pb-0"
+              className="mb-0"
               label="Télécharger la pièce justificative"
               format="pdf"
               url={Routes.Document.télécharger(rejet.réponseSignée)}
@@ -155,7 +155,7 @@ export const EtapesAbandon: FC<EtapesAbandonProps> = ({
         <>
           {confirmation.réponseSignée && (
             <DownloadDocument
-              className="mb-0 pb-0"
+              className="mb-0"
               label="Télécharger la pièce justificative"
               format="pdf"
               url={Routes.Document.télécharger(confirmation.réponseSignée)}
@@ -185,7 +185,7 @@ export const EtapesAbandon: FC<EtapesAbandonProps> = ({
         </div>
         {justificatifDemande && (
           <DownloadDocument
-            className="mb-0 pb-0"
+            className="mb-0"
             label="Télécharger la pièce justificative"
             format="pdf"
             url={Routes.Document.télécharger(justificatifDemande)}

--- a/packages/applications/ssr/src/components/pages/abandon/lister/AbandonList.page.tsx
+++ b/packages/applications/ssr/src/components/pages/abandon/lister/AbandonList.page.tsx
@@ -70,6 +70,7 @@ export const AbandonListPage: FC<AbandonListPageProps> = ({
       ItemComponent={AbandonListItem}
       tagFilters={tagFilters}
       filters={filters}
+      search={{ label: 'Rechercher par nom de projet', params: 'nomProjet' }}
     />
   );
 };

--- a/packages/applications/ssr/src/components/templates/ListPage.template.tsx
+++ b/packages/applications/ssr/src/components/templates/ListPage.template.tsx
@@ -4,7 +4,7 @@ import { useSearchParams } from 'next/navigation';
 import { FC } from 'react';
 
 import { LinkAction } from '../atoms/LinkAction';
-import { Heading1, Heading2 } from '../atoms/headings';
+import { Heading1 } from '../atoms/headings';
 import { Search, SearchProps } from '../molecules/Search';
 import { List } from '../organisms/List';
 import { ListFilters, ListFiltersProps } from '../organisms/ListFilters';
@@ -63,18 +63,18 @@ export const ListPageTemplate = <TItem,>({
               ))}
             </>
           ) : null}
-          {search || filters.length ? (
-            <Heading2 className="mt-1 mb-4">Affiner la recherche</Heading2>
-          ) : null}
-          {search ? <Search label={search.label} params={search.params} /> : null}
           {filters.length ? <ListFilters key={listFiltersKey} filters={filters} /> : null}
         </div>
 
         <div className="flex flex-col gap-3 flex-grow md:w-3/4">
+          <div className="w-full flex justify-end">
+            <div className="w-2/3">
+              {search ? <Search label={search.label} params={search.params} /> : null}
+            </div>
+          </div>
           <div className="flex flex-col md:flex-row md:items-center gap-3">
             <ListHeader tagFilters={tagFilters} totalCount={totalItems} />
           </div>
-
           {items.length ? (
             <List
               items={items}

--- a/packages/applications/ssr/src/components/templates/ListPage.template.tsx
+++ b/packages/applications/ssr/src/components/templates/ListPage.template.tsx
@@ -4,7 +4,7 @@ import { useSearchParams } from 'next/navigation';
 import { FC } from 'react';
 
 import { LinkAction } from '../atoms/LinkAction';
-import { Heading1 } from '../atoms/headings';
+import { Heading1, Heading2 } from '../atoms/headings';
 import { Search, SearchProps } from '../molecules/Search';
 import { List } from '../organisms/List';
 import { ListFilters, ListFiltersProps } from '../organisms/ListFilters';
@@ -62,6 +62,9 @@ export const ListPageTemplate = <TItem,>({
                 />
               ))}
             </>
+          ) : null}
+          {search || filters.length ? (
+            <Heading2 className="mt-1 mb-4">Affiner la recherche</Heading2>
           ) : null}
           {search ? <Search label={search.label} params={search.params} /> : null}
           {filters.length ? <ListFilters key={listFiltersKey} filters={filters} /> : null}

--- a/packages/domain/lauréat/src/abandon/lister/listerAbandon.query.ts
+++ b/packages/domain/lauréat/src/abandon/lister/listerAbandon.query.ts
@@ -19,6 +19,14 @@ const mapToWhereEqual = <T>(value: T | undefined) =>
       }
     : undefined;
 
+const mapToWhereLike = (value: string | undefined) =>
+  value
+    ? {
+        operator: 'like' as const,
+        value: `%${value}%` as `%${string}%`,
+      }
+    : undefined;
+
 type AbandonListItemReadModel = {
   identifiantProjet: IdentifiantProjet.ValueType;
   appelOffre: string;
@@ -48,6 +56,7 @@ export type ListerAbandonsQuery = Message<
     statut?: StatutAbandon.RawType;
     appelOffre?: string;
     preuveRecandidatureStatut?: StatutPreuveRecandidature.RawType;
+    nomProjet?: string;
     range: RangeOptions;
   },
   ListerAbandonReadModel
@@ -69,6 +78,7 @@ export const registerListerAbandonQuery = ({
     statut,
     appelOffre,
     preuveRecandidatureStatut,
+    nomProjet,
     utilisateur: { email, rôle },
     range,
   }) => {
@@ -82,6 +92,7 @@ export const registerListerAbandonQuery = ({
           statut: mapToWhereEqual(statut),
           projet: {
             appelOffre: mapToWhereEqual(appelOffre),
+            nom: mapToWhereLike(nomProjet),
           },
           demande: {
             estUneRecandidature: mapToWhereEqual(recandidature),


### PR DESCRIPTION
# Description

- ajout barre de recherche
- correction des DownloadDocument pour abandon (la partie format était cachée sous le label)
- suggestion pour la mise en forme barre de recherche / filtres

Ticket : https://linear.app/startup-potentiel/issue/POT-390/ajout-dune-barre-de-recherche-par-nom-de-projets-sur-la-page-abandon

## Type de changement

Veuillez supprimer les options qui ne sont pas pertinentes.

- [ ] Correction de bug
- [ ] Nouvelle fonctionnalité
- [ ] Refacto de code
- [ ] Breaking changes (correction ou fonctionnalité qui ferait en sorte que la fonctionnalité existante ne fonctionne pas comme prévu)
- [ ] Ce changement nécessite une mise à jour de la documentation

# Comment cela a-t-il été testé?

<img width="1108" alt="Capture d’écran 2024-07-03 à 18 15 28" src="https://github.com/MTES-MCT/potentiel/assets/27735540/3f94f466-da25-4d3f-80c2-a93abdb90ce6">


# Check-up :

- [ ] Mon code [suit les directives de style](../docs/contributing//DEVELOPMENT_FLOW.md) de ce projet
- [ ] J'ai effectué une auto-revue de mon code
- [ ] J'ai commenté mon code, en particulier dans les zones difficiles à comprendre
- [ ] J'ai apporté des modifications correspondantes à la documentation
- [ ] Mes modifications ne génèrent aucun warning
- [ ] J'ai ajouté des tests qui prouvent l'efficacité de ma correction ou que ma fonctionnalité fonctionne
- [ ] Les nouveaux tests unitaires et les tests existants passent en local / dans la CI avec mes modifications
