### PR TITLE
✨ Notifier la CRE quand un recours est accepté

### DIFF
--- a/packages/applications/legacy/src/config/eventHandlers/notification.eventHandlers.ts
+++ b/packages/applications/legacy/src/config/eventHandlers/notification.eventHandlers.ts
@@ -36,6 +36,7 @@ import {
   getProjectInfoForModificationRequestedNotification,
   getRecipientsForPeriodeNotifiedNotification,
   récupérerDonnéesPorteursParProjetQueryHandler,
+  getUsersByRole,
 } from '../queries.config';
 import { getProjectAppelOffre } from '../queryProjectAO.config';
 import { oldProjectRepo, oldUserRepo, projectRepo } from '../repos.config';
@@ -52,6 +53,7 @@ eventStore.subscribe(ProjectCertificateRegenerated.type, projectCertificateChang
 const modificationRequestStatusChangeHandler = handleModificationRequestStatusChanged({
   sendNotification,
   getModificationRequestInfoForStatusNotification,
+  getUsersByRole,
 });
 eventStore.subscribe(
   ModificationRequestInstructionStarted.type,

--- a/packages/applications/legacy/src/infra/mail/mailjet.ts
+++ b/packages/applications/legacy/src/infra/mail/mailjet.ts
@@ -34,6 +34,7 @@ const TEMPLATE_ID_BY_TYPE: Record<NotificationProps['type'], number> = {
   'date-mise-en-service-transmise-annule-delai-cdc-2022': 5169667,
   'demande-complete-raccordement-transmise-annule-delai-Cdc-2022': 5219626,
   'dreal-modification-puissance-cdc-2022': 5446765,
+  'cre-recours-accepté': 6189222,
 };
 
 interface SendEmailFromMailjetDeps {

--- a/packages/applications/legacy/src/infra/sequelize/queries/users/getUsersByRole.ts
+++ b/packages/applications/legacy/src/infra/sequelize/queries/users/getUsersByRole.ts
@@ -1,0 +1,10 @@
+import { ok, Result, wrapInfra } from '../../../../core/utils';
+import { User } from '../../projectionsNext';
+import { InfraNotAvailableError } from '../../../../modules/shared';
+import { GetUsersByRole } from '../../../../modules/users';
+
+export const getUsersByRole: GetUsersByRole = (role) => {
+  return wrapInfra(User.findAll({ where: { role } })).andThen(
+    (users): Result<User[], InfraNotAvailableError> => ok(users),
+  );
+};

--- a/packages/applications/legacy/src/infra/sequelize/queries/users/index.ts
+++ b/packages/applications/legacy/src/infra/sequelize/queries/users/index.ts
@@ -2,3 +2,4 @@ export * from './dreals';
 export * from './partnerUsers';
 export * from './getUserByEmail';
 export * from './getUserById';
+export * from './getUsersByRole';

--- a/packages/applications/legacy/src/modules/notification/Notification.ts
+++ b/packages/applications/legacy/src/modules/notification/Notification.ts
@@ -171,6 +171,15 @@ type DrealModificationPuissanceCDC2022 = {
   };
 };
 
+type CreRecoursAccepté = {
+  type: 'cre-recours-accepté';
+  context: {};
+  variables: {
+    nom_projet: string;
+    modification_request_url: string;
+  };
+};
+
 type AdminModificationRequested = {
   type: 'admin-modification-requested';
   context: {
@@ -350,7 +359,8 @@ type NotificationVariants =
   | DateMiseEnServiceTransmiseAnnuleDélaiCDC2022
   | DemandeComplèteRaccordementTransmiseAnnuleDélaiCDC2022
   | PP_DélaiAccordéCorrigé
-  | DrealModificationPuissanceCDC2022;
+  | DrealModificationPuissanceCDC2022
+  | CreRecoursAccepté;
 
 export type NotificationProps = BaseNotification & NotificationVariants;
 

--- a/packages/applications/legacy/src/modules/notification/eventHandlers/modificationRequests/handleModificationRequestStatusChanged.ts
+++ b/packages/applications/legacy/src/modules/notification/eventHandlers/modificationRequests/handleModificationRequestStatusChanged.ts
@@ -10,11 +10,13 @@ import {
   ModificationRequestRejected,
 } from '../../../modificationRequest';
 import { GetModificationRequestInfoForStatusNotification } from '../../../modificationRequest/queries/GetModificationRequestInfoForStatusNotification';
+import { GetUsersByRole } from '../../../../modules/users';
 
 export const handleModificationRequestStatusChanged =
   (deps: {
     sendNotification: NotificationService['sendNotification'];
     getModificationRequestInfoForStatusNotification: GetModificationRequestInfoForStatusNotification;
+    getUsersByRole: GetUsersByRole;
   }) =>
   async (
     event:
@@ -76,6 +78,30 @@ export const handleModificationRequestStatusChanged =
             }),
           ),
         );
+
+        if (type === 'recours') {
+          const result = await deps.getUsersByRole('cre');
+
+          if (result.isOk()) {
+            await Promise.all(
+              result.value.map(({ email, fullName }) => {
+                deps.sendNotification({
+                  type: 'cre-recours-accepté',
+                  message: {
+                    email,
+                    name: fullName,
+                    subject: `Un recours a été accepté par la DGEC`,
+                  },
+                  context: {},
+                  variables: {
+                    nom_projet: nomProjet,
+                    modification_request_url: routes.DEMANDE_PAGE_DETAILS(modificationRequestId),
+                  },
+                });
+              }),
+            );
+          }
+        }
       },
       (e: Error) => {
         logger.error(e);

--- a/packages/applications/legacy/src/modules/users/queries/GetUsersByRole.ts
+++ b/packages/applications/legacy/src/modules/users/queries/GetUsersByRole.ts
@@ -1,0 +1,8 @@
+import { ResultAsync } from '../../../core/utils';
+import { User } from '../../../entities';
+import { InfraNotAvailableError } from '../../shared';
+import { UserRole } from '../UserRoles';
+
+export interface GetUsersByRole {
+  (role: UserRole): ResultAsync<ReadonlyArray<User>, InfraNotAvailableError>;
+}

--- a/packages/applications/legacy/src/modules/users/queries/index.ts
+++ b/packages/applications/legacy/src/modules/users/queries/index.ts
@@ -1,3 +1,4 @@
 export * from './GetUserByEmail';
 export * from './GetUserName';
+export * from './GetUsersByRole';
 export * from './ResendInvitationEmail';


### PR DESCRIPTION
# Description

ETQ CRE, je dois être notifiée par email quand un recours est accepté par la DGEC afin de pouvoir suivre les lauréats des AO dans le cadre de sa politique publique de régulation du marché de l'énergie, de comprendre les raisons de l'acceptation du recours par la DGEC pour éventuellement modifier ses pratiques d'instruction.

## Type de changement

- Nouvelle fonctionnalité

# Comment cela a-t-il été testé?

Localement avec les logs dans la console. Et dans l'application mailjet en testant le nouveau modèle créé.