### PR TITLE
💄 Affichage de l'adresse email ayant servi à la candidature

### DIFF
--- a/packages/applications/legacy/src/views/pages/projectDetailsPage/sections/Contact.tsx
+++ b/packages/applications/legacy/src/views/pages/projectDetailsPage/sections/Contact.tsx
@@ -29,6 +29,7 @@ export const Contact = ({ project, user }: ContactProps) => (
     <div>
       <Heading3 className="mb-1">Représentant légal</Heading3>
       <div>{project.nomRepresentantLegal}</div>
+      <Heading3 className="mb-1">Adresse email de candidature</Heading3>
       <div>{project.email}</div>
     </div>
 


### PR DESCRIPTION
# Description

Création de la rubrique "Adresse email de candidature" dans la partie "Contact" pour pouvoir y intégrer l'adresse email contact

## Type de changement

- Nouvelle fonctionnalité