### PR TITLE
👷 Annulation des builds concurrents sur PR

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,6 +24,10 @@ on:
   schedule:
     - cron: '16 6 * * 6'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,6 +12,10 @@ on:
       - '.prettier**'
       - 'LICENSE'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   call-shared-workflow:
     uses: ./.github/workflows/shared-workflow.yml


### PR DESCRIPTION
Quand on pousse un nouveau commit sur une PR, on peut annuler la github action en cours 