### PR TITLE
🐛 Fix detail abandon

### DIFF
--- a/packages/applications/ssr/src/components/pages/abandon/détails/DétailsAbandon.page.tsx
+++ b/packages/applications/ssr/src/components/pages/abandon/détails/DétailsAbandon.page.tsx
@@ -85,7 +85,7 @@ type MapToActionsComponentsProps = {
 
 const mapToActionComponents = ({ actions, identifiantProjet }: MapToActionsComponentsProps) => {
   return actions.length ? (
-    <div className="flex flex-col items-center">
+    <div className="flex flex-col items-center gap-4">
       {actions.includes('demander-confirmation') && (
         <DemanderConfirmationAbandon identifiantProjet={identifiantProjet} />
       )}


### PR DESCRIPTION
# Description

Oublie `gap` entre les boutons

## Type de changement

<img width="1011" alt="Capture d’écran 2024-07-18 à 14 08 13" src="https://github.com/user-attachments/assets/ee04b02b-b6e2-4ef2-858f-923d00257ddb">
