### PR TITLE
🐛 Fix nom du script npm appelé depuis attribuer-grd.sh

### DIFF
--- a/packages/applications/scheduled-tasks/attribuer-grd.sh
+++ b/packages/applications/scheduled-tasks/attribuer-grd.sh
@@ -14,6 +14,6 @@ fi
 
 echo "Launching job [ATTRIBUER GRD]"
 
-npm run start:start:attribuer-grd -w @potentiel-applications/scheduled-tasks
+npm run start:attribuer-grd -w @potentiel-applications/scheduled-tasks
 
 exit 0


### PR DESCRIPTION
# Description

Le script bash appelait `npm run start:start:attribuer-grd` au lieu de `npm run start:attribuer-grd`

## Type de changement
- [x] Correction de bug

# Comment cela a-t-il été testé?

Lancement du script bash en local : `ORE_ENDPOINT=XXXXXX EVENT_STORE_CONNECTION_STRING=XXXXX sh packages/applications/scheduled-tasks/attribuer-grd.sh`
