### PR TITLE
🐛 Correction des étapes d'un abandon pour affichage transmission preuve uniquement si abandon accordé

### DIFF
--- a/packages/applications/ssr/src/components/pages/abandon/détails/EtapesAbandon.tsx
+++ b/packages/applications/ssr/src/components/pages/abandon/détails/EtapesAbandon.tsx
@@ -55,7 +55,7 @@ export const EtapesAbandon: FC<EtapesAbandonProps> = ({
 }) => {
   const items: TimelineProps['items'] = [];
 
-  if (preuveRecandidatureStatut === 'en-attente') {
+  if (preuveRecandidatureStatut === 'en-attente' && accord) {
     items.push({
       status: 'warning',
       date: 'En attente',


### PR DESCRIPTION
# Description

Fix accés à la transmission de la preuve de rencandidature depuis les étapes alors qu'il n'y a pas d'accord ni de tâche

Avant :
![image](https://github.com/MTES-MCT/potentiel/assets/3357643/7d3c4a0b-7b40-4580-b2fa-3df04a0027f0)

Aprés : 
![image](https://github.com/MTES-MCT/potentiel/assets/3357643/12be249d-d37c-45d3-93ed-2b815b14aee1)

## Type de changement

Veuillez supprimer les options qui ne sont pas pertinentes.

- [x] Correction de bug

# Check-up :

- [x] Mon code [suit les directives de style](../docs/contributing//DEVELOPMENT_FLOW.md) de ce projet
- [x] J'ai effectué une auto-revue de mon code
- [x] J'ai commenté mon code, en particulier dans les zones difficiles à comprendre
- [x] J'ai apporté des modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun warning
- [x] J'ai ajouté des tests qui prouvent l'efficacité de ma correction ou que ma fonctionnalité fonctionne
- [x] Les nouveaux tests unitaires et les tests existants passent en local / dans la CI avec mes modifications
