### PR TITLE
✨ Avoir un lien d'accès au détail de la mainlevée

### DIFF
--- a/packages/applications/ssr/src/components/pages/garanties-financières/mainlevée/lister/ListItemDemandeMainlevée.tsx
+++ b/packages/applications/ssr/src/components/pages/garanties-financières/mainlevée/lister/ListItemDemandeMainlevée.tsx
@@ -42,11 +42,9 @@ export const ListItemDemandeMainlevée: FC<ListItemDemandeMainlevéeProps> = ({
       />
     }
     actions={
-      showInstruction && (
-        <Link href={Routes.GarantiesFinancières.détail(identifiantProjet)} aria-label={`instruire`}>
-          Instruire
-        </Link>
-      )
+      <Link href={Routes.GarantiesFinancières.détail(identifiantProjet)} aria-label={`instruire`}>
+        {showInstruction ? 'Instruire' : 'Voir'}
+      </Link>
     }
   >
     <StatutMainlevéeBadge statut={statut} />


### PR DESCRIPTION
# Description

En tant qu'utilisateur de la DGEC (ADMIN, DGEC, DGEC-VALIDATEUR) je dois avoir accès à un raccourci vers le détail des mainlevées depuis la page listing des mainlevée sur Potentiel

## Type de changement

Veuillez supprimer les options qui ne sont pas pertinentes.

- Nouvelle fonctionnalité