### PR TITLE
✅ Planifier / Annuler des tâches programmés liées aux gfs manquants

### DIFF
--- a/packages/applications/bootstrap/src/setupTâchePlanifiée.ts
+++ b/packages/applications/bootstrap/src/setupTâchePlanifiée.ts
@@ -59,6 +59,7 @@ async function registerTâchePlanifiéeGarantiesFinancièresSaga() {
       'GarantiesFinancièresModifiées-V1',
       'GarantiesFinancièresEnregistrées-V1',
       'DépôtGarantiesFinancièresEnCoursValidé-V2',
+      'TypeGarantiesFinancièresImporté-V1',
     ],
     eventHandler: async (event) => {
       await mediator.publish<TâchePlanifiéeGarantiesFinancièresSaga.Execute>({

--- a/packages/applications/bootstrap/src/setupTâchePlanifiée.ts
+++ b/packages/applications/bootstrap/src/setupTâchePlanifiée.ts
@@ -50,12 +50,16 @@ const registerTâchePlanifiéeProjector = async () => {
 
 async function registerTâchePlanifiéeGarantiesFinancièresSaga() {
   TâchePlanifiéeGarantiesFinancièresSaga.register();
-  const unsubscribeTâcheAbandonSaga = await subscribe<
+  const unsubscribeTâchePlanifiéeGarantiesFinancièresSaga = await subscribe<
     TâchePlanifiéeGarantiesFinancièresSaga.SubscriptionEvent & Event
   >({
     name: 'tache-planifiee-saga',
     streamCategory: 'garanties-financieres',
-    eventType: ['GarantiesFinancièresModifiées-V1', 'DépôtGarantiesFinancièresEnCoursValidé-V2'],
+    eventType: [
+      'GarantiesFinancièresModifiées-V1',
+      'GarantiesFinancièresEnregistrées-V1',
+      'DépôtGarantiesFinancièresEnCoursValidé-V2',
+    ],
     eventHandler: async (event) => {
       await mediator.publish<TâchePlanifiéeGarantiesFinancièresSaga.Execute>({
         type: 'System.Saga.TâchePlanifiéeGarantiesFinancières',
@@ -63,12 +67,12 @@ async function registerTâchePlanifiéeGarantiesFinancièresSaga() {
       });
     },
   });
-  return unsubscribeTâcheAbandonSaga;
+  return unsubscribeTâchePlanifiéeGarantiesFinancièresSaga;
 }
 
 async function registerTâchePlanifiéeAchévementSaga() {
   TâchePlanifiéeAchévementSaga.register();
-  const unsubscribeTâcheAbandonSaga = await subscribe<
+  const unsubscribeTâchePlanifiéeAchèvementSaga = await subscribe<
     TâchePlanifiéeAchévementSaga.SubscriptionEvent & Event
   >({
     name: 'tache-planifiee-saga',
@@ -81,5 +85,5 @@ async function registerTâchePlanifiéeAchévementSaga() {
       });
     },
   });
-  return unsubscribeTâcheAbandonSaga;
+  return unsubscribeTâchePlanifiéeAchèvementSaga;
 }

--- a/packages/domain/tâche-planifiée/src/saga/tâchePlanifiéeGarantiesFinancières.saga.ts
+++ b/packages/domain/tâche-planifiée/src/saga/tâchePlanifiéeGarantiesFinancières.saga.ts
@@ -8,7 +8,8 @@ import { AjouterTâchePlanifiéeCommand } from '../ajouter/ajouterTâchePlanifi�
 
 export type SubscriptionEvent =
   | GarantiesFinancières.DépôtGarantiesFinancièresEnCoursValidéEvent
-  | GarantiesFinancières.GarantiesFinancièresModifiéesEvent;
+  | GarantiesFinancières.GarantiesFinancièresModifiéesEvent
+  | GarantiesFinancières.GarantiesFinancièresEnregistréesEvent;
 
 export type Execute = Message<'System.Saga.TâchePlanifiéeGarantiesFinancières', SubscriptionEvent>;
 
@@ -20,6 +21,7 @@ export const register = () => {
     switch (event.type) {
       case 'DépôtGarantiesFinancièresEnCoursValidé-V2':
       case 'GarantiesFinancièresModifiées-V1':
+      case 'GarantiesFinancièresEnregistrées-V1':
         if (event.payload.type === 'avec-date-échéance' && event.payload.dateÉchéance) {
           await mediator.send<AjouterTâchePlanifiéeCommand>({
             type: 'System.TâchePlanifiée.Command.AjouterTâchePlanifiée',

--- a/packages/domain/tâche-planifiée/src/saga/tâchePlanifiéeGarantiesFinancières.saga.ts
+++ b/packages/domain/tâche-planifiée/src/saga/tâchePlanifiéeGarantiesFinancières.saga.ts
@@ -9,7 +9,8 @@ import { AjouterTâchePlanifiéeCommand } from '../ajouter/ajouterTâchePlanifi�
 export type SubscriptionEvent =
   | GarantiesFinancières.DépôtGarantiesFinancièresEnCoursValidéEvent
   | GarantiesFinancières.GarantiesFinancièresModifiéesEvent
-  | GarantiesFinancières.GarantiesFinancièresEnregistréesEvent;
+  | GarantiesFinancières.GarantiesFinancièresEnregistréesEvent
+  | GarantiesFinancières.TypeGarantiesFinancièresImportéEvent;
 
 export type Execute = Message<'System.Saga.TâchePlanifiéeGarantiesFinancières', SubscriptionEvent>;
 
@@ -22,6 +23,7 @@ export const register = () => {
       case 'DépôtGarantiesFinancièresEnCoursValidé-V2':
       case 'GarantiesFinancièresModifiées-V1':
       case 'GarantiesFinancièresEnregistrées-V1':
+      case 'TypeGarantiesFinancièresImporté-V1':
         if (event.payload.type === 'avec-date-échéance' && event.payload.dateÉchéance) {
           await mediator.send<AjouterTâchePlanifiéeCommand>({
             type: 'System.TâchePlanifiée.Command.AjouterTâchePlanifiée',

--- a/packages/specifications/src/projet/lauréat/garantiesFinancières/importerTypeGarantiesFinancières.feature
+++ b/packages/specifications/src/projet/lauréat/garantiesFinancières/importerTypeGarantiesFinancières.feature
@@ -5,7 +5,7 @@ Fonctionnalité: Importer le type (et la date d'échéance selon le cas) des gar
         Etant donné le projet lauréat "Centrale PV"
 
     Plan du Scénario: Un admin importe le type des garanties financières d'un projet
-        Quand l'admin importe le type des garanties financières pour le projet "Centrale PV" avec :
+        Quand un admin importe le type des garanties financières pour le projet "Centrale PV" avec :
             | type            | <type>            |
             | date d'échéance | <date d'échéance> |
             | date d'import   | <date import>     |
@@ -21,13 +21,13 @@ Fonctionnalité: Importer le type (et la date d'échéance selon le cas) des gar
             | six-mois-après-achèvement |                 | 2024-01-01  |
 
     Scénario: Impossible d'importer le type (et la date d'échéance selon le cas) des garanties financières d'un projet si date d'échéance manquante
-        Quand l'admin importe le type des garanties financières pour le projet "Centrale PV" avec :
+        Quand un admin importe le type des garanties financières pour le projet "Centrale PV" avec :
             | type            | avec-date-échéance |
             | date d'échéance |                    |
         Alors l'utilisateur devrait être informé que "Vous devez renseigner la date d'échéance pour ce type de garanties financières"
 
     Plan du Scénario: Impossible d'importer le type (et la date d'échéance selon le cas) des garanties financières d'un projet si date d'échéance non compatible avec le type
-        Quand l'admin importe le type des garanties financières pour le projet "Centrale PV" avec :
+        Quand un admin importe le type des garanties financières pour le projet "Centrale PV" avec :
             | type            | <type>     |
             | date d'échéance | 2028-01-01 |
         Alors l'utilisateur devrait être informé que "Vous ne pouvez pas renseigner de date d'échéance pour ce type de garanties financières"

--- a/packages/specifications/src/projet/lauréat/garantiesFinancières/soumettreGarantiesFinancières.feature
+++ b/packages/specifications/src/projet/lauréat/garantiesFinancières/soumettreGarantiesFinancières.feature
@@ -9,7 +9,7 @@ Fonctionnalité: Soumettre de nouvelles garanties financières
             | date limite de soumission | 2023-11-01    |
             | date de notification      | 2023-09-01    |
             | motif                     | motif-inconnu |
-        Quand le porteur soumet des garanties financières pour le projet "Centrale PV" avec :
+        Quand un porteur soumet des garanties financières pour le projet "Centrale PV" avec :
             | type                 | <type>                 |
             | date d'échéance      | <date d'échéance>      |
             | format               | <format du fichier>    |
@@ -35,18 +35,18 @@ Fonctionnalité: Soumettre de nouvelles garanties financières
             | six-mois-après-achèvement |                 | application/pdf   | le contenu du fichier | 2023-06-01           | 2023-10-01         |
 
     Scénario: Impossible de soumettre de nouvelles garanties financières si date de constitution dans le futur
-        Quand le porteur soumet des garanties financières pour le projet "Centrale PV" avec :
+        Quand un porteur soumet des garanties financières pour le projet "Centrale PV" avec :
             | date de constitution | 2055-01-01 |
         Alors l'utilisateur devrait être informé que "La date de constitution des garanties financières ne peut pas être une date future"
 
     Scénario: Impossible de soumettre de nouvelles garanties financières si date d'échéance manquante
-        Quand le porteur soumet des garanties financières pour le projet "Centrale PV" avec :
+        Quand un porteur soumet des garanties financières pour le projet "Centrale PV" avec :
             | type         | avec-date-échéance |
             | dateÉchéance |                    |
         Alors l'utilisateur devrait être informé que "Vous devez renseigner la date d'échéance pour ce type de garanties financières"
 
     Plan du Scénario: Impossible de soumettre de nouvelles garanties financières si date d'échéance non compatible avec le type
-        Quand le porteur soumet des garanties financières pour le projet "Centrale PV" avec :
+        Quand un porteur soumet des garanties financières pour le projet "Centrale PV" avec :
             | type            | <type>     |
             | date d'échéance | 2028-01-01 |
         Alors l'utilisateur devrait être informé que "Vous ne pouvez pas renseigner de date d'échéance pour ce type de garanties financières"
@@ -60,7 +60,7 @@ Fonctionnalité: Soumettre de nouvelles garanties financières
         Etant donné des garanties financières à traiter pour le projet "Centrale PV" avec :
             | type            | avec-date-échéance |
             | date d'échéance | 2027-12-01         |
-        Quand le porteur soumet des garanties financières pour le projet "Centrale PV" avec :
+        Quand un porteur soumet des garanties financières pour le projet "Centrale PV" avec :
             | type | consignation |
         Alors l'utilisateur devrait être informé que "Il y a déjà des garanties financières en attente de validation pour ce projet"
 
@@ -69,7 +69,7 @@ Fonctionnalité: Soumettre de nouvelles garanties financières
         Et des garanties financières validées pour le projet "Centrale PV"
         Et une demande de mainlevée de garanties financières pour le projet "Centrale PV" avec :
             | motif | projet-achevé |
-        Quand le porteur soumet des garanties financières pour le projet "Centrale PV" avec :
+        Quand un porteur soumet des garanties financières pour le projet "Centrale PV" avec :
             | type | consignation |
         Alors l'utilisateur devrait être informé que "Vous ne pouvez pas déposer de nouvelles garanties financières car vous avez une demande de mainlevée de garanties financières en cours"
 
@@ -77,7 +77,7 @@ Fonctionnalité: Soumettre de nouvelles garanties financières
         Etant donné une attestation de conformité transmise pour le projet "Centrale PV"
         Et des garanties financières validées pour le projet "Centrale PV"
         Et une demande de mainlevée de garanties financières en instruction pour le projet "Centrale PV"
-        Quand le porteur soumet des garanties financières pour le projet "Centrale PV" avec :
+        Quand un porteur soumet des garanties financières pour le projet "Centrale PV" avec :
             | type | consignation |
         Alors l'utilisateur devrait être informé que "Vous ne pouvez pas déposer de nouvelles garanties financières car vous avez une mainlevée de garanties financières en cours d'instruction"
 
@@ -85,6 +85,6 @@ Fonctionnalité: Soumettre de nouvelles garanties financières
         Etant donné une attestation de conformité transmise pour le projet "Centrale PV"
         Et des garanties financières validées pour le projet "Centrale PV"
         Et une demande de mainlevée de garanties financières accordée pour le projet "Centrale PV" achevé
-        Quand le porteur soumet des garanties financières pour le projet "Centrale PV" avec :
+        Quand un porteur soumet des garanties financières pour le projet "Centrale PV" avec :
             | type | consignation |
         Alors l'utilisateur devrait être informé que "Vous ne pouvez pas déposer ou modifier des garanties financières car elles ont déjà été levées pour ce projet"

--- a/packages/specifications/src/projet/lauréat/garantiesFinancières/stepDefinitions/garantiesFinancières.when.ts
+++ b/packages/specifications/src/projet/lauréat/garantiesFinancières/stepDefinitions/garantiesFinancières.when.ts
@@ -122,7 +122,7 @@ Quand(
 );
 
 Quand(
-  `l'admin importe le type des garanties financières pour le projet {string} avec :`,
+  `un admin importe le type des garanties financières pour le projet {string} avec :`,
   async function (this: PotentielWorld, nomProjet: string, dataTable: DataTable) {
     const exemple = dataTable.rowsHash();
 

--- a/packages/specifications/src/projet/lauréat/garantiesFinancières/stepDefinitions/garantiesFinancières.when.ts
+++ b/packages/specifications/src/projet/lauréat/garantiesFinancières/stepDefinitions/garantiesFinancières.when.ts
@@ -8,7 +8,7 @@ import { sleep } from '../../../../helpers/sleep';
 import { convertStringToReadableStream } from '../../../../helpers/convertStringToReadable';
 
 Quand(
-  'le porteur soumet des garanties financières pour le projet {string} avec :',
+  'un porteur soumet des garanties financières pour le projet {string} avec :',
   async function (this: PotentielWorld, nomProjet: string, dataTable: DataTable) {
     const exemple = dataTable.rowsHash();
 

--- a/packages/specifications/src/tâche-planifiée/ajouterTâchePlanifiée.feature
+++ b/packages/specifications/src/tâche-planifiée/ajouterTâchePlanifiée.feature
@@ -32,3 +32,10 @@ Fonctionnalité: Planifier une tâche
             | date d'échéance  | 2024-12-02         |
             | date mise à jour | 2024-11-02         |
         Alors une tâche "échoir les garanties financières" est planifiée à la date du "2024-12-03" pour le projet "Du boulodrome de Marseille"
+
+    Scénario: Une tâche est planifiée quand l'administration importe le type d'une garanties financières pour un projet
+        Quand un admin importe le type des garanties financières pour le projet "Centrale PV" avec :
+            | type            | <type>            |
+            | date d'échéance | <date d'échéance> |
+            | date d'import   | <date import>     |
+        Alors une tâche "échoir les garanties financières" est planifiée à la date du "2024-12-03" pour le projet "Du boulodrome de Marseille"

--- a/packages/specifications/src/tâche-planifiée/ajouterTâchePlanifiée.feature
+++ b/packages/specifications/src/tâche-planifiée/ajouterTâchePlanifiée.feature
@@ -25,3 +25,10 @@ Fonctionnalité: Planifier une tâche
             | type            | avec-date-échéance |
             | date d'échéance | 2024-12-02         |
         Alors une tâche "échoir les garanties financières" est planifiée à la date du "2024-12-03" pour le projet "Du boulodrome de Marseille"
+
+    Scénario: Une tâche est planifiée quand des garanties financières sont enregisrées par l'administration
+        Quand un admin enregistre les garanties financières validées pour le projet "Du boulodrome de Marseille" avec :
+            | type             | avec-date-échéance |
+            | date d'échéance  | 2024-12-02         |
+            | date mise à jour | 2024-11-02         |
+        Alors une tâche "échoir les garanties financières" est planifiée à la date du "2024-12-03" pour le projet "Du boulodrome de Marseille"

--- a/packages/specifications/src/tâche-planifiée/ajouterTâchePlanifiée.feature
+++ b/packages/specifications/src/tâche-planifiée/ajouterTâchePlanifiée.feature
@@ -34,8 +34,7 @@ Fonctionnalité: Planifier une tâche
         Alors une tâche "échoir les garanties financières" est planifiée à la date du "2024-12-03" pour le projet "Du boulodrome de Marseille"
 
     Scénario: Une tâche est planifiée quand l'administration importe le type d'une garanties financières pour un projet
-        Quand un admin importe le type des garanties financières pour le projet "Centrale PV" avec :
-            | type            | <type>            |
-            | date d'échéance | <date d'échéance> |
-            | date d'import   | <date import>     |
+        Quand un admin importe le type des garanties financières pour le projet "Du boulodrome de Marseille" avec :
+            | type            | avec-date-échéance |
+            | date d'échéance | 2024-12-02         |
         Alors une tâche "échoir les garanties financières" est planifiée à la date du "2024-12-03" pour le projet "Du boulodrome de Marseille"

--- a/packages/specifications/src/tâche-planifiée/annulerTâchePlanifiée.feature
+++ b/packages/specifications/src/tâche-planifiée/annulerTâchePlanifiée.feature
@@ -8,8 +8,7 @@ Fonctionnalité: Annuler une tâche planifiée
             | nom   | Porteur Projet Test |
             | role  | porteur-projet      |
 
-    @select
-    Scénario: Une tâche est annulée quand une attestation de confirmité est transimise
+    Scénario: Une tâche est annulée quand une attestation de conformité est transmise
         Etant donné des garanties financières validées pour le projet "Du boulodrome de Marseille" avec :
             | type               | avec-date-échéance |
             | date d'échéance    | 2024-12-01         |

--- a/packages/specifications/src/tâche/acheverTâche.feature
+++ b/packages/specifications/src/tâche/acheverTâche.feature
@@ -25,7 +25,7 @@ Fonctionnalité: Achever une tâche
             | date limite de soumission | 2023-11-01    |
             | date de notification      | 2023-09-01    |
             | motif                     | motif-inconnu |
-        Quand le porteur soumet des garanties financières pour le projet "Du boulodrome de Marseille" avec :
+        Quand un porteur soumet des garanties financières pour le projet "Du boulodrome de Marseille" avec :
             | type                 | consignation          |
             | format               | application/pdf       |
             | contenu fichier      | le contenu du fichier |


### PR DESCRIPTION
# Description

- Une tâche est planifiée quand des garanties financières sont enregistrées par l'administration
- Une tâche est planifiée quand l'administration importe le type d'une garanties financières pour un projet
- Une tâche planifiée est annulée lorsqu'un dépôt de garanties financières est soumis


## Type de changement

Veuillez supprimer les options qui ne sont pas pertinentes.

- [x] Nouvelle fonctionnalité

# Comment cela a-t-il été testé?

TDD
