### PR TITLE
🔊 Ajout d'un nom de service et fix sur les metadata

### DIFF
--- a/packages/infrastructure/ore-client/src/helper/matchOutreMerAndCorseCodePostalToGRD.test.ts
+++ b/packages/infrastructure/ore-client/src/helper/matchOutreMerAndCorseCodePostalToGRD.test.ts
@@ -22,9 +22,9 @@ describe(matchOutreMerAndCorseCodePostalToGRD.name, () => {
     for (const [input, expected] of codePostauxAndExpected) {
       test(`${input} should be matched to raison sociale ${expected}`, () => {
         expect(
-          Option.match(matchOutreMerAndCorseCodePostalToGRD(input)).some(
-            (gestionnaire) => gestionnaire.raisonSociale,
-          ),
+          Option.match(matchOutreMerAndCorseCodePostalToGRD(input))
+            .some((gestionnaire) => gestionnaire.raisonSociale)
+            .none(() => ''),
         ).to.eq(expected);
       });
     }

--- a/packages/libraries/monitoring/package.json
+++ b/packages/libraries/monitoring/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "scripts": {
     "build": "tsc",
-    "test": "tsx --test src/**/*.spec.ts"
+    "test": "tsx --test ./**/*.spec.ts"
   },
   "dependencies": {
     "@sentry/node": "^7.112.2",

--- a/packages/libraries/monitoring/package.json
+++ b/packages/libraries/monitoring/package.json
@@ -6,7 +6,8 @@
   "types": "dist/index.d.ts",
   "private": true,
   "scripts": {
-    "build": "tsc"
+    "build": "tsc",
+    "test": "tsx --test src/**/*.spec.ts"
   },
   "dependencies": {
     "@sentry/node": "^7.112.2",

--- a/packages/libraries/monitoring/src/logger.spec.ts
+++ b/packages/libraries/monitoring/src/logger.spec.ts
@@ -1,18 +1,19 @@
-import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { afterEach, beforeEach, describe, it, mock } from 'node:test';
 
-import { getLogger, levels, resetLogger } from './logger';
+import { expect } from 'chai';
+
+import { getLogger, resetLogger, levels } from './logger';
 
 describe('winston-logger', () => {
+  const logMock = mock.fn();
   beforeEach(() => {
     resetLogger();
-    global.console = {
-      log: jest.spyOn(console, 'log').mockImplementation(jest.fn()),
-    } as any;
+    global.console = { log: logMock } as any;
     process.env.LOGGER_LEVEL = undefined;
   });
 
   afterEach(() => {
-    (global.console.log as jest.Mock).mockClear();
+    logMock.mock.resetCalls();
   });
   // Test all cases for non error logs
   for (const level of levels) {
@@ -34,7 +35,7 @@ describe('winston-logger', () => {
       (logger as any)[level](message, meta);
 
       // Assert
-      expect(global.console.log as any).toHaveBeenCalledTimes(1);
+      expect(logMock.mock.callCount()).to.eq(1);
     });
 
     for (const otherLevel of levels.filter((l) => l !== level)) {
@@ -58,7 +59,7 @@ describe('winston-logger', () => {
         (logger as any)[otherLevel](message, meta);
 
         // Assert
-        expect(global.console.log as any).toHaveBeenCalledTimes(
+        expect(logMock.mock.callCount()).to.eq(
           levels.indexOf(otherLevel) <= levels.indexOf(level) ? 1 : 0,
         );
       });

--- a/packages/libraries/monitoring/src/logger.spec.ts
+++ b/packages/libraries/monitoring/src/logger.spec.ts
@@ -26,6 +26,7 @@ describe('winston-logger', () => {
       const message = level === 'error' ? new Error('an error') : 'a message';
       const meta = {
         test: 'a test meta',
+        deep: { foo: 'bar' },
       };
       process.env.LOGGER_LEVEL = level;
       process.env.APPLICATION_NAME = applicationName;
@@ -36,6 +37,9 @@ describe('winston-logger', () => {
 
       // Assert
       expect(logMock.mock.callCount()).to.eq(1);
+      expect(logMock.mock.calls[0].arguments[0]).to.contain(
+        `${level === 'error' ? 'an error' : 'a message'} | Service(an application name) | Metadata({test="a test meta"} {deep={"foo":"bar"}})`,
+      );
     });
 
     for (const otherLevel of levels.filter((l) => l !== level)) {

--- a/packages/libraries/monitoring/src/logger.ts
+++ b/packages/libraries/monitoring/src/logger.ts
@@ -14,7 +14,7 @@ export type Logger = {
   error(error: Error, meta?: Record<string, unknown>): void;
 };
 
-type GetLogger = () => Logger;
+type GetLogger = (serviceName?: string) => Logger;
 
 const getLevel = (): Level => {
   const level = process.env.LOGGER_LEVEL;
@@ -41,19 +41,19 @@ let logger: Logger | undefined;
  */
 const customFormat = winston.format((info) => {
   const meta = Object.keys(info.meta)
-    .map((k) => `{${k}=${info.meta[k]}}`)
+    .map((k) => `{${k}=${JSON.stringify(info.meta[k])}}`)
     .join(' ');
   info.message = `${info.message} | Service(${info.service}) | Metadata(${meta})`;
   return info;
 });
 
-export const getLogger: GetLogger = (): Logger => {
+export const getLogger: GetLogger = (serviceName?: string): Logger => {
   if (!logger) {
     const winstonLogger = winston.createLogger({
       format: winston.format.combine(customFormat(), winston.format.cli()),
       transports: [new winston.transports.Console()],
       defaultMeta: {
-        service: getApplicationName() || 'unknown',
+        service: getApplicationName() || serviceName || 'unknown',
       },
       level: getLevel(),
     });


### PR DESCRIPTION
- résolution du problème d'affichage des objets
- ajout d'un paramètre optionnel `serviceName` afin de clarifier où le code est exécuté