### PR TITLE
🔥 Supprimer les scénarios notimplemented inutiles après analyse métier

### DIFF
--- a/packages/specifications/src/projet/lauréat/garantiesFinancières/actuelles/enregistrerAttestationGarantiesFinancièresActuelles.feature
+++ b/packages/specifications/src/projet/lauréat/garantiesFinancières/actuelles/enregistrerAttestationGarantiesFinancièresActuelles.feature
@@ -42,8 +42,3 @@ Fonctionnalité: Enregistrer l'attestation des garanties financières actuelles
         Quand un porteur enregistre l'attestation des garanties financières actuelles pour le projet "Du boulodrome de Marseille" avec :
             | date de constitution | 2020-01-01 |
         Alors l'utilisateur devrait être informé que "Il n'y a aucunes garanties financières actuelles pour ce projet"
-
-    # À vérifier côté métier
-    @NotImplemented
-    Scénario: Impossible d'enregistrer l'attestation des garanties financières actuelles si celles-ci sont échues
-

--- a/packages/specifications/src/projet/lauréat/garantiesFinancières/actuelles/importerTypeGarantiesFinancièresActuelles.feature
+++ b/packages/specifications/src/projet/lauréat/garantiesFinancières/actuelles/importerTypeGarantiesFinancièresActuelles.feature
@@ -53,8 +53,3 @@ Fonctionnalité: Importer le type (et la date d'échéance selon le cas) des gar
             | type                      |
             | consignation              |
             | six-mois-après-achèvement |
-
-    # À vérifier côté métier
-    @NotImplemented
-    Scénario: Impossible d'importer le type (et la date d'échéance selon le cas) des garanties financières actuelles si le projet dispose déjà de garanties financières échues
-


### PR DESCRIPTION
# Description

Les scénarios supprimés : 
- Impossible d'enregistrer l'attestation des garanties financières actuelles si celles-ci sont échues
- Impossible d'importer le type (et la date d'échéance selon le cas) des garanties financières actuelles si le projet dispose déjà de garanties financières échues