### PR TITLE
🐛 Enregistrer les détails avant d'importer

### DIFF
--- a/packages/domain/candidature/src/corriger/corrigerCandidature.usecase.ts
+++ b/packages/domain/candidature/src/corriger/corrigerCandidature.usecase.ts
@@ -26,15 +26,6 @@ export const registerCorrigerCandidatureUseCase = () => {
       `${payload.appelOffreValue}#${payload.périodeValue}#${payload.familleValue}#${payload.numéroCREValue}`,
     );
     const corrigéLe = DateTime.convertirEnValueType(payload.corrigéLe);
-    await mediator.send<CorrigerCandidatureCommand>({
-      type: 'Candidature.Command.CorrigerCandidature',
-      data: {
-        identifiantProjet,
-        ...mapPayloadForCommand(payload),
-        corrigéLe: DateTime.convertirEnValueType(payload.corrigéLe),
-        corrigéPar: Email.convertirEnValueType(payload.corrigéPar),
-      },
-    });
 
     const buf = Buffer.from(JSON.stringify(payload.détailsValue));
     const blob = new Blob([buf]);
@@ -48,6 +39,16 @@ export const registerCorrigerCandidatureUseCase = () => {
           corrigéLe.formatter(),
           'application/json',
         ),
+      },
+    });
+
+    await mediator.send<CorrigerCandidatureCommand>({
+      type: 'Candidature.Command.CorrigerCandidature',
+      data: {
+        identifiantProjet,
+        ...mapPayloadForCommand(payload),
+        corrigéLe: DateTime.convertirEnValueType(payload.corrigéLe),
+        corrigéPar: Email.convertirEnValueType(payload.corrigéPar),
       },
     });
   };

--- a/packages/domain/candidature/src/importer/importerCandidature.usecase.ts
+++ b/packages/domain/candidature/src/importer/importerCandidature.usecase.ts
@@ -64,16 +64,6 @@ export const registerImporterCandidatureUseCase = () => {
     );
     const importéLe = DateTime.convertirEnValueType(payload.importéLe);
 
-    await mediator.send<ImporterCandidatureCommand>({
-      type: 'Candidature.Command.ImporterCandidature',
-      data: {
-        identifiantProjet,
-        ...mapPayloadForCommand(payload),
-        importéLe,
-        importéPar: Email.convertirEnValueType(payload.importéPar),
-      },
-    });
-
     const buf = Buffer.from(JSON.stringify(payload.détailsValue));
     const blob = new Blob([buf]);
     await mediator.send<EnregistrerDocumentProjetCommand>({
@@ -86,6 +76,15 @@ export const registerImporterCandidatureUseCase = () => {
           importéLe.formatter(),
           'application/json',
         ),
+      },
+    });
+    await mediator.send<ImporterCandidatureCommand>({
+      type: 'Candidature.Command.ImporterCandidature',
+      data: {
+        identifiantProjet,
+        ...mapPayloadForCommand(payload),
+        importéLe,
+        importéPar: Email.convertirEnValueType(payload.importéPar),
       },
     });
   };


### PR DESCRIPTION
Si le document est enregistré après, il n'est pas disponible dans la saga legacy et `récupérerDocument` plante
