### PR TITLE
✅ Impossible de modifier des gfs actuelles si role cre ou caisse des dépôts

### DIFF
--- a/packages/applications/ssr/src/components/pages/garanties-financières/actuelles/modifier/modifierGarantiesFinancièresActuelles.action.ts
+++ b/packages/applications/ssr/src/components/pages/garanties-financières/actuelles/modifier/modifierGarantiesFinancièresActuelles.action.ts
@@ -44,6 +44,7 @@ const action: FormAction<FormState, typeof schema> = async (_, data) =>
         attestationValue: data.attestation,
         modifiéLeValue: new Date().toISOString(),
         modifiéParValue: utilisateur.identifiantUtilisateur.formatter(),
+        rôleValue: utilisateur.role.nom,
       },
     });
 

--- a/packages/applications/ssr/tsconfig.json
+++ b/packages/applications/ssr/tsconfig.json
@@ -53,9 +53,6 @@
       "path": "../../domain/utilisateur"
     },
     {
-      "path": "../../infrastructure/document-builder"
-    },
-    {
       "path": "../../libraries/csv"
     },
     {

--- a/packages/domain/lauréat/src/garantiesFinancières/garantiesFinancièresActuelles/modifier/modifierGarantiesFinancières.behavior.ts
+++ b/packages/domain/lauréat/src/garantiesFinancières/garantiesFinancièresActuelles/modifier/modifierGarantiesFinancières.behavior.ts
@@ -1,6 +1,6 @@
 import { DateTime, IdentifiantProjet } from '@potentiel-domain/common';
-import { DomainEvent } from '@potentiel-domain/core';
-import { IdentifiantUtilisateur } from '@potentiel-domain/utilisateur';
+import { DomainEvent, InvalidOperationError } from '@potentiel-domain/core';
+import { IdentifiantUtilisateur, Role } from '@potentiel-domain/utilisateur';
 
 import { StatutGarantiesFinancières, TypeGarantiesFinancières } from '../..';
 import { DateConstitutionDansLeFuturError } from '../../dateConstitutionDansLeFutur.error';
@@ -31,6 +31,7 @@ export type Options = {
   dateConstitution: DateTime.ValueType;
   modifiéLe: DateTime.ValueType;
   modifiéPar: IdentifiantUtilisateur.ValueType;
+  rôle: Role.ValueType;
 };
 
 export async function modifier(
@@ -43,8 +44,13 @@ export async function modifier(
     dateÉchéance,
     modifiéLe,
     modifiéPar,
+    rôle,
   }: Options,
 ) {
+  if (rôle.estÉgaleÀ(Role.cre) || rôle.estÉgaleÀ(Role.caisseDesDépôts)) {
+    throw new RôleNonAutoriséError();
+  }
+
   if (!this.actuelles) {
     throw new AucunesGarantiesFinancièresActuellesError();
   }
@@ -91,4 +97,10 @@ export function applyModifierGarantiesFinancières(
     dateConstitution: DateTime.convertirEnValueType(dateConstitution),
     attestation,
   };
+}
+
+class RôleNonAutoriséError extends InvalidOperationError {
+  constructor() {
+    super("L'accés à cette fonctionnalité n'est pas autorisé");
+  }
 }

--- a/packages/domain/lauréat/src/garantiesFinancières/garantiesFinancièresActuelles/modifier/modifierGarantiesFinancières.command.ts
+++ b/packages/domain/lauréat/src/garantiesFinancières/garantiesFinancièresActuelles/modifier/modifierGarantiesFinancières.command.ts
@@ -3,7 +3,7 @@ import { Message, MessageHandler, mediator } from 'mediateur';
 import { DateTime, IdentifiantProjet } from '@potentiel-domain/common';
 import { DocumentProjet } from '@potentiel-domain/document';
 import { LoadAggregate } from '@potentiel-domain/core';
-import { IdentifiantUtilisateur } from '@potentiel-domain/utilisateur';
+import { IdentifiantUtilisateur, Role } from '@potentiel-domain/utilisateur';
 
 import { TypeGarantiesFinancières } from '../..';
 import { loadGarantiesFinancièresFactory } from '../../garantiesFinancières.aggregate';
@@ -18,6 +18,7 @@ export type ModifierGarantiesFinancièresCommand = Message<
     dateConstitution: DateTime.ValueType;
     modifiéPar: IdentifiantUtilisateur.ValueType;
     modifiéLe: DateTime.ValueType;
+    rôle: Role.ValueType;
   }
 >;
 
@@ -31,6 +32,7 @@ export const registerModifierGarantiesFinancièresCommand = (loadAggregate: Load
     dateÉchéance,
     modifiéLe,
     modifiéPar,
+    rôle,
   }) => {
     const garantiesFinancières = await loadGarantiesFinancières(identifiantProjet, false);
     await garantiesFinancières.modifier({
@@ -41,6 +43,7 @@ export const registerModifierGarantiesFinancièresCommand = (loadAggregate: Load
       dateÉchéance,
       modifiéLe,
       modifiéPar,
+      rôle,
     });
   };
   mediator.register('Lauréat.GarantiesFinancières.Command.ModifierGarantiesFinancières', handler);

--- a/packages/domain/lauréat/src/garantiesFinancières/garantiesFinancièresActuelles/modifier/modifierGarantiesFinancières.usecase.ts
+++ b/packages/domain/lauréat/src/garantiesFinancières/garantiesFinancièresActuelles/modifier/modifierGarantiesFinancières.usecase.ts
@@ -2,7 +2,7 @@ import { Message, MessageHandler, mediator } from 'mediateur';
 
 import { DocumentProjet, EnregistrerDocumentProjetCommand } from '@potentiel-domain/document';
 import { DateTime, IdentifiantProjet } from '@potentiel-domain/common';
-import { IdentifiantUtilisateur } from '@potentiel-domain/utilisateur';
+import { IdentifiantUtilisateur, Role } from '@potentiel-domain/utilisateur';
 import { AjouterTâchePlanifiéeCommand } from '@potentiel-domain/tache-planifiee';
 
 import { TypeDocumentGarantiesFinancières, TypeGarantiesFinancières } from '../..';
@@ -23,6 +23,7 @@ export type ModifierGarantiesFinancièresUseCase = Message<
     dateConstitutionValue: string;
     modifiéLeValue: string;
     modifiéParValue: string;
+    rôleValue: string;
   }
 >;
 
@@ -35,6 +36,7 @@ export const registerModifierGarantiesFinancièresUseCase = () => {
     typeValue,
     dateÉchéanceValue,
     modifiéParValue,
+    rôleValue,
   }) => {
     const identifiantProjet = IdentifiantProjet.convertirEnValueType(identifiantProjetValue);
     const type = TypeGarantiesFinancières.convertirEnValueType(typeValue);
@@ -50,6 +52,7 @@ export const registerModifierGarantiesFinancièresUseCase = () => {
       attestationValue.format,
     );
     const modifiéPar = IdentifiantUtilisateur.convertirEnValueType(modifiéParValue);
+    const rôle = Role.convertirEnValueType(rôleValue);
 
     await mediator.send<EnregistrerDocumentProjetCommand>({
       type: 'Document.Command.EnregistrerDocumentProjet',
@@ -69,6 +72,7 @@ export const registerModifierGarantiesFinancièresUseCase = () => {
         dateÉchéance,
         modifiéLe,
         modifiéPar,
+        rôle,
       },
     });
 

--- a/packages/specifications/src/projet/lauréat/garantiesFinancières/actuelles/modifierGarantiesFinancièresActuelles.feature
+++ b/packages/specifications/src/projet/lauréat/garantiesFinancières/actuelles/modifierGarantiesFinancièresActuelles.feature
@@ -18,7 +18,7 @@ Fonctionnalité: Modifier des garanties financières actuelles
             | date de soumission   | 2023-11-01        |
             | soumis par           | porteur@test.test |
             | date de validation   | 2023-11-03        |
-        Quand un admin modifie les garanties financières actuelles pour le projet "Du boulodrome de Marseille" avec :
+        Quand l'utilisateur avec le rôle "admin" modifie les garanties financières actuelles pour le projet "Du boulodrome de Marseille" avec :
             | type                 | <type>            |
             | date d'échéance      | <date d'échéance> |
             | format               | application/pdf   |
@@ -45,7 +45,7 @@ Fonctionnalité: Modifier des garanties financières actuelles
             | type               | avec-date-échéance |
             | date d'échéance    | 2024-12-01         |
             | date de validation | 2024-11-24         |
-        Quand un admin modifie les garanties financières actuelles pour le projet "Du boulodrome de Marseille" avec :
+        Quand l'utilisateur avec le rôle "admin" modifie les garanties financières actuelles pour le projet "Du boulodrome de Marseille" avec :
             | type            | avec-date-échéance |
             | date d'échéance | 2024-12-02         |
         Alors une tâche "échoir les garanties financières" est planifiée à la date du "2024-12-03" pour le projet "Du boulodrome de Marseille"
@@ -54,16 +54,28 @@ Fonctionnalité: Modifier des garanties financières actuelles
         Etant donné des garanties financières actuelles pour le projet "Du boulodrome de Marseille" avec :
             | type            | avec-date-échéance |
             | date d'échéance | 2024-08-01         |
-        Quand un admin modifie les garanties financières actuelles pour le projet "Du boulodrome de Marseille" avec :
+        Quand l'utilisateur avec le rôle "admin" modifie les garanties financières actuelles pour le projet "Du boulodrome de Marseille" avec :
             | type            | avec-date-échéance |
             | date d'échéance | 2024-10-01         |
         Alors une tâche "rappel échéance garanties financières à un mois" est planifiée à la date du "2024-09-01" pour le projet "Du boulodrome de Marseille"
         Et une tâche "rappel échéance garanties financières à deux mois" est planifiée à la date du "2024-08-01" pour le projet "Du boulodrome de Marseille"
 
+    Plan du Scénario: Impossible de modifier des garanties financières actuelles en tant qu'utilisateur n'ayant pas l'autorisation
+        Etant donné des garanties financières actuelles pour le projet "Du boulodrome de Marseille"
+        Quand l'utilisateur avec le rôle "<Role non autorisé>" modifie les garanties financières actuelles pour le projet "Du boulodrome de Marseille" avec :
+            | type            | avec-date-échéance |
+            | date d'échéance | 2024-10-01         |
+        Alors l'utilisateur avec le rôle "<Role non autorisé>" devrait être informé que "L'accés à cette fonctionnalité n'est pas autorisé"
+
+        Exemples:
+            | Role non autorisé |
+            | cre               |
+            | caisse-des-dépôts |
+
     Plan du Scénario: Impossible de modifier des garanties financières actuelles si le type renseigné n'est pas compatible avec une date d'échéance
         Etant donné des garanties financières actuelles pour le projet "Du boulodrome de Marseille" avec :
             | type | type-inconnu |
-        Quand un admin modifie les garanties financières actuelles pour le projet "Du boulodrome de Marseille" avec :
+        Quand l'utilisateur avec le rôle "admin" modifie les garanties financières actuelles pour le projet "Du boulodrome de Marseille" avec :
             | type            | <type>            |
             | date d'échéance | <date d'échéance> |
         Alors l'utilisateur devrait être informé que "Vous ne pouvez pas renseigner de date d'échéance pour ce type de garanties financières"
@@ -76,7 +88,7 @@ Fonctionnalité: Modifier des garanties financières actuelles
     Scénario: Impossible de modifier des garanties financières actuelles si la date d'échéance est manquante
         Etant donné des garanties financières actuelles pour le projet "Du boulodrome de Marseille" avec :
             | type | type-inconnu |
-        Quand un admin modifie les garanties financières actuelles pour le projet "Du boulodrome de Marseille" avec :
+        Quand l'utilisateur avec le rôle "admin" modifie les garanties financières actuelles pour le projet "Du boulodrome de Marseille" avec :
             | type            | avec-date-échéance |
             | date d'échéance |                    |
         Alors l'utilisateur devrait être informé que "Vous devez renseigner la date d'échéance pour ce type de garanties financières"
@@ -84,12 +96,12 @@ Fonctionnalité: Modifier des garanties financières actuelles
     Scénario: Impossible de modifier des garanties financières actuelles si la date de constitution est dans le futur
         Etant donné des garanties financières actuelles pour le projet "Du boulodrome de Marseille" avec :
             | type | type-inconnu |
-        Quand un admin modifie les garanties financières actuelles pour le projet "Du boulodrome de Marseille" avec :
+        Quand l'utilisateur avec le rôle "admin" modifie les garanties financières actuelles pour le projet "Du boulodrome de Marseille" avec :
             | date de constitution | 2050-01-01 |
         Alors l'utilisateur devrait être informé que "La date de constitution des garanties financières ne peut pas être une date future"
 
-    Scénario: Impossible de modifier des garanties financières actuelles si aucunes garanties financières actuelles ne sont trouvées
-        Quand un admin modifie les garanties financières actuelles pour le projet "Du boulodrome de Marseille" avec :
+    Scénario: Impossible de modifier des garanties financières actuelles si aucunes garanties financières actuelles trouvées
+        Quand l'utilisateur avec le rôle "admin" modifie les garanties financières actuelles pour le projet "Du boulodrome de Marseille" avec :
             | date de constitution | 2020-01-01 |
         Alors l'utilisateur devrait être informé que "Il n'y a aucunes garanties financières actuelles pour ce projet"
 
@@ -97,7 +109,7 @@ Fonctionnalité: Modifier des garanties financières actuelles
         Etant donné une attestation de conformité transmise pour le projet "Du boulodrome de Marseille"
         Et des garanties financières actuelles pour le projet "Du boulodrome de Marseille"
         Et une demande de mainlevée de garanties financières accordée pour le projet "Du boulodrome de Marseille" achevé
-        Quand un admin modifie les garanties financières actuelles pour le projet "Du boulodrome de Marseille" avec :
+        Quand l'utilisateur avec le rôle "admin" modifie les garanties financières actuelles pour le projet "Du boulodrome de Marseille" avec :
             | date de constitution | 2020-01-01 |
         Alors l'utilisateur devrait être informé que "Vous ne pouvez pas déposer ou modifier des garanties financières car elles ont déjà été levées pour ce projet"
 

--- a/packages/specifications/src/projet/lauréat/garantiesFinancières/actuelles/stepDefinitions/garantiesFinancièresActuelles.when.ts
+++ b/packages/specifications/src/projet/lauréat/garantiesFinancières/actuelles/stepDefinitions/garantiesFinancièresActuelles.when.ts
@@ -41,8 +41,8 @@ Quand(
 );
 
 Quand(
-  `un admin modifie les garanties financières actuelles pour le projet {string} avec :`,
-  async function (this: PotentielWorld, nomProjet: string, dataTable: DataTable) {
+  `l'utilisateur avec le rôle {string} modifie les garanties financières actuelles pour le projet {string} avec :`,
+  async function (this: PotentielWorld, rôle: string, nomProjet: string, dataTable: DataTable) {
     const exemple = dataTable.rowsHash();
 
     try {
@@ -65,6 +65,7 @@ Quand(
           dateConstitutionValue: new Date(dateConstitution).toISOString(),
           modifiéLeValue: new Date(modifiéLe).toISOString(),
           modifiéParValue: 'admin@test.test',
+          rôleValue: rôle,
         },
       });
       await sleep(300);


### PR DESCRIPTION
# Description
Les utilisateurs avec le rôle cre ou caisse-des-dépots ne doivent pas pouvoir modifier des GFs

## Type de changement

Veuillez supprimer les options qui ne sont pas pertinentes.

- [x] Nouvelle fonctionnalité


# Comment cela a-t-il été testé?

TDD