### PR TITLE
🐛 Les utilisateurs de type CRE + caisse des dépôts doivent avoir accès à l'historique des mainlevée d'une GF

### DIFF
--- a/packages/domain/utilisateur/src/role.valueType.ts
+++ b/packages/domain/utilisateur/src/role.valueType.ts
@@ -70,6 +70,7 @@ export const dgecValidateur = convertirEnValueType('dgec-validateur');
 export const dreal = convertirEnValueType('dreal');
 export const cre = convertirEnValueType('cre');
 export const acheteurObligé = convertirEnValueType('acheteur-obligé');
+export const caisseDesDépôts = convertirEnValueType('caisse-des-dépôts');
 
 class RoleRefuséError extends OperationRejectedError {
   constructor(value: string) {
@@ -742,6 +743,7 @@ const permissionCRE: Policy[] = [
   'garantiesFinancières.actuelles.enregistrerAttestation',
   'garantiesFinancières.actuelles.enregistrer',
   'garantiesFinancières.mainlevée.consulter',
+  'garantiesFinancières.mainlevée.consulterHistorique',
 ];
 
 const permissionDreal: Policy[] = [
@@ -895,6 +897,7 @@ const permissionCaisseDesDépôts: Policy[] = [
   'garantiesFinancières.actuelles.enregistrerAttestation',
   'garantiesFinancières.actuelles.enregistrer',
   'garantiesFinancières.mainlevée.consulter',
+  'garantiesFinancières.mainlevée.consulterHistorique',
 
   // Achèvement
   'achèvement.consulter',

--- a/packages/domain/utilisateur/src/vérifierAccèsProjet/vérifierAccèsProjet.query.ts
+++ b/packages/domain/utilisateur/src/vérifierAccèsProjet/vérifierAccèsProjet.query.ts
@@ -41,6 +41,7 @@ export const registerVérifierAccèsProjetQuery = ({
       utilisateur.role.estÉgaleÀ(Role.dgecValidateur) ||
       utilisateur.role.estÉgaleÀ(Role.dreal) ||
       utilisateur.role.estÉgaleÀ(Role.cre) ||
+      utilisateur.role.estÉgaleÀ(Role.caisseDesDépôts) ||
       utilisateur.role.estÉgaleÀ(Role.acheteurObligé)
     ) {
       return;


### PR DESCRIPTION
## Type de changement
- [x] Correction de bug
