### PR TITLE
🐛 Recadrer les droits de modifications d'une DCR en fonction de si le dossier de raccordement a une date de mise en service

### DIFF
--- a/packages/applications/ssr/src/components/pages/réseau/raccordement/modifier/modifierDemandeComplèteRaccordement/ModifierDemandeComplèteRaccordement.form.tsx
+++ b/packages/applications/ssr/src/components/pages/réseau/raccordement/modifier/modifierDemandeComplèteRaccordement/ModifierDemandeComplèteRaccordement.form.tsx
@@ -18,12 +18,15 @@ import { modifierDemandeComplèteRaccordementAction } from './modifierDemandeCom
 export type ModifierDemandeComplèteRaccordementFormProps = {
   identifiantProjet: string;
   raccordement: {
-    référence: string;
+    référence: {
+      value: string;
+      canEdit: boolean;
+    };
     demandeComplèteRaccordement: {
+      canEdit: boolean;
       dateQualification?: Iso8601DateTime;
       accuséRéception?: string;
     };
-    canEditRéférence: boolean;
   };
   gestionnaireRéseauActuel: {
     identifiantGestionnaireRéseau: string;
@@ -44,7 +47,6 @@ export const ModifierDemandeComplèteRaccordementForm: FC<
   raccordement: {
     référence,
     demandeComplèteRaccordement: { accuséRéception, dateQualification },
-    canEditRéférence,
   },
 }) => {
   const router = useRouter();
@@ -64,7 +66,7 @@ export const ModifierDemandeComplèteRaccordementForm: FC<
       onValidationError={(validationErrors) => setValidationErrors(validationErrors)}
     >
       <input name="identifiantProjet" type="hidden" value={identifiantProjet} />
-      <input name="referenceDossierRaccordementActuelle" type="hidden" value={référence} />
+      <input name="referenceDossierRaccordementActuelle" type="hidden" value={référence.value} />
       <input
         name="identifiantGestionnaireReseau"
         type="hidden"
@@ -79,7 +81,7 @@ export const ModifierDemandeComplèteRaccordementForm: FC<
         </strong>
       </div>
 
-      {canEditRéférence ? (
+      {référence.canEdit ? (
         <Input
           id="referenceDossierRaccordement"
           label="Référence du dossier de raccordement du projet *"
@@ -107,15 +109,15 @@ export const ModifierDemandeComplèteRaccordementForm: FC<
               ? `Exemple: ${aideSaisieRéférenceDossierRaccordement?.format}`
               : `Renseigner l'identifiant`,
             required: true,
-            defaultValue: référence ?? '',
+            defaultValue: référence.value ?? '',
             pattern: aideSaisieRéférenceDossierRaccordement?.expressionReguliere || undefined,
           }}
         />
       ) : (
         <>
-          <input name="referenceDossierRaccordement" type="hidden" value={référence} />
+          <input name="referenceDossierRaccordement" type="hidden" value={référence.value} />
           <div>
-            Référence du dossier de raccordement du projet : <strong>{référence}</strong>
+            Référence du dossier de raccordement du projet : <strong>{référence.value}</strong>
           </div>
         </>
       )}

--- a/packages/applications/ssr/src/components/pages/réseau/raccordement/modifier/modifierDemandeComplèteRaccordement/ModifierDemandeComplèteRaccordement.stories.tsx
+++ b/packages/applications/ssr/src/components/pages/réseau/raccordement/modifier/modifierDemandeComplèteRaccordement/ModifierDemandeComplèteRaccordement.stories.tsx
@@ -32,9 +32,12 @@ export const Default: Story = {
       raisonSociale: 'Raison sociale',
     },
     raccordement: {
-      référence: 'référence#1',
-      canEditRéférence: true,
+      référence: {
+        value: 'référence#1',
+        canEdit: true,
+      },
       demandeComplèteRaccordement: {
+        canEdit: true,
         accuséRéception: 'référence#1/accuséRéception',
         dateQualification: new Date('2024-01-18').toISOString() as Iso8601DateTime,
       },

--- a/packages/applications/ssr/src/components/pages/réseau/raccordement/modifier/modifierDemandeComplèteRaccordement/modifierDemandeComplèteRaccordement.action.ts
+++ b/packages/applications/ssr/src/components/pages/réseau/raccordement/modifier/modifierDemandeComplèteRaccordement/modifierDemandeComplèteRaccordement.action.ts
@@ -52,6 +52,7 @@ const action: FormAction<FormState, typeof schema> = async (
         accuséRéceptionValue: accuseReception,
         dateQualificationValue: new Date(dateQualification).toISOString(),
         référenceDossierRaccordementValue: referenceDossierRaccordement,
+        rôleValue: utilisateur.role.nom,
       },
     });
 

--- a/packages/domain/réseau/src/raccordement/modifier/modifierDemandeComplèteRaccordement.behavior.ts
+++ b/packages/domain/réseau/src/raccordement/modifier/modifierDemandeComplèteRaccordement.behavior.ts
@@ -144,7 +144,7 @@ export function applyDemandeComplèteRaccordementModifiéeEventV3(
 class DemandeComplèteRaccordementNonModifiableCarDossierAvecDateDeMiseEnServiceError extends InvalidOperationError {
   constructor(référenceDossier: string) {
     super(
-      `La demande complète de raccordement du dossier ${référenceDossier} ne peut pas être modifiée celui-ci dispose déjà d'une date de mise en service`,
+      `La demande complète de raccordement du dossier ${référenceDossier} ne peut pas être modifiée car celui-ci dispose déjà d'une date de mise en service`,
     );
   }
 }

--- a/packages/domain/réseau/src/raccordement/modifier/modifierDemandeComplèteRaccordement.command.ts
+++ b/packages/domain/réseau/src/raccordement/modifier/modifierDemandeComplèteRaccordement.command.ts
@@ -2,6 +2,7 @@ import { Message, MessageHandler, mediator } from 'mediateur';
 
 import { DateTime, IdentifiantProjet } from '@potentiel-domain/common';
 import { LoadAggregate } from '@potentiel-domain/core';
+import { Role } from '@potentiel-domain/utilisateur';
 
 import * as RéférenceDossierRaccordement from '../référenceDossierRaccordement.valueType';
 import { loadRaccordementAggregateFactory } from '../raccordement.aggregate';
@@ -16,6 +17,7 @@ export type ModifierDemandeComplèteRaccordementCommand = Message<
     dateQualification: DateTime.ValueType;
     référenceDossierRaccordement: RéférenceDossierRaccordement.ValueType;
     formatAccuséRéception: string;
+    rôle: Role.ValueType;
   }
 >;
 
@@ -31,6 +33,7 @@ export const registerModifierDemandeComplèteRaccordementCommand = (
     dateQualification,
     référenceDossierRaccordement,
     formatAccuséRéception,
+    rôle,
   }) => {
     const raccordement = await loadRaccordement(identifiantProjet);
     const gestionnaireRéseau = await loadGestionnaireRéseau(identifiantGestionnaireRéseau, true);
@@ -42,6 +45,7 @@ export const registerModifierDemandeComplèteRaccordementCommand = (
       formatAccuséRéception,
       référenceDossierExpressionRegulière:
         gestionnaireRéseau.référenceDossierRaccordementExpressionRegulière,
+      rôle,
     });
   };
 

--- a/packages/domain/réseau/src/raccordement/modifier/modifierDemandeComplèteRaccordement.usecase.ts
+++ b/packages/domain/réseau/src/raccordement/modifier/modifierDemandeComplèteRaccordement.usecase.ts
@@ -2,6 +2,7 @@ import { mediator, MessageHandler, Message } from 'mediateur';
 
 import { DocumentProjet, EnregistrerDocumentProjetCommand } from '@potentiel-domain/document';
 import { DateTime, IdentifiantProjet } from '@potentiel-domain/common';
+import { Role } from '@potentiel-domain/utilisateur';
 
 import * as TypeDocumentRaccordement from '../typeDocumentRaccordement.valueType';
 import * as RéférenceDossierRaccordement from '../référenceDossierRaccordement.valueType';
@@ -16,6 +17,7 @@ export type ModifierDemandeComplèteRaccordementUseCase = Message<
     dateQualificationValue: string;
     identifiantGestionnaireRéseauValue: string;
     référenceDossierRaccordementValue: string;
+    rôleValue: string;
     accuséRéceptionValue: {
       content: ReadableStream;
       format: string;
@@ -30,6 +32,7 @@ export const registerModifierDemandeComplèteRaccordementUseCase = () => {
     identifiantGestionnaireRéseauValue,
     identifiantProjetValue,
     référenceDossierRaccordementValue,
+    rôleValue,
   }) => {
     const accuséRéception = DocumentProjet.convertirEnValueType(
       identifiantProjetValue,
@@ -48,6 +51,7 @@ export const registerModifierDemandeComplèteRaccordementUseCase = () => {
     const référenceDossierRaccordement = RéférenceDossierRaccordement.convertirEnValueType(
       référenceDossierRaccordementValue,
     );
+    const rôle = Role.convertirEnValueType(rôleValue);
 
     await mediator.send<EnregistrerDocumentProjetCommand>({
       type: 'Document.Command.EnregistrerDocumentProjet',
@@ -65,6 +69,7 @@ export const registerModifierDemandeComplèteRaccordementUseCase = () => {
         identifiantGestionnaireRéseau,
         identifiantProjet,
         référenceDossierRaccordement,
+        rôle,
       },
     });
   };

--- a/packages/specifications/src/raccordement/modifierDemandeComplèteDeRaccordement.feature
+++ b/packages/specifications/src/raccordement/modifierDemandeComplèteDeRaccordement.feature
@@ -33,7 +33,7 @@ Fonctionnalité: Modifier une demande complète de raccordement
         Et la demande complète de raccordement devrait être consultable dans le dossier de raccordement du projet lauréat "Du boulodrome de Marseille"
 
     Scénario: Impossible de modifier une demande complète de raccordement pour un projet sans dossier de raccordement
-        Quand l'utilisateur avec le rôle "porteur-projet" modifie la demande complète de raccordement pour le projet lauréat  "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000033" auprès du gestionnaire de réseau "Enedis" avec :
+        Quand l'utilisateur avec le rôle "porteur-projet" modifie la demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000033" auprès du gestionnaire de réseau "Enedis" avec :
             | La date de qualification            | 2022-10-29                                                                                                      |
             | Le format de l'accusé de réception  | text/plain                                                                                                      |
             | Le contenu de l'accusé de réception | Une autre accusé de réception ayant pour référence OUE-RP-2022-000033 et la date de qualification au 2022-10-29 |
@@ -45,7 +45,7 @@ Fonctionnalité: Modifier une demande complète de raccordement
             | La référence du dossier de raccordement | OUE-RP-2022-000033                                                                                    |
             | Le format de l'accusé de réception      | application/pdf                                                                                       |
             | Le contenu de l'accusé de réception     | Accusé de réception ayant pour référence OUE-RP-2022-000033 et la date de qualification au 2022-10-28 |
-        Quand l'utilisateur avec le rôle "porteur-projet" modifie la demande complète de raccordement pour le projet lauréat  "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000034" auprès du gestionnaire de réseau "Enedis" avec :
+        Quand l'utilisateur avec le rôle "porteur-projet" modifie la demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000034" auprès du gestionnaire de réseau "Enedis" avec :
             | La date de qualification            | 2022-10-29                                                                                                      |
             | Le format de l'accusé de réception  | text/plain                                                                                                      |
             | Le contenu de l'accusé de réception | Une autre accusé de réception ayant pour référence OUE-RP-2022-000034 et la date de qualification au 2022-10-29 |
@@ -57,7 +57,7 @@ Fonctionnalité: Modifier une demande complète de raccordement
             | La référence du dossier de raccordement | OUE-RP-2022-000033                                                                                    |
             | Le format de l'accusé de réception      | application/pdf                                                                                       |
             | Le contenu de l'accusé de réception     | Accusé de réception ayant pour référence OUE-RP-2022-000033 et la date de qualification au 2022-10-28 |
-        Quand l'utilisateur avec le rôle "porteur-projet" modifie la demande complète de raccordement pour le projet lauréat  "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000034" auprès du gestionnaire de réseau "Enedis" avec :
+        Quand l'utilisateur avec le rôle "porteur-projet" modifie la demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000034" auprès du gestionnaire de réseau "Enedis" avec :
             | La date de qualification            | 2999-12-31                                                                                                      |
             | Le format de l'accusé de réception  | text/plain                                                                                                      |
             | Le contenu de l'accusé de réception | Une autre accusé de réception ayant pour référence OUE-RP-2022-000033 et la date de qualification au 2022-10-29 |

--- a/packages/specifications/src/raccordement/modifierDemandeComplèteDeRaccordement.feature
+++ b/packages/specifications/src/raccordement/modifierDemandeComplèteDeRaccordement.feature
@@ -48,3 +48,16 @@ Fonctionnalité: Modifier une demande complète de raccordement
             | Le format de l'accusé de réception  | text/plain                                                                                                      |
             | Le contenu de l'accusé de réception | Une autre accusé de réception ayant pour référence OUE-RP-2022-000033 et la date de qualification au 2022-10-29 |
         Alors le porteur devrait être informé que "La date ne peut pas être une date future"
+
+    Scénario: Impossible de modifier une demande complète de raccordement si la date de mise en service est déjà renseignée
+        Etant donné une demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" transmise auprès du gestionnaire de réseau "Enedis" avec :
+            | La date de qualification                | 2022-10-28                                                                                            |
+            | La référence du dossier de raccordement | OUE-RP-2022-000033                                                                                    |
+            | Le format de l'accusé de réception      | application/pdf                                                                                       |
+            | Le contenu de l'accusé de réception     | Accusé de réception ayant pour référence OUE-RP-2022-000033 et la date de qualification au 2022-10-28 |
+        Et une date de mise en service "2023-01-01" pour le dossier de raccordement pour le projet lauréat "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000033"
+        Quand le porteur modifie la demande complète de raccordement pour le dossier de raccordement du projet lauréat "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000033" auprès du gestionnaire de réseau "Enedis" avec :
+            | La date de qualification            | 2023-12-31                                                                                                      |
+            | Le format de l'accusé de réception  | text/plain                                                                                                      |
+            | Le contenu de l'accusé de réception | Une autre accusé de réception ayant pour référence OUE-RP-2022-000033 et la date de qualification au 2022-10-29 |
+        Alors le porteur devrait être informé que "Impossible de modifier la demande complète de raccordement car le dossier dispose d'une mise en service"

--- a/packages/specifications/src/raccordement/modifierDemandeComplèteDeRaccordement.feature
+++ b/packages/specifications/src/raccordement/modifierDemandeComplèteDeRaccordement.feature
@@ -61,4 +61,4 @@ Fonctionnalité: Modifier une demande complète de raccordement
             | La date de qualification            | 2022-10-29                                                                                                      |
             | Le format de l'accusé de réception  | text/plain                                                                                                      |
             | Le contenu de l'accusé de réception | Une autre accusé de réception ayant pour référence OUE-RP-2022-000033 et la date de qualification au 2022-10-29 |
-        Alors le porteur devrait être informé que "La demande complète de raccordement du dossier OUE-RP-2022-000033 ne peut pas être modifiée celui-ci dispose déjà d'une date de mise en service"
+        Alors le porteur devrait être informé que "La demande complète de raccordement du dossier OUE-RP-2022-000033 ne peut pas être modifiée car celui-ci dispose déjà d'une date de mise en service"

--- a/packages/specifications/src/raccordement/modifierDemandeComplèteDeRaccordement.feature
+++ b/packages/specifications/src/raccordement/modifierDemandeComplèteDeRaccordement.feature
@@ -11,7 +11,21 @@ Fonctionnalité: Modifier une demande complète de raccordement
             | La référence du dossier de raccordement | OUE-RP-2022-000033                                                                                    |
             | Le format de l'accusé de réception      | application/pdf                                                                                       |
             | Le contenu de l'accusé de réception     | Accusé de réception ayant pour référence OUE-RP-2022-000033 et la date de qualification au 2022-10-28 |
-        Quand l'utilisateur avec le rôle "porteur-projet" modifie la demande complète de raccordement pour le projet lauréat  "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000033" auprès du gestionnaire de réseau "Enedis" avec :
+        Quand l'utilisateur avec le rôle "porteur-projet" modifie la demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000033" auprès du gestionnaire de réseau "Enedis" avec :
+            | La date de qualification            | 2022-10-29                                                                                                      |
+            | Le format de l'accusé de réception  | text/plain                                                                                                      |
+            | Le contenu de l'accusé de réception | Une autre accusé de réception ayant pour référence OUE-RP-2022-000033 et la date de qualification au 2022-10-29 |
+        Alors le dossier est consultable dans la liste des dossiers de raccordement du projet lauréat "Du boulodrome de Marseille"
+        Et la demande complète de raccordement devrait être consultable dans le dossier de raccordement du projet lauréat "Du boulodrome de Marseille"
+
+    Scénario: Une dreal de projet modifie une demande complète de raccordement même si la date de mise en service est déjà renseignée
+        Etant donné une demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" transmise auprès du gestionnaire de réseau "Enedis" avec :
+            | La date de qualification                | 2022-10-28                                                                                            |
+            | La référence du dossier de raccordement | OUE-RP-2022-000033                                                                                    |
+            | Le format de l'accusé de réception      | application/pdf                                                                                       |
+            | Le contenu de l'accusé de réception     | Accusé de réception ayant pour référence OUE-RP-2022-000033 et la date de qualification au 2022-10-28 |
+        Et une date de mise en service "2023-01-01" pour le dossier de raccordement pour le projet lauréat "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000033"
+        Quand l'utilisateur avec le rôle "dreal" modifie la demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000033" auprès du gestionnaire de réseau "Enedis" avec :
             | La date de qualification            | 2022-10-29                                                                                                      |
             | Le format de l'accusé de réception  | text/plain                                                                                                      |
             | Le contenu de l'accusé de réception | Une autre accusé de réception ayant pour référence OUE-RP-2022-000033 et la date de qualification au 2022-10-29 |
@@ -49,7 +63,6 @@ Fonctionnalité: Modifier une demande complète de raccordement
             | Le contenu de l'accusé de réception | Une autre accusé de réception ayant pour référence OUE-RP-2022-000033 et la date de qualification au 2022-10-29 |
         Alors le porteur devrait être informé que "La date ne peut pas être une date future"
 
-    @select
     Scénario: Impossible de modifier une demande complète de raccordement si la date de mise en service est déjà renseignée
         Etant donné une demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" transmise auprès du gestionnaire de réseau "Enedis" avec :
             | La date de qualification                | 2022-10-28                                                                                            |

--- a/packages/specifications/src/raccordement/modifierDemandeComplèteDeRaccordement.feature
+++ b/packages/specifications/src/raccordement/modifierDemandeComplèteDeRaccordement.feature
@@ -11,7 +11,7 @@ Fonctionnalité: Modifier une demande complète de raccordement
             | La référence du dossier de raccordement | OUE-RP-2022-000033                                                                                    |
             | Le format de l'accusé de réception      | application/pdf                                                                                       |
             | Le contenu de l'accusé de réception     | Accusé de réception ayant pour référence OUE-RP-2022-000033 et la date de qualification au 2022-10-28 |
-        Quand le porteur modifie la demande complète de raccordement pour le dossier de raccordement du projet lauréat "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000033" auprès du gestionnaire de réseau "Enedis" avec :
+        Quand l'utilisateur avec le rôle "porteur-projet" modifie la demande complète de raccordement pour le projet lauréat  "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000033" auprès du gestionnaire de réseau "Enedis" avec :
             | La date de qualification            | 2022-10-29                                                                                                      |
             | Le format de l'accusé de réception  | text/plain                                                                                                      |
             | Le contenu de l'accusé de réception | Une autre accusé de réception ayant pour référence OUE-RP-2022-000033 et la date de qualification au 2022-10-29 |
@@ -19,7 +19,7 @@ Fonctionnalité: Modifier une demande complète de raccordement
         Et la demande complète de raccordement devrait être consultable dans le dossier de raccordement du projet lauréat "Du boulodrome de Marseille"
 
     Scénario: Impossible de modifier une demande complète de raccordement pour un projet sans dossier de raccordement
-        Quand le porteur modifie la demande complète de raccordement pour le dossier de raccordement du projet lauréat "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000033" auprès du gestionnaire de réseau "Enedis" avec :
+        Quand l'utilisateur avec le rôle "porteur-projet" modifie la demande complète de raccordement pour le projet lauréat  "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000033" auprès du gestionnaire de réseau "Enedis" avec :
             | La date de qualification            | 2022-10-29                                                                                                      |
             | Le format de l'accusé de réception  | text/plain                                                                                                      |
             | Le contenu de l'accusé de réception | Une autre accusé de réception ayant pour référence OUE-RP-2022-000033 et la date de qualification au 2022-10-29 |
@@ -31,7 +31,7 @@ Fonctionnalité: Modifier une demande complète de raccordement
             | La référence du dossier de raccordement | OUE-RP-2022-000033                                                                                    |
             | Le format de l'accusé de réception      | application/pdf                                                                                       |
             | Le contenu de l'accusé de réception     | Accusé de réception ayant pour référence OUE-RP-2022-000033 et la date de qualification au 2022-10-28 |
-        Quand le porteur modifie la demande complète de raccordement pour le dossier de raccordement du projet lauréat "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000034" auprès du gestionnaire de réseau "Enedis" avec :
+        Quand l'utilisateur avec le rôle "porteur-projet" modifie la demande complète de raccordement pour le projet lauréat  "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000034" auprès du gestionnaire de réseau "Enedis" avec :
             | La date de qualification            | 2022-10-29                                                                                                      |
             | Le format de l'accusé de réception  | text/plain                                                                                                      |
             | Le contenu de l'accusé de réception | Une autre accusé de réception ayant pour référence OUE-RP-2022-000034 et la date de qualification au 2022-10-29 |
@@ -43,12 +43,13 @@ Fonctionnalité: Modifier une demande complète de raccordement
             | La référence du dossier de raccordement | OUE-RP-2022-000033                                                                                    |
             | Le format de l'accusé de réception      | application/pdf                                                                                       |
             | Le contenu de l'accusé de réception     | Accusé de réception ayant pour référence OUE-RP-2022-000033 et la date de qualification au 2022-10-28 |
-        Quand le porteur modifie la demande complète de raccordement pour le dossier de raccordement du projet lauréat "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000034" auprès du gestionnaire de réseau "Enedis" avec :
+        Quand l'utilisateur avec le rôle "porteur-projet" modifie la demande complète de raccordement pour le projet lauréat  "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000034" auprès du gestionnaire de réseau "Enedis" avec :
             | La date de qualification            | 2999-12-31                                                                                                      |
             | Le format de l'accusé de réception  | text/plain                                                                                                      |
             | Le contenu de l'accusé de réception | Une autre accusé de réception ayant pour référence OUE-RP-2022-000033 et la date de qualification au 2022-10-29 |
         Alors le porteur devrait être informé que "La date ne peut pas être une date future"
 
+    @select
     Scénario: Impossible de modifier une demande complète de raccordement si la date de mise en service est déjà renseignée
         Etant donné une demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" transmise auprès du gestionnaire de réseau "Enedis" avec :
             | La date de qualification                | 2022-10-28                                                                                            |
@@ -56,8 +57,8 @@ Fonctionnalité: Modifier une demande complète de raccordement
             | Le format de l'accusé de réception      | application/pdf                                                                                       |
             | Le contenu de l'accusé de réception     | Accusé de réception ayant pour référence OUE-RP-2022-000033 et la date de qualification au 2022-10-28 |
         Et une date de mise en service "2023-01-01" pour le dossier de raccordement pour le projet lauréat "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000033"
-        Quand le porteur modifie la demande complète de raccordement pour le dossier de raccordement du projet lauréat "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000033" auprès du gestionnaire de réseau "Enedis" avec :
-            | La date de qualification            | 2023-12-31                                                                                                      |
+        Quand l'utilisateur avec le rôle "porteur-projet" modifie la demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000033" auprès du gestionnaire de réseau "Enedis" avec :
+            | La date de qualification            | 2022-10-29                                                                                                      |
             | Le format de l'accusé de réception  | text/plain                                                                                                      |
             | Le contenu de l'accusé de réception | Une autre accusé de réception ayant pour référence OUE-RP-2022-000033 et la date de qualification au 2022-10-29 |
-        Alors le porteur devrait être informé que "Impossible de modifier la demande complète de raccordement car le dossier dispose d'une mise en service"
+        Alors le porteur devrait être informé que "La demande complète de raccordement du dossier OUE-RP-2022-000033 ne peut pas être modifiée celui-ci dispose déjà d'une date de mise en service"

--- a/packages/specifications/src/raccordement/modifierPropositionTechniqueEtFinancière.feature
+++ b/packages/specifications/src/raccordement/modifierPropositionTechniqueEtFinancière.feature
@@ -55,3 +55,8 @@ Fonctionnalité: Modifier une proposition technique et financière
             | Le format de la proposition technique et financière | text/plain                                                                                                                  |
             | Le contenu de proposition technique et financière   | Une autre proposition technique et financière pour la référence OUE-RP-2022-000033 avec une date de signature au 2023-02-12 |
         Alors le porteur devrait être informé que "La date ne peut pas être une date future"
+
+    # À vérifier côté métier
+    @NotImplemented
+    Scénario: Impossible de modifier une proposition technique et financière si la date de mise en service est déjà renseignée
+

--- a/packages/specifications/src/raccordement/modifierRéférenceDemandeComplèteDeRaccordement.feature
+++ b/packages/specifications/src/raccordement/modifierRéférenceDemandeComplèteDeRaccordement.feature
@@ -49,7 +49,7 @@ Fonctionnalité: Modifier la référence d'une demande complète de raccordement
             | Le format de l'accusé de réception      | application/pdf                                                                                         |
             | Le contenu de l'accusé de réception     | Accusé de réception ayant pour référence <Référence actuelle> et la date de qualification au 2022-10-28 |
         Quand l'utilisateur avec le rôle "porteur-projet" modifie la demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" ayant pour référence "<Référence actuelle>" avec la référence "OUE-RP-2022-000034"
-        Et l'utilisateur avec le rôle "porteur-projet" modifie la demande complète de raccordement pour le projet lauréat  "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000034" auprès du gestionnaire de réseau "Enedis" avec :
+        Et l'utilisateur avec le rôle "porteur-projet" modifie la demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000034" auprès du gestionnaire de réseau "Enedis" avec :
             | La date de qualification            | 2022-10-29                                                                                                      |
             | Le format de l'accusé de réception  | text/plain                                                                                                      |
             | Le contenu de l'accusé de réception | Une autre accusé de réception ayant pour référence OUE-RP-2022-000034 et la date de qualification au 2022-10-29 |

--- a/packages/specifications/src/raccordement/modifierRéférenceDemandeComplèteDeRaccordement.feature
+++ b/packages/specifications/src/raccordement/modifierRéférenceDemandeComplèteDeRaccordement.feature
@@ -111,7 +111,6 @@ Fonctionnalité: Modifier la référence d'une demande complète de raccordement
         Quand l'utilisateur avec le rôle "porteur-projet" modifie la demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000034" avec la référence "OUE-RP-2022-000035"
         Alors le porteur devrait être informé que "Le dossier de raccordement n'est pas référencé"
 
-    @select
     Scénario: Impossible pour un porteur de modifier la référence pour un dossier de raccordement ayant déjà une date de mise en service
         Etant donné une demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" transmise auprès du gestionnaire de réseau "Enedis" avec :
             | La date de qualification                | 2022-10-28                                                                                            |

--- a/packages/specifications/src/raccordement/modifierRéférenceDemandeComplèteDeRaccordement.feature
+++ b/packages/specifications/src/raccordement/modifierRéférenceDemandeComplèteDeRaccordement.feature
@@ -49,7 +49,7 @@ Fonctionnalité: Modifier la référence d'une demande complète de raccordement
             | Le format de l'accusé de réception      | application/pdf                                                                                         |
             | Le contenu de l'accusé de réception     | Accusé de réception ayant pour référence <Référence actuelle> et la date de qualification au 2022-10-28 |
         Quand l'utilisateur avec le rôle "porteur-projet" modifie la demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" ayant pour référence "<Référence actuelle>" avec la référence "OUE-RP-2022-000034"
-        Et le porteur modifie la demande complète de raccordement pour le dossier de raccordement du projet lauréat "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000034" auprès du gestionnaire de réseau "Enedis" avec :
+        Et l'utilisateur avec le rôle "porteur-projet" modifie la demande complète de raccordement pour le projet lauréat  "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000034" auprès du gestionnaire de réseau "Enedis" avec :
             | La date de qualification            | 2022-10-29                                                                                                      |
             | Le format de l'accusé de réception  | text/plain                                                                                                      |
             | Le contenu de l'accusé de réception | Une autre accusé de réception ayant pour référence OUE-RP-2022-000034 et la date de qualification au 2022-10-29 |
@@ -111,6 +111,7 @@ Fonctionnalité: Modifier la référence d'une demande complète de raccordement
         Quand l'utilisateur avec le rôle "porteur-projet" modifie la demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000034" avec la référence "OUE-RP-2022-000035"
         Alors le porteur devrait être informé que "Le dossier de raccordement n'est pas référencé"
 
+    @select
     Scénario: Impossible pour un porteur de modifier la référence pour un dossier de raccordement ayant déjà une date de mise en service
         Etant donné une demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" transmise auprès du gestionnaire de réseau "Enedis" avec :
             | La date de qualification                | 2022-10-28                                                                                            |
@@ -119,4 +120,4 @@ Fonctionnalité: Modifier la référence d'une demande complète de raccordement
             | Le contenu de l'accusé de réception     | Accusé de réception ayant pour référence OUE-RP-2022-000033 et la date de qualification au 2022-10-28 |
         Et une date de mise en service "2022-01-12" pour le dossier de raccordement pour le projet lauréat "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000033"
         Quand l'utilisateur avec le rôle "porteur-projet" modifie la demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000033" avec la référence "OUE-RP-2022-000034"
-        Alors le porteur devrait être informé que "La référence du dossier de raccordement ne peut pas être modifiée car le dossier dispose déjà d'une date de mise en service"
+        Alors le porteur devrait être informé que "La référence du dossier de raccordement OUE-RP-2022-000033 ne peut pas être modifiée car le dossier dispose déjà d'une date de mise en service"

--- a/packages/specifications/src/raccordement/stepDefinitions/raccordement.when.ts
+++ b/packages/specifications/src/raccordement/stepDefinitions/raccordement.when.ts
@@ -143,9 +143,10 @@ Quand(
 );
 
 Quand(
-  `le porteur modifie la demande complète de raccordement pour le dossier de raccordement du projet lauréat {string} ayant pour référence {string} auprès du gestionnaire de réseau {string} avec :`,
+  `l'utilisateur avec le rôle {string} modifie la demande complète de raccordement pour le projet lauréat {string} ayant pour référence {string} auprès du gestionnaire de réseau {string} avec :`,
   async function (
     this: PotentielWorld,
+    rôleUtilisateur: string,
     nomProjet: string,
     référenceDossierRaccordement: string,
     raisonSocialeGestionnaire: string,
@@ -182,6 +183,7 @@ Quand(
           référenceDossierRaccordementValue: référenceDossierRaccordement,
           dateQualificationValue: dateQualification,
           accuséRéceptionValue: accuséRéception,
+          rôleValue: rôleUtilisateur,
         },
       });
     } catch (e) {


### PR DESCRIPTION
# Description

- Les DREALS doivent pouvoir modifier une DCR meme si le dossier de raccordement a une date de mise en service 
- Les PP ne doivent pas pouvoir modifier les DCR si le dossier de raccordement a une date de mise en service 

## Type de changement

- [x] Nouvelle fonctionnalité
