### PR TITLE
🚸 Ajout d'un bouton pour transmettre l'attestation de conformité depuis la page des gfs (encart dédiée)

### DIFF
--- a/packages/applications/ssr/src/components/pages/garanties-financières/détails/DétailsGarantiesFinancières.page.tsx
+++ b/packages/applications/ssr/src/components/pages/garanties-financières/détails/DétailsGarantiesFinancières.page.tsx
@@ -80,7 +80,13 @@ export const DétailsGarantiesFinancièresPage: FC<DétailsGarantiesFinancières
                   </li>
                   <li>
                     L'attestation de conformité a été transmise dans Potentiel ou le projet est
-                    abandonné (abandon accordé par la DGEC)
+                    abandonné (abandon accordé par la DGEC). Vous pouvez la transmettre{' '}
+                    <Link
+                      href={Routes.Achèvement.transmettreAttestationConformité(identifiantProjet)}
+                      className="font-semibold"
+                    >
+                      ici
+                    </Link>
                   </li>
                 </ul>
               </div>


### PR DESCRIPTION
# Description

Améliorer la navigation vers la page de transmission de l'attestation de conformité depuis la page détails des GFs

![Capture d’écran 2024-07-10 à 15 27 20](https://github.com/MTES-MCT/potentiel/assets/13203242/022c6aa9-f09a-4bd7-ac0d-39c4998c369d)
