### PR TITLE
✨ Schema de validation du fichier CSV d'import des candidatures

### DIFF
--- a/packages/applications/ssr/src/components/pages/candidatures/importer/candidature.schema.test.ts
+++ b/packages/applications/ssr/src/components/pages/candidatures/importer/candidature.schema.test.ts
@@ -1,0 +1,285 @@
+import { test, describe } from 'node:test';
+
+import { expect, assert } from 'chai';
+import { SafeParseReturnType } from 'zod';
+
+import { CandidatureSchema, candidatureSchema } from './candidature.schema';
+
+const minimumValues: Partial<Record<keyof CandidatureSchema, string>> = {
+  "Appel d'offres": "appel d'offre",
+  'N°CRE': 'numéro cre',
+  'Nom projet': 'nom projet',
+  Candidat: 'candidat',
+  Période: 'période',
+  puissance_production_annuelle: '1',
+  prix_reference: '1',
+  'Note totale': '1',
+  'Nom et prénom du représentant légal': 'valentin cognito',
+  'Adresse électronique du contact': 'porteur@test.com',
+  'N°, voie, lieu-dit 1': 'adresse ',
+  CP: '12345',
+  Commune: 'MARSEILLE',
+  'Classé ?': 'Eliminé',
+  'Gouvernance partagée (Oui/Non)': 'Oui',
+  'Financement collectif (Oui/Non)': 'Non',
+  'Evaluation carbone simplifiée indiquée au C. du formulaire de candidature et arrondie (kg eq CO2/kWc)':
+    'N/A',
+  'Technologie\n(dispositif de production)': 'N/A',
+  "Motif d'élimination": 'motif',
+  "1. Lauréat d'aucun AO\n2. Abandon classique\n3. Abandon avec recandidature\n4. Lauréat d'un AO":
+    '1',
+};
+
+const assertNoError = (result: SafeParseReturnType<unknown, unknown>) => {
+  if (!result.success) {
+    expect(result.error).to.be.undefined;
+  }
+  assert(result.success);
+};
+
+describe('Schema candidature', () => {
+  test('Cas nominal', () => {
+    const result = candidatureSchema.safeParse({
+      ...minimumValues,
+    });
+    assertNoError(result);
+  });
+
+  describe('Erreurs courantes', () => {
+    test('chaîne de caractères obligatoire sans valeur', () => {
+      const result = candidatureSchema.safeParse({});
+      assert(!result.success);
+      expect(result.error.errors[0]).to.deep.eq({
+        code: 'invalid_type',
+        expected: 'string',
+        received: 'undefined',
+        path: ["Appel d'offres"],
+        message: 'Required',
+      });
+    });
+
+    test('chaîne de caractères obligatoire avec valeur vide', () => {
+      const result = candidatureSchema.safeParse({
+        "Appel d'offres": '',
+      });
+      assert(!result.success);
+      expect(result.error.errors[0]).to.deep.eq({
+        code: 'too_small',
+        minimum: 1,
+        type: 'string',
+        inclusive: true,
+        exact: false,
+        path: ["Appel d'offres"],
+        message: 'String must contain at least 1 character(s)',
+      });
+    });
+
+    test('chaîne de caractères obligatoire avec espaces', () => {
+      const result = candidatureSchema.safeParse({
+        "Appel d'offres": ' ',
+      });
+      assert(!result.success);
+      expect(result.error.errors[0]).to.deep.eq({
+        code: 'too_small',
+        minimum: 1,
+        type: 'string',
+        inclusive: true,
+        exact: false,
+        path: ["Appel d'offres"],
+        message: 'String must contain at least 1 character(s)',
+      });
+    });
+
+    test('nombre avec charactères', () => {
+      const result = candidatureSchema.safeParse({
+        ...minimumValues,
+        puissance_production_annuelle: 'abcd',
+      });
+      assert(!result.success);
+      expect(result.error.errors[0]).to.deep.eq({
+        code: 'invalid_type',
+        expected: 'number',
+        received: 'nan',
+        path: ['puissance_production_annuelle'],
+        message: 'Expected number, received nan',
+      });
+    });
+
+    test('nombre strictement positif vaut 0', () => {
+      const result = candidatureSchema.safeParse({
+        ...minimumValues,
+        puissance_production_annuelle: '0',
+      });
+      assert(!result.success);
+      expect(result.error.errors[0]).to.deep.eq({
+        code: 'too_small',
+        minimum: 0,
+        type: 'number',
+        inclusive: false,
+        exact: false,
+        message: 'Number must be greater than 0',
+        path: ['puissance_production_annuelle'],
+      });
+    });
+
+    test('nombre strictement positif avec valeur négative', () => {
+      const result = candidatureSchema.safeParse({
+        ...minimumValues,
+        puissance_production_annuelle: 0,
+      });
+      assert(!result.success);
+      expect(result.error.errors[0]).to.deep.eq({
+        code: 'invalid_type',
+        expected: 'string',
+        received: 'number',
+        path: ['puissance_production_annuelle'],
+        message: 'Expected string, received number',
+      });
+    });
+
+    test('oui/non valeur manquante', () => {
+      const result = candidatureSchema.safeParse({
+        ...minimumValues,
+        'Financement collectif (Oui/Non)': '',
+      });
+      assert(!result.success);
+      expect(result.error.errors[0]).to.deep.eq({
+        received: '',
+        code: 'invalid_enum_value',
+        options: ['oui', 'non'],
+        path: ['Financement collectif (Oui/Non)'],
+        message: "Invalid enum value. Expected 'oui' | 'non', received ''",
+      });
+    });
+
+    test('oui/non avec valeur invalide', () => {
+      const result = candidatureSchema.safeParse({
+        ...minimumValues,
+        'Financement collectif (Oui/Non)': 'peut-être',
+      });
+      assert(!result.success);
+      expect(result.error.errors[0]).to.deep.eq({
+        received: 'peut-être',
+        code: 'invalid_enum_value',
+        options: ['oui', 'non'],
+        path: ['Financement collectif (Oui/Non)'],
+        message: "Invalid enum value. Expected 'oui' | 'non', received 'peut-être'",
+      });
+    });
+
+    test('Enum avec valeur invalide', () => {
+      const result = candidatureSchema.safeParse({
+        ...minimumValues,
+        'Classé ?': 'wrong',
+      });
+      assert(!result.success);
+      expect(result.error.errors[0]).to.deep.eq({
+        received: 'wrong',
+        code: 'invalid_enum_value',
+        options: ['Eliminé', 'Classé'],
+        path: ['Classé ?'],
+        message: "Invalid enum value. Expected 'Eliminé' | 'Classé', received 'wrong'",
+      });
+    });
+
+    test('Email non valide', () => {
+      const result = candidatureSchema.safeParse({
+        ...minimumValues,
+        'Adresse électronique du contact': 'wrong',
+      });
+      assert(!result.success);
+      expect(result.error.errors[0]).to.deep.eq({
+        validation: 'email',
+        code: 'invalid_string',
+        message: 'Invalid email',
+        path: ['Adresse électronique du contact'],
+      });
+    });
+  });
+
+  describe('Règles métier', () => {
+    test("Motif d'élimination n'est pas obligatoire si classé", () => {
+      const result = candidatureSchema.safeParse({
+        ...minimumValues,
+        'Classé ?': 'Classé',
+        "Motif d'élimination": undefined,
+        "1. Garantie financière jusqu'à 6 mois après la date d'achèvement\n2. Garantie financière avec date d'échéance et à renouveler\n3. Consignation":
+          '1',
+      });
+      assertNoError(result);
+    });
+
+    test("Motif d'élimination est obligatoire si éliminé", () => {
+      const result = candidatureSchema.safeParse({
+        ...minimumValues,
+        "Motif d'élimination": undefined,
+      });
+      assert(!result.success);
+      expect(result.error.errors[0]).to.deep.eq({
+        code: 'invalid_type',
+        expected: 'string',
+        received: 'undefined',
+        path: ["Motif d'élimination"],
+        message: `"Motif d'élimination" est requis lorsque "Classé ?" a la valeur "Eliminé"`,
+      });
+    });
+
+    test("Date d'échéance est obligatoire si GF avec date d'échéance", () => {
+      const result = candidatureSchema.safeParse({
+        ...minimumValues,
+        'Classé ?': 'Classé',
+        "Motif d'élimination": undefined,
+        "1. Garantie financière jusqu'à 6 mois après la date d'achèvement\n2. Garantie financière avec date d'échéance et à renouveler\n3. Consignation":
+          '2',
+      });
+      assert(!result.success);
+      expect(result.error.errors[0]).to.deep.eq({
+        code: 'invalid_type',
+        expected: 'string',
+        received: 'undefined',
+        path: ["Date d'échéance au format JJ/MM/AAAA"],
+        message: `"Date d'échéance au format JJ/MM/AAAA" est requis lorsque "1. Garantie financière jusqu'à 6 mois après la date d'achèvement\n2. Garantie financière avec date d'échéance et à renouveler\n3. Consignation" a la valeur "2"`,
+      });
+    });
+  });
+
+  describe('Cas particuliers', () => {
+    describe('Evaluation carbone', () => {
+      test('accepte N/A', () => {
+        const result = candidatureSchema.safeParse({
+          ...minimumValues,
+          'Evaluation carbone simplifiée indiquée au C. du formulaire de candidature et arrondie (kg eq CO2/kWc)':
+            'N/A',
+        });
+        assert(result.success);
+      });
+
+      test('accepte un nombre positif', () => {
+        const result = candidatureSchema.safeParse({
+          ...minimumValues,
+          'Evaluation carbone simplifiée indiquée au C. du formulaire de candidature et arrondie (kg eq CO2/kWc)':
+            '1',
+        });
+        assert(result.success);
+      });
+
+      test(`n'accepte pas un nombre négatif`, () => {
+        const result = candidatureSchema.safeParse({
+          ...minimumValues,
+          'Evaluation carbone simplifiée indiquée au C. du formulaire de candidature et arrondie (kg eq CO2/kWc)':
+            '-1',
+        });
+        assert(!result.success);
+      });
+
+      test(`n'accepte pas du texte`, () => {
+        const result = candidatureSchema.safeParse({
+          ...minimumValues,
+          'Evaluation carbone simplifiée indiquée au C. du formulaire de candidature et arrondie (kg eq CO2/kWc)':
+            'abcd',
+        });
+        assert(!result.success);
+      });
+    });
+  });
+});

--- a/packages/applications/ssr/src/components/pages/candidatures/importer/candidature.schema.test.ts
+++ b/packages/applications/ssr/src/components/pages/candidatures/importer/candidature.schema.test.ts
@@ -73,7 +73,7 @@ describe('Schema candidature', () => {
       adresse2: undefined,
       code_postal: '12345',
       commune: 'MARSEILLE',
-      statut: 'Eliminé',
+      statut: 'éliminé',
       motif_élimination: 'motif',
       puissance_a_la_pointe: undefined,
       evaluation_carbone_simplifiée: 'N/A',
@@ -90,6 +90,9 @@ describe('Schema candidature', () => {
   test('Cas nominal, classé', () => {
     const result = candidatureSchema.safeParse({
       ...minimumValuesClassé,
+      'Technologie\n(dispositif de production)': 'Eolien',
+      'Valeur de l’évaluation carbone des modules (kg eq CO2/kWc)': '2',
+      'Engagement de fourniture de puissance à la pointe\n(AO ZNI)': 'Oui',
     });
     assertNoError(result);
     expect(result.data).to.deep.equal({
@@ -109,12 +112,12 @@ describe('Schema candidature', () => {
       adresse2: undefined,
       code_postal: '12345',
       commune: 'MARSEILLE',
-      statut: 'Classé',
+      statut: 'classé',
       motif_élimination: undefined,
       puissance_a_la_pointe: undefined,
       evaluation_carbone_simplifiée: 'N/A',
-      valeur_évaluation_carbone: undefined,
-      technologie: 'N/A',
+      valeur_évaluation_carbone: 2,
+      technologie: 'eolien',
       type_gf: 'avec-date-échéance',
       financement_collectif: 'non',
       gouvernance_partagée: 'oui',

--- a/packages/applications/ssr/src/components/pages/candidatures/importer/candidature.schema.ts
+++ b/packages/applications/ssr/src/components/pages/candidatures/importer/candidature.schema.ts
@@ -100,6 +100,14 @@ const historiqueAbandon = [
   'lauréat_ao',
 ] as const;
 
+const statut = { Eliminé: 'éliminé', Classé: 'classé' } as const;
+const technologie = {
+  Eolien: 'eolien',
+  Hydraulique: 'hydraulique',
+  PV: 'pv',
+  'N/A': 'N/A',
+} as const;
+
 const candidatureCsvRowSchema = z
   .object({
     [colonnes.appel_offre]: requiredStringSchema,
@@ -165,6 +173,8 @@ export const candidatureSchema = candidatureCsvRowSchema
       ...val,
       type_gf: val.type_gf ? typeGf[Number(val.type_gf) - 1] : undefined,
       historique_abandon: historiqueAbandon[Number(val.historique_abandon) - 1],
+      statut: statut[val.statut],
+      technologie: technologie[val.technologie],
     };
   });
 

--- a/packages/applications/ssr/src/components/pages/candidatures/importer/candidature.schema.ts
+++ b/packages/applications/ssr/src/components/pages/candidatures/importer/candidature.schema.ts
@@ -1,0 +1,117 @@
+import { z } from 'zod';
+
+const requiredStringSchema = z.string().trim().min(1);
+const numberSchema = z
+  .string()
+  // replace french commas to "."
+  .transform((str) => str.replace(/,/g, '.'))
+  // transform to number
+  .pipe(z.coerce.number());
+const strictlyPositiveNumberSchema = z
+  .string()
+  // replace french commas to "."
+  .transform((str) => str.replace(/,/g, '.'))
+  // transform to number and validate
+  .pipe(z.coerce.number().gt(0));
+
+const ouiNonSchema = z
+  .string()
+  .transform((str) => str.toLowerCase())
+  .pipe(z.enum(['oui', 'non']));
+
+const dateSchema = z
+  .string()
+  .regex(/^\d{2}\/\d{2}\/\d{4}$/, {
+    message: "Le format de la date n'est pas respecté (format attendu : JJ/MM/AAAA)",
+  })
+  .transform((val) => {
+    const [day, month, year] = val.split('/');
+    return new Date(`${year}-${month}-${day}`);
+  });
+
+const requiredFieldIfReferenceFieldEquals = <
+  T,
+  TField extends keyof T,
+  TReferenceField extends keyof T,
+>(
+  field: TField,
+  referenceField: TReferenceField,
+  expectedValue: T[TReferenceField],
+): ((arg: T, ctx: z.RefinementCtx) => unknown | Promise<unknown>) => {
+  return (val, ctx) => {
+    if (val[referenceField] === expectedValue && !val[field]) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.invalid_type,
+        expected: z.ZodParsedType.string,
+        received: z.ZodParsedType.undefined,
+        path: [String(field)],
+        message: `"${String(field)}" est requis lorsque "${String(referenceField)}" a la valeur "${expectedValue}"`,
+      });
+      return false;
+    }
+    return true;
+  };
+};
+
+const TYPE_GF_FIELD_NAME =
+  "1. Garantie financière jusqu'à 6 mois après la date d'achèvement\n2. Garantie financière avec date d'échéance et à renouveler\n3. Consignation";
+
+const typeGf = {
+  'six-mois-après-achèvement': '1' as const,
+  'avec-date-échéance': '2' as const,
+  consignation: '3' as const,
+};
+
+export const candidatureSchema = z
+  .object({
+    "Appel d'offres": requiredStringSchema,
+    Période: requiredStringSchema,
+    Famille: z.string().optional(),
+    'N°CRE': requiredStringSchema,
+    'Nom projet': requiredStringSchema,
+    'Société mère': z.string().optional(),
+    Candidat: requiredStringSchema,
+    puissance_production_annuelle: strictlyPositiveNumberSchema,
+    prix_reference: strictlyPositiveNumberSchema,
+    'Note totale': numberSchema,
+    'Nom et prénom du représentant légal': requiredStringSchema,
+    'Adresse électronique du contact': requiredStringSchema.email(), // TODO
+    'N°, voie, lieu-dit 1': requiredStringSchema,
+    'N°, voie, lieu-dit 2': z.string().optional(),
+    CP: requiredStringSchema,
+    Commune: requiredStringSchema,
+    'Classé ?': z.string().pipe(z.enum(['Eliminé', 'Classé'])),
+    "Motif d'élimination": z.string().optional(), // see refine below
+    'Engagement de fourniture de puissance à la pointe\n(AO ZNI)': ouiNonSchema.optional(),
+    'Evaluation carbone simplifiée indiquée au C. du formulaire de candidature et arrondie (kg eq CO2/kWc)':
+      z.union([z.enum(['N/A']), strictlyPositiveNumberSchema]),
+    'Valeur de l’évaluation carbone des modules (kg eq CO2/kWc)':
+      strictlyPositiveNumberSchema.optional(),
+    'Technologie\n(dispositif de production)': z.enum(['N/A', 'Eolien', 'Hydraulique', 'PV']),
+    'Financement collectif (Oui/Non)': ouiNonSchema,
+    'Gouvernance partagée (Oui/Non)': ouiNonSchema,
+    [TYPE_GF_FIELD_NAME]: z
+      .enum([
+        typeGf['six-mois-après-achèvement'],
+        typeGf['avec-date-échéance'],
+        typeGf.consignation,
+      ])
+      .optional(), // see refine below
+    "Date d'échéance au format JJ/MM/AAAA": dateSchema.optional(), // see refine below
+    "1. Lauréat d'aucun AO\n2. Abandon classique\n3. Abandon avec recandidature\n4. Lauréat d'un AO":
+      z.enum(['1', '2', '3', '4']),
+  })
+  // le motif d'élimination est obligatoire si la candidature est éliminée
+  .superRefine(requiredFieldIfReferenceFieldEquals("Motif d'élimination", 'Classé ?', 'Eliminé'))
+  // le type de GF est obligatoire si la candidature est classée
+  .superRefine(requiredFieldIfReferenceFieldEquals(TYPE_GF_FIELD_NAME, 'Classé ?', 'Classé'))
+  // la date d'échéance est obligatoire si les GF sont de type "avec date d'échéance"
+  .superRefine(
+    requiredFieldIfReferenceFieldEquals(
+      "Date d'échéance au format JJ/MM/AAAA",
+      TYPE_GF_FIELD_NAME,
+      typeGf['avec-date-échéance'],
+    ),
+  );
+
+export type CandidatureSchema = z.infer<typeof candidatureSchema>;


### PR DESCRIPTION
## Choix technique
les noms des colonnes du fichier sont assez longs, ce qui rend peu lisible leur utilisation dans le code. Afin de garder quelque chose de lisible, on a un champs `colonnes` qui fait le mapping entre un nom facile à maniupler, et le nom réel de la colonne. 

Le mapping est fait en tout dernier, afin que les erreurs de validations référencent le nom tel qu'écrit dans le fichier, pour plus de clarté pour l'utilisateur. 

## Traduction
La partie traduction en 🇫🇷 sera faite plus tard, quand #2055 sera fini, afin de visualiser l'affichage des erreurs et d'adapter le wording en fonction