### PR TITLE
✨ Mise à jour de la date d'achèvement lors d'un ré-import avec changement de technologie

### DIFF
--- a/packages/applications/legacy/src/modules/project/Project.ts
+++ b/packages/applications/legacy/src/modules/project/Project.ts
@@ -471,11 +471,8 @@ export const makeProject = (args: {
             }
           } else {
             if (props.isClasse) {
-              if (hasNotificationDateChanged) {
-                // remains classé
-                _updateDCRDate(appelOffre);
-                _updateCompletionDate(appelOffre);
-              }
+              _updateDCRDate(appelOffre);
+              _updateCompletionDate(appelOffre);
             }
             // remains éliminé
           }

--- a/packages/applications/legacy/src/modules/project/Project.ts
+++ b/packages/applications/legacy/src/modules/project/Project.ts
@@ -471,11 +471,18 @@ export const makeProject = (args: {
             }
           } else {
             if (props.isClasse) {
-              _updateDCRDate(appelOffre);
-              _updateCompletionDate(appelOffre);
+              if (hasNotificationDateChanged) {
+                // remains classé
+                _updateDCRDate(appelOffre);
+                _updateCompletionDate(appelOffre);
+              }
             }
             // remains éliminé
           }
+        }
+
+        if (changes.technologie) {
+          _updateCompletionDate(appelOffre);
         }
       }
 


### PR DESCRIPTION
# Description

Afin de corriger les dates d'achèvement erronées de projets ayant la mauvaise technologie
Cette PR active la mise à jour de la date à chaque fois lors d'un ré-import qui entraîne un changement de technologie.

## Type de changement

- Nouvelle fonctionnalité

# Comment cela a-t-il été testé?

Avec un dump de prod et un fichier de correction pour la période 2 de l'appel d'offre `PPE2 - Neutre` présent dans l'issue Linear.