### PR TITLE
🐛 Mise a jour des droits DREAL sur raccordement si date de mise en service v2

### DIFF
--- a/packages/applications/ssr/src/app/laureats/[identifiant]/raccordements/[reference]/demande-complete-raccordement:modifier/page.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/raccordements/[reference]/demande-complete-raccordement:modifier/page.tsx
@@ -67,7 +67,8 @@ export default async function Page({ params: { identifiant, reference } }: PageP
       const canEdit =
         utilisateur.role.estÉgaleÀ(Role.admin) ||
         utilisateur.role.estÉgaleÀ(Role.dgecValidateur) ||
-        (utilisateur.role.estÉgaleÀ(Role.porteur) && !dossierRaccordement.miseEnService);
+        ((utilisateur.role.estÉgaleÀ(Role.porteur) || utilisateur.role.estÉgaleÀ(Role.dreal)) &&
+          !dossierRaccordement.miseEnService);
 
       const props = mapToProps({
         appelOffre,

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/raccordements/page.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/raccordements/page.tsx
@@ -116,8 +116,8 @@ const mapToPropsDossiers = ({
     const canEditDemandeComplèteRaccordement =
       rôleUtilisateur.estÉgaleÀ(Role.admin) ||
       rôleUtilisateur.estÉgaleÀ(Role.dgecValidateur) ||
-      rôleUtilisateur.estÉgaleÀ(Role.dreal) ||
-      (rôleUtilisateur.estÉgaleÀ(Role.porteur) && !dossier.miseEnService?.dateMiseEnService);
+      ((rôleUtilisateur.estÉgaleÀ(Role.porteur) || rôleUtilisateur.estÉgaleÀ(Role.dreal)) &&
+        !dossier.miseEnService?.dateMiseEnService);
 
     const canEditPropositionTechniqueEtFinancière =
       rôleUtilisateur.estÉgaleÀ(Role.admin) ||

--- a/packages/domain/réseau/src/raccordement/modifier/modifierDemandeComplèteRaccordement.behavior.ts
+++ b/packages/domain/réseau/src/raccordement/modifier/modifierDemandeComplèteRaccordement.behavior.ts
@@ -75,7 +75,10 @@ export async function modifierDemandeComplèteRaccordement(
 
   const dossier = this.récupérerDossier(référenceDossierRaccordement.formatter());
 
-  if (rôle.estÉgaleÀ(Role.porteur) && Option.isSome(dossier.miseEnService.dateMiseEnService)) {
+  if (
+    (rôle.estÉgaleÀ(Role.porteur) || rôle.estÉgaleÀ(Role.dreal)) &&
+    Option.isSome(dossier.miseEnService.dateMiseEnService)
+  ) {
     throw new DemandeComplèteRaccordementNonModifiableCarDossierAvecDateDeMiseEnServiceError(
       référenceDossierRaccordement.formatter(),
     );

--- a/packages/domain/réseau/src/raccordement/modifier/modifierRéférenceDossierRaccordement.behavior.ts
+++ b/packages/domain/réseau/src/raccordement/modifier/modifierRéférenceDossierRaccordement.behavior.ts
@@ -37,7 +37,6 @@ export async function modifierRéférenceDossierRacordement(
   if (nouvelleRéférenceDossierRaccordement.estÉgaleÀ(référenceDossierRaccordementActuelle)) {
     throw new RéférencesDossierRaccordementIdentiquesError();
   }
-  const dossier = this.récupérerDossier(référenceDossierRaccordementActuelle.formatter());
 
   if (
     !référenceDossierExpressionRegulière.valider(nouvelleRéférenceDossierRaccordement.référence)
@@ -45,7 +44,12 @@ export async function modifierRéférenceDossierRacordement(
     throw new FormatRéférenceDossierRaccordementInvalideError();
   }
 
-  if (rôle.estÉgaleÀ(Role.porteur) && Option.isSome(dossier.miseEnService.dateMiseEnService)) {
+  const dossier = this.récupérerDossier(référenceDossierRaccordementActuelle.formatter());
+
+  if (
+    (rôle.estÉgaleÀ(Role.porteur) || rôle.estÉgaleÀ(Role.dreal)) &&
+    Option.isSome(dossier.miseEnService.dateMiseEnService)
+  ) {
     throw new RéférenceDossierRaccordementNonModifiableCarDossierAvecDateDeMiseEnServiceError(
       référenceDossierRaccordementActuelle.formatter(),
     );

--- a/packages/domain/réseau/src/raccordement/transmettre/transmettreDemandeComplèteRaccordement.behavior.ts
+++ b/packages/domain/réseau/src/raccordement/transmettre/transmettreDemandeComplèteRaccordement.behavior.ts
@@ -188,7 +188,7 @@ export function applyDemandeComplèteDeRaccordementTransmiseEventV2(
 export class RéférenceDossierRaccordementDéjàExistantePourLeProjetError extends InvalidOperationError {
   constructor() {
     super(
-      `Il impossible d'avoir plusieurs dossiers de raccordement avec la même référence pour un projet`,
+      `Il est impossible d'avoir plusieurs dossiers de raccordement avec la même référence pour un projet`,
     );
   }
 }

--- a/packages/specifications/src/raccordement/modifierDemandeComplèteDeRaccordement.feature
+++ b/packages/specifications/src/raccordement/modifierDemandeComplèteDeRaccordement.feature
@@ -18,13 +18,12 @@ Fonctionnalité: Modifier une demande complète de raccordement
         Alors le dossier est consultable dans la liste des dossiers de raccordement du projet lauréat "Du boulodrome de Marseille"
         Et la demande complète de raccordement devrait être consultable dans le dossier de raccordement du projet lauréat "Du boulodrome de Marseille"
 
-    Scénario: Une dreal de projet modifie une demande complète de raccordement même si la date de mise en service est déjà renseignée
+    Scénario: Une dreal modifie une demande complète de raccordement
         Etant donné une demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" transmise auprès du gestionnaire de réseau "Enedis" avec :
             | La date de qualification                | 2022-10-28                                                                                            |
             | La référence du dossier de raccordement | OUE-RP-2022-000033                                                                                    |
             | Le format de l'accusé de réception      | application/pdf                                                                                       |
             | Le contenu de l'accusé de réception     | Accusé de réception ayant pour référence OUE-RP-2022-000033 et la date de qualification au 2022-10-28 |
-        Et une date de mise en service "2023-01-01" pour le dossier de raccordement pour le projet lauréat "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000033"
         Quand l'utilisateur avec le rôle "dreal" modifie la demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000033" auprès du gestionnaire de réseau "Enedis" avec :
             | La date de qualification            | 2022-10-29                                                                                                      |
             | Le format de l'accusé de réception  | text/plain                                                                                                      |
@@ -63,7 +62,33 @@ Fonctionnalité: Modifier une demande complète de raccordement
             | Le contenu de l'accusé de réception | Une autre accusé de réception ayant pour référence OUE-RP-2022-000033 et la date de qualification au 2022-10-29 |
         Alors le porteur devrait être informé que "La date ne peut pas être une date future"
 
-    Scénario: Impossible de modifier une demande complète de raccordement si la date de mise en service est déjà renseignée
+    Scénario: Impossible de modifier une demande complète de raccordement si la date de mise en service est déjà renseignée pour un porteur
+        Etant donné une demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" transmise auprès du gestionnaire de réseau "Enedis" avec :
+            | La date de qualification                | 2022-10-28                                                                                            |
+            | La référence du dossier de raccordement | OUE-RP-2022-000033                                                                                    |
+            | Le format de l'accusé de réception      | application/pdf                                                                                       |
+            | Le contenu de l'accusé de réception     | Accusé de réception ayant pour référence OUE-RP-2022-000033 et la date de qualification au 2022-10-28 |
+        Et une date de mise en service "2023-01-01" pour le dossier de raccordement pour le projet lauréat "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000033"
+        Quand l'utilisateur avec le rôle "porteur-projet" modifie la demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000033" auprès du gestionnaire de réseau "Enedis" avec :
+            | La date de qualification            | 2022-10-29                                                                                                      |
+            | Le format de l'accusé de réception  | text/plain                                                                                                      |
+            | Le contenu de l'accusé de réception | Une autre accusé de réception ayant pour référence OUE-RP-2022-000033 et la date de qualification au 2022-10-29 |
+        Alors le porteur devrait être informé que "La demande complète de raccordement du dossier OUE-RP-2022-000033 ne peut pas être modifiée car celui-ci dispose déjà d'une date de mise en service"
+
+    Scénario: Impossible de modifier une demande complète de raccordement si la date de mise en service est déjà renseignée pour une dreal
+        Etant donné une demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" transmise auprès du gestionnaire de réseau "Enedis" avec :
+            | La date de qualification                | 2022-10-28                                                                                            |
+            | La référence du dossier de raccordement | OUE-RP-2022-000033                                                                                    |
+            | Le format de l'accusé de réception      | application/pdf                                                                                       |
+            | Le contenu de l'accusé de réception     | Accusé de réception ayant pour référence OUE-RP-2022-000033 et la date de qualification au 2022-10-28 |
+        Et une date de mise en service "2023-01-01" pour le dossier de raccordement pour le projet lauréat "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000033"
+        Quand l'utilisateur avec le rôle "dreal" modifie la demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000033" auprès du gestionnaire de réseau "Enedis" avec :
+            | La date de qualification            | 2022-10-29                                                                                                      |
+            | Le format de l'accusé de réception  | text/plain                                                                                                      |
+            | Le contenu de l'accusé de réception | Une autre accusé de réception ayant pour référence OUE-RP-2022-000033 et la date de qualification au 2022-10-29 |
+        Alors la dreal devrait être informé que "La demande complète de raccordement du dossier OUE-RP-2022-000033 ne peut pas être modifiée car celui-ci dispose déjà d'une date de mise en service"
+
+    Scénario: Impossible de modifier une demande complète de raccordement si la date de mise en service est déjà renseignée pour une dreal
         Etant donné une demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" transmise auprès du gestionnaire de réseau "Enedis" avec :
             | La date de qualification                | 2022-10-28                                                                                            |
             | La référence du dossier de raccordement | OUE-RP-2022-000033                                                                                    |

--- a/packages/specifications/src/raccordement/modifierDemandeComplèteDeRaccordement.feature
+++ b/packages/specifications/src/raccordement/modifierDemandeComplèteDeRaccordement.feature
@@ -62,7 +62,7 @@ Fonctionnalité: Modifier une demande complète de raccordement
             | Le contenu de l'accusé de réception | Une autre accusé de réception ayant pour référence OUE-RP-2022-000033 et la date de qualification au 2022-10-29 |
         Alors le porteur devrait être informé que "La date ne peut pas être une date future"
 
-    Scénario: Impossible de modifier une demande complète de raccordement si la date de mise en service est déjà renseignée pour un porteur
+    Scénario: Impossible pour un porteur de modifier une demande complète de raccordement si le projet est déjà en service
         Etant donné une demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" transmise auprès du gestionnaire de réseau "Enedis" avec :
             | La date de qualification                | 2022-10-28                                                                                            |
             | La référence du dossier de raccordement | OUE-RP-2022-000033                                                                                    |
@@ -75,7 +75,7 @@ Fonctionnalité: Modifier une demande complète de raccordement
             | Le contenu de l'accusé de réception | Une autre accusé de réception ayant pour référence OUE-RP-2022-000033 et la date de qualification au 2022-10-29 |
         Alors le porteur devrait être informé que "La demande complète de raccordement du dossier OUE-RP-2022-000033 ne peut pas être modifiée car celui-ci dispose déjà d'une date de mise en service"
 
-    Scénario: Impossible de modifier une demande complète de raccordement si la date de mise en service est déjà renseignée pour une dreal
+    Scénario: Impossible pour une dreal de modifier une demande complète de raccordement si le projet est déjà en service
         Etant donné une demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" transmise auprès du gestionnaire de réseau "Enedis" avec :
             | La date de qualification                | 2022-10-28                                                                                            |
             | La référence du dossier de raccordement | OUE-RP-2022-000033                                                                                    |
@@ -87,16 +87,3 @@ Fonctionnalité: Modifier une demande complète de raccordement
             | Le format de l'accusé de réception  | text/plain                                                                                                      |
             | Le contenu de l'accusé de réception | Une autre accusé de réception ayant pour référence OUE-RP-2022-000033 et la date de qualification au 2022-10-29 |
         Alors la dreal devrait être informé que "La demande complète de raccordement du dossier OUE-RP-2022-000033 ne peut pas être modifiée car celui-ci dispose déjà d'une date de mise en service"
-
-    Scénario: Impossible de modifier une demande complète de raccordement si la date de mise en service est déjà renseignée pour une dreal
-        Etant donné une demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" transmise auprès du gestionnaire de réseau "Enedis" avec :
-            | La date de qualification                | 2022-10-28                                                                                            |
-            | La référence du dossier de raccordement | OUE-RP-2022-000033                                                                                    |
-            | Le format de l'accusé de réception      | application/pdf                                                                                       |
-            | Le contenu de l'accusé de réception     | Accusé de réception ayant pour référence OUE-RP-2022-000033 et la date de qualification au 2022-10-28 |
-        Et une date de mise en service "2023-01-01" pour le dossier de raccordement pour le projet lauréat "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000033"
-        Quand l'utilisateur avec le rôle "porteur-projet" modifie la demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000033" auprès du gestionnaire de réseau "Enedis" avec :
-            | La date de qualification            | 2022-10-29                                                                                                      |
-            | Le format de l'accusé de réception  | text/plain                                                                                                      |
-            | Le contenu de l'accusé de réception | Une autre accusé de réception ayant pour référence OUE-RP-2022-000033 et la date de qualification au 2022-10-29 |
-        Alors le porteur devrait être informé que "La demande complète de raccordement du dossier OUE-RP-2022-000033 ne peut pas être modifiée car celui-ci dispose déjà d'une date de mise en service"

--- a/packages/specifications/src/raccordement/modifierRéférenceDemandeComplèteDeRaccordement.feature
+++ b/packages/specifications/src/raccordement/modifierRéférenceDemandeComplèteDeRaccordement.feature
@@ -120,3 +120,13 @@ Fonctionnalité: Modifier la référence d'une demande complète de raccordement
         Et une date de mise en service "2022-01-12" pour le dossier de raccordement pour le projet lauréat "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000033"
         Quand l'utilisateur avec le rôle "porteur-projet" modifie la demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000033" avec la référence "OUE-RP-2022-000034"
         Alors le porteur devrait être informé que "La référence du dossier de raccordement OUE-RP-2022-000033 ne peut pas être modifiée car le dossier dispose déjà d'une date de mise en service"
+
+    Scénario: Impossible pour une dreal de modifier la référence pour un dossier de raccordement ayant déjà une date de mise en service
+        Etant donné une demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" transmise auprès du gestionnaire de réseau "Enedis" avec :
+            | La date de qualification                | 2022-10-28                                                                                            |
+            | La référence du dossier de raccordement | OUE-RP-2022-000033                                                                                    |
+            | Le format de l'accusé de réception      | application/pdf                                                                                       |
+            | Le contenu de l'accusé de réception     | Accusé de réception ayant pour référence OUE-RP-2022-000033 et la date de qualification au 2022-10-28 |
+        Et une date de mise en service "2022-01-12" pour le dossier de raccordement pour le projet lauréat "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000033"
+        Quand l'utilisateur avec le rôle "dreal" modifie la demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" ayant pour référence "OUE-RP-2022-000033" avec la référence "OUE-RP-2022-000034"
+        Alors la dreal devrait être informé que "La référence du dossier de raccordement OUE-RP-2022-000033 ne peut pas être modifiée car le dossier dispose déjà d'une date de mise en service"

--- a/packages/specifications/src/raccordement/transmettreDemandeComplèteDeRaccordement.feature
+++ b/packages/specifications/src/raccordement/transmettreDemandeComplèteDeRaccordement.feature
@@ -39,7 +39,7 @@ Fonctionnalité: Transmettre une demande complète de raccordement
             | La référence du dossier de raccordement | OUE-RP-2022-000033                                                                                    |
             | Le format de l'accusé de réception      | application/pdf                                                                                       |
             | Le contenu de l'accusé de réception     | Accusé de réception ayant pour référence OUE-RP-2022-000033 et la date de qualification au 2022-10-28 |
-        Alors le porteur devrait être informé que "Il impossible d'avoir plusieurs dossiers de raccordement avec la même référence pour un projet"
+        Alors le porteur devrait être informé que "Il est impossible d'avoir plusieurs dossiers de raccordement avec la même référence pour un projet"
 
     Scénario: Impossible de transmettre une demande complète de raccordement auprès d'un autre gestionnaire de réseau
         Etant donné un gestionnaire de réseau


### PR DESCRIPTION
# Description

**Quand une date de mise en service est transmise sur un DCR**
ETQ DREAL je dois pouvoir soumettre une nouvelle DCR  ✅ 
ETQ DREAL je peux modifier une DCR qui n'est pas en service  ✅ 
ETQ DREAL je ne peux plus modifier la DCR en service  ✅ 
ETQ DREAL je dois pouvoir soumettre une PTF  ✅ 
ETQ DREAL je dois pouvoir modifier une PTF  ✅ 
ETQ PP  je ne peux pas modifier la référence de raccordement  d'une DCR "en service"  ✅ 
ETQ DREAL je ne dois pas pouvoir modifier la référence de raccordement d'une DCR "en service"  ✅

https://linear.app/startup-potentiel/issue/POT-400/%5Bdreal%5D-en-tant-que-dreal-je-dois-avoir-les-meme-droits-sur-la-page

## Type de changement

Veuillez supprimer les options qui ne sont pas pertinentes.

- [x] Correction de bug
- [ ] Nouvelle fonctionnalité
- [ ] Refacto de code
- [ ] Breaking changes (correction ou fonctionnalité qui ferait en sorte que la fonctionnalité existante ne fonctionne pas comme prévu)
- [ ] Ce changement nécessite une mise à jour de la documentation

# Comment cela a-t-il été testé?

front / back

# Check-up :

- [ ] Mon code [suit les directives de style](../docs/contributing//DEVELOPMENT_FLOW.md) de ce projet
- [ ] J'ai effectué une auto-revue de mon code
- [ ] J'ai commenté mon code, en particulier dans les zones difficiles à comprendre
- [ ] J'ai apporté des modifications correspondantes à la documentation
- [ ] Mes modifications ne génèrent aucun warning
- [ ] J'ai ajouté des tests qui prouvent l'efficacité de ma correction ou que ma fonctionnalité fonctionne
- [ ] Les nouveaux tests unitaires et les tests existants passent en local / dans la CI avec mes modifications
