### PR TITLE
🐛 Modification du logo dans les modèles de document

### DIFF
--- a/packages/applications/document-builder/src/buildDocxDocument/buildDocxDocument.ts
+++ b/packages/applications/document-builder/src/buildDocxDocument/buildDocxDocument.ts
@@ -135,9 +135,7 @@ export const buildDocxDocument: GénérerModèleDocumentPort = async ({ type, lo
     try {
       const imageContents = fs.readFileSync(logoFilePath, 'binary');
       zip.file('word/media/image1.png', imageContents, { binary: true });
-    } catch (e) {
-      console.log(e);
-    }
+    } catch (e) {}
   }
 
   const buf = doc.getZip().generate({

--- a/packages/applications/document-builder/src/buildDocxDocument/buildDocxDocument.ts
+++ b/packages/applications/document-builder/src/buildDocxDocument/buildDocxDocument.ts
@@ -130,20 +130,22 @@ export const buildDocxDocument: GénérerModèleDocumentPort = async ({ type, lo
 
   doc.render(data);
 
+  if (logo) {
+    const logoFilePath = path.resolve(imagesFolderPath, `${logo}.png`);
+    try {
+      const imageContents = fs.readFileSync(logoFilePath, 'binary');
+      zip.file('word/media/image1.png', imageContents, { binary: true });
+    } catch (e) {
+      console.log(e);
+    }
+  }
+
   const buf = doc.getZip().generate({
     type: 'nodebuffer',
     // compression: DEFLATE adds a compression step.
     // For a 50MB output document, expect 500ms additional CPU time
     compression: 'DEFLATE',
   });
-
-  if (logo) {
-    const logoFilePath = path.resolve(imagesFolderPath, `${logo}.png`);
-    try {
-      const imageContents = fs.readFileSync(logoFilePath, 'binary');
-      zip.file('word/media/image1.png', imageContents, { binary: true });
-    } catch (e) {}
-  }
 
   return new ReadableStream({
     start: async (controller) => {


### PR DESCRIPTION
Suite à #1894, les logos ne pouvaient plus être modifiés (par exemple pour les Dreal)