### PR TITLE
🐛 Mise a jour des droits DREAL sur raccordement si date de mise en service

### DIFF
--- a/packages/applications/ssr/src/app/laureats/[identifiant]/raccordements/page.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/raccordements/page.tsx
@@ -75,10 +75,12 @@ const mapToProps: MapToProps = ({
   gestionnaireRéseau,
   raccordement,
 }) => {
+  const aUneDateDeMiseEnService = raccordement.dossiers.some((dossier) => dossier.miseEnService);
   const canEditGestionnaireRéseau =
     rôleUtilisateur.estÉgaleÀ(Role.admin) ||
     rôleUtilisateur.estÉgaleÀ(Role.dgecValidateur) ||
-    rôleUtilisateur.estÉgaleÀ(Role.porteur);
+    (!aUneDateDeMiseEnService &&
+      (rôleUtilisateur.estÉgaleÀ(Role.porteur) || rôleUtilisateur.estÉgaleÀ(Role.dreal)));
 
   return {
     identifiantProjet,

--- a/packages/applications/ssr/src/components/pages/réseau/raccordement/modifier/modifierGestionnaireRéseauRaccordement/modifierGestionnaireRéseauRaccordement.action.ts
+++ b/packages/applications/ssr/src/components/pages/réseau/raccordement/modifier/modifierGestionnaireRéseauRaccordement/modifierGestionnaireRéseauRaccordement.action.ts
@@ -6,6 +6,7 @@ import * as zod from 'zod';
 import { Raccordement } from '@potentiel-domain/reseau';
 
 import { FormAction, FormState, formAction } from '@/utils/formAction';
+import { withUtilisateur } from '@/utils/withUtilisateur';
 
 export type ModifierGestionnaireRéseauRaccordementState = FormState;
 
@@ -17,18 +18,20 @@ const schema = zod.object({
 const action: FormAction<FormState, typeof schema> = async (
   previousState,
   { identifiantProjet, identifiantGestionnaireReseau },
-) => {
-  await mediator.send<Raccordement.RaccordementUseCase>({
-    type: 'Réseau.Raccordement.UseCase.ModifierGestionnaireRéseauRaccordement',
-    data: {
-      identifiantProjetValue: identifiantProjet,
-      identifiantGestionnaireRéseauValue: identifiantGestionnaireReseau,
-    },
-  });
+) =>
+  withUtilisateur(async (utilisateur) => {
+    await mediator.send<Raccordement.RaccordementUseCase>({
+      type: 'Réseau.Raccordement.UseCase.ModifierGestionnaireRéseauRaccordement',
+      data: {
+        identifiantProjetValue: identifiantProjet,
+        identifiantGestionnaireRéseauValue: identifiantGestionnaireReseau,
+        rôleValue: utilisateur.nom,
+      },
+    });
 
-  return {
-    status: 'success',
-  };
-};
+    return {
+      status: 'success',
+    };
+  });
 
 export const modifierGestionnaireRéseauRaccordementAction = formAction(action, schema);

--- a/packages/applications/ssr/src/components/pages/réseau/raccordement/modifier/modifierGestionnaireRéseauRaccordement/modifierGestionnaireRéseauRaccordement.action.ts
+++ b/packages/applications/ssr/src/components/pages/réseau/raccordement/modifier/modifierGestionnaireRéseauRaccordement/modifierGestionnaireRéseauRaccordement.action.ts
@@ -25,7 +25,7 @@ const action: FormAction<FormState, typeof schema> = async (
       data: {
         identifiantProjetValue: identifiantProjet,
         identifiantGestionnaireRéseauValue: identifiantGestionnaireReseau,
-        rôleValue: utilisateur.nom,
+        rôleValue: utilisateur.role.nom,
       },
     });
 

--- a/packages/domain/réseau/src/raccordement/modifier/modifierGestionnaireRéseauRaccordement.command.ts
+++ b/packages/domain/réseau/src/raccordement/modifier/modifierGestionnaireRéseauRaccordement.command.ts
@@ -2,6 +2,7 @@ import { Message, MessageHandler, mediator } from 'mediateur';
 
 import { IdentifiantProjet } from '@potentiel-domain/common';
 import { LoadAggregate } from '@potentiel-domain/core';
+import { Role } from '@potentiel-domain/utilisateur';
 
 import { IdentifiantGestionnaireRéseau } from '../../gestionnaire';
 import { loadRaccordementAggregateFactory } from '../raccordement.aggregate';
@@ -12,6 +13,7 @@ export type ModifierGestionnaireRéseauRaccordementCommand = Message<
   {
     identifiantGestionnaireRéseau: IdentifiantGestionnaireRéseau.ValueType;
     identifiantProjet: IdentifiantProjet.ValueType;
+    rôle: Role.ValueType;
   }
 >;
 
@@ -22,6 +24,7 @@ export const registerModifierGestionnaireRéseauProjetCommand = (loadAggregate: 
   const handler: MessageHandler<ModifierGestionnaireRéseauRaccordementCommand> = async ({
     identifiantProjet,
     identifiantGestionnaireRéseau,
+    rôle,
   }) => {
     const gestionnaireRéseau = await loadGestionnaireRéseau(identifiantGestionnaireRéseau);
     const raccordement = await loadRaccordement(identifiantProjet);
@@ -29,6 +32,7 @@ export const registerModifierGestionnaireRéseauProjetCommand = (loadAggregate: 
     await raccordement.modifierGestionnaireRéseau({
       identifiantProjet,
       identifiantGestionnaireRéseau: gestionnaireRéseau.identifiantGestionnaireRéseau,
+      rôle,
     });
   };
 

--- a/packages/domain/réseau/src/raccordement/modifier/modifierGestionnaireRéseauRaccordement.usecase.ts
+++ b/packages/domain/réseau/src/raccordement/modifier/modifierGestionnaireRéseauRaccordement.usecase.ts
@@ -1,6 +1,7 @@
 import { Message, MessageHandler, mediator } from 'mediateur';
 
 import { IdentifiantProjet } from '@potentiel-domain/common';
+import { Role } from '@potentiel-domain/utilisateur';
 
 import { IdentifiantGestionnaireRéseau } from '../../gestionnaire';
 
@@ -11,6 +12,7 @@ export type ModifierGestionnaireRéseauRaccordementUseCase = Message<
   {
     identifiantGestionnaireRéseauValue: string;
     identifiantProjetValue: string;
+    rôleValue: string;
   }
 >;
 
@@ -18,16 +20,19 @@ export const registerModifierGestionnaireRéseauRaccordementUseCase = () => {
   const runner: MessageHandler<ModifierGestionnaireRéseauRaccordementUseCase> = async ({
     identifiantGestionnaireRéseauValue,
     identifiantProjetValue,
+    rôleValue,
   }) => {
     const identifiantProjet = IdentifiantProjet.convertirEnValueType(identifiantProjetValue);
     const identifiantGestionnaireRéseau = IdentifiantGestionnaireRéseau.convertirEnValueType(
       identifiantGestionnaireRéseauValue,
     );
+    const rôle = Role.convertirEnValueType(rôleValue);
     await mediator.send<ModifierGestionnaireRéseauRaccordementCommand>({
       type: 'Réseau.Raccordement.Command.ModifierGestionnaireRéseauRaccordement',
       data: {
         identifiantProjet,
         identifiantGestionnaireRéseau,
+        rôle,
       },
     });
   };

--- a/packages/domain/réseau/src/raccordement/raccordement.aggregate.ts
+++ b/packages/domain/réseau/src/raccordement/raccordement.aggregate.ts
@@ -117,6 +117,7 @@ export type RaccordementAggregate = Aggregate<RaccordementEvent> & {
   readonly modifierGestionnaireRéseau: typeof modifierGestionnaireRéseau;
   readonly contientLeDossier: (référence: RéférenceDossierRaccordement.ValueType) => boolean;
   readonly récupérerDossier: (référence: string) => DossierRaccordement;
+  readonly aUneDateDeMiseEnService: () => boolean;
   readonly attribuerGestionnaireRéseau: typeof attribuerGestionnaireRéseau;
   readonly dateModifiée: (
     référence: RéférenceDossierRaccordement.ValueType,
@@ -151,6 +152,14 @@ export const getDefaultRaccordementAggregate: GetDefaultAggregateState<
     }
 
     return dossier;
+  },
+  aUneDateDeMiseEnService(): boolean {
+    for (const [, dossier] of this.dossiers.entries()) {
+      if (Option.isSome(dossier.miseEnService.dateMiseEnService)) {
+        return true;
+      }
+    }
+    return false;
   },
   dateModifiée({ référence }, date) {
     const dossier = this.récupérerDossier(référence);

--- a/packages/specifications/src/raccordement/modifierGestionnaireRéseauRaccordement.feature
+++ b/packages/specifications/src/raccordement/modifierGestionnaireRéseauRaccordement.feature
@@ -47,3 +47,23 @@ Fonctionnalité: Modifier le gestionnaire de réseau d'un raccordement
             | Le contenu de l'accusé de réception     | Accusé de réception ayant pour référence OUE-RP-2022-000034 et la date de qualification au 2022-10-28 |
         Alors le projet lauréat "Du boulodrome de Marseille" devrait avoir 2 dossiers de raccordement pour le gestionnaire de réseau "Arc Energies Maurienne"
         Et le dossier est consultable dans la liste des dossiers de raccordement du projet lauréat "Du boulodrome de Marseille"
+
+    Scénario: Impossible pour un porteur de projet de modifier le gestionnaire de réseau d'un raccordement avec mise en service
+        Etant donné une demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" transmise auprès du gestionnaire de réseau "Enedis" avec :
+            | La date de qualification                | 2022-10-28                                                                                            |
+            | La référence du dossier de raccordement | OUE-RP-2022-000033                                                                                    |
+            | Le format de l'accusé de réception      | application/pdf                                                                                       |
+            | Le contenu de l'accusé de réception     | Accusé de réception ayant pour référence OUE-RP-2022-000033 et la date de qualification au 2022-10-28 |
+        Et une date de mise en service "2023-01-01" pour le dossier de raccordement pour le projet lauréat "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000033"
+        Quand un porteur modifie le gestionnaire de réseau du projet "Du boulodrome de Marseille" avec le gestionnaire "Arc Energies Maurienne"
+        Alors le porteur devrait être informé que "Le gestionnaire de réseau ne peut être modifié car le raccordement a une date de mise en service"
+
+    Scénario: Impossible pour une dreal de modifier le gestionnaire de réseau d'un raccordement avec mise en service
+        Etant donné une demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" transmise auprès du gestionnaire de réseau "Enedis" avec :
+            | La date de qualification                | 2022-10-28                                                                                            |
+            | La référence du dossier de raccordement | OUE-RP-2022-000033                                                                                    |
+            | Le format de l'accusé de réception      | application/pdf                                                                                       |
+            | Le contenu de l'accusé de réception     | Accusé de réception ayant pour référence OUE-RP-2022-000033 et la date de qualification au 2022-10-28 |
+        Et une date de mise en service "2023-01-01" pour le dossier de raccordement pour le projet lauréat "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000033"
+        Quand une dreal modifie le gestionnaire de réseau du projet "Du boulodrome de Marseille" avec le gestionnaire "Arc Energies Maurienne"
+        Alors la dreal devrait être informé que "Le gestionnaire de réseau ne peut être modifié car le raccordement a une date de mise en service"

--- a/packages/specifications/src/raccordement/stepDefinitions/raccordement.when.ts
+++ b/packages/specifications/src/raccordement/stepDefinitions/raccordement.when.ts
@@ -3,6 +3,7 @@ import { mediator } from 'mediateur';
 
 import { Raccordement } from '@potentiel-domain/reseau';
 import { DateTime } from '@potentiel-domain/common';
+import { Role } from '@potentiel-domain/utilisateur';
 
 import { convertStringToReadableStream } from '../../helpers/convertStringToReadable';
 import { PotentielWorld } from '../../potentiel.world';
@@ -247,6 +248,7 @@ Quand(
         data: {
           identifiantProjetValue: identifiantProjet.formatter(),
           identifiantGestionnaireRéseauValue: 'GESTIONNAIRE NON RÉFÉRENCÉ',
+          rôleValue: Role.porteur.nom,
         },
       });
     } catch (e) {
@@ -266,6 +268,7 @@ Quand(
         data: {
           identifiantProjetValue: identifiantProjet.formatter(),
           identifiantGestionnaireRéseauValue: 'inconnu',
+          rôleValue: Role.admin.nom,
         },
       });
     } catch (e) {
@@ -288,6 +291,30 @@ Quand(
         data: {
           identifiantProjetValue: identifiantProjet.formatter(),
           identifiantGestionnaireRéseauValue: codeEIC,
+          rôleValue: Role.porteur.nom,
+        },
+      });
+    } catch (e) {
+      this.error = e as Error;
+    }
+  },
+);
+
+Quand(
+  `une dreal modifie le gestionnaire de réseau du projet {string} avec le gestionnaire {string}`,
+  async function (this: PotentielWorld, nomProjet: string, raisonSocialGestionnaireRéseau: string) {
+    const { identifiantProjet } = this.lauréatWorld.rechercherLauréatFixture(nomProjet);
+    const { codeEIC } = this.gestionnaireRéseauWorld.rechercherGestionnaireRéseauFixture(
+      raisonSocialGestionnaireRéseau,
+    );
+
+    try {
+      await mediator.send<Raccordement.ModifierGestionnaireRéseauRaccordementUseCase>({
+        type: 'Réseau.Raccordement.UseCase.ModifierGestionnaireRéseauRaccordement',
+        data: {
+          identifiantProjetValue: identifiantProjet.formatter(),
+          identifiantGestionnaireRéseauValue: codeEIC,
+          rôleValue: Role.dreal.nom,
         },
       });
     } catch (e) {


### PR DESCRIPTION
# Description

- ETQ PP, Impossibilite de changer gestionnaire du raccordement si DMS
- ETQ DREAL, Impossibilite de changer gestionnaire du raccordement si DMS
- 
https://linear.app/startup-potentiel/issue/POT-476/impossible-pour-un-porteur-de-projet-de-modifier-le-gestionnaire-de


## Type de changement

Veuillez supprimer les options qui ne sont pas pertinentes.

- [x] Correction de bug
- [ ] Nouvelle fonctionnalité
- [ ] Refacto de code
- [ ] Breaking changes (correction ou fonctionnalité qui ferait en sorte que la fonctionnalité existante ne fonctionne pas comme prévu)
- [ ] Ce changement nécessite une mise à jour de la documentation

# Comment cela a-t-il été testé?

Veuillez décrire les tests que vous avez effectués pour vérifier vos changements. Fournissez des instructions afin que nous puissions les reproduire. Veuillez également lister tous les détails pertinents pour la configuration de votre test.

## Pré-requis 

- [ ] Pré-requis A   
- [ ] Pré-requis B   
 
## Scénarios 

- [ ] Scénario A
- [ ] Scénario B

# Check-up :

- [ ] Mon code [suit les directives de style](../docs/contributing//DEVELOPMENT_FLOW.md) de ce projet
- [ ] J'ai effectué une auto-revue de mon code
- [ ] J'ai commenté mon code, en particulier dans les zones difficiles à comprendre
- [ ] J'ai apporté des modifications correspondantes à la documentation
- [ ] Mes modifications ne génèrent aucun warning
- [ ] J'ai ajouté des tests qui prouvent l'efficacité de ma correction ou que ma fonctionnalité fonctionne
- [ ] Les nouveaux tests unitaires et les tests existants passent en local / dans la CI avec mes modifications
