### PR TITLE
✨ ETQ porteur Infobox mainlevée si abandon accordé

### DIFF
--- a/packages/applications/ssr/src/app/laureats/[identifiant]/abandon/page.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/abandon/page.tsx
@@ -152,6 +152,9 @@ const mapToActions = ({
       if (statut.estEnCours()) {
         actions.push('annuler');
       }
+      if (statut.estAccordé()) {
+        actions.push('demander-mainlevée');
+      }
       if (recandidature) break;
   }
 

--- a/packages/applications/ssr/src/components/pages/abandon/détails/DétailsAbandon.page.tsx
+++ b/packages/applications/ssr/src/components/pages/abandon/détails/DétailsAbandon.page.tsx
@@ -68,7 +68,7 @@ export const DétailsAbandonPage: FC<DétailsAbandonPageProps> = ({
         children: <EtapesAbandon {...abandon} />,
       }}
       rightColumn={{
-        className: 'flex flex-col w-full md:flex-1 gap-4',
+        className: 'flex flex-col w-full gap-4',
         children: mapToActionComponents({
           actions,
           identifiantProjet,

--- a/packages/applications/ssr/src/components/pages/abandon/détails/DétailsAbandon.page.tsx
+++ b/packages/applications/ssr/src/components/pages/abandon/détails/DétailsAbandon.page.tsx
@@ -17,6 +17,7 @@ import { AccorderAbandonSansRecandidature } from './accorder/AccorderAbandonSans
 import { AnnulerAbandon } from './annuler/AnnulerAbandon';
 import { ConfirmerAbandon } from './confirmer/ConfirmerAbandon';
 import { RejeterAbandon } from './rejeter/RejeterAbandon';
+import { InfoBoxMainlevéeSiAbandonAccordé } from './InfoBoxMainlevéeSiAbandonAccordé';
 
 type AvailableActions = Array<
   | 'demander-confirmation'
@@ -25,6 +26,7 @@ type AvailableActions = Array<
   | 'accorder-avec-recandidature'
   | 'accorder-sans-recandidature'
   | 'rejeter'
+  | 'demander-mainlevée'
 >;
 
 export type DétailsAbandonPageProps = {
@@ -66,7 +68,7 @@ export const DétailsAbandonPage: FC<DétailsAbandonPageProps> = ({
         children: <EtapesAbandon {...abandon} />,
       }}
       rightColumn={{
-        className: 'flex flex-col w-full md:w-1/4 gap-4',
+        className: 'flex flex-col w-full md:flex-1 gap-4',
         children: mapToActionComponents({
           actions,
           identifiantProjet,
@@ -83,7 +85,7 @@ type MapToActionsComponentsProps = {
 
 const mapToActionComponents = ({ actions, identifiantProjet }: MapToActionsComponentsProps) => {
   return actions.length ? (
-    <>
+    <div className="flex flex-col items-center">
       {actions.includes('demander-confirmation') && (
         <DemanderConfirmationAbandon identifiantProjet={identifiantProjet} />
       )}
@@ -96,6 +98,9 @@ const mapToActionComponents = ({ actions, identifiantProjet }: MapToActionsCompo
       {actions.includes('rejeter') && <RejeterAbandon identifiantProjet={identifiantProjet} />}
       {actions.includes('confirmer') && <ConfirmerAbandon identifiantProjet={identifiantProjet} />}
       {actions.includes('annuler') && <AnnulerAbandon identifiantProjet={identifiantProjet} />}
-    </>
+      {actions.includes('demander-mainlevée') && (
+        <InfoBoxMainlevéeSiAbandonAccordé identifiantProjet={identifiantProjet} />
+      )}
+    </div>
   ) : null;
 };

--- a/packages/applications/ssr/src/components/pages/abandon/détails/InfoBoxMainlevéeSiAbandonAccordé.tsx
+++ b/packages/applications/ssr/src/components/pages/abandon/détails/InfoBoxMainlevéeSiAbandonAccordé.tsx
@@ -1,0 +1,34 @@
+import Alert from '@codegouvfr/react-dsfr/Alert';
+import Link from 'next/link';
+
+import { Routes } from '@potentiel-applications/routes';
+
+type Props = {
+  identifiantProjet: string;
+};
+
+export const InfoBoxMainlevéeSiAbandonAccordé = ({ identifiantProjet }: Props) => (
+  <Alert
+    severity="info"
+    small
+    description={
+      <div className="p-3 flex flex-col">
+        <span>
+          Votre demande d'abandon ayant été validée, vous pouvez demander la mainlevée de vos
+          garanties financières sur Potentiel depuis
+          <Link
+            href={Routes.GarantiesFinancières.détail(identifiantProjet)}
+            className="font-semibold"
+          >
+            {' '}
+            la page des garanties financières du projet
+          </Link>
+        </span>
+        <span>
+          Vos garanties financières doivent toutefois être validées et complètes sur Potentiel et ne
+          pas faire l'objet de demande de modification ou de renouvellement.
+        </span>
+      </div>
+    }
+  />
+);

--- a/packages/applications/ssr/src/components/pages/abandon/détails/accorder/AccorderAbandonAvecRecandidature.tsx
+++ b/packages/applications/ssr/src/components/pages/abandon/détails/accorder/AccorderAbandonAvecRecandidature.tsx
@@ -25,7 +25,7 @@ export const AccorderAbandonAvecRecandidature = ({
       <Button
         priority="secondary"
         onClick={() => setIsOpen(true)}
-        className="block w-full text-center"
+        className="block w-1/2 text-center"
       >
         Accorder
       </Button>

--- a/packages/applications/ssr/src/components/pages/abandon/détails/accorder/AccorderAbandonSansRecandidature.tsx
+++ b/packages/applications/ssr/src/components/pages/abandon/détails/accorder/AccorderAbandonSansRecandidature.tsx
@@ -28,7 +28,7 @@ export const AccorderAbandonSansRecandidature = ({
       <Button
         priority="secondary"
         onClick={() => setIsOpen(true)}
-        className="block w-full text-center"
+        className="block w-1/2 text-center"
       >
         Accorder
       </Button>

--- a/packages/applications/ssr/src/components/pages/abandon/détails/annuler/AnnulerAbandon.tsx
+++ b/packages/applications/ssr/src/components/pages/abandon/détails/annuler/AnnulerAbandon.tsx
@@ -21,7 +21,7 @@ export const AnnulerAbandon = ({ identifiantProjet }: AnnulerAbandonFormProps) =
       <Button
         priority="secondary"
         onClick={() => setIsOpen(true)}
-        className="block w-full text-center"
+        className="block w-1/2 text-center"
       >
         Annuler
       </Button>

--- a/packages/applications/ssr/src/components/pages/abandon/détails/confirmer/ConfirmerAbandon.tsx
+++ b/packages/applications/ssr/src/components/pages/abandon/détails/confirmer/ConfirmerAbandon.tsx
@@ -21,7 +21,7 @@ export const ConfirmerAbandon = ({ identifiantProjet }: ConfirmerAbandonFormProp
       <Button
         priority="secondary"
         onClick={() => setIsOpen(true)}
-        className="block w-full text-center"
+        className="block w-1/2 text-center"
       >
         Confirmer
       </Button>

--- a/packages/applications/ssr/src/components/pages/abandon/détails/demanderConfirmation/DemanderConfirmationAbandon.tsx
+++ b/packages/applications/ssr/src/components/pages/abandon/détails/demanderConfirmation/DemanderConfirmationAbandon.tsx
@@ -28,7 +28,7 @@ export const DemanderConfirmationAbandon = ({
       <Button
         priority="secondary"
         onClick={() => setIsOpen(true)}
-        className="block w-full text-center"
+        className="block w-1/2 text-center"
       >
         Demander la confirmation
       </Button>

--- a/packages/applications/ssr/src/components/pages/abandon/détails/rejeter/RejeterAbandon.tsx
+++ b/packages/applications/ssr/src/components/pages/abandon/détails/rejeter/RejeterAbandon.tsx
@@ -25,7 +25,7 @@ export const RejeterAbandon = ({ identifiantProjet }: RejeterAbandonFormProps) =
       <Button
         priority="secondary"
         onClick={() => setIsOpen(true)}
-        className="block w-full text-center"
+        className="block w-1/2 text-center"
       >
         Rejeter
       </Button>


### PR DESCRIPTION
# Description

- Création d'une infobox ETQ porteur si abandon accordé
- petites corrections d'affichage (sinon infobox toute petite)
[Issue Linear
](https://linear.app/startup-potentiel/issue/POT-431/[pp]-infox-pour-la-demande-de-mainlevee-des-gf-suite-a-une-demande)

## Type de changement

Veuillez supprimer les options qui ne sont pas pertinentes.

- [ ] Correction de bug
- [x] Nouvelle fonctionnalité
- [ ] Refacto de code
- [ ] Breaking changes (correction ou fonctionnalité qui ferait en sorte que la fonctionnalité existante ne fonctionne pas comme prévu)
- [ ] Ce changement nécessite une mise à jour de la documentation

# Comment cela a-t-il été testé?

Visuellement

# Check-up :

- [ ] Mon code [suit les directives de style](../docs/contributing//DEVELOPMENT_FLOW.md) de ce projet
- [ ] J'ai effectué une auto-revue de mon code
- [ ] J'ai commenté mon code, en particulier dans les zones difficiles à comprendre
- [ ] J'ai apporté des modifications correspondantes à la documentation
- [ ] Mes modifications ne génèrent aucun warning
- [ ] J'ai ajouté des tests qui prouvent l'efficacité de ma correction ou que ma fonctionnalité fonctionne
- [ ] Les nouveaux tests unitaires et les tests existants passent en local / dans la CI avec mes modifications
