### PR TITLE
🐛 Correction du projector pour la ptf signée

### DIFF
--- a/packages/applications/projectors/src/subscribers/réseau/raccordement.projector.ts
+++ b/packages/applications/projectors/src/subscribers/réseau/raccordement.projector.ts
@@ -198,9 +198,6 @@ export const register = () => {
                   ...dossier,
                   propositionTechniqueEtFinancière: {
                     dateSignature: event.payload.dateSignature,
-                    propositionTechniqueEtFinancièreSignée: {
-                      format: '',
-                    },
                   },
                   misÀJourLe: event.created_at,
                 };

--- a/packages/domain/réseau/src/raccordement/transmettre/transmettrePropositionTechniqueEtFinancière.behavior.ts
+++ b/packages/domain/réseau/src/raccordement/transmettre/transmettrePropositionTechniqueEtFinancière.behavior.ts
@@ -8,7 +8,7 @@ import { DossierRaccordementNonRéférencéError } from '../dossierRaccordementN
 
 /**
  * @deprecated Utilisez PropositionTechniqueEtFinancièreTransmiseEvent à la place.
- * Cet event a été conserver pour la compatibilité avec le chargement des aggrégats et la fonctionnalité de rebuild des projections
+ * Cet event a été conservé pour la compatibilité avec le chargement des aggrégats et la fonctionnalité de rebuild des projections
  */
 export type PropositionTechniqueEtFinancièreTransmiseEventV1 = DomainEvent<
   'PropositionTechniqueEtFinancièreTransmise-V1',
@@ -21,7 +21,7 @@ export type PropositionTechniqueEtFinancièreTransmiseEventV1 = DomainEvent<
 
 /**
  * @deprecated Utilisez PropositionTechniqueEtFinancièreTransmiseEvent à la place.
- * Cet event a été conserver pour la compatibilité avec le chargement des aggrégats et la fonctionnalité de rebuild des projections
+ * Cet event a été conservé pour la compatibilité avec le chargement des aggrégats et la fonctionnalité de rebuild des projections
  */
 export type PropositionTechniqueEtFinancièreSignéeTransmiseEventV1 = DomainEvent<
   'PropositionTechniqueEtFinancièreSignéeTransmise-V1',


### PR DESCRIPTION
ne concerne que 2 dossiers de raccordement
les dossiers n'ont pas de fichier de PTF
L'alternative serait de publier un event V2 mais cette version nécessite un fichier