### PR TITLE
🎨 Suppression du filtre actif dans ListFilters quand on supprime un tag appliqué

### DIFF
--- a/packages/applications/ssr/src/components/molecules/Filter.tsx
+++ b/packages/applications/ssr/src/components/molecules/Filter.tsx
@@ -6,14 +6,22 @@ type FilterProps = {
   label: string;
   options: Array<{ label: string; value: string }>;
   defaultValue: string;
+  value: string;
   onValueSelected?: (value: string | undefined) => void;
 };
-export const Filter: FC<FilterProps> = ({ label, options, defaultValue, onValueSelected }) => (
+export const Filter: FC<FilterProps> = ({
+  label,
+  options,
+  defaultValue,
+  value,
+  onValueSelected,
+}) => (
   <SelectNext
     label={label}
     placeholder={`Filtrer par ${label.toLocaleLowerCase()}`}
     nativeSelectProps={{
       defaultValue,
+      value,
       onChange: (e) => {
         const value = e.currentTarget.value;
         if (onValueSelected) {

--- a/packages/applications/ssr/src/components/molecules/ListFilters.tsx
+++ b/packages/applications/ssr/src/components/molecules/ListFilters.tsx
@@ -30,7 +30,8 @@ export const ListFilters: FC<ListFiltersProps> = ({ filters }) => {
           key={`filter-${searchParamKey}`}
           label={label}
           options={options}
-          defaultValue={searchParams.get(searchParamKey) ?? defaultValue ?? ''}
+          defaultValue={defaultValue ?? ''}
+          value={searchParams.get(searchParamKey) ?? ''}
           onValueSelected={(value) => {
             const newSearchParams = new URLSearchParams(searchParams);
             if (value === '') {


### PR DESCRIPTION
# Description
Quand on sélectionnait un filtre sur une liste, alors un tag apparait et nous permet d'afficher la liste filtrée. Si je clique sur la croix du tag pour le supprimer, la liste se mettait bien à jour, par contre la valeur du filtre sélectionné restait actif dans ListFilters. Cette PR fixe ce problème.

## Type de changement

- [x] Correction de bug