### PR TITLE
⚡️ Optimisation CD - application version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,8 +38,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 18.x
-          cache: 'npm'
-      - run: npm ci
       - name: Set application version
         id: app_version
         run: |


### PR DESCRIPTION
Le step "application-version" du workflow de release n'a pas besoin des packages, donc on peut se passer de l'étape d'installation des packages, qui prend ~53s (voir [ici](https://github.com/MTES-MCT/potentiel/actions/runs/9874527938/job/27270622625))