### PR TITLE
♻️ Renommage de ConsulterCandidature en ConsulterProjet

### DIFF
--- a/packages/applications/cli/src/commands/raccordement/importer-date-mes.ts
+++ b/packages/applications/cli/src/commands/raccordement/importer-date-mes.ts
@@ -5,7 +5,7 @@ import { z } from 'zod';
 import { bootstrap } from '@potentiel-applications/bootstrap';
 import { Raccordement } from '@potentiel-domain/reseau';
 import { Option } from '@potentiel-libraries/monads';
-import { ConsulterCandidatureQuery } from '@potentiel-domain/candidature';
+import { ConsulterProjetQuery } from '@potentiel-domain/candidature';
 import { DateTime } from '@potentiel-domain/common';
 
 import { parseCsvFile } from '../../helpers/parse-file';
@@ -104,8 +104,8 @@ export default class ImporterDateMiseEnService extends Command {
       }
 
       try {
-        const candidature = await mediator.send<ConsulterCandidatureQuery>({
-          type: 'Candidature.Query.ConsulterCandidature',
+        const candidature = await mediator.send<ConsulterProjetQuery>({
+          type: 'Candidature.Query.ConsulterProjet',
           data: {
             identifiantProjet: identifiantProjet,
           },

--- a/packages/applications/legacy/src/controllers/modificationRequest/délai/getCorrigerDelaiAccordePage.ts
+++ b/packages/applications/legacy/src/controllers/modificationRequest/délai/getCorrigerDelaiAccordePage.ts
@@ -14,7 +14,7 @@ import { v1Router } from '../../v1Router';
 import { validateUniqueId } from '../../../helpers/validateUniqueId';
 import { ModificationRequest, Project } from '../../../infra/sequelize/projectionsNext';
 import { ConsulterAppelOffreQuery } from '@potentiel-domain/appel-offre';
-import { ConsulterCandidatureQuery } from '@potentiel-domain/candidature';
+import { ConsulterProjetQuery } from '@potentiel-domain/candidature';
 import { mediator } from 'mediateur';
 import { getDelaiDeRealisation } from '../../../modules/projectAppelOffre';
 import { add, sub } from 'date-fns';
@@ -59,13 +59,13 @@ v1Router.get(
     }
 
     const identifiantProjet = await getIdentifiantProjetByLegacyId(projectId);
-    
+
     if (!identifiantProjet) {
       return notFoundResponse({ request, response, ressourceTitle: 'Demande' });
     }
 
-    const résuméProjet = await mediator.send<ConsulterCandidatureQuery>({
-      type: 'Candidature.Query.ConsulterCandidature',
+    const résuméProjet = await mediator.send<ConsulterProjetQuery>({
+      type: 'Candidature.Query.ConsulterProjet',
       data: { identifiantProjet: identifiantProjet.identifiantProjetValue },
     });
 

--- a/packages/applications/legacy/src/controllers/modificationRequest/délai/postCorrigerDelaiAccorde.ts
+++ b/packages/applications/legacy/src/controllers/modificationRequest/délai/postCorrigerDelaiAccorde.ts
@@ -20,7 +20,7 @@ import { logger } from '../../../core/utils';
 import { DomainError } from '../../../core/domain';
 import { mediator } from 'mediateur';
 import { ConsulterAppelOffreQuery } from '@potentiel-domain/appel-offre';
-import { ConsulterCandidatureQuery } from '@potentiel-domain/candidature';
+import { ConsulterProjetQuery } from '@potentiel-domain/candidature';
 import { getDelaiDeRealisation } from '../../../modules/projectAppelOffre';
 import { add, sub } from 'date-fns';
 import { ModificationRequest } from '../../../infra/sequelize/projectionsNext';
@@ -93,8 +93,8 @@ v1Router.post(
         return notFoundResponse({ request, response, ressourceTitle: 'Demande' });
       }
 
-      const résuméProjet = await mediator.send<ConsulterCandidatureQuery>({
-        type: 'Candidature.Query.ConsulterCandidature',
+      const résuméProjet = await mediator.send<ConsulterProjetQuery>({
+        type: 'Candidature.Query.ConsulterProjet',
         data: { identifiantProjet: identifiantProjet.identifiantProjetValue },
       });
 

--- a/packages/applications/legacy/src/views/components/UI/templates/PageProjetTemplate.tsx
+++ b/packages/applications/legacy/src/views/components/UI/templates/PageProjetTemplate.tsx
@@ -3,12 +3,12 @@ import React, { FC, ReactNode } from 'react';
 import { UtilisateurReadModel } from '../../../../modules/utilisateur/récupérer/UtilisateurReadModel';
 import { Badge, BadgeType, Heading1, KeyIcon, Link, MapPinIcon, PageTemplate } from '../..';
 import routes from '../../../../routes';
-import { ConsulterCandidatureReadModel } from '@potentiel-domain/candidature';
+import { ConsulterProjetReadModel } from '@potentiel-domain/candidature';
 import { formatProjectDataToIdentifiantProjetValueType } from '../../../../helpers/dataToValueTypes';
 
 export const PageProjetTemplate: FC<{
   user: UtilisateurReadModel;
-  résuméProjet: ConsulterCandidatureReadModel;
+  résuméProjet: ConsulterProjetReadModel;
   titre: ReactNode;
   children: ReactNode;
 }> = ({ user, résuméProjet, titre, children }) => (
@@ -18,7 +18,7 @@ export const PageProjetTemplate: FC<{
   </PageTemplate>
 );
 
-const EntêteProjet: FC<ConsulterCandidatureReadModel> = ({
+const EntêteProjet: FC<ConsulterProjetReadModel> = ({
   appelOffre,
   période,
   famille,
@@ -59,7 +59,7 @@ const EntêteProjet: FC<ConsulterCandidatureReadModel> = ({
   </div>
 );
 
-const getBadgeType = (statut: ConsulterCandidatureReadModel['statut']): BadgeType => {
+const getBadgeType = (statut: ConsulterProjetReadModel['statut']): BadgeType => {
   switch (statut) {
     case 'abandonné':
       return 'warning';
@@ -73,7 +73,7 @@ const getBadgeType = (statut: ConsulterCandidatureReadModel['statut']): BadgeTyp
 };
 
 const StatutProjet: FC<{
-  statut: ConsulterCandidatureReadModel['statut'];
+  statut: ConsulterProjetReadModel['statut'];
 }> = ({ statut }) => (
   <Badge type={getBadgeType(statut)} className="ml-2 self-center">
     {statut}

--- a/packages/applications/legacy/src/views/pages/délai/CorrigerDelaiAccordePage.tsx
+++ b/packages/applications/legacy/src/views/pages/délai/CorrigerDelaiAccordePage.tsx
@@ -13,7 +13,7 @@ import {
   SecondaryLinkButton,
 } from '../../components';
 import { DetailDemandeDelaiPageDTO } from '../../../modules/modificationRequest/dtos';
-import { ConsulterCandidatureReadModel } from '@potentiel-domain/candidature';
+import { ConsulterProjetReadModel } from '@potentiel-domain/candidature';
 import { UtilisateurReadModel } from '../../../modules/utilisateur/récupérer/UtilisateurReadModel';
 import { afficherDate, formatDateForInput, hydrateOnClient } from '../../helpers';
 import routes from '../../../routes';
@@ -21,7 +21,7 @@ import { DownloadResponseTemplate } from '../modificationRequestPage/components'
 
 type CorrigerDelaiAccordeProps = {
   demandeDélai: DetailDemandeDelaiPageDTO;
-  résuméProjet: ConsulterCandidatureReadModel;
+  résuméProjet: ConsulterProjetReadModel;
   dateAchèvementInitiale: string;
   dateAchèvementActuelle: string;
   utilisateur: UtilisateurReadModel;

--- a/packages/applications/notifications/src/subscribers/lauréat/tâchePlanifiée.notification.ts
+++ b/packages/applications/notifications/src/subscribers/lauréat/tâchePlanifiée.notification.ts
@@ -7,7 +7,7 @@ import {
 } from '@potentiel-infrastructure/domain-adapters';
 import { Routes } from '@potentiel-applications/routes';
 import { TâchePlanifiéeExecutéeEvent } from '@potentiel-domain/tache-planifiee';
-import { ConsulterCandidatureQuery } from '@potentiel-domain/candidature';
+import { ConsulterProjetQuery } from '@potentiel-domain/candidature';
 import { IdentifiantProjet } from '@potentiel-domain/common';
 import { getLogger } from '@potentiel-libraries/monitoring';
 import { Option } from '@potentiel-libraries/monads';
@@ -34,8 +34,8 @@ export const register = ({ sendEmail }: RegisterTâchePlanifiéeNotificationDepe
     switch (payload.typeTâchePlanifiée) {
       case 'garanties-financières.rappel-échéance-un-mois':
       case 'garanties-financières.rappel-échéance-deux-mois':
-        const candidature = await mediator.send<ConsulterCandidatureQuery>({
-          type: 'Candidature.Query.ConsulterCandidature',
+        const candidature = await mediator.send<ConsulterProjetQuery>({
+          type: 'Candidature.Query.ConsulterProjet',
           data: {
             identifiantProjet: identifiantProjet.formatter(),
           },

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/abandon/demander/page.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/abandon/demander/page.tsx
@@ -3,7 +3,7 @@ import { Metadata } from 'next';
 import { notFound, redirect } from 'next/navigation';
 
 import { ConsulterAppelOffreQuery } from '@potentiel-domain/appel-offre';
-import { ConsulterCandidatureQuery } from '@potentiel-domain/candidature';
+import { ConsulterProjetQuery } from '@potentiel-domain/candidature';
 import { CahierDesCharges } from '@potentiel-domain/laureat';
 import { Routes } from '@potentiel-applications/routes';
 import { StatutProjet } from '@potentiel-domain/common';
@@ -27,8 +27,8 @@ export default async function Page({ params: { identifiant } }: IdentifiantParam
   return PageWithErrorHandling(async () => {
     const identifiantProjet = decodeParameter(identifiant);
 
-    const candidature = await mediator.send<ConsulterCandidatureQuery>({
-      type: 'Candidature.Query.ConsulterCandidature',
+    const candidature = await mediator.send<ConsulterProjetQuery>({
+      type: 'Candidature.Query.ConsulterProjet',
       data: {
         identifiantProjet,
       },

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/abandon/modele-reponse/route.ts
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/abandon/modele-reponse/route.ts
@@ -2,7 +2,7 @@ import { mediator } from 'mediateur';
 import { notFound } from 'next/navigation';
 
 import { Abandon, CahierDesCharges } from '@potentiel-domain/laureat';
-import { ConsulterCandidatureQuery } from '@potentiel-domain/candidature';
+import { ConsulterProjetQuery } from '@potentiel-domain/candidature';
 import { ConsulterAppelOffreQuery, AppelOffre } from '@potentiel-domain/appel-offre';
 import { DateTime } from '@potentiel-domain/common';
 import { ConsulterUtilisateurQuery } from '@potentiel-domain/utilisateur';
@@ -31,8 +31,8 @@ export const GET = async (_: Request, { params: { identifiant } }: IdentifiantPa
 
     const { nomComplet } = utilisateurDétails;
 
-    const candidature = await mediator.send<ConsulterCandidatureQuery>({
-      type: 'Candidature.Query.ConsulterCandidature',
+    const candidature = await mediator.send<ConsulterProjetQuery>({
+      type: 'Candidature.Query.ConsulterProjet',
       data: {
         identifiantProjet,
       },

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/achevement/attestation-conformite:modifier/page.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/achevement/attestation-conformite:modifier/page.tsx
@@ -2,7 +2,7 @@ import { Metadata } from 'next';
 import { mediator } from 'mediateur';
 import { notFound } from 'next/navigation';
 
-import { ConsulterCandidatureQuery } from '@potentiel-domain/candidature';
+import { ConsulterProjetQuery } from '@potentiel-domain/candidature';
 import { InvalidOperationError } from '@potentiel-domain/core';
 import { Achèvement } from '@potentiel-domain/laureat';
 import { Option } from '@potentiel-libraries/monads';
@@ -24,8 +24,8 @@ export default async function Page({ params: { identifiant } }: IdentifiantParam
   return PageWithErrorHandling(async () => {
     const identifiantProjet = decodeParameter(identifiant);
 
-    const candidature = await mediator.send<ConsulterCandidatureQuery>({
-      type: 'Candidature.Query.ConsulterCandidature',
+    const candidature = await mediator.send<ConsulterProjetQuery>({
+      type: 'Candidature.Query.ConsulterProjet',
       data: { identifiantProjet },
     });
 

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/achevement/attestation-conformite:transmettre/page.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/achevement/attestation-conformite:transmettre/page.tsx
@@ -2,7 +2,7 @@ import { Metadata } from 'next';
 import { mediator } from 'mediateur';
 import { notFound } from 'next/navigation';
 
-import { ConsulterCandidatureQuery } from '@potentiel-domain/candidature';
+import { ConsulterProjetQuery } from '@potentiel-domain/candidature';
 import { InvalidOperationError } from '@potentiel-domain/core';
 import { GarantiesFinancières } from '@potentiel-domain/laureat';
 import { Option } from '@potentiel-libraries/monads';
@@ -24,8 +24,8 @@ export default async function Page({ params: { identifiant } }: IdentifiantParam
   return PageWithErrorHandling(async () => {
     const identifiantProjet = decodeParameter(identifiant);
 
-    const candidature = await mediator.send<ConsulterCandidatureQuery>({
-      type: 'Candidature.Query.ConsulterCandidature',
+    const candidature = await mediator.send<ConsulterProjetQuery>({
+      type: 'Candidature.Query.ConsulterProjet',
       data: { identifiantProjet },
     });
 

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/garanties-financieres/actuelles:enregistrer-attestation/page.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/garanties-financieres/actuelles:enregistrer-attestation/page.tsx
@@ -2,7 +2,7 @@ import { Metadata } from 'next';
 import { mediator } from 'mediateur';
 import { notFound } from 'next/navigation';
 
-import { ConsulterCandidatureQuery } from '@potentiel-domain/candidature';
+import { ConsulterProjetQuery } from '@potentiel-domain/candidature';
 import { Option } from '@potentiel-libraries/monads';
 
 import { PageWithErrorHandling } from '@/utils/PageWithErrorHandling';
@@ -24,8 +24,8 @@ export default async function Page({ params: { identifiant } }: IdentifiantParam
   return PageWithErrorHandling(async () => {
     const identifiantProjet = decodeParameter(identifiant);
 
-    const candidature = await mediator.send<ConsulterCandidatureQuery>({
-      type: 'Candidature.Query.ConsulterCandidature',
+    const candidature = await mediator.send<ConsulterProjetQuery>({
+      type: 'Candidature.Query.ConsulterProjet',
       data: { identifiantProjet },
     });
 

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/garanties-financieres/actuelles:enregistrer/page.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/garanties-financieres/actuelles:enregistrer/page.tsx
@@ -2,7 +2,7 @@ import { Metadata } from 'next';
 import { mediator } from 'mediateur';
 import { notFound } from 'next/navigation';
 
-import { ConsulterCandidatureQuery } from '@potentiel-domain/candidature';
+import { ConsulterProjetQuery } from '@potentiel-domain/candidature';
 import { Option } from '@potentiel-libraries/monads';
 
 import { PageWithErrorHandling } from '@/utils/PageWithErrorHandling';
@@ -25,8 +25,8 @@ export default async function Page({ params: { identifiant } }: IdentifiantParam
   return PageWithErrorHandling(async () => {
     const identifiantProjet = decodeParameter(identifiant);
 
-    const candidature = await mediator.send<ConsulterCandidatureQuery>({
-      type: 'Candidature.Query.ConsulterCandidature',
+    const candidature = await mediator.send<ConsulterProjetQuery>({
+      type: 'Candidature.Query.ConsulterProjet',
       data: { identifiantProjet },
     });
 

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/garanties-financieres/actuelles:modifier/page.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/garanties-financieres/actuelles:modifier/page.tsx
@@ -2,7 +2,7 @@ import { Metadata } from 'next';
 import { mediator } from 'mediateur';
 import { notFound } from 'next/navigation';
 
-import { ConsulterCandidatureQuery } from '@potentiel-domain/candidature';
+import { ConsulterProjetQuery } from '@potentiel-domain/candidature';
 import { GarantiesFinancières } from '@potentiel-domain/laureat';
 import { Option } from '@potentiel-libraries/monads';
 
@@ -26,8 +26,8 @@ export default async function Page({ params: { identifiant } }: IdentifiantParam
   return PageWithErrorHandling(async () => {
     const identifiantProjet = decodeParameter(identifiant);
 
-    const candidature = await mediator.send<ConsulterCandidatureQuery>({
-      type: 'Candidature.Query.ConsulterCandidature',
+    const candidature = await mediator.send<ConsulterProjetQuery>({
+      type: 'Candidature.Query.ConsulterProjet',
       data: { identifiantProjet },
     });
 

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/garanties-financieres/depot:modifier/page.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/garanties-financieres/depot:modifier/page.tsx
@@ -3,7 +3,7 @@ import { mediator } from 'mediateur';
 import { notFound } from 'next/navigation';
 
 import { Option } from '@potentiel-libraries/monads';
-import { ConsulterCandidatureQuery } from '@potentiel-domain/candidature';
+import { ConsulterProjetQuery } from '@potentiel-domain/candidature';
 import { GarantiesFinancières } from '@potentiel-domain/laureat';
 import { Role } from '@potentiel-domain/utilisateur';
 
@@ -30,8 +30,8 @@ export default async function Page({ params: { identifiant } }: IdentifiantParam
     withUtilisateur(async (utilisateur) => {
       const identifiantProjet = decodeParameter(identifiant);
 
-      const candidature = await mediator.send<ConsulterCandidatureQuery>({
-        type: 'Candidature.Query.ConsulterCandidature',
+      const candidature = await mediator.send<ConsulterProjetQuery>({
+        type: 'Candidature.Query.ConsulterProjet',
         data: { identifiantProjet },
       });
 

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/garanties-financieres/depot:soumettre/page.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/garanties-financieres/depot:soumettre/page.tsx
@@ -3,7 +3,7 @@ import { mediator } from 'mediateur';
 import { notFound } from 'next/navigation';
 
 import { Option } from '@potentiel-libraries/monads';
-import { ConsulterCandidatureQuery } from '@potentiel-domain/candidature';
+import { ConsulterProjetQuery } from '@potentiel-domain/candidature';
 import { GarantiesFinancières } from '@potentiel-domain/laureat';
 
 import { PageWithErrorHandling } from '@/utils/PageWithErrorHandling';
@@ -27,8 +27,8 @@ export default async function Page({ params: { identifiant } }: IdentifiantParam
   return PageWithErrorHandling(async () => {
     const identifiantProjet = decodeParameter(identifiant);
 
-    const candidature = await mediator.send<ConsulterCandidatureQuery>({
-      type: 'Candidature.Query.ConsulterCandidature',
+    const candidature = await mediator.send<ConsulterProjetQuery>({
+      type: 'Candidature.Query.ConsulterProjet',
       data: { identifiantProjet },
     });
 

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/garanties-financieres/modele-mise-en-demeure/route.ts
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/garanties-financieres/modele-mise-en-demeure/route.ts
@@ -4,7 +4,7 @@ import { notFound } from 'next/navigation';
 
 import { GarantiesFinancières } from '@potentiel-domain/laureat';
 import { Option } from '@potentiel-libraries/monads';
-import { ConsulterCandidatureQuery } from '@potentiel-domain/candidature';
+import { ConsulterProjetQuery } from '@potentiel-domain/candidature';
 import { ConsulterAppelOffreQuery } from '@potentiel-domain/appel-offre';
 import { DateTime } from '@potentiel-domain/common';
 import { buildDocxDocument } from '@potentiel-applications/document-builder';
@@ -21,8 +21,8 @@ export const GET = async (
   withUtilisateur(async (utilisateur) => {
     const identifiantProjetValue = decodeParameter(identifiant);
 
-    const candidature = await mediator.send<ConsulterCandidatureQuery>({
-      type: 'Candidature.Query.ConsulterCandidature',
+    const candidature = await mediator.send<ConsulterProjetQuery>({
+      type: 'Candidature.Query.ConsulterProjet',
       data: {
         identifiantProjet: identifiantProjetValue,
       },

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/garanties-financieres/modele-reponse-mainlevee/route.ts
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/garanties-financieres/modele-reponse-mainlevee/route.ts
@@ -4,7 +4,7 @@ import { notFound } from 'next/navigation';
 
 import { Abandon, Achèvement, GarantiesFinancières } from '@potentiel-domain/laureat';
 import { Option } from '@potentiel-libraries/monads';
-import { ConsulterCandidatureQuery } from '@potentiel-domain/candidature';
+import { ConsulterProjetQuery } from '@potentiel-domain/candidature';
 import { ConsulterAppelOffreQuery } from '@potentiel-domain/appel-offre';
 import { DateTime } from '@potentiel-domain/common';
 import { buildDocxDocument } from '@potentiel-applications/document-builder';
@@ -22,8 +22,8 @@ export const GET = async (
     const identifiantProjetValue = decodeParameter(identifiant);
     const estAccordée = request.nextUrl.searchParams.get('estAccordée') === 'true';
 
-    const candidature = await mediator.send<ConsulterCandidatureQuery>({
-      type: 'Candidature.Query.ConsulterCandidature',
+    const candidature = await mediator.send<ConsulterProjetQuery>({
+      type: 'Candidature.Query.ConsulterProjet',
       data: {
         identifiantProjet: identifiantProjetValue,
       },

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/garanties-financieres/page.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/garanties-financieres/page.tsx
@@ -3,7 +3,7 @@ import { mediator } from 'mediateur';
 import { notFound } from 'next/navigation';
 
 import { Option } from '@potentiel-libraries/monads';
-import { ConsulterCandidatureQuery } from '@potentiel-domain/candidature';
+import { ConsulterProjetQuery } from '@potentiel-domain/candidature';
 import { Achèvement, GarantiesFinancières } from '@potentiel-domain/laureat';
 import { Role } from '@potentiel-domain/utilisateur';
 import { AppelOffre, ConsulterAppelOffreQuery } from '@potentiel-domain/appel-offre';
@@ -39,8 +39,8 @@ export default async function Page({ params: { identifiant } }: IdentifiantParam
     withUtilisateur(async (utilisateur) => {
       const identifiantProjet = decodeParameter(identifiant);
 
-      const candidature = await mediator.send<ConsulterCandidatureQuery>({
-        type: 'Candidature.Query.ConsulterCandidature',
+      const candidature = await mediator.send<ConsulterProjetQuery>({
+        type: 'Candidature.Query.ConsulterProjet',
         data: { identifiantProjet },
       });
 

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/raccordements/[reference]/date-mise-en-service:transmettre/page.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/raccordements/[reference]/date-mise-en-service:transmettre/page.tsx
@@ -2,7 +2,7 @@ import { mediator } from 'mediateur';
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 
-import { ConsulterCandidatureQuery } from '@potentiel-domain/candidature';
+import { ConsulterProjetQuery } from '@potentiel-domain/candidature';
 import { Raccordement } from '@potentiel-domain/reseau';
 import { ConsulterAppelOffreQuery } from '@potentiel-domain/appel-offre';
 import { DateTime } from '@potentiel-domain/common';
@@ -33,8 +33,8 @@ export default async function Page({ params: { identifiant, reference } }: PageP
     const identifiantProjet = decodeParameter(identifiant);
     const referenceDossierRaccordement = decodeParameter(reference);
 
-    const candidature = await mediator.send<ConsulterCandidatureQuery>({
-      type: 'Candidature.Query.ConsulterCandidature',
+    const candidature = await mediator.send<ConsulterProjetQuery>({
+      type: 'Candidature.Query.ConsulterProjet',
       data: {
         identifiantProjet,
       },

--- a/packages/applications/ssr/src/components/molecules/projet/ProjetBanner.tsx
+++ b/packages/applications/ssr/src/components/molecules/projet/ProjetBanner.tsx
@@ -5,7 +5,7 @@ import { mediator } from 'mediateur';
 import { notFound } from 'next/navigation';
 
 import { Routes } from '@potentiel-applications/routes';
-import { ConsulterCandidatureQuery } from '@potentiel-domain/candidature';
+import { ConsulterProjetQuery } from '@potentiel-domain/candidature';
 import { Option } from '@potentiel-libraries/monads';
 
 import { StatutProjetBadge } from '@/components/molecules/projet/StatutProjetBadge';
@@ -15,8 +15,8 @@ export type ProjetBannerProps = {
 };
 
 export const ProjetBanner: FC<ProjetBannerProps> = async ({ identifiantProjet }) => {
-  const candidature = await mediator.send<ConsulterCandidatureQuery>({
-    type: 'Candidature.Query.ConsulterCandidature',
+  const candidature = await mediator.send<ConsulterProjetQuery>({
+    type: 'Candidature.Query.ConsulterProjet',
     data: {
       identifiantProjet,
     },

--- a/packages/applications/ssr/src/components/pages/abandon/détails/accorder/accorderAbandonAvecRecandidature.action.ts
+++ b/packages/applications/ssr/src/components/pages/abandon/détails/accorder/accorderAbandonAvecRecandidature.action.ts
@@ -5,7 +5,7 @@ import * as zod from 'zod';
 import { notFound } from 'next/navigation';
 
 import { ConsulterAppelOffreQuery } from '@potentiel-domain/appel-offre';
-import { ConsulterCandidatureQuery } from '@potentiel-domain/candidature';
+import { ConsulterProjetQuery } from '@potentiel-domain/candidature';
 import { IdentifiantProjet } from '@potentiel-domain/common';
 import { Abandon } from '@potentiel-domain/laureat';
 import { ConsulterUtilisateurQuery } from '@potentiel-domain/utilisateur';
@@ -62,9 +62,9 @@ const buildReponseSignee = async (
   abandon: Abandon.ConsulterAbandonReadModel,
   identifiantUtilisateur: string,
 ): Promise<Abandon.AccorderAbandonUseCase['data']['réponseSignéeValue']> => {
-  const candidature = await mediator.send<ConsulterCandidatureQuery>({
+  const candidature = await mediator.send<ConsulterProjetQuery>({
     data: { identifiantProjet: abandon.identifiantProjet.formatter() },
-    type: 'Candidature.Query.ConsulterCandidature',
+    type: 'Candidature.Query.ConsulterProjet',
   });
 
   if (Option.isNone(candidature)) {

--- a/packages/applications/ssr/src/components/pages/réseau/raccordement/importerDatesMiseEnService/importDatesMiseEnService.action.ts
+++ b/packages/applications/ssr/src/components/pages/réseau/raccordement/importerDatesMiseEnService/importDatesMiseEnService.action.ts
@@ -5,7 +5,7 @@ import { mediator } from 'mediateur';
 import { notFound } from 'next/navigation';
 
 import { Raccordement } from '@potentiel-domain/reseau';
-import { ConsulterCandidatureQuery } from '@potentiel-domain/candidature';
+import { ConsulterProjetQuery } from '@potentiel-domain/candidature';
 import { DomainError } from '@potentiel-domain/core';
 import { parseCsv } from '@potentiel-libraries/csv';
 import { Option } from '@potentiel-libraries/monads';
@@ -63,8 +63,8 @@ const action: FormAction<FormState, typeof schema> = async (_, { fichierDatesMis
 
     for (const { identifiantProjet, référenceDossierRaccordement } of dossiers) {
       try {
-        const candidature = await mediator.send<ConsulterCandidatureQuery>({
-          type: 'Candidature.Query.ConsulterCandidature',
+        const candidature = await mediator.send<ConsulterProjetQuery>({
+          type: 'Candidature.Query.ConsulterProjet',
           data: {
             identifiantProjet: identifiantProjet.formatter(),
           },

--- a/packages/domain/candidature/src/consulter/consulterProjet.query.ts
+++ b/packages/domain/candidature/src/consulter/consulterProjet.query.ts
@@ -7,7 +7,7 @@ import { IdentifiantUtilisateur } from '@potentiel-domain/utilisateur';
 import { CandidatureEntity } from '../candidature.entity';
 import * as Technologie from '../technologie.valueType';
 
-export type ConsulterCandidatureReadModel = {
+export type ConsulterProjetReadModel = {
   appelOffre: string;
   période: string;
   famille: string;
@@ -32,26 +32,26 @@ export type ConsulterCandidatureReadModel = {
   technologie: Technologie.TypeTechnologie;
 };
 
-export type ConsulterCandidatureQuery = Message<
-  'Candidature.Query.ConsulterCandidature',
+export type ConsulterProjetQuery = Message<
+  'Candidature.Query.ConsulterProjet',
   {
     identifiantProjet: string;
   },
-  Option.Type<ConsulterCandidatureReadModel>
+  Option.Type<ConsulterProjetReadModel>
 >;
 
 export type RécupérerCandidaturePort = (
   identifiantProjet: string,
 ) => Promise<Option.Type<CandidatureEntity>>;
 
-export type ConsulterCandidatureDependencies = {
+export type ConsulterProjetDependencies = {
   récupérerCandidature: RécupérerCandidaturePort;
 };
 
-export const registerConsulterCandidatureQuery = ({
+export const registerConsulterProjetQuery = ({
   récupérerCandidature,
-}: ConsulterCandidatureDependencies) => {
-  const handler: MessageHandler<ConsulterCandidatureQuery> = async ({ identifiantProjet }) => {
+}: ConsulterProjetDependencies) => {
+  const handler: MessageHandler<ConsulterProjetQuery> = async ({ identifiantProjet }) => {
     const result = await récupérerCandidature(identifiantProjet);
 
     if (Option.isNone(result)) {
@@ -61,7 +61,7 @@ export const registerConsulterCandidatureQuery = ({
     return mapToReadModel(result);
   };
 
-  mediator.register('Candidature.Query.ConsulterCandidature', handler);
+  mediator.register('Candidature.Query.ConsulterProjet', handler);
 };
 
 const mapToReadModel = ({
@@ -79,7 +79,7 @@ const mapToReadModel = ({
   statut,
   adressePostaleCandidat,
   technologie,
-}: CandidatureEntity): ConsulterCandidatureReadModel => {
+}: CandidatureEntity): ConsulterProjetReadModel => {
   return {
     appelOffre,
     candidat: {

--- a/packages/domain/candidature/src/index.ts
+++ b/packages/domain/candidature/src/index.ts
@@ -1,8 +1,8 @@
 import {
-  ConsulterCandidatureQuery,
+  ConsulterProjetQuery,
   RécupérerCandidaturePort,
-  ConsulterCandidatureReadModel,
-} from './consulter/consulterCandidature.query';
+  ConsulterProjetReadModel,
+} from './consulter/consulterProjet.query';
 import {
   ListerCandidaturesEligiblesPreuveRecanditureQuery,
   RécupérerCandidaturesEligiblesPreuveRecanditurePort,
@@ -17,14 +17,14 @@ import {
 
 // Query
 export type CandidatureQuery =
-  | ConsulterCandidatureQuery
+  | ConsulterProjetQuery
   | ListerCandidaturesEligiblesPreuveRecanditureQuery
   | ListerCandidaturesQuery;
 
 export {
-  ConsulterCandidatureQuery,
+  ConsulterProjetQuery,
   ListerCandidaturesEligiblesPreuveRecanditureQuery,
-  ConsulterCandidatureReadModel,
+  ConsulterProjetReadModel,
   ListerCandidaturesEligiblesPreuveRecanditureReadModel,
   ListerCandidaturesQuery,
   ListerCandidaturesListItemReadModel,

--- a/packages/domain/candidature/src/register.ts
+++ b/packages/domain/candidature/src/register.ts
@@ -1,7 +1,7 @@
 import {
-  ConsulterCandidatureDependencies,
-  registerConsulterCandidatureQuery,
-} from './consulter/consulterCandidature.query';
+  ConsulterProjetDependencies,
+  registerConsulterProjetQuery,
+} from './consulter/consulterProjet.query';
 import {
   ListerCandidaturesDependencies,
   registerCandidaturesQuery,
@@ -11,12 +11,12 @@ import {
   registerCandidaturesEligiblesPreuveRecanditureQuery,
 } from './lister/listerCandidaturesEligiblesPreuveRecanditure.query';
 
-type CandidatureQueryDependencies = ConsulterCandidatureDependencies &
+type CandidatureQueryDependencies = ConsulterProjetDependencies &
   ListerCandidaturesEligiblesPreuveRecanditureDependencies &
   ListerCandidaturesDependencies;
 
 export const registerCandidatureQueries = (dependencies: CandidatureQueryDependencies) => {
-  registerConsulterCandidatureQuery(dependencies);
+  registerConsulterProjetQuery(dependencies);
   registerCandidaturesQuery(dependencies);
   registerCandidaturesEligiblesPreuveRecanditureQuery(dependencies);
 };

--- a/packages/domain/utilisateur/src/role.valueType.ts
+++ b/packages/domain/utilisateur/src/role.valueType.ts
@@ -221,7 +221,7 @@ const référencielPermissions = {
   },
   candidature: {
     query: {
-      consulter: 'Candidature.Query.ConsulterCandidature',
+      consulter: 'Candidature.Query.ConsulterProjet',
       listerCandidaturesPreuveRecandidature:
         'Candidature.Query.ListerCandidaturesEligiblesPreuveRecandidature',
     },


### PR DESCRIPTION
## Contexte
la "candidature" concerne les données du projet au moment où il a candidaté. 
le "projet" a des données supplémentaires, comme un statut différent et une date de désignation. C'est l'état "actuel" du projet. En réalité, "projet" disparaitra au profit de "lauréat", "éliminé" et "candidature".

## Description
Dans #2058, on ajoute l'import des candidatures dans la nouvelle stack, et on aura besoin de consulter ces données, d'où le renommage.