### PR TITLE
♻️ Proposition d'harmonisation d'un step commun pour given gf validée pour projet (avec défaut ou avec surcharge datatable)

### DIFF
--- a/packages/specifications/src/projet/lauréat/garantiesFinancières/effacerHistoriqueGarantiesFinancières.feature
+++ b/packages/specifications/src/projet/lauréat/garantiesFinancières/effacerHistoriqueGarantiesFinancières.feature
@@ -5,7 +5,7 @@ Fonctionnalité: Effacer tout l'historique de garanties financières d'un projet
         Etant donné le projet lauréat "Centrale PV"
 
     Scénario: Un admin supprime l'historique de garanties financières d'un projet
-        Etant donné des garanties financières validées pour le projet "Centrale PV" avec :
+        Etant donné des garanties financières validées pour le projet "Centrale PV"
             | type | six-mois-après-achèvement |
         Et des garanties financières à traiter pour le projet "Centrale PV" avec :
             | type | consignation |

--- a/packages/specifications/src/projet/lauréat/garantiesFinancières/enregistrerAttestationGarantiesFinancières.feature
+++ b/packages/specifications/src/projet/lauréat/garantiesFinancières/enregistrerAttestationGarantiesFinancières.feature
@@ -23,7 +23,7 @@ Fonctionnalité: Enregistrer l'attestation des garanties financières validées
             | soumis par           | porteur@test.test |
 
     Scénario: Impossible d'enregistrer l'attestation des garanties financières si l'attestation est déjà présente
-        Etant donné des garanties financières validées pour le projet "Centrale PV" avec :
+        Etant donné des garanties financières validées pour le projet "Centrale PV"
             | format               | application/pdf |
             | contenu fichier      | contenu fichier |
             | date de constitution | 2023-06-12      |

--- a/packages/specifications/src/projet/lauréat/garantiesFinancières/enregistrerGarantiesFinancières.feature
+++ b/packages/specifications/src/projet/lauréat/garantiesFinancières/enregistrerGarantiesFinancières.feature
@@ -79,7 +79,7 @@ Fonctionnalité: Enregistrer des garanties financières validées
         Alors l'utilisateur devrait être informé que "La date de constitution des garanties financières ne peut pas être une date future"
 
     Scénario: Impossible d'enregister des garanties financières validées s'il y a déjà des garanties financières validées
-        Etant donné des garanties financières validées pour le projet "Centrale PV" avec :
+        Etant donné des garanties financières validées pour le projet "Centrale PV"
             | type                 | type-inconnu      |
             | date d'échéance      |                   |
             | format               | application/pdf   |

--- a/packages/specifications/src/projet/lauréat/garantiesFinancières/modifierGarantiesFinancières.feature
+++ b/packages/specifications/src/projet/lauréat/garantiesFinancières/modifierGarantiesFinancières.feature
@@ -5,7 +5,7 @@ Fonctionnalité: Modifier des garanties financières validées
         Etant donné le projet lauréat "Centrale PV"
 
     Plan du Scénario: Un admin modifie des garanties financières validées
-        Etant donné des garanties financières validées pour le projet "Centrale PV" avec :
+        Etant donné des garanties financières validées pour le projet "Centrale PV"
             | type                 | type-inconnu      |
             | date d'échéance      |                   |
             | format               | application/pdf   |
@@ -37,7 +37,7 @@ Fonctionnalité: Modifier des garanties financières validées
             | six-mois-après-achèvement |                 |
 
     Plan du Scénario: Impossible de modifier des garanties financières validées si le type renseigné n'est pas compatible avec une date d'échéance
-        Etant donné des garanties financières validées pour le projet "Centrale PV" avec :
+        Etant donné des garanties financières validées pour le projet "Centrale PV"
             | type | type-inconnu |
         Quand un admin modifie les garanties financières validées pour le projet "Centrale PV" avec :
             | type            | <type>            |
@@ -50,7 +50,7 @@ Fonctionnalité: Modifier des garanties financières validées
             | six-mois-après-achèvement | 2027-12-01      |
 
     Scénario: Impossible de modifier des garanties financières validées si la date d'échéance est manquante
-        Etant donné des garanties financières validées pour le projet "Centrale PV" avec :
+        Etant donné des garanties financières validées pour le projet "Centrale PV"
             | type | type-inconnu |
         Quand un admin modifie les garanties financières validées pour le projet "Centrale PV" avec :
             | type            | avec-date-échéance |
@@ -58,7 +58,7 @@ Fonctionnalité: Modifier des garanties financières validées
         Alors l'utilisateur devrait être informé que "Vous devez renseigner la date d'échéance pour ce type de garanties financières"
 
     Scénario: Impossible de modifier des garanties financières validées si la date de constitution est dans le futur
-        Etant donné des garanties financières validées pour le projet "Centrale PV" avec :
+        Etant donné des garanties financières validées pour le projet "Centrale PV"
             | type | type-inconnu |
         Quand un admin modifie les garanties financières validées pour le projet "Centrale PV" avec :
             | date de constitution | 2050-01-01 |

--- a/packages/specifications/src/projet/lauréat/garantiesFinancières/stepDefinitions/garantiesFinancières.given.ts
+++ b/packages/specifications/src/projet/lauréat/garantiesFinancières/stepDefinitions/garantiesFinancières.given.ts
@@ -92,59 +92,17 @@ EtantDonné(
 );
 
 EtantDonné(
-  'des garanties financières validées pour le projet {string} avec :',
+  'des garanties financières validées pour le projet {string}',
   async function (this: PotentielWorld, nomProjet: string, dataTable: DataTable) {
     const exemple = dataTable.rowsHash();
 
-    const typeGarantiesFinancières = exemple['type'] || 'consignation';
-    const dateÉchéance = exemple[`date d'échéance`] || undefined;
-    const format = exemple['format'] || 'application/pdf';
-    const dateConstitution = exemple[`date de constitution`] || '2024-01-01';
-    const contenuFichier = exemple['contenu fichier'] || 'contenu fichier';
-    const dateSoumission = exemple['date de soumission'] || '2024-01-02';
-    const soumisPar = exemple['soumis par'] || 'user@test.test';
-    const validéLe = exemple['date validation'] || '2024-01-03';
-
-    const { identifiantProjet } = this.lauréatWorld.rechercherLauréatFixture(nomProjet);
-
-    await mediator.send<GarantiesFinancières.SoumettreDépôtGarantiesFinancièresUseCase>({
-      type: 'Lauréat.GarantiesFinancières.UseCase.SoumettreDépôtGarantiesFinancières',
-      data: {
-        identifiantProjetValue: identifiantProjet.formatter(),
-        typeValue: typeGarantiesFinancières,
-        dateConstitutionValue: new Date(dateConstitution).toISOString(),
-        soumisLeValue: new Date(dateSoumission).toISOString(),
-        soumisParValue: soumisPar,
-        attestationValue: { content: convertStringToReadableStream(contenuFichier), format },
-        ...(dateÉchéance && { dteÉchéanceValue: new Date(dateÉchéance).toISOString() }),
-      },
-    });
-
-    await sleep(100);
-
-    await mediator.send<GarantiesFinancières.ValiderDépôtGarantiesFinancièresEnCoursUseCase>({
-      type: 'Lauréat.GarantiesFinancières.UseCase.ValiderDépôtGarantiesFinancièresEnCours',
-      data: {
-        identifiantProjetValue: identifiantProjet.formatter(),
-        validéLeValue: new Date(validéLe).toISOString(),
-        validéParValue: 'dreal@test.test',
-      },
-    });
-
-    await sleep(100);
-  },
-);
-
-EtantDonné(
-  'des garanties financières validées pour le projet {string}',
-  async function (this: PotentielWorld, nomProjet: string) {
-    const typeGarantiesFinancières = 'consignation';
-    const format = 'application/pdf';
-    const dateConstitution = '2024-01-01';
-    const contenuFichier = 'contenu fichier';
-    const dateSoumission = '2024-01-02';
-    const soumisPar = 'user@test.test';
-    const validéLe = '2024-01-03';
+    const typeGarantiesFinancières = exemple['type'] ?? 'consignation';
+    const dateConstitution = exemple[`date de constitution`] ?? '2024-01-01';
+    const contenuFichier = exemple['contenu fichier'] ?? 'contenu fichier';
+    const dateSoumission = exemple['date de soumission'] ?? '2024-01-02';
+    const format = exemple['format'] ?? 'application/pdf';
+    const soumisPar = exemple['soumis par'] ?? 'porteur@test.test';
+    const validéLe = exemple['date validation'] ?? '2024-01-03';
 
     const { identifiantProjet } = this.lauréatWorld.rechercherLauréatFixture(nomProjet);
 

--- a/packages/specifications/src/projet/lauréat/mainLevéeGarantiesFinancières/accorderDemandeMainlevéeGarantiesFinancières.feature
+++ b/packages/specifications/src/projet/lauréat/mainLevéeGarantiesFinancières/accorderDemandeMainlevéeGarantiesFinancières.feature
@@ -48,6 +48,7 @@ Fonctionnalité: Accorder une demande de mainlevée des garanties financières
 
     Scénario: Impossible d'accorder une demande de mainlevée si le projet a déjà une demande de mainlevée accordée
         Etant donné des garanties financières validées pour le projet "Centrale PV"
+            |  |  |
         Et une attestation de conformité transmise pour le projet "Centrale PV"
         Et une demande de mainlevée de garanties financières accordée pour le projet "Centrale PV" achevé
         Quand un utilisateur Dreal accorde la demande de mainlevée des garanties financières du projet "Centrale PV"
@@ -55,6 +56,7 @@ Fonctionnalité: Accorder une demande de mainlevée des garanties financières
 
     Scénario: Impossible d'accorder une demande de mainlevée si le projet a déjà une demande de mainlevée rejetée et aucune en cours
         Etant donné des garanties financières validées pour le projet "Centrale PV"
+            |  |  |
         Et une attestation de conformité transmise pour le projet "Centrale PV"
         Et une demande de mainlevée de garanties financières rejetée pour le projet "Centrale PV" achevé
         Quand un utilisateur Dreal accorde la demande de mainlevée des garanties financières du projet "Centrale PV"

--- a/packages/specifications/src/projet/lauréat/mainLevéeGarantiesFinancières/demanderMainlevéeGarantiesFinancières.feature
+++ b/packages/specifications/src/projet/lauréat/mainLevéeGarantiesFinancières/demanderMainlevéeGarantiesFinancières.feature
@@ -34,12 +34,14 @@ Fonctionnalité: Demander la mainlevée des garanties financières d'un projet
 
     Scénario: Impossible de demander la mainlevée des garanties financières d'un projet si le projet n'est pas abandonné
         Etant donné des garanties financières validées pour le projet "Centrale PV"
+            |  |  |
         Quand le porteur demande la levée des garanties financières pour le projet "Centrale PV" avec :
             | motif | projet-abandonné |
         Alors le porteur devrait être informé que "Votre demande de mainlevée de garanties financières est invalide car le projet n'est pas en statut abandonné"
 
     Scénario: Impossible de demander la mainlevée des garanties financières d'un projet si le projet n'est pas achevé
         Etant donné des garanties financières validées pour le projet "Centrale PV"
+            |  |  |
         Quand le porteur demande la levée des garanties financières pour le projet "Centrale PV" avec :
             | motif | projet-achevé |
         Alors le porteur devrait être informé que "Votre demande de mainlevée de garanties financières est invalide car le projet n'est pas achevé (attestation de conformité non transmise au co-contractant et dans Potentiel)"
@@ -73,6 +75,7 @@ Fonctionnalité: Demander la mainlevée des garanties financières d'un projet
     Scénario: Impossible de demander la mainlevée des garanties financières d'un projet s'il y a des garanties financières à traiter pour le projet
         Etant donné une attestation de conformité transmise pour le projet "Centrale PV"
         Etant donné des garanties financières validées pour le projet "Centrale PV"
+            |  |  |
         Et des garanties financières à traiter pour le projet "Centrale PV"
         Quand le porteur demande la levée des garanties financières pour le projet "Centrale PV" avec :
             | motif | projet-achevé |
@@ -80,6 +83,7 @@ Fonctionnalité: Demander la mainlevée des garanties financières d'un projet
 
     Scénario: Impossible de demander la mainlevée des garanties financières d'un projet si le projet a déjà une demande de mainlevée
         Etant donné des garanties financières validées pour le projet "Centrale PV"
+            |  |  |
         Et une attestation de conformité transmise pour le projet "Centrale PV"
         Et une demande de mainlevée de garanties financières pour le projet "Centrale PV" avec :
             | motif | projet-achevé |
@@ -89,6 +93,7 @@ Fonctionnalité: Demander la mainlevée des garanties financières d'un projet
 
     Scénario: Impossible de demander la mainlevée des garanties financières d'un projet si le projet a déjà une demande de mainlevée en cours d'instruction
         Etant donné des garanties financières validées pour le projet "Centrale PV"
+            |  |  |
         Et une attestation de conformité transmise pour le projet "Centrale PV"
         Et une demande de mainlevée de garanties financières en instruction pour le projet "Centrale PV"
         Quand le porteur demande la levée des garanties financières pour le projet "Centrale PV" avec :
@@ -97,6 +102,7 @@ Fonctionnalité: Demander la mainlevée des garanties financières d'un projet
 
     Scénario: Impossible de demander la mainlevée des garanties financières d'un projet si le projet a déjà une demande de mainlevée accordée
         Etant donné des garanties financières validées pour le projet "Centrale PV"
+            |  |  |
         Et une attestation de conformité transmise pour le projet "Centrale PV"
         Et une demande de mainlevée de garanties financières accordée pour le projet "Centrale PV" achevé
         Quand le porteur demande la levée des garanties financières pour le projet "Centrale PV" avec :

--- a/packages/specifications/src/projet/lauréat/mainLevéeGarantiesFinancières/démarrerInstructionDemandeMainlevéeGarantiesFinancières.feature
+++ b/packages/specifications/src/projet/lauréat/mainLevéeGarantiesFinancières/démarrerInstructionDemandeMainlevéeGarantiesFinancières.feature
@@ -34,11 +34,13 @@ Fonctionnalité: Démarrer l'instruction d'une demande de mainlevée des garanti
 
     Scénario: Impossible de démarrer une instruction de demande de mainlevée si le projet n'a pas de demande de mainlevée
         Etant donné des garanties financières validées pour le projet "Centrale PV"
+            |  |  |
         Quand un utilisateur Dreal démarre l'instruction de la demande de mainlevée des garanties financières du projet "Centrale PV"
         Alors le porteur devrait être informé que "Il n'y a pas de demande de mainlevée de garanties financières en cours pour ce projet"
 
     Scénario: Impossible de démarrer une instruction de demande de mainlevée si le projet a déjà une demande de mainlevée en cours d'instruction
         Etant donné des garanties financières validées pour le projet "Centrale PV"
+            |  |  |
         Et une attestation de conformité transmise pour le projet "Centrale PV"
         Et une demande de mainlevée de garanties financières en instruction pour le projet "Centrale PV"
         Quand un utilisateur Dreal démarre l'instruction de la demande de mainlevée des garanties financières du projet "Centrale PV"
@@ -46,6 +48,7 @@ Fonctionnalité: Démarrer l'instruction d'une demande de mainlevée des garanti
 
     Scénario: Impossible de démarrer une instruction de demande de mainlevée si le projet a déjà une demande de mainlevée accordée
         Etant donné des garanties financières validées pour le projet "Centrale PV"
+            |  |  |
         Et une attestation de conformité transmise pour le projet "Centrale PV"
         Et une demande de mainlevée de garanties financières accordée pour le projet "Centrale PV" achevé
         Quand un utilisateur Dreal démarre l'instruction de la demande de mainlevée des garanties financières du projet "Centrale PV"
@@ -53,6 +56,7 @@ Fonctionnalité: Démarrer l'instruction d'une demande de mainlevée des garanti
 
     Scénario: Impossible de démarrer une instruction de demande de mainlevée si le projet a déjà une demande de mainlevée rejetée et aucune en cours
         Etant donné des garanties financières validées pour le projet "Centrale PV"
+            |  |  |
         Et une attestation de conformité transmise pour le projet "Centrale PV"
         Et une demande de mainlevée de garanties financières rejetée pour le projet "Centrale PV" achevé
         Quand un utilisateur Dreal démarre l'instruction de la demande de mainlevée des garanties financières du projet "Centrale PV" avec :

--- a/packages/specifications/src/projet/lauréat/mainLevéeGarantiesFinancières/rejeterDemandeMainlevéeGarantiesFinancières.feature
+++ b/packages/specifications/src/projet/lauréat/mainLevéeGarantiesFinancières/rejeterDemandeMainlevéeGarantiesFinancières.feature
@@ -56,6 +56,7 @@ Fonctionnalité: Rejeter une demande de mainlevée des garanties financières
 
     Scénario: Impossible de rejeter une demande de mainelevée si le projet a déjà une demande de mainlevée accordée
         Etant donné des garanties financières validées pour le projet "Centrale PV"
+            |  |  |
         Et une attestation de conformité transmise pour le projet "Centrale PV"
         Et une demande de mainlevée de garanties financières accordée pour le projet "Centrale PV" achevé
         Quand un utilisateur Dreal rejette une demande de mainlevée des garanties financières du projet "Centrale PV"
@@ -63,6 +64,7 @@ Fonctionnalité: Rejeter une demande de mainlevée des garanties financières
 
     Scénario: Impossible de rejeter une demande de mainelevée si le projet a déjà une demande de mainlevée rejetée et aucune en cours
         Etant donné des garanties financières validées pour le projet "Centrale PV"
+            |  |  |
         Et une attestation de conformité transmise pour le projet "Centrale PV"
         Et une demande de mainlevée de garanties financières rejetée pour le projet "Centrale PV" achevé
         Quand un utilisateur Dreal rejette une demande de mainlevée des garanties financières du projet "Centrale PV"


### PR DESCRIPTION
# Description

On duplique souvent les steps pour avoir des steps "default" et d'autres avec des databale pour passer des valeurs à la volée.

J'ai regardé et fais plusieurs tests mais il est impossible de passer datatable en optionnel.

Je propose donc de rendre obligatoire l'utilisation d'un datable. Si on veut utiliser des valeurs par défaut, il suffit d'ajouter un datatable vide : 

Exemple : 

```
        Etant donné des garanties financières validées pour le projet "Centrale PV"
            |  |  |
```