### PR TITLE
🐛 Ne pas spread la prop `key` dans List

### DIFF
--- a/packages/applications/ssr/src/components/organisms/List.tsx
+++ b/packages/applications/ssr/src/components/organisms/List.tsx
@@ -8,7 +8,7 @@ type ListProps<TItem> = {
   currentPage: number;
   totalItems: number;
   itemsPerPage: number;
-  ItemComponent: FC<TItem>;
+  ItemComponent: FC<Omit<TItem, 'key'>>;
 };
 
 export const List = <TItem,>({
@@ -20,8 +20,8 @@ export const List = <TItem,>({
 }: ListProps<TItem>) => (
   <>
     <ul>
-      {items.map((item) => (
-        <li className="mb-6" key={`abandon-projet-${item.key}`}>
+      {items.map(({ key, ...item }) => (
+        <li className="mb-6" key={key}>
           <Tile className="flex flex-col md:flex-row md:justify-between">
             <ItemComponent {...item} />
           </Tile>

--- a/packages/applications/ssr/src/components/templates/ListPage.template.tsx
+++ b/packages/applications/ssr/src/components/templates/ListPage.template.tsx
@@ -21,7 +21,7 @@ export type ListPageTemplateProps<TItem> = {
   totalItems: number;
   itemsPerPage: number;
   items: Array<TItem & { key: string }>;
-  ItemComponent: FC<TItem>;
+  ItemComponent: FC<Omit<TItem, 'key'>>;
   search?: SearchProps;
   legend?: ListLegendProps['legend'];
 };


### PR DESCRIPTION
Supprime un warning affiché lors du render des listes