### PR TITLE
🎨 Lien vers la nouvelle page d'import des candidats

### DIFF
--- a/packages/applications/legacy/src/controllers/notificationCandidats/index.ts
+++ b/packages/applications/legacy/src/controllers/notificationCandidats/index.ts
@@ -1,5 +1,5 @@
 export * from './getCandidateCertificatePreview';
-export * from './getAdminImporterCandidatsPage';
+export * from './legacyGetAdminImporterCandidatsPage';
 export * from './getAdminNotificationCandidatsPage';
 export * from './getProjectCertificateFile';
 export * from './postImportProjects';

--- a/packages/applications/legacy/src/controllers/notificationCandidats/legacyGetAdminImporterCandidatsPage.ts
+++ b/packages/applications/legacy/src/controllers/notificationCandidats/legacyGetAdminImporterCandidatsPage.ts
@@ -2,14 +2,18 @@ import asyncHandler from '../helpers/asyncHandler';
 import routes from '../../routes';
 import { ensureRole } from '../../config';
 import { v1Router } from '../v1Router';
-import { AdminImporterCandidatsPage } from '../../views';
+import { LegacyAdminImporterCandidatsPage } from '../../views';
 
+/**
+ * @deprecated
+ * @description Route legacy pour avoir la page d'import des projets
+ */
 v1Router.get(
-  routes.IMPORT_PROJECTS,
+  routes.LEGACY_IMPORT_PROJECTS,
   ensureRole(['admin', 'dgec-validateur']),
   asyncHandler(async (request, response) => {
     return response.send(
-      AdminImporterCandidatsPage({
+      LegacyAdminImporterCandidatsPage({
         request,
       }),
     );

--- a/packages/applications/legacy/src/controllers/notificationCandidats/postImportProjects.ts
+++ b/packages/applications/legacy/src/controllers/notificationCandidats/postImportProjects.ts
@@ -7,16 +7,20 @@ import { IllegalProjectDataError } from '../../modules/project';
 import routes from '../../routes';
 import { upload } from '../upload';
 import { v1Router } from '../v1Router';
-import { AdminImporterCandidatsPage } from '../../views';
+import { LegacyAdminImporterCandidatsPage } from '../../views';
 
+/**
+ * @deprecated
+ * @description Route legacy pour importer des candidats
+ */
 v1Router.post(
-  routes.IMPORT_PROJECTS_ACTION,
+  routes.LEGACY_IMPORT_PROJECTS_ACTION,
   ensureRole(['admin', 'dgec-validateur']),
   upload.single('candidats'),
   asyncHandler(async (request, response) => {
     if (!request.file || !request.file.path) {
       return response.redirect(
-        addQueryParams(routes.IMPORT_PROJECTS, {
+        addQueryParams(routes.LEGACY_IMPORT_PROJECTS, {
           error: 'Le fichier candidat est manquant.',
         }),
       );
@@ -27,7 +31,7 @@ v1Router.post(
     if (linesResult.isErr()) {
       const csvError = linesResult.error;
       return response.send(
-        AdminImporterCandidatsPage({
+        LegacyAdminImporterCandidatsPage({
           request,
           otherError: `Le fichier csv n'a pas pu être importé: ${csvError.message}`,
         }),
@@ -43,13 +47,13 @@ v1Router.post(
         importId,
       });
 
-      return response.send(AdminImporterCandidatsPage({ request, isSuccess: true }));
+      return response.send(LegacyAdminImporterCandidatsPage({ request, isSuccess: true }));
     } catch (e) {
       if (e instanceof IllegalProjectDataError) {
-        return response.send(AdminImporterCandidatsPage({ request, importErrors: e.errors }));
+        return response.send(LegacyAdminImporterCandidatsPage({ request, importErrors: e.errors }));
       }
 
-      return response.send(AdminImporterCandidatsPage({ request, otherError: e.message }));
+      return response.send(LegacyAdminImporterCandidatsPage({ request, otherError: e.message }));
     }
   }),
 );

--- a/packages/applications/legacy/src/routes.ts
+++ b/packages/applications/legacy/src/routes.ts
@@ -63,8 +63,8 @@ class routes {
 
   static USER_INVITATION = '/enregistrement.html';
 
-  static IMPORT_PROJECTS_ACTION = '/admin/importer-candidats.html';
-  static IMPORT_PROJECTS = '/admin/importer-candidats.html';
+  static LEGACY_IMPORT_PROJECTS_ACTION = '/admin/importer-candidats-legacy.html';
+  static LEGACY_IMPORT_PROJECTS = '/admin/importer-candidats-legacy.html';
 
   static ADMIN_STATISTIQUES = '/admin/statistiques.html';
   static ADEME_STATISTIQUES = '/ademe/statistiques.html';

--- a/packages/applications/legacy/src/views/components/UI/organisms/UserNavigation.tsx
+++ b/packages/applications/legacy/src/views/components/UI/organisms/UserNavigation.tsx
@@ -115,7 +115,7 @@ const MenuAdmin = (currentPage?: string) => (
     <MenuGarantiesFinancières currentPage={currentPage} />
     <DropdownMenu buttonChildren={'Imports'}>
       <DropdownMenu.DropdownItem
-        href={routes.IMPORT_PROJECTS}
+        href={routes.LEGACY_IMPORT_PROJECTS}
         {...(currentPage === 'import-projects' && { isCurrent: true })}
       >
         Nouveaux candidats

--- a/packages/applications/legacy/src/views/components/UI/organisms/UserNavigation.tsx
+++ b/packages/applications/legacy/src/views/components/UI/organisms/UserNavigation.tsx
@@ -115,7 +115,7 @@ const MenuAdmin = (currentPage?: string) => (
     <MenuGarantiesFinancières currentPage={currentPage} />
     <DropdownMenu buttonChildren={'Imports'}>
       <DropdownMenu.DropdownItem
-        href={routes.LEGACY_IMPORT_PROJECTS}
+        href={Routes.Candidature.importer}
         {...(currentPage === 'import-projects' && { isCurrent: true })}
       >
         Nouveaux candidats
@@ -127,7 +127,7 @@ const MenuAdmin = (currentPage?: string) => (
         Courriers historiques
       </DropdownMenu.DropdownItem>
       <DropdownMenu.DropdownItem
-        href={Routes.Raccordement.importer()}
+        href={Routes.Raccordement.importer}
         {...(currentPage === 'importer-dates-mise-en-service' && { isCurrent: true })}
       >
         Dates de mise en service

--- a/packages/applications/legacy/src/views/index.ts
+++ b/packages/applications/legacy/src/views/index.ts
@@ -23,7 +23,7 @@ import {
   ChangerFournisseur,
   AdminNotificationCandidats,
   AdminRegénérerPeriodeAttestations,
-  AdminImporterCandidats,
+  LegacyAdminImporterCandidats,
   ListeProjets,
   SuccèsOuErreur,
   InvitationsCandidatsEnAttente,
@@ -243,9 +243,11 @@ export const AdminRegénérerPeriodeAttestationsPage = (
     title: 'Regénérer période attestations',
   });
 
-export const AdminImporterCandidatsPage = (props: Parameters<typeof AdminImporterCandidats>[0]) =>
+export const LegacyAdminImporterCandidatsPage = (
+  props: Parameters<typeof LegacyAdminImporterCandidats>[0],
+) =>
   makeHtml({
-    Component: AdminImporterCandidats,
+    Component: LegacyAdminImporterCandidats,
     props,
     title: 'Importer des candidats',
   });

--- a/packages/applications/legacy/src/views/pages/LegacyAdminImporterCandidatsPage.tsx
+++ b/packages/applications/legacy/src/views/pages/LegacyAdminImporterCandidatsPage.tsx
@@ -10,30 +10,39 @@ import {
   LegacyPageTemplate,
   SuccessBox,
   Form,
+  InfoBox,
+  Link,
 } from '../components';
 import { hydrateOnClient } from '../helpers';
+import { Routes } from '@potentiel-applications/routes';
 
-type AdminImporterCandidatsProps = {
+type LegacyAdminImporterCandidatsProps = {
   request: Request;
   importErrors?: Record<number, string>;
   otherError?: string;
   isSuccess?: boolean;
 };
 
-export const AdminImporterCandidats = ({
+export const LegacyAdminImporterCandidats = ({
   request,
   importErrors,
   isSuccess,
   otherError,
-}: AdminImporterCandidatsProps) => {
+}: LegacyAdminImporterCandidatsProps) => {
   return (
     <LegacyPageTemplate user={request.user} currentPage="import-projects">
       <Heading1>Importer des candidats</Heading1>
+      <InfoBox title="Cette page est obsolète" className="mb-8">
+        <div>
+          Cette page n'est plus utilisée. Pour importer des candidats, rendez-vous sur la{' '}
+          <Link href={Routes.Candidature.importer}>nouvelle page d'import de candidats.</Link>
+        </div>
+      </InfoBox>
       <Form
-        action={ROUTES.IMPORT_PROJECTS_ACTION}
+        action={ROUTES.LEGACY_IMPORT_PROJECTS_ACTION}
         method="post"
         encType="multipart/form-data"
-        className="mx-auto"
+        // className="mx-auto"
       >
         {isSuccess && <SuccessBox title="Les projets ont bien été importés." />}
         {!!importErrors && (
@@ -62,4 +71,4 @@ export const AdminImporterCandidats = ({
   );
 };
 
-hydrateOnClient(AdminImporterCandidats);
+hydrateOnClient(LegacyAdminImporterCandidats);

--- a/packages/applications/legacy/src/views/pages/index.ts
+++ b/packages/applications/legacy/src/views/pages/index.ts
@@ -18,7 +18,7 @@ export * from './signalerDemandeRecoursPage';
 export * from './AbonnementLettreInformation';
 export * from './AcheteurObligeStatistiquesPage';
 export * from './AdemeStatistiquesPage';
-export * from './AdminImporterCandidatsPage';
+export * from './LegacyAdminImporterCandidatsPage';
 export * from './AdminNotificationCandidatsPage';
 export * from './AdminRegénérerPeriodeAttestationsPage';
 export * from './AdminStatistiquesPage';

--- a/packages/applications/routes/src/candidature/candidature.routes.ts
+++ b/packages/applications/routes/src/candidature/candidature.routes.ts
@@ -1,0 +1,1 @@
+export const importer = '/candidatures/importer';

--- a/packages/applications/routes/src/candidature/index.ts
+++ b/packages/applications/routes/src/candidature/index.ts
@@ -1,0 +1,1 @@
+export * as Candidature from './candidature.routes';

--- a/packages/applications/routes/src/index.ts
+++ b/packages/applications/routes/src/index.ts
@@ -1,19 +1,21 @@
 import { Abandon, Raccordement, Achèvement } from './lauréat';
-import { Recours } from './éliminé';
+import { Candidature } from './candidature';
 import { Document } from './document';
+import { GarantiesFinancières } from './garanties-financières';
 import { Gestionnaire } from './réseau';
 import { Projet } from './projet';
+import { Recours } from './éliminé';
 import { Tache } from './tâche';
-import { GarantiesFinancières } from './garanties-financières';
 
 export const Routes = {
   Abandon,
   Achèvement,
+  Candidature,
   Document,
+  GarantiesFinancières,
   Gestionnaire,
   Projet,
   Raccordement,
-  Tache,
-  GarantiesFinancières,
   Recours,
+  Tache,
 };

--- a/packages/applications/routes/src/lauréat/raccordement.routes.ts
+++ b/packages/applications/routes/src/lauréat/raccordement.routes.ts
@@ -3,7 +3,7 @@ import { encodeParameter } from '../encodeParameter';
 export const détail = (identifiantProjet: string) =>
   `/laureats/${encodeParameter(identifiantProjet)}/raccordements`;
 
-export const importer = () => `/reseaux/raccordements/importer`;
+export const importer = `/reseaux/raccordements/importer`;
 
 export const modifierGestionnaireDeRéseau = (identifiantProjet: string) =>
   `/laureats/${encodeParameter(identifiantProjet)}/raccordements/gestionnaire:modifier`;

--- a/packages/applications/ssr/src/components/molecules/UserBasedRoleNavigation.tsx
+++ b/packages/applications/ssr/src/components/molecules/UserBasedRoleNavigation.tsx
@@ -78,7 +78,7 @@ const getNavigationItemsBasedOnRole = (
             {
               text: 'Nouveaux candidats',
               linkProps: {
-                href: '/admin/importer-candidats-legacy.html',
+                href: Routes.Candidature.importer,
               },
             },
             {
@@ -90,7 +90,7 @@ const getNavigationItemsBasedOnRole = (
             {
               text: 'Dates de mise en service',
               linkProps: {
-                href: Routes.Raccordement.importer(),
+                href: Routes.Raccordement.importer,
               },
             },
           ],

--- a/packages/applications/ssr/src/components/molecules/UserBasedRoleNavigation.tsx
+++ b/packages/applications/ssr/src/components/molecules/UserBasedRoleNavigation.tsx
@@ -78,7 +78,7 @@ const getNavigationItemsBasedOnRole = (
             {
               text: 'Nouveaux candidats',
               linkProps: {
-                href: '/admin/importer-candidats.html',
+                href: '/admin/importer-candidats-legacy.html',
               },
             },
             {

--- a/packages/applications/ssr/src/components/molecules/projet/ProjetListItem.tsx
+++ b/packages/applications/ssr/src/components/molecules/projet/ProjetListItem.tsx
@@ -57,7 +57,6 @@ export const ProjetListItem: FC<ProjetListItemProps> = (projet) => {
             'transmettreDemandeComplèteRaccordement',
             'détail',
             'modifierGestionnaireDeRéseau',
-            'importer',
           ]}
         />
       </div>


### PR DESCRIPTION
# Description

On garde l'ancienne page le temps que la feature soit full migrée, elle sera dispo via l'url seulement.
La nouvelle route vient remplacer l'ancienne dans le menu