### PR TITLE
🚑️ Correction sur les filtres de la page de notification des candidats

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31868,6 +31868,7 @@
       }
     },
     "packages/applications/scheduler": {
+      "name": "@potentiel-applications/scheduler",
       "version": "0.0.0",
       "dependencies": {
         "@potentiel-domain/common": "*",

--- a/packages/applications/legacy/src/views/pages/AdminNotificationCandidatsPage.tsx
+++ b/packages/applications/legacy/src/views/pages/AdminNotificationCandidatsPage.tsx
@@ -152,6 +152,7 @@ export const AdminNotificationCandidats = ({
               }
               onChange={(event) =>
                 updateUrlParams({
+                  appelOffreId: données?.AOSélectionné ?? null,
                   periodeId: event.target.value,
                 })
               }
@@ -241,12 +242,12 @@ export const AdminNotificationCandidats = ({
                       title: ' Télécharger la liste des lauréats (document csv)',
                       url: `
                 ${ROUTES.ADMIN_DOWNLOAD_PROJECTS_LAUREATS_CSV}?${querystring.stringify({
-                        ...request.query,
-                        appelOffreId: données.AOSélectionné,
-                        periodeId: données.périodeSélectionnée,
-                        beforeNotification: true,
-                        pageSize: 10000,
-                      })}`,
+                  ...request.query,
+                  appelOffreId: données.AOSélectionné,
+                  periodeId: données.périodeSélectionnée,
+                  beforeNotification: true,
+                  pageSize: 10000,
+                })}`,
                     }
                   : undefined
               }


### PR DESCRIPTION
# Description

Quand il n'y a aucun filtre dans l'url et qu'on sélectionne une période différente alors le filtre ne s'applique pas et la prériode est remise à celle de départ. Cela est dû au fait que l'on ne transmet pas l'appel d'offres au changement de période.

## Type de changement

- Correction de bug