### PR TITLE
🐛 Utilisation du mediator dans withUtilisateur

### DIFF
--- a/packages/applications/ssr/src/app/BootstrapApp.tsx
+++ b/packages/applications/ssr/src/app/BootstrapApp.tsx
@@ -3,9 +3,9 @@ import { mediator } from 'mediateur';
 import { bootstrap } from '@potentiel-applications/bootstrap';
 import { permissionMiddleware } from '@potentiel-domain/utilisateur';
 
-import { getAuthenticatedUser } from '@/utils/getAuthenticatedUser.handler';
+import { getOptionalAuthenticatedUser } from '@/utils/getAuthenticatedUser.handler';
 
-mediator.register('System.Authorization.RécupérerUtilisateur', getAuthenticatedUser);
+mediator.register('System.Authorization.RécupérerUtilisateur', getOptionalAuthenticatedUser);
 
 export const BootstrapApp = async () => {
   await bootstrap({ middlewares: [permissionMiddleware] });

--- a/packages/applications/ssr/src/components/molecules/UserBasedRoleNavigation.stories.tsx
+++ b/packages/applications/ssr/src/components/molecules/UserBasedRoleNavigation.stories.tsx
@@ -1,0 +1,81 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import MainNavigation from '@codegouvfr/react-dsfr/MainNavigation';
+import DsfrHeader from '@codegouvfr/react-dsfr/Header';
+
+import { Role } from '@potentiel-domain/utilisateur';
+
+import { getNavigationItemsBasedOnRole } from './UserBasedRoleNavigation';
+
+const Navigation = ({ role }: { role: Role.RawType | undefined }) => {
+  const navigationItems = role
+    ? getNavigationItemsBasedOnRole({ role: Role.convertirEnValueType(role) })
+    : [];
+
+  return (
+    <DsfrHeader
+      navigation={<MainNavigation items={navigationItems} />}
+      brandTop={
+        <>
+          République
+          <br />
+          Française
+        </>
+      }
+      homeLinkProps={{ href: '/', title: "Retour à l'accueil" }}
+    />
+  );
+};
+
+const meta = {
+  title: 'Molecules/UserBasedRoleNavigation',
+  component: Navigation,
+  parameters: {},
+  tags: ['autodocs'],
+  argTypes: {
+    role: {
+      control: {
+        type: 'select',
+        labels: Role.roles,
+      },
+    },
+  },
+} satisfies Meta<{}>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: { role: undefined },
+};
+
+export const Admin: Story = {
+  args: { role: 'admin' },
+};
+
+export const Porteur: Story = {
+  args: { role: 'porteur-projet' },
+};
+
+export const Dreal: Story = {
+  args: { role: 'dreal' },
+};
+
+export const AcheteurObligé: Story = {
+  args: { role: 'acheteur-obligé' },
+};
+
+export const Ademe: Story = {
+  args: { role: 'ademe' },
+};
+
+export const DgecValidateur: Story = {
+  args: { role: 'dgec-validateur' },
+};
+
+export const CaisseDesDépôt: Story = {
+  args: { role: 'caisse-des-dépôts' },
+};
+
+export const CRE: Story = {
+  args: { role: 'cre' },
+};

--- a/packages/applications/ssr/src/components/molecules/UserBasedRoleNavigation.tsx
+++ b/packages/applications/ssr/src/components/molecules/UserBasedRoleNavigation.tsx
@@ -1,18 +1,23 @@
 import { MainNavigation, MainNavigationProps } from '@codegouvfr/react-dsfr/MainNavigation';
+import { mediator } from 'mediateur';
 
 import { Routes } from '@potentiel-applications/routes';
+import { Option } from '@potentiel-libraries/monads';
 
 import {
   AuthenticatedUserReadModel,
-  getOptionalAuthenticatedUser,
+  GetAuthenticatedUserMessage,
 } from '@/utils/getAuthenticatedUser.handler';
 
 export async function UserBasedRoleNavigation() {
-  const utilisateur = await getOptionalAuthenticatedUser();
-
-  const navigationItems = utilisateur ? getNavigationItemsBasedOnRole(utilisateur) : [];
-
-  return <MainNavigation items={navigationItems} />;
+  const utilisateur = await mediator.send<GetAuthenticatedUserMessage>({
+    type: 'System.Authorization.RécupérerUtilisateur',
+    data: {},
+  });
+  if (Option.isNone(utilisateur)) {
+    return <MainNavigation items={[]} />;
+  }
+  return <MainNavigation items={getNavigationItemsBasedOnRole(utilisateur)} />;
 }
 
 const menuLinks = {
@@ -38,8 +43,8 @@ const menuLinks = {
   ],
 };
 
-const getNavigationItemsBasedOnRole = (
-  utilisateur: AuthenticatedUserReadModel,
+export const getNavigationItemsBasedOnRole = (
+  utilisateur: Pick<AuthenticatedUserReadModel, 'role'>,
 ): MainNavigationProps['items'] => {
   switch (utilisateur.role.nom) {
     case 'admin':

--- a/packages/applications/ssr/src/components/molecules/UserHeaderQuickAccessItem.tsx
+++ b/packages/applications/ssr/src/components/molecules/UserHeaderQuickAccessItem.tsx
@@ -4,17 +4,21 @@ import { mediator } from 'mediateur';
 import { ConsulterNombreTâchesQuery } from '@potentiel-domain/tache';
 import { Role } from '@potentiel-domain/utilisateur';
 import { Routes } from '@potentiel-applications/routes';
+import { Option } from '@potentiel-libraries/monads';
 
 import {
   AuthenticatedUserReadModel,
-  getOptionalAuthenticatedUser,
+  GetAuthenticatedUserMessage,
 } from '@/utils/getAuthenticatedUser.handler';
 
 export async function UserHeaderQuickAccessItem() {
-  const utilisateur = await getOptionalAuthenticatedUser();
+  const utilisateur = await mediator.send<GetAuthenticatedUserMessage>({
+    type: 'System.Authorization.RécupérerUtilisateur',
+    data: {},
+  });
   const accountUrl = `${process.env.KEYCLOAK_SERVER}/realms/${process.env.KEYCLOAK_REALM}/account`;
 
-  if (utilisateur) {
+  if (Option.isSome(utilisateur)) {
     return (
       <>
         {await getTâcheHeaderQuickAccessItem(utilisateur)}

--- a/packages/applications/ssr/src/utils/NoAuthenticatedUser.error.ts
+++ b/packages/applications/ssr/src/utils/NoAuthenticatedUser.error.ts
@@ -1,0 +1,5 @@
+export class NoAuthenticatedUserError extends Error {
+  constructor(cause?: Error) {
+    super(`Authentification obligatoire`, { cause });
+  }
+}

--- a/packages/applications/ssr/src/utils/getAuthenticatedUser.handler.ts
+++ b/packages/applications/ssr/src/utils/getAuthenticatedUser.handler.ts
@@ -7,6 +7,8 @@ import { IdentifiantUtilisateur, Role, Utilisateur } from '@potentiel-domain/uti
 import { Option } from '@potentiel-libraries/monads';
 import { récupérerUtilisateurAdapter } from '@potentiel-infrastructure/domain-adapters';
 
+import { NoAuthenticatedUserError } from './NoAuthenticatedUser.error';
+
 export type AuthenticatedUserReadModel = {
   nom: string;
   identifiantUtilisateur: IdentifiantUtilisateur.ValueType;
@@ -78,9 +80,3 @@ export const getAuthenticatedUser: MessageHandler<GetAuthenticatedUserMessage> =
 
   return user;
 };
-
-export class NoAuthenticatedUserError extends Error {
-  constructor(cause?: Error) {
-    super(`Authentification obligatoire`, { cause });
-  }
-}

--- a/packages/applications/ssr/src/utils/withErrorHandling.ts
+++ b/packages/applications/ssr/src/utils/withErrorHandling.ts
@@ -5,7 +5,7 @@ import { redirect } from 'next/navigation';
 import { getLogger } from '@potentiel-libraries/monitoring';
 import { DomainError } from '@potentiel-domain/core';
 
-import { NoAuthenticatedUserError } from './getAuthenticatedUser.handler';
+import { NoAuthenticatedUserError } from './NoAuthenticatedUser.error';
 
 export async function withErrorHandling<TResult>(
   action: () => Promise<TResult>,

--- a/packages/applications/ssr/src/utils/withUtilisateur.ts
+++ b/packages/applications/ssr/src/utils/withUtilisateur.ts
@@ -1,12 +1,23 @@
-import {
-  AuthenticatedUserReadModel,
-  getAuthenticatedUser,
-} from '@/utils/getAuthenticatedUser.handler';
+import { Message, mediator } from 'mediateur';
+
+import { Utilisateur } from '@potentiel-domain/utilisateur';
+import { Option } from '@potentiel-libraries/monads';
+
+import { AuthenticatedUserReadModel } from '@/utils/getAuthenticatedUser.handler';
+
+type GetAuthenticatedUserMessage = Message<
+  'System.Authorization.RécupérerUtilisateur',
+  {},
+  Utilisateur.ValueType & { régionDreal: Option.Type<string> }
+>;
 
 export async function withUtilisateur<TResult>(
   action: (Utilisateur: AuthenticatedUserReadModel) => Promise<TResult>,
 ): Promise<TResult> {
-  const utilisateur = await getAuthenticatedUser({});
+  const utilisateur = await mediator.send<GetAuthenticatedUserMessage>({
+    type: 'System.Authorization.RécupérerUtilisateur',
+    data: {},
+  });
 
   return await action(utilisateur);
 }

--- a/packages/applications/ssr/src/utils/withUtilisateur.ts
+++ b/packages/applications/ssr/src/utils/withUtilisateur.ts
@@ -5,6 +5,8 @@ import { Option } from '@potentiel-libraries/monads';
 
 import { AuthenticatedUserReadModel } from '@/utils/getAuthenticatedUser.handler';
 
+import { NoAuthenticatedUserError } from './NoAuthenticatedUser.error';
+
 type GetAuthenticatedUserMessage = Message<
   'System.Authorization.RécupérerUtilisateur',
   {},
@@ -18,6 +20,10 @@ export async function withUtilisateur<TResult>(
     type: 'System.Authorization.RécupérerUtilisateur',
     data: {},
   });
+
+  if (Option.isNone(utilisateur)) {
+    throw new NoAuthenticatedUserError();
+  }
 
   return await action(utilisateur);
 }

--- a/packages/domain/utilisateur/src/permission.middleware.ts
+++ b/packages/domain/utilisateur/src/permission.middleware.ts
@@ -1,6 +1,7 @@
 import { Message, Middleware, mediator } from 'mediateur';
 
 import { IdentifiantProjet } from '@potentiel-domain/common';
+import { Option } from '@potentiel-libraries/monads';
 
 import * as Utilisateur from './utilisateur.valueType';
 import { VérifierAccèsProjetQuery } from './vérifierAccèsProjet/vérifierAccèsProjet.query';
@@ -8,7 +9,7 @@ import { VérifierAccèsProjetQuery } from './vérifierAccèsProjet/vérifierAcc
 type GetAuthenticatedUserMessage = Message<
   'System.Authorization.RécupérerUtilisateur',
   {},
-  Utilisateur.ValueType
+  Option.Type<Utilisateur.ValueType>
 >;
 
 export const permissionMiddleware: Middleware = async (message, next) => {
@@ -16,7 +17,7 @@ export const permissionMiddleware: Middleware = async (message, next) => {
     return await next();
   }
 
-  let utilisateur: Utilisateur.ValueType | undefined;
+  let utilisateur: Option.Type<Utilisateur.ValueType> | undefined;
 
   try {
     utilisateur = await mediator.send<GetAuthenticatedUserMessage>({
@@ -36,6 +37,10 @@ export const permissionMiddleware: Middleware = async (message, next) => {
     }
 
     throw new AuthenticationError(error as Error);
+  }
+
+  if (Option.isNone(utilisateur)) {
+    throw new AuthenticationError();
   }
 
   utilisateur.role.peutExécuterMessage(message.type);

--- a/packages/domain/utilisateur/src/role.valueType.ts
+++ b/packages/domain/utilisateur/src/role.valueType.ts
@@ -10,7 +10,7 @@ export type RawType =
   | 'caisse-des-dépôts'
   | 'cre';
 
-const roles: Array<RawType> = [
+export const roles: Array<RawType> = [
   'admin',
   'porteur-projet',
   'dreal',
@@ -71,6 +71,7 @@ export const dreal = convertirEnValueType('dreal');
 export const cre = convertirEnValueType('cre');
 export const acheteurObligé = convertirEnValueType('acheteur-obligé');
 export const caisseDesDépôts = convertirEnValueType('caisse-des-dépôts');
+export const ademe = convertirEnValueType('ademe');
 
 class RoleRefuséError extends OperationRejectedError {
   constructor(value: string) {


### PR DESCRIPTION
Storybook crash sur les pages qui utilisent `withUtilisateur` en raison d'une dépendance à AWS, via le package domain-adapters (adapters candidats).

Un fix plus "correct" serait peut-être d'utiliser `ConsulterUtilisateur` dans [getAuthenticatedUser.handler.ts](https://github.com/MTES-MCT/potentiel/blob/main/packages/applications/ssr/src/utils/getAuthenticatedUser.handler.ts#L55) à la place de l'adapteur directement, mais comme cette fonction est utilisée par le middleware d'authentification, cela causerait une boucle infinie.

