### PR TITLE
🐛 Doublons dans l'event stream pour DateMiseEnServiceTransmise

### DIFF
--- a/packages/applications/ssr/next.config.js
+++ b/packages/applications/ssr/next.config.js
@@ -9,8 +9,22 @@ const nextConfig = {
 
     if (isServer) {
       config.externals.push(/^@potentiel-/, 'mediateur');
+    } else {
+      // This resolves an issue with sentry in the logger.
+      // Without this, the logger cannot be used in domain packages for instance
+      config.resolve = {
+        ...config.resolve,
+        fallback: {
+          ...(config.resolve || {}).fallback,
+          async_hooks: false,
+          inspector: false,
+          child_process: false,
+          net: false,
+          tls: false,
+          fs: false,
+        },
+      };
     }
-
     return config;
   },
 };

--- a/packages/domain/réseau/package.json
+++ b/packages/domain/réseau/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@potentiel-libraries/monads": "*",
+    "@potentiel-libraries/monitoring": "*",
     "@potentiel-domain/document": "*",
     "@potentiel-domain/common": "*",
     "@potentiel-domain/core": "*"

--- a/packages/domain/réseau/src/raccordement/raccordement.aggregate.ts
+++ b/packages/domain/réseau/src/raccordement/raccordement.aggregate.ts
@@ -114,6 +114,10 @@ export type RaccordementAggregate = Aggregate<RaccordementEvent> & {
   readonly contientLeDossier: (référence: RéférenceDossierRaccordement.ValueType) => boolean;
   readonly récupérerDossier: (référence: string) => DossierRaccordement;
   readonly attribuerGestionnaireRéseau: typeof attribuerGestionnaireRéseau;
+  readonly dateModifiée: (
+    référence: RéférenceDossierRaccordement.ValueType,
+    nouvelleDate: DateTime.ValueType,
+  ) => boolean;
 };
 
 export const getDefaultRaccordementAggregate: GetDefaultAggregateState<
@@ -143,6 +147,16 @@ export const getDefaultRaccordementAggregate: GetDefaultAggregateState<
     }
 
     return dossier;
+  },
+  dateModifiée({ référence }, date) {
+    const dossier = this.récupérerDossier(référence);
+    if (
+      !dossier.miseEnService?.dateMiseEnService ||
+      Option.isNone(dossier.miseEnService.dateMiseEnService)
+    ) {
+      return true;
+    }
+    return !date.estÉgaleÀ(dossier.miseEnService.dateMiseEnService);
   },
 });
 

--- a/packages/domain/réseau/src/raccordement/transmettre/transmettreDateMiseEnService.behavior.ts
+++ b/packages/domain/réseau/src/raccordement/transmettre/transmettreDateMiseEnService.behavior.ts
@@ -44,7 +44,7 @@ export async function transmettreDateMiseEnService(
   }
 
   if (!this.dateModifiée(référenceDossier, dateMiseEnService)) {
-    throw new DateMiseEnServiceDéjàTransmiseError();
+    throw new DateIdentiqueDeMiseEnServiceDéjàTransmiseError();
   }
 
   const dateMiseEnServiceTransmise: DateMiseEnServiceTransmiseEvent = {
@@ -75,7 +75,7 @@ export class DateMiseEnServiceAntérieureDateDésignationProjetError extends Inv
   }
 }
 
-class DateMiseEnServiceDéjàTransmiseError extends InvalidOperationError {
+class DateIdentiqueDeMiseEnServiceDéjàTransmiseError extends InvalidOperationError {
   constructor() {
     super(`La date de mise en service est déjà transmise pour ce dossier de raccordement`);
   }

--- a/packages/domain/réseau/src/raccordement/transmettre/transmettreDateMiseEnService.behavior.ts
+++ b/packages/domain/réseau/src/raccordement/transmettre/transmettreDateMiseEnService.behavior.ts
@@ -56,7 +56,7 @@ export async function transmettreDateMiseEnService(
 
     await this.publish(dateMiseEnServiceTransmise);
   } else {
-    getLogger().info('Skipping update dateMiseEnService, values are identical', {
+    getLogger().info('Mise à jour de dateMiseEnService ignorée, les valeurs sont identiques', {
       dateMiseEnService: dateMiseEnService.formatter(),
       identifiantProjet: identifiantProjet.formatter(),
       référenceDossierRaccordement: référenceDossier.formatter(),

--- a/packages/domain/réseau/src/raccordement/transmettre/transmettreDateMiseEnService.command.ts
+++ b/packages/domain/réseau/src/raccordement/transmettre/transmettreDateMiseEnService.command.ts
@@ -12,6 +12,7 @@ export type TransmettreDateMiseEnServiceCommand = Message<
     dateMiseEnService: DateTime.ValueType;
     référenceDossier: RéférenceDossierRaccordement.ValueType;
     identifiantProjet: IdentifiantProjet.ValueType;
+    // TODO après la migration Candidature, la date de désignation devrait être chargée par Aggregate
     dateDésignation: DateTime.ValueType;
   }
 >;

--- a/packages/domain/réseau/tsconfig.json
+++ b/packages/domain/réseau/tsconfig.json
@@ -9,6 +9,9 @@
       "path": "../../libraries/monads"
     },
     {
+      "path": "../../libraries/monitoring"
+    },
+    {
       "path": "../core"
     },
     {

--- a/packages/specifications/src/raccordement/transmettreDateMiseEnService.feature
+++ b/packages/specifications/src/raccordement/transmettreDateMiseEnService.feature
@@ -46,3 +46,13 @@ Fonctionnalité: Transmettre une date de mise en service pour une demande compl�
             | Le contenu de l'accusé de réception     | Accusé de réception ayant pour référence OUE-RP-2022-000033 et la date de qualification au 2022-10-28 |
         Quand le porteur transmet la date de mise en service "2021-12-31" pour le dossier de raccordement du le projet lauréat "Du boulodrome de Lille" ayant pour référence "OUE-RP-2022-000033"
         Alors le porteur devrait être informé que "La date de mise en service ne peut pas être antérieure à la date de désignation du projet"
+
+    Scénario: Impossible d'enregistrer une date de mise en service plus d'une fois
+        Etant donné une demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" transmise auprès du gestionnaire de réseau "Enedis" avec :
+            | La date de qualification                | 2022-10-28                                                                                            |
+            | La référence du dossier de raccordement | OUE-RP-2022-000033                                                                                    |
+            | Le format de l'accusé de réception      | application/pdf                                                                                       |
+            | Le contenu de l'accusé de réception     | Accusé de réception ayant pour référence OUE-RP-2022-000033 et la date de qualification au 2022-10-28 |
+        Quand le porteur transmet la date de mise en service "2023-03-27" pour le dossier de raccordement du le projet lauréat "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000033"
+        Et le porteur transmet la date de mise en service "2023-03-27" pour le dossier de raccordement du le projet lauréat "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000033"
+        Alors le porteur devrait être informé que "La date de mise en service est déjà transmise pour ce dossier de raccordement"


### PR DESCRIPTION
Suite à l'import des dates de MES vendredi, et de multiples essais dû à différents problèmes d'import, nous avons de nombreux doublons sur l'event stream, sans modification réelle de la donnée.