### PR TITLE
🚸 Fix alerte si pas d'attestation de constitution

### DIFF
--- a/packages/applications/legacy/src/views/pages/projectDetailsPage/sections/InfoGenerales.tsx
+++ b/packages/applications/legacy/src/views/pages/projectDetailsPage/sections/InfoGenerales.tsx
@@ -172,13 +172,11 @@ const GarantiesFinancièresProjet = ({
               )}
             .
           </p>
-
           {!garantiesFinancières.actuelles?.dateConstitution && (
             <AlertMessage>
               L'attestation de constitution des garanties financières reste à transmettre.
             </AlertMessage>
           )}
-
           {garantiesFinancières.actuelles.type === 'type-inconnu' && (
             <AlertMessage>Le type de garanties financières reste à préciser.</AlertMessage>
           )}

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/garanties-financieres/page.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/garanties-financieres/page.tsx
@@ -200,12 +200,13 @@ const mapToProps: MapToProps = ({
     (Option.isSome(mainlevée) && mainlevée.statut.estAccordé()) ||
     Option.isSome(historiqueMainlevée);
 
+  if (aGarantiesFinancièresSansAttestation) {
+    garantiesFinancièresActuellesActions.push('enregister-attestation');
+  }
+
   if ((estAdminOuDGEC || estDreal) && aGarantiesFinancièresNonLevées) {
     garantiesFinancièresActuellesActions.push('modifier');
   } else if (estPorteur) {
-    if (aGarantiesFinancièresSansAttestation) {
-      garantiesFinancièresActuellesActions.push('enregister-attestation');
-    }
     if (aGarantiesFinancièresAvecAttestationSansDepotNiMainlevée && projetAbandonne) {
       garantiesFinancièresActuellesActions.push('demander-mainlevée-gf-pour-projet-abandonné');
     }

--- a/packages/applications/ssr/src/components/organisms/garantiesFinancières/GarantiesFinancières.tsx
+++ b/packages/applications/ssr/src/components/organisms/garantiesFinancières/GarantiesFinancières.tsx
@@ -67,12 +67,9 @@ export const GarantiesFinancières: FC<GarantiesFinancièresProps> = ({
                     : `Type à compléter par l'autorité instructrice compétente`}
                 </span>
               )}
-              {!garantiesFinancières.attestation && garantiesFinancières.isActuelle && (
+              {!garantiesFinancières.attestation && (
                 <span className="font-semibold italic">
-                  {garantiesFinancières.actions.includes('enregister-attestation')
-                    ? 'Attestation de constitution des garanties financières manquante'
-                    : `Attestation de constitution des garanties financières à transmettre par l'autorité
-                  instructrice compétente`}
+                  Attestation de constitution des garanties financières manquante
                 </span>
               )}
             </div>

--- a/packages/applications/ssr/src/components/organisms/garantiesFinancières/GarantiesFinancières.tsx
+++ b/packages/applications/ssr/src/components/organisms/garantiesFinancières/GarantiesFinancières.tsx
@@ -22,109 +22,122 @@ export const GarantiesFinancières: FC<GarantiesFinancièresProps> = ({
   identifiantProjet,
   contactPorteurs,
   garantiesFinancières,
-}) => (
-  <CallOut
-    className="flex-1"
-    colorVariant={'info'}
-    content={
-      <>
-        <div className="flex flex-col h-full">
-          <div>
-            <div className="flex gap-2">
-              <Heading2>
-                Garanties financières {garantiesFinancières.isActuelle ? 'actuelles' : 'à traiter'}
-              </Heading2>
-              {garantiesFinancières.isActuelle ? (
-                <StatutGarantiesFinancièresBadge statut={garantiesFinancières.statut} />
-              ) : null}
-            </div>
-            <div className="text-xs italic">
-              Dernière mise à jour le{' '}
-              <FormattedDate
-                className="font-semibold"
-                date={garantiesFinancières.dernièreMiseÀJour.date}
-              />
-              {garantiesFinancières.dernièreMiseÀJour.par && (
-                <>
-                  {' '}
-                  par{' '}
-                  <span className="font-semibold">
-                    {garantiesFinancières.dernièreMiseÀJour.par}
-                  </span>
-                </>
-              )}
-            </div>
-            <div className="mt-5 mb-5 gap-2 text-base flex flex-col">
-              {garantiesFinancières.type && (
-                <div>
-                  Type : <span className="font-semibold">{garantiesFinancières.type}</span>
-                </div>
-              )}
-              {!garantiesFinancières.type && (
-                <span className="font-semibold italic">
-                  {garantiesFinancières.actions.includes('modifier')
-                    ? 'Type de garanties financières manquant'
-                    : `Type à compléter par l'autorité instructrice compétente`}
-                </span>
-              )}
-              {!garantiesFinancières.attestation && (
-                <span className="font-semibold italic">
-                  {garantiesFinancières.actions.includes('modifier')
-                    ? 'Attestation de constitution des garanties financières manquante'
-                    : `Attestation de constitution des garanties financières à transmettre par l'autorité
-                  instructrice compétente`}
-                </span>
-              )}
-            </div>
-
-            {garantiesFinancières.dateÉchéance && (
-              <div>
-                Date d'échéance :{' '}
-                <FormattedDate className="font-semibold" date={garantiesFinancières.dateÉchéance} />
+}) => {
+  console.log(garantiesFinancières.actions);
+  return (
+    <CallOut
+      className="flex-1"
+      colorVariant={'info'}
+      content={
+        <>
+          <div className="flex flex-col h-full">
+            <div>
+              <div className="flex gap-2">
+                <Heading2>
+                  Garanties financières{' '}
+                  {garantiesFinancières.isActuelle ? 'actuelles' : 'à traiter'}
+                </Heading2>
+                {garantiesFinancières.isActuelle ? (
+                  <StatutGarantiesFinancièresBadge statut={garantiesFinancières.statut} />
+                ) : null}
               </div>
-            )}
-            {garantiesFinancières.dateConstitution && (
-              <div>
-                Date de constitution :{' '}
+              <div className="text-xs italic">
+                Dernière mise à jour le{' '}
                 <FormattedDate
                   className="font-semibold"
-                  date={garantiesFinancières.dateConstitution}
+                  date={garantiesFinancières.dernièreMiseÀJour.date}
                 />
+                {garantiesFinancières.dernièreMiseÀJour.par && (
+                  <>
+                    {' '}
+                    par{' '}
+                    <span className="font-semibold">
+                      {garantiesFinancières.dernièreMiseÀJour.par}
+                    </span>
+                  </>
+                )}
               </div>
-            )}
-            {garantiesFinancières.isActuelle && (
-              <>
-                {garantiesFinancières.validéLe && (
+              <div className="mt-5 mb-5 gap-2 text-base flex flex-col">
+                {garantiesFinancières.type && (
                   <div>
-                    Validé le :{' '}
-                    <FormattedDate className="font-semibold" date={garantiesFinancières.validéLe} />
+                    Type : <span className="font-semibold">{garantiesFinancières.type}</span>
                   </div>
                 )}
-                {garantiesFinancières.soumisLe && (
-                  <div>
-                    Soumis le :{' '}
-                    <FormattedDate className="font-semibold" date={garantiesFinancières.soumisLe} />
-                  </div>
+                {!garantiesFinancières.type && (
+                  <span className="font-semibold italic">
+                    {garantiesFinancières.actions.includes('modifier')
+                      ? 'Type de garanties financières manquant'
+                      : `Type à compléter par l'autorité instructrice compétente`}
+                  </span>
                 )}
-              </>
-            )}
-            <div>
-              {garantiesFinancières.attestation && (
-                <DownloadDocument
-                  format="pdf"
-                  label="Télécharger l'attestation de constitution"
-                  url={Routes.Document.télécharger(garantiesFinancières.attestation)}
-                />
+                {!garantiesFinancières.attestation && garantiesFinancières.isActuelle && (
+                  <span className="font-semibold italic">
+                    {garantiesFinancières.actions.includes('enregister-attestation')
+                      ? 'Attestation de constitution des garanties financières manquante'
+                      : `Attestation de constitution des garanties financières à transmettre par l'autorité
+                  instructrice compétente`}
+                  </span>
+                )}
+              </div>
+
+              {garantiesFinancières.dateÉchéance && (
+                <div>
+                  Date d'échéance :{' '}
+                  <FormattedDate
+                    className="font-semibold"
+                    date={garantiesFinancières.dateÉchéance}
+                  />
+                </div>
               )}
+              {garantiesFinancières.dateConstitution && (
+                <div>
+                  Date de constitution :{' '}
+                  <FormattedDate
+                    className="font-semibold"
+                    date={garantiesFinancières.dateConstitution}
+                  />
+                </div>
+              )}
+              {garantiesFinancières.isActuelle && (
+                <>
+                  {garantiesFinancières.validéLe && (
+                    <div>
+                      Validé le :{' '}
+                      <FormattedDate
+                        className="font-semibold"
+                        date={garantiesFinancières.validéLe}
+                      />
+                    </div>
+                  )}
+                  {garantiesFinancières.soumisLe && (
+                    <div>
+                      Soumis le :{' '}
+                      <FormattedDate
+                        className="font-semibold"
+                        date={garantiesFinancières.soumisLe}
+                      />
+                    </div>
+                  )}
+                </>
+              )}
+              <div>
+                {garantiesFinancières.attestation && (
+                  <DownloadDocument
+                    format="pdf"
+                    label="Télécharger l'attestation de constitution"
+                    url={Routes.Document.télécharger(garantiesFinancières.attestation)}
+                  />
+                )}
+              </div>
             </div>
+            <GarantiesFinancièresActions
+              identifiantProjet={identifiantProjet}
+              contactPorteurs={contactPorteurs}
+              {...garantiesFinancières}
+            />
           </div>
-          <GarantiesFinancièresActions
-            identifiantProjet={identifiantProjet}
-            contactPorteurs={contactPorteurs}
-            {...garantiesFinancières}
-          />
-        </div>
-      </>
-    }
-  />
-);
+        </>
+      }
+    />
+  );
+};

--- a/packages/applications/ssr/src/components/organisms/garantiesFinancières/GarantiesFinancières.tsx
+++ b/packages/applications/ssr/src/components/organisms/garantiesFinancières/GarantiesFinancières.tsx
@@ -22,122 +22,109 @@ export const GarantiesFinancières: FC<GarantiesFinancièresProps> = ({
   identifiantProjet,
   contactPorteurs,
   garantiesFinancières,
-}) => {
-  console.log(garantiesFinancières.actions);
-  return (
-    <CallOut
-      className="flex-1"
-      colorVariant={'info'}
-      content={
-        <>
-          <div className="flex flex-col h-full">
-            <div>
-              <div className="flex gap-2">
-                <Heading2>
-                  Garanties financières{' '}
-                  {garantiesFinancières.isActuelle ? 'actuelles' : 'à traiter'}
-                </Heading2>
-                {garantiesFinancières.isActuelle ? (
-                  <StatutGarantiesFinancièresBadge statut={garantiesFinancières.statut} />
-                ) : null}
-              </div>
-              <div className="text-xs italic">
-                Dernière mise à jour le{' '}
-                <FormattedDate
-                  className="font-semibold"
-                  date={garantiesFinancières.dernièreMiseÀJour.date}
-                />
-                {garantiesFinancières.dernièreMiseÀJour.par && (
-                  <>
-                    {' '}
-                    par{' '}
-                    <span className="font-semibold">
-                      {garantiesFinancières.dernièreMiseÀJour.par}
-                    </span>
-                  </>
-                )}
-              </div>
-              <div className="mt-5 mb-5 gap-2 text-base flex flex-col">
-                {garantiesFinancières.type && (
-                  <div>
-                    Type : <span className="font-semibold">{garantiesFinancières.type}</span>
-                  </div>
-                )}
-                {!garantiesFinancières.type && (
-                  <span className="font-semibold italic">
-                    {garantiesFinancières.actions.includes('modifier')
-                      ? 'Type de garanties financières manquant'
-                      : `Type à compléter par l'autorité instructrice compétente`}
-                  </span>
-                )}
-                {!garantiesFinancières.attestation && garantiesFinancières.isActuelle && (
-                  <span className="font-semibold italic">
-                    {garantiesFinancières.actions.includes('enregister-attestation')
-                      ? 'Attestation de constitution des garanties financières manquante'
-                      : `Attestation de constitution des garanties financières à transmettre par l'autorité
-                  instructrice compétente`}
-                  </span>
-                )}
-              </div>
-
-              {garantiesFinancières.dateÉchéance && (
-                <div>
-                  Date d'échéance :{' '}
-                  <FormattedDate
-                    className="font-semibold"
-                    date={garantiesFinancières.dateÉchéance}
-                  />
-                </div>
-              )}
-              {garantiesFinancières.dateConstitution && (
-                <div>
-                  Date de constitution :{' '}
-                  <FormattedDate
-                    className="font-semibold"
-                    date={garantiesFinancières.dateConstitution}
-                  />
-                </div>
-              )}
-              {garantiesFinancières.isActuelle && (
+}) => (
+  <CallOut
+    className="flex-1"
+    colorVariant={'info'}
+    content={
+      <>
+        <div className="flex flex-col h-full">
+          <div>
+            <div className="flex gap-2">
+              <Heading2>
+                Garanties financières {garantiesFinancières.isActuelle ? 'actuelles' : 'à traiter'}
+              </Heading2>
+              {garantiesFinancières.isActuelle ? (
+                <StatutGarantiesFinancièresBadge statut={garantiesFinancières.statut} />
+              ) : null}
+            </div>
+            <div className="text-xs italic">
+              Dernière mise à jour le{' '}
+              <FormattedDate
+                className="font-semibold"
+                date={garantiesFinancières.dernièreMiseÀJour.date}
+              />
+              {garantiesFinancières.dernièreMiseÀJour.par && (
                 <>
-                  {garantiesFinancières.validéLe && (
-                    <div>
-                      Validé le :{' '}
-                      <FormattedDate
-                        className="font-semibold"
-                        date={garantiesFinancières.validéLe}
-                      />
-                    </div>
-                  )}
-                  {garantiesFinancières.soumisLe && (
-                    <div>
-                      Soumis le :{' '}
-                      <FormattedDate
-                        className="font-semibold"
-                        date={garantiesFinancières.soumisLe}
-                      />
-                    </div>
-                  )}
+                  {' '}
+                  par{' '}
+                  <span className="font-semibold">
+                    {garantiesFinancières.dernièreMiseÀJour.par}
+                  </span>
                 </>
               )}
-              <div>
-                {garantiesFinancières.attestation && (
-                  <DownloadDocument
-                    format="pdf"
-                    label="Télécharger l'attestation de constitution"
-                    url={Routes.Document.télécharger(garantiesFinancières.attestation)}
-                  />
-                )}
-              </div>
             </div>
-            <GarantiesFinancièresActions
-              identifiantProjet={identifiantProjet}
-              contactPorteurs={contactPorteurs}
-              {...garantiesFinancières}
-            />
+            <div className="mt-5 mb-5 gap-2 text-base flex flex-col">
+              {garantiesFinancières.type && (
+                <div>
+                  Type : <span className="font-semibold">{garantiesFinancières.type}</span>
+                </div>
+              )}
+              {!garantiesFinancières.type && (
+                <span className="font-semibold italic">
+                  {garantiesFinancières.actions.includes('modifier')
+                    ? 'Type de garanties financières manquant'
+                    : `Type à compléter par l'autorité instructrice compétente`}
+                </span>
+              )}
+              {!garantiesFinancières.attestation && garantiesFinancières.isActuelle && (
+                <span className="font-semibold italic">
+                  {garantiesFinancières.actions.includes('enregister-attestation')
+                    ? 'Attestation de constitution des garanties financières manquante'
+                    : `Attestation de constitution des garanties financières à transmettre par l'autorité
+                  instructrice compétente`}
+                </span>
+              )}
+            </div>
+
+            {garantiesFinancières.dateÉchéance && (
+              <div>
+                Date d'échéance :{' '}
+                <FormattedDate className="font-semibold" date={garantiesFinancières.dateÉchéance} />
+              </div>
+            )}
+            {garantiesFinancières.dateConstitution && (
+              <div>
+                Date de constitution :{' '}
+                <FormattedDate
+                  className="font-semibold"
+                  date={garantiesFinancières.dateConstitution}
+                />
+              </div>
+            )}
+            {garantiesFinancières.isActuelle && (
+              <>
+                {garantiesFinancières.validéLe && (
+                  <div>
+                    Validé le :{' '}
+                    <FormattedDate className="font-semibold" date={garantiesFinancières.validéLe} />
+                  </div>
+                )}
+                {garantiesFinancières.soumisLe && (
+                  <div>
+                    Soumis le :{' '}
+                    <FormattedDate className="font-semibold" date={garantiesFinancières.soumisLe} />
+                  </div>
+                )}
+              </>
+            )}
+            <div>
+              {garantiesFinancières.attestation && (
+                <DownloadDocument
+                  format="pdf"
+                  label="Télécharger l'attestation de constitution"
+                  url={Routes.Document.télécharger(garantiesFinancières.attestation)}
+                />
+              )}
+            </div>
           </div>
-        </>
-      }
-    />
-  );
-};
+          <GarantiesFinancièresActions
+            identifiantProjet={identifiantProjet}
+            contactPorteurs={contactPorteurs}
+            {...garantiesFinancières}
+          />
+        </div>
+      </>
+    }
+  />
+);

--- a/packages/applications/ssr/src/components/organisms/garantiesFinancières/GarantiesFinancièresActions.tsx
+++ b/packages/applications/ssr/src/components/organisms/garantiesFinancières/GarantiesFinancièresActions.tsx
@@ -50,10 +50,6 @@ export const GarantiesFinancièresActions = ({
           )}
           {actions.includes('enregister-attestation') && (
             <div className="flex flex-col gap-1">
-              <p className="italic">
-                Les garanties financières sont incomplètes, merci de les compléter en enregistrant
-                l'attestation de constitution
-              </p>
               <Button
                 linkProps={{
                   href: Routes.GarantiesFinancières.actuelles.enregistrerAttestation(


### PR DESCRIPTION
# Description

- meilleure condition
=> tout le monde a le droit d'enregistrer une attestation de constitution donc suppression de la condition
- supprimer doublon de wording

## Type de changement

Veuillez supprimer les options qui ne sont pas pertinentes.

- [ ] Correction de bug
- [ ] Nouvelle fonctionnalité
- [x] Refacto de code
- [ ] Breaking changes (correction ou fonctionnalité qui ferait en sorte que la fonctionnalité existante ne fonctionne pas comme prévu)
- [ ] Ce changement nécessite une mise à jour de la documentation

# Comment cela a-t-il été testé?

<img width="1117" alt="Capture d’écran 2024-07-26 à 10 56 19" src="https://github.com/user-attachments/assets/3d20bed6-baa0-41f0-96cc-a37126c015b9">
<img width="1094" alt="Capture d’écran 2024-07-26 à 10 56 48" src="https://github.com/user-attachments/assets/3cbbc1f0-28d3-4c4e-a4e3-cd42649bfb90">


# Check-up :

- [ ] Mon code [suit les directives de style](../docs/contributing//DEVELOPMENT_FLOW.md) de ce projet
- [ ] J'ai effectué une auto-revue de mon code
- [ ] J'ai commenté mon code, en particulier dans les zones difficiles à comprendre
- [ ] J'ai apporté des modifications correspondantes à la documentation
- [ ] Mes modifications ne génèrent aucun warning
- [ ] J'ai ajouté des tests qui prouvent l'efficacité de ma correction ou que ma fonctionnalité fonctionne
- [ ] Les nouveaux tests unitaires et les tests existants passent en local / dans la CI avec mes modifications
