### PR TITLE
♻️ Uniformiser les boutons d'actions des formulaires

### DIFF
--- a/packages/applications/ssr/src/components/atoms/form/Form.tsx
+++ b/packages/applications/ssr/src/components/atoms/form/Form.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { FC, FormHTMLAttributes } from 'react';
+import { FC, FormHTMLAttributes, ReactNode } from 'react';
 import { useFormState } from 'react-dom';
 
 import { formAction } from '@/utils/formAction';
@@ -14,10 +14,11 @@ import { FormFeedbackCsvError } from './FormFeedbackCsvErrors';
 export type FormProps = Omit<FormHTMLAttributes<HTMLFormElement>, 'action' | 'method'> & {
   method?: 'POST';
   action: ReturnType<typeof formAction>;
-  children: React.ReactNode;
-  heading?: React.ReactNode;
+  children: ReactNode;
+  heading?: ReactNode;
   omitMandatoryFieldsLegend?: true;
   pendingModal?: FormPendingModalProps;
+  actionButtons: ReactNode;
   onSuccess?: () => void;
   onValidationError?: (validationErrors: Array<string>) => void;
   successMessage?: string;
@@ -33,6 +34,7 @@ export const Form: FC<FormProps> = ({
   pendingModal,
   className,
   successMessage,
+  actionButtons,
   ...props
 }) => {
   const [state, formAction] = useFormState(action, {
@@ -59,7 +61,11 @@ export const Form: FC<FormProps> = ({
         </div>
       )}
 
-      <div className={`flex flex-col gap-5 ${className || ''}`}>{children}</div>
+      <div className={`flex flex-col gap-5 ${className || ''}`}>
+        {children}
+
+        <div className="flex flex-col md:flex-row gap-2">{actionButtons}</div>
+      </div>
 
       <FormFeedbackCsvError formState={state} />
     </form>

--- a/packages/applications/ssr/src/components/atoms/form/Form.tsx
+++ b/packages/applications/ssr/src/components/atoms/form/Form.tsx
@@ -18,7 +18,7 @@ export type FormProps = Omit<FormHTMLAttributes<HTMLFormElement>, 'action' | 'me
   heading?: ReactNode;
   omitMandatoryFieldsLegend?: true;
   pendingModal?: FormPendingModalProps;
-  actionButtons: ReactNode;
+  actions: ReactNode;
   onSuccess?: () => void;
   onValidationError?: (validationErrors: Array<string>) => void;
   successMessage?: string;
@@ -34,7 +34,7 @@ export const Form: FC<FormProps> = ({
   pendingModal,
   className,
   successMessage,
-  actionButtons,
+  actions,
   ...props
 }) => {
   const [state, formAction] = useFormState(action, {
@@ -64,7 +64,7 @@ export const Form: FC<FormProps> = ({
       <div className={`flex flex-col gap-5 ${className || ''}`}>
         {children}
 
-        <div className="flex flex-col md:flex-row gap-2">{actionButtons}</div>
+        <div className="flex flex-col md:flex-row gap-2">{actions}</div>
       </div>
 
       <FormFeedbackCsvError formState={state} />

--- a/packages/applications/ssr/src/components/molecules/ModalWithForm.tsx
+++ b/packages/applications/ssr/src/components/molecules/ModalWithForm.tsx
@@ -11,7 +11,7 @@ import { SubmitButton } from '../atoms/form/SubmitButton';
 
 export type ModalWithFormProps = {
   acceptButtonLabel: string;
-  form: Omit<FormProps, 'actionButtons'>;
+  form: Omit<FormProps, 'actions'>;
   isOpen: boolean;
   rejectButtonLabel: string;
   onClose: () => void;
@@ -65,7 +65,7 @@ export const ModalWithForm: FC<ModalWithFormProps> = ({
         {...form}
         onSuccess={onFormSuccess}
         key={id}
-        actionButtons={
+        actions={
           <>
             <Button priority="secondary" onClick={handleRejectClick} type="button">
               {rejectButtonLabel}

--- a/packages/applications/ssr/src/components/molecules/ModalWithForm.tsx
+++ b/packages/applications/ssr/src/components/molecules/ModalWithForm.tsx
@@ -11,7 +11,7 @@ import { SubmitButton } from '../atoms/form/SubmitButton';
 
 export type ModalWithFormProps = {
   acceptButtonLabel: string;
-  form: FormProps;
+  form: Omit<FormProps, 'actionButtons'>;
   isOpen: boolean;
   rejectButtonLabel: string;
   onClose: () => void;
@@ -61,14 +61,20 @@ export const ModalWithForm: FC<ModalWithFormProps> = ({
 
   return (
     <modal.Component title={title}>
-      <Form {...form} onSuccess={onFormSuccess} key={id}>
+      <Form
+        {...form}
+        onSuccess={onFormSuccess}
+        key={id}
+        actionButtons={
+          <>
+            <Button priority="secondary" onClick={handleRejectClick} type="button">
+              {rejectButtonLabel}
+            </Button>
+            <SubmitButton>{acceptButtonLabel}</SubmitButton>
+          </>
+        }
+      >
         {form.children}
-        <div className="flex flex-col md:flex-row gap-4 mt-1">
-          <Button priority="secondary" onClick={handleRejectClick} type="button">
-            {rejectButtonLabel}
-          </Button>
-          <SubmitButton>{acceptButtonLabel}</SubmitButton>
-        </div>
       </Form>
     </modal.Component>
   );

--- a/packages/applications/ssr/src/components/pages/abandon/demander/DemanderAbandon.form.tsx
+++ b/packages/applications/ssr/src/components/pages/abandon/demander/DemanderAbandon.form.tsx
@@ -34,7 +34,7 @@ export const DemanderAbandonForm: FC<DemanderAbandonFormProps> = ({
       encType="multipart/form-data"
       onSuccess={() => router.push(Routes.Abandon.détail(identifiantProjet))}
       onValidationError={(validationErrors) => setValidationErrors(validationErrors)}
-      actionButtons={<SubmitButton>Demander l'abandon</SubmitButton>}
+      actions={<SubmitButton>Demander l'abandon</SubmitButton>}
     >
       <input type={'hidden'} value={identifiantProjet} name="identifiantProjet" />
 

--- a/packages/applications/ssr/src/components/pages/abandon/demander/DemanderAbandon.form.tsx
+++ b/packages/applications/ssr/src/components/pages/abandon/demander/DemanderAbandon.form.tsx
@@ -34,6 +34,7 @@ export const DemanderAbandonForm: FC<DemanderAbandonFormProps> = ({
       encType="multipart/form-data"
       onSuccess={() => router.push(Routes.Abandon.détail(identifiantProjet))}
       onValidationError={(validationErrors) => setValidationErrors(validationErrors)}
+      actionButtons={<SubmitButton>Demander l'abandon</SubmitButton>}
     >
       <input type={'hidden'} value={identifiantProjet} name="identifiantProjet" />
 
@@ -112,8 +113,6 @@ export const DemanderAbandonForm: FC<DemanderAbandonFormProps> = ({
           }
         />
       ) : null}
-
-      <SubmitButton>Envoyer</SubmitButton>
     </Form>
   );
 };

--- a/packages/applications/ssr/src/components/pages/abandon/transmettrePreuveRecandidature/TransmettrePreuveRecandidature.form.tsx
+++ b/packages/applications/ssr/src/components/pages/abandon/transmettrePreuveRecandidature/TransmettrePreuveRecandidature.form.tsx
@@ -50,6 +50,11 @@ export const TransmettrePreuveRecandidatureForm: FC<TransmettrePreuveRecandidatu
       method="POST"
       onValidationError={(validationErrors) => setValidationErrors(validationErrors)}
       onSuccess={() => router.push(Routes.Abandon.détail(identifiantProjet))}
+      actionButtons={
+        <SubmitButton disabledCondition={() => !projetSélectionné}>
+          Transmettre la preuve de recandidature
+        </SubmitButton>
+      }
     >
       <input type={'hidden'} value={identifiantProjet} name="identifiantProjet" />
 
@@ -88,10 +93,6 @@ export const TransmettrePreuveRecandidatureForm: FC<TransmettrePreuveRecandidatu
           <input type={'hidden'} value={projetSélectionné.dateDésignation} name="dateDesignation" />
         </>
       )}
-
-      <SubmitButton disabledCondition={() => !projetSélectionné}>
-        Transmettre la preuve de recandidature
-      </SubmitButton>
     </Form>
   );
 };

--- a/packages/applications/ssr/src/components/pages/abandon/transmettrePreuveRecandidature/TransmettrePreuveRecandidature.form.tsx
+++ b/packages/applications/ssr/src/components/pages/abandon/transmettrePreuveRecandidature/TransmettrePreuveRecandidature.form.tsx
@@ -50,7 +50,7 @@ export const TransmettrePreuveRecandidatureForm: FC<TransmettrePreuveRecandidatu
       method="POST"
       onValidationError={(validationErrors) => setValidationErrors(validationErrors)}
       onSuccess={() => router.push(Routes.Abandon.détail(identifiantProjet))}
-      actionButtons={
+      actions={
         <SubmitButton disabledCondition={() => !projetSélectionné}>
           Transmettre la preuve de recandidature
         </SubmitButton>

--- a/packages/applications/ssr/src/components/pages/attestation-conformité/AttestationConformité.form.tsx
+++ b/packages/applications/ssr/src/components/pages/attestation-conformité/AttestationConformité.form.tsx
@@ -50,7 +50,7 @@ export const AttestationConformitéForm: FC<AttestationConformitéFormProps> = (
       action={action}
       onSuccess={() => router.push(Routes.Projet.details(identifiantProjet))}
       onValidationError={(validationErrors) => setValidationErrors(validationErrors)}
-      actionButtons={
+      actions={
         <>
           <Button
             priority="secondary"

--- a/packages/applications/ssr/src/components/pages/attestation-conformité/AttestationConformité.form.tsx
+++ b/packages/applications/ssr/src/components/pages/attestation-conformité/AttestationConformité.form.tsx
@@ -21,7 +21,7 @@ type Action =
   | typeof transmettreAttestationConformitéAction
   | typeof modifierAttestationConformitéAction;
 
-export type FormulaireAttestationConformitéProps = {
+export type AttestationConformitéFormProps = {
   identifiantProjet: string;
   action: Action;
   submitButtonLabel: string;
@@ -33,7 +33,7 @@ export type FormulaireAttestationConformitéProps = {
   demanderMainlevée: { visible: boolean; canBeDone: boolean };
 };
 
-export const FormulaireAttestationConformité: FC<FormulaireAttestationConformitéProps> = ({
+export const AttestationConformitéForm: FC<AttestationConformitéFormProps> = ({
   identifiantProjet,
   action,
   submitButtonLabel,

--- a/packages/applications/ssr/src/components/pages/attestation-conformité/FormulaireAttestationConformité.tsx
+++ b/packages/applications/ssr/src/components/pages/attestation-conformité/FormulaireAttestationConformité.tsx
@@ -50,6 +50,21 @@ export const FormulaireAttestationConformité: FC<FormulaireAttestationConformit
       action={action}
       onSuccess={() => router.push(Routes.Projet.details(identifiantProjet))}
       onValidationError={(validationErrors) => setValidationErrors(validationErrors)}
+      actionButtons={
+        <>
+          <Button
+            priority="secondary"
+            linkProps={{
+              href: Routes.Projet.details(identifiantProjet),
+              prefetch: false,
+            }}
+            iconId="fr-icon-arrow-left-line"
+          >
+            Retour sur le projet
+          </Button>
+          <SubmitButton>{submitButtonLabel}</SubmitButton>
+        </>
+      }
     >
       <input name="identifiantProjet" type="hidden" value={identifiantProjet} />
 
@@ -143,20 +158,6 @@ export const FormulaireAttestationConformité: FC<FormulaireAttestationConformit
             )}
           </>
         )}
-      </div>
-
-      <div className="flex flex-col md:flex-row gap-4 mt-5">
-        <Button
-          priority="secondary"
-          linkProps={{
-            href: Routes.Projet.details(identifiantProjet),
-            prefetch: false,
-          }}
-          iconId="fr-icon-arrow-left-line"
-        >
-          Retour sur le projet
-        </Button>
-        <SubmitButton>{submitButtonLabel}</SubmitButton>
       </div>
     </Form>
   );

--- a/packages/applications/ssr/src/components/pages/attestation-conformité/modifier/modifierAttestationConformité.page.tsx
+++ b/packages/applications/ssr/src/components/pages/attestation-conformité/modifier/modifierAttestationConformité.page.tsx
@@ -5,15 +5,15 @@ import { ProjetBanner, ProjetBannerProps } from '@/components/molecules/projet/P
 
 import { TitrePageAttestationConformité } from '../TitrePageAttestationConformité';
 import {
-  FormulaireAttestationConformité,
-  FormulaireAttestationConformitéProps,
-} from '../FormulaireAttestationConformité';
+  AttestationConformitéForm,
+  type AttestationConformitéFormProps,
+} from '../AttestationConformité.form';
 
 import { modifierAttestationConformitéAction } from './modifierAttestationConformité.action';
 
 export type ModifierAttestationConformitéPageProps = {
   projet: ProjetBannerProps;
-  attestationConformitéActuelle: FormulaireAttestationConformitéProps['donnéesActuelles'];
+  attestationConformitéActuelle: AttestationConformitéFormProps['donnéesActuelles'];
 };
 
 export const ModifierAttestationConformitéPage: FC<ModifierAttestationConformitéPageProps> = ({
@@ -23,7 +23,7 @@ export const ModifierAttestationConformitéPage: FC<ModifierAttestationConformit
   <PageTemplate banner={<ProjetBanner {...projet} />}>
     <TitrePageAttestationConformité title="Modifier l'attestation de conformité du projet" />
 
-    <FormulaireAttestationConformité
+    <AttestationConformitéForm
       identifiantProjet={projet.identifiantProjet}
       action={modifierAttestationConformitéAction}
       submitButtonLabel="Modifier"

--- a/packages/applications/ssr/src/components/pages/attestation-conformité/transmettre/transmettreAttestationConformité.page.tsx
+++ b/packages/applications/ssr/src/components/pages/attestation-conformité/transmettre/transmettreAttestationConformité.page.tsx
@@ -4,7 +4,7 @@ import { PageTemplate } from '@/components/templates/Page.template';
 import { ProjetBanner, ProjetBannerProps } from '@/components/molecules/projet/ProjetBanner';
 
 import { TitrePageAttestationConformité } from '../TitrePageAttestationConformité';
-import { FormulaireAttestationConformité } from '../FormulaireAttestationConformité';
+import { AttestationConformitéForm } from '../AttestationConformité.form';
 
 import { transmettreAttestationConformitéAction } from './transmettreAttestationConformité.action';
 
@@ -20,7 +20,7 @@ export const TransmettreAttestationConformitéPage: FC<
   <PageTemplate banner={<ProjetBanner {...projet} />}>
     <TitrePageAttestationConformité title="Transmettre l'attestation de conformité du projet" />
 
-    <FormulaireAttestationConformité
+    <AttestationConformitéForm
       identifiantProjet={projet.identifiantProjet}
       action={transmettreAttestationConformitéAction}
       submitButtonLabel="Transmettre"

--- a/packages/applications/ssr/src/components/pages/candidature/corriger/CorrigerCandidatures.form.tsx
+++ b/packages/applications/ssr/src/components/pages/candidature/corriger/CorrigerCandidatures.form.tsx
@@ -24,6 +24,7 @@ export const CorrigerCandidaturesForm: FC = () => {
       }}
       onValidationError={(validationErrors) => setValidationErrors(validationErrors)}
       successMessage={'candidats corrigés'}
+      actionButtons={<SubmitButton>Corriger</SubmitButton>}
     >
       <UploadDocument
         label="Fichier CSV"
@@ -34,10 +35,6 @@ export const CorrigerCandidaturesForm: FC = () => {
         state={validationErrors.includes('fichierImport') ? 'error' : 'default'}
         stateRelatedMessage="Fichier CSV obligatoire"
       />
-
-      <div className="flex flex-col md:flex-row gap-2">
-        <SubmitButton>Corriger</SubmitButton>
-      </div>
     </Form>
   );
 };

--- a/packages/applications/ssr/src/components/pages/candidature/corriger/CorrigerCandidatures.form.tsx
+++ b/packages/applications/ssr/src/components/pages/candidature/corriger/CorrigerCandidatures.form.tsx
@@ -24,7 +24,7 @@ export const CorrigerCandidaturesForm: FC = () => {
       }}
       onValidationError={(validationErrors) => setValidationErrors(validationErrors)}
       successMessage={'candidats corrigés'}
-      actionButtons={<SubmitButton>Corriger</SubmitButton>}
+      actions={<SubmitButton>Corriger</SubmitButton>}
     >
       <UploadDocument
         label="Fichier CSV"

--- a/packages/applications/ssr/src/components/pages/candidature/importer/ImporterCandidatures.form.tsx
+++ b/packages/applications/ssr/src/components/pages/candidature/importer/ImporterCandidatures.form.tsx
@@ -23,7 +23,7 @@ export const ImporterCandidaturesForm: FC = () => {
       }}
       onValidationError={(validationErrors) => setValidationErrors(validationErrors)}
       successMessage={'candidats importés'}
-      actionButtons={<SubmitButton>Importer</SubmitButton>}
+      actions={<SubmitButton>Importer</SubmitButton>}
     >
       <UploadDocument
         label="Fichier CSV"

--- a/packages/applications/ssr/src/components/pages/candidature/importer/ImporterCandidatures.form.tsx
+++ b/packages/applications/ssr/src/components/pages/candidature/importer/ImporterCandidatures.form.tsx
@@ -23,6 +23,7 @@ export const ImporterCandidaturesForm: FC = () => {
       }}
       onValidationError={(validationErrors) => setValidationErrors(validationErrors)}
       successMessage={'candidats importés'}
+      actionButtons={<SubmitButton>Importer</SubmitButton>}
     >
       <UploadDocument
         label="Fichier CSV"
@@ -33,10 +34,6 @@ export const ImporterCandidaturesForm: FC = () => {
         state={validationErrors.includes('fichierImport') ? 'error' : 'default'}
         stateRelatedMessage="Fichier CSV obligatoire"
       />
-
-      <div className="flex flex-col md:flex-row">
-        <SubmitButton>Importer</SubmitButton>
-      </div>
     </Form>
   );
 };

--- a/packages/applications/ssr/src/components/pages/garanties-financières/FormulaireGarantiesFinancières.tsx
+++ b/packages/applications/ssr/src/components/pages/garanties-financières/FormulaireGarantiesFinancières.tsx
@@ -54,6 +54,21 @@ export const FormulaireGarantiesFinancières: FC<FormulaireGarantiesFinancières
       action={action}
       onSuccess={() => router.push(Routes.GarantiesFinancières.détail(identifiantProjet))}
       onValidationError={(validationErrors) => setValidationErrors(validationErrors)}
+      actionButtons={
+        <>
+          <Button
+            priority="secondary"
+            linkProps={{
+              href: Routes.GarantiesFinancières.détail(identifiantProjet),
+              prefetch: false,
+            }}
+            iconId="fr-icon-arrow-left-line"
+          >
+            Retour au détail des garanties financières
+          </Button>
+          <SubmitButton>{submitButtonLabel}</SubmitButton>
+        </>
+      }
     >
       <input name="identifiantProjet" type="hidden" value={identifiantProjet} />
 
@@ -87,20 +102,6 @@ export const FormulaireGarantiesFinancières: FC<FormulaireGarantiesFinancières
         state={validationErrors.includes('attestation') ? 'error' : 'default'}
         documentKey={defaultValues?.attestation}
       />
-
-      <div className="flex flex-col md:flex-row gap-4 mt-5">
-        <Button
-          priority="secondary"
-          linkProps={{
-            href: Routes.GarantiesFinancières.détail(identifiantProjet),
-            prefetch: false,
-          }}
-          iconId="fr-icon-arrow-left-line"
-        >
-          Retour au détail des garanties financières
-        </Button>
-        <SubmitButton>{submitButtonLabel}</SubmitButton>
-      </div>
     </Form>
   );
 };

--- a/packages/applications/ssr/src/components/pages/garanties-financières/GarantiesFinancières.form.tsx
+++ b/packages/applications/ssr/src/components/pages/garanties-financières/GarantiesFinancières.form.tsx
@@ -54,7 +54,7 @@ export const GarantiesFinancièresForm: FC<GarantiesFinancièresFormProps> = ({
       action={action}
       onSuccess={() => router.push(Routes.GarantiesFinancières.détail(identifiantProjet))}
       onValidationError={(validationErrors) => setValidationErrors(validationErrors)}
-      actionButtons={
+      actions={
         <>
           <Button
             priority="secondary"

--- a/packages/applications/ssr/src/components/pages/garanties-financières/GarantiesFinancières.form.tsx
+++ b/packages/applications/ssr/src/components/pages/garanties-financières/GarantiesFinancières.form.tsx
@@ -25,7 +25,7 @@ type Action =
   | typeof modifierDépôtEnCoursGarantiesFinancièresAction
   | typeof enregistrerGarantiesFinancièresAction;
 
-export type FormulaireGarantiesFinancièresProps = {
+export type GarantiesFinancièresFormProps = {
   identifiantProjet: string;
   action: Action;
   submitButtonLabel: string;
@@ -38,7 +38,7 @@ export type FormulaireGarantiesFinancièresProps = {
   };
 };
 
-export const FormulaireGarantiesFinancières: FC<FormulaireGarantiesFinancièresProps> = ({
+export const GarantiesFinancièresForm: FC<GarantiesFinancièresFormProps> = ({
   identifiantProjet,
   action,
   submitButtonLabel,

--- a/packages/applications/ssr/src/components/pages/garanties-financières/actuelles/enregistrer/EnregistrerGarantiesFinancières.page.tsx
+++ b/packages/applications/ssr/src/components/pages/garanties-financières/actuelles/enregistrer/EnregistrerGarantiesFinancières.page.tsx
@@ -5,14 +5,14 @@ import { ProjetBanner } from '@/components/molecules/projet/ProjetBanner';
 
 import { TitrePageGarantiesFinancières } from '../../TitrePageGarantiesFinancières';
 import {
-  FormulaireGarantiesFinancières,
-  FormulaireGarantiesFinancièresProps,
-} from '../../FormulaireGarantiesFinancières';
+  GarantiesFinancièresForm,
+  type GarantiesFinancièresFormProps,
+} from '../../GarantiesFinancières.form';
 
 import { enregistrerGarantiesFinancièresAction } from './enregistrerGarantiesFinancières.action';
 
 export type EnregistrerGarantiesFinancièresPageProps = Pick<
-  FormulaireGarantiesFinancièresProps,
+  GarantiesFinancièresFormProps,
   'identifiantProjet' | 'typesGarantiesFinancières'
 >;
 
@@ -23,7 +23,7 @@ export const EnregistrerGarantiesFinancièresPage: FC<EnregistrerGarantiesFinanc
   <PageTemplate banner={<ProjetBanner identifiantProjet={identifiantProjet} />}>
     <TitrePageGarantiesFinancières title="Enregistrer des garanties financières" />
 
-    <FormulaireGarantiesFinancières
+    <GarantiesFinancièresForm
       identifiantProjet={identifiantProjet}
       action={enregistrerGarantiesFinancièresAction}
       submitButtonLabel="Enregistrer"

--- a/packages/applications/ssr/src/components/pages/garanties-financières/actuelles/enregistrerAttestation/EnregistrerAttestationGarantiesFinancières.form.tsx
+++ b/packages/applications/ssr/src/components/pages/garanties-financières/actuelles/enregistrerAttestation/EnregistrerAttestationGarantiesFinancières.form.tsx
@@ -30,6 +30,21 @@ export const EnregistrerAttestationGarantiesFinancièresForm: FC<
       action={enregistrerAttestationGarantiesFinancièresAction}
       onSuccess={() => router.push(Routes.GarantiesFinancières.détail(identifiantProjet))}
       onValidationError={(validationErrors) => setValidationErrors(validationErrors)}
+      actionButtons={
+        <>
+          <Button
+            priority="secondary"
+            linkProps={{
+              href: Routes.GarantiesFinancières.détail(identifiantProjet),
+              prefetch: false,
+            }}
+            iconId="fr-icon-arrow-left-line"
+          >
+            Retour au détail des garanties financières
+          </Button>
+          <SubmitButton>Enregistrer</SubmitButton>
+        </>
+      }
     >
       <input type="hidden" name="identifiantProjet" value={identifiantProjet} />
 
@@ -52,20 +67,6 @@ export const EnregistrerAttestationGarantiesFinancièresForm: FC<
         required
         state={validationErrors.includes('attestation') ? 'error' : 'default'}
       />
-
-      <div className="flex flex-col md:flex-row gap-4 mt-5">
-        <Button
-          priority="secondary"
-          linkProps={{
-            href: Routes.GarantiesFinancières.détail(identifiantProjet),
-            prefetch: false,
-          }}
-          iconId="fr-icon-arrow-left-line"
-        >
-          Retour au détail des garanties financières
-        </Button>
-        <SubmitButton>Enregistrer</SubmitButton>
-      </div>
     </Form>
   );
 };

--- a/packages/applications/ssr/src/components/pages/garanties-financières/actuelles/enregistrerAttestation/EnregistrerAttestationGarantiesFinancières.form.tsx
+++ b/packages/applications/ssr/src/components/pages/garanties-financières/actuelles/enregistrerAttestation/EnregistrerAttestationGarantiesFinancières.form.tsx
@@ -30,7 +30,7 @@ export const EnregistrerAttestationGarantiesFinancièresForm: FC<
       action={enregistrerAttestationGarantiesFinancièresAction}
       onSuccess={() => router.push(Routes.GarantiesFinancières.détail(identifiantProjet))}
       onValidationError={(validationErrors) => setValidationErrors(validationErrors)}
-      actionButtons={
+      actions={
         <>
           <Button
             priority="secondary"

--- a/packages/applications/ssr/src/components/pages/garanties-financières/actuelles/modifier/ModifierGarantiesFinancièresActuelles.form.tsx
+++ b/packages/applications/ssr/src/components/pages/garanties-financières/actuelles/modifier/ModifierGarantiesFinancièresActuelles.form.tsx
@@ -39,6 +39,21 @@ export const ModifierGarantiesFinancièresActuellesForm: FC<
       action={modifierGarantiesFinancièresActuellesAction}
       onSuccess={() => router.push(Routes.GarantiesFinancières.détail(identifiantProjet))}
       onValidationError={(validationErrors) => setValidationErrors(validationErrors)}
+      actionButtons={
+        <>
+          <Button
+            priority="secondary"
+            linkProps={{
+              href: Routes.GarantiesFinancières.détail(identifiantProjet),
+              prefetch: false,
+            }}
+            iconId="fr-icon-arrow-left-line"
+          >
+            Retour au détail des garanties financières
+          </Button>
+          <SubmitButton>Modifier</SubmitButton>
+        </>
+      }
     >
       <input type="hidden" name="identifiantProjet" value={identifiantProjet} />
 
@@ -74,20 +89,6 @@ export const ModifierGarantiesFinancièresActuellesForm: FC<
         state={validationErrors.includes('attestation') ? 'error' : 'default'}
         documentKey={actuelles.attestation}
       />
-
-      <div className="flex flex-col md:flex-row gap-4 mt-5">
-        <Button
-          priority="secondary"
-          linkProps={{
-            href: Routes.GarantiesFinancières.détail(identifiantProjet),
-            prefetch: false,
-          }}
-          iconId="fr-icon-arrow-left-line"
-        >
-          Retour au détail des garanties financières
-        </Button>
-        <SubmitButton>Modifier</SubmitButton>
-      </div>
     </Form>
   );
 };

--- a/packages/applications/ssr/src/components/pages/garanties-financières/actuelles/modifier/ModifierGarantiesFinancièresActuelles.form.tsx
+++ b/packages/applications/ssr/src/components/pages/garanties-financières/actuelles/modifier/ModifierGarantiesFinancièresActuelles.form.tsx
@@ -39,7 +39,7 @@ export const ModifierGarantiesFinancièresActuellesForm: FC<
       action={modifierGarantiesFinancièresActuellesAction}
       onSuccess={() => router.push(Routes.GarantiesFinancières.détail(identifiantProjet))}
       onValidationError={(validationErrors) => setValidationErrors(validationErrors)}
-      actionButtons={
+      actions={
         <>
           <Button
             priority="secondary"

--- a/packages/applications/ssr/src/components/pages/garanties-financières/dépôt/modifier/ModifierDépôtEnCoursGarantiesFinancières.page.tsx
+++ b/packages/applications/ssr/src/components/pages/garanties-financières/dépôt/modifier/ModifierDépôtEnCoursGarantiesFinancières.page.tsx
@@ -6,17 +6,17 @@ import { ProjetBanner } from '@/components/molecules/projet/ProjetBanner';
 
 import { TitrePageGarantiesFinancières } from '../../TitrePageGarantiesFinancières';
 import {
-  FormulaireGarantiesFinancières,
-  FormulaireGarantiesFinancièresProps,
-} from '../../FormulaireGarantiesFinancières';
+  GarantiesFinancièresForm,
+  type GarantiesFinancièresFormProps,
+} from '../../GarantiesFinancières.form';
 
 import { modifierDépôtEnCoursGarantiesFinancièresAction } from './modifierDépôtEnCoursGarantiesFinancières.action';
 
 export type ModifierDépôtEnCoursGarantiesFinancièresPageProps = Pick<
-  FormulaireGarantiesFinancièresProps,
+  GarantiesFinancièresFormProps,
   'identifiantProjet' | 'typesGarantiesFinancières'
 > & {
-  dépôtEnCours: FormulaireGarantiesFinancièresProps['defaultValues'];
+  dépôtEnCours: GarantiesFinancièresFormProps['defaultValues'];
   showWarning?: true;
 };
 
@@ -31,7 +31,7 @@ export const ModifierDépôtEnCoursGarantiesFinancièresPage: FC<
     leftColumn={{
       children: (
         <>
-          <FormulaireGarantiesFinancières
+          <GarantiesFinancièresForm
             identifiantProjet={identifiantProjet}
             action={modifierDépôtEnCoursGarantiesFinancièresAction}
             submitButtonLabel="Modifier"

--- a/packages/applications/ssr/src/components/pages/garanties-financières/dépôt/soumettre/SoumettreGarantiesFinancières.page.tsx
+++ b/packages/applications/ssr/src/components/pages/garanties-financières/dépôt/soumettre/SoumettreGarantiesFinancières.page.tsx
@@ -6,7 +6,7 @@ import { ProjetBanner } from '@/components/molecules/projet/ProjetBanner';
 
 import { TitrePageGarantiesFinancières } from '../../TitrePageGarantiesFinancières';
 import { TypeGarantiesFinancièresSelectProps } from '../../TypeGarantiesFinancièresSelect';
-import { FormulaireGarantiesFinancières } from '../../FormulaireGarantiesFinancières';
+import { GarantiesFinancièresForm } from '../../GarantiesFinancières.form';
 
 import { soumettreGarantiesFinancièresAction } from './soumettreGarantiesFinancières.action';
 
@@ -24,7 +24,7 @@ export const SoumettreGarantiesFinancièresPage: FC<SoumettreGarantiesFinancièr
     heading={<TitrePageGarantiesFinancières title="Soumettre des garanties financières" />}
     leftColumn={{
       children: (
-        <FormulaireGarantiesFinancières
+        <GarantiesFinancièresForm
           identifiantProjet={identifiantProjet}
           action={soumettreGarantiesFinancièresAction}
           submitButtonLabel="Soumettre"

--- a/packages/applications/ssr/src/components/pages/réseau/gestionnaire/ajouter/AjouterGestionnaireRéseau.form.tsx
+++ b/packages/applications/ssr/src/components/pages/réseau/gestionnaire/ajouter/AjouterGestionnaireRéseau.form.tsx
@@ -21,7 +21,7 @@ export const AjouterGestionnaireRéseauForm = () => {
       encType="multipart/form-data"
       onSuccess={() => router.push(Routes.Gestionnaire.lister)}
       onValidationError={(validationErrors) => setValidationErrors(validationErrors)}
-      actionButtons={<SubmitButton>Ajouter</SubmitButton>}
+      actions={<SubmitButton>Ajouter</SubmitButton>}
     >
       <Input
         label="Code EIC ou gestionnaire"

--- a/packages/applications/ssr/src/components/pages/réseau/gestionnaire/ajouter/AjouterGestionnaireRéseau.form.tsx
+++ b/packages/applications/ssr/src/components/pages/réseau/gestionnaire/ajouter/AjouterGestionnaireRéseau.form.tsx
@@ -21,6 +21,7 @@ export const AjouterGestionnaireRéseauForm = () => {
       encType="multipart/form-data"
       onSuccess={() => router.push(Routes.Gestionnaire.lister)}
       onValidationError={(validationErrors) => setValidationErrors(validationErrors)}
+      actionButtons={<SubmitButton>Ajouter</SubmitButton>}
     >
       <Input
         label="Code EIC ou gestionnaire"
@@ -64,8 +65,6 @@ export const AjouterGestionnaireRéseauForm = () => {
         stateRelatedMessage="expression régulière à préciser"
         hintText="Exemple : [a-zA-Z]{3}-RP-2[0-9]{3}-[0-9]{6}"
       />
-
-      <SubmitButton>Envoyer</SubmitButton>
     </Form>
   );
 };

--- a/packages/applications/ssr/src/components/pages/réseau/gestionnaire/modifier/ModifierGestionnaireRéseau.form.tsx
+++ b/packages/applications/ssr/src/components/pages/réseau/gestionnaire/modifier/ModifierGestionnaireRéseau.form.tsx
@@ -49,7 +49,7 @@ export const ModifierGestionnaireRéseauForm: FC<ModifierGestionnaireRéseauForm
       encType="multipart/form-data"
       onSuccess={() => router.push(Routes.Gestionnaire.lister)}
       onValidationError={(validationErrors) => setValidationErrors(validationErrors)}
-      actionButtons={<SubmitButton>Modifier</SubmitButton>}
+      actions={<SubmitButton>Modifier</SubmitButton>}
     >
       <div className="mb-6">
         <label>Code EIC ou Gestionnaire: {identifiantGestionnaireReseauValue}</label>

--- a/packages/applications/ssr/src/components/pages/réseau/gestionnaire/modifier/ModifierGestionnaireRéseau.form.tsx
+++ b/packages/applications/ssr/src/components/pages/réseau/gestionnaire/modifier/ModifierGestionnaireRéseau.form.tsx
@@ -41,6 +41,7 @@ export const ModifierGestionnaireRéseauForm: FC<ModifierGestionnaireRéseauForm
   const identifiantGestionnaireReseauValue = GestionnaireRéseau.IdentifiantGestionnaireRéseau.bind(
     identifiantGestionnaireRéseau,
   ).formatter();
+
   return (
     <Form
       action={modifierGestionnaireRéseauAction}
@@ -48,6 +49,7 @@ export const ModifierGestionnaireRéseauForm: FC<ModifierGestionnaireRéseauForm
       encType="multipart/form-data"
       onSuccess={() => router.push(Routes.Gestionnaire.lister)}
       onValidationError={(validationErrors) => setValidationErrors(validationErrors)}
+      actionButtons={<SubmitButton>Modifier</SubmitButton>}
     >
       <div className="mb-6">
         <label>Code EIC ou Gestionnaire: {identifiantGestionnaireReseauValue}</label>
@@ -118,8 +120,6 @@ export const ModifierGestionnaireRéseauForm: FC<ModifierGestionnaireRéseauForm
         stateRelatedMessage="Expression régulière à préciser"
         hintText="Exemple : [a-zA-Z]{3}-RP-2[0-9]{3}-[0-9]{6}"
       />
-
-      <SubmitButton>Envoyer</SubmitButton>
     </Form>
   );
 };

--- a/packages/applications/ssr/src/components/pages/réseau/raccordement/importerDatesMiseEnService/importerDatesMiseEnService.form.tsx
+++ b/packages/applications/ssr/src/components/pages/réseau/raccordement/importerDatesMiseEnService/importerDatesMiseEnService.form.tsx
@@ -23,6 +23,7 @@ export const ImporterDatesMiseEnServiceForm: FC = () => {
       }}
       onValidationError={(validationErrors) => setValidationErrors(validationErrors)}
       successMessage={'dates de mise en service transmises'}
+      actionButtons={<SubmitButton>Importer</SubmitButton>}
     >
       <UploadDocument
         label="Fichier des dates de mise en service"
@@ -31,9 +32,6 @@ export const ImporterDatesMiseEnServiceForm: FC = () => {
         required
         state={validationErrors.includes('fichierDatesMiseEnService') ? 'error' : 'default'}
       />
-      <div className="flex flex-col md:flex-row mx-auto">
-        <SubmitButton>Importer</SubmitButton>
-      </div>
     </Form>
   );
 };

--- a/packages/applications/ssr/src/components/pages/réseau/raccordement/importerDatesMiseEnService/importerDatesMiseEnService.form.tsx
+++ b/packages/applications/ssr/src/components/pages/réseau/raccordement/importerDatesMiseEnService/importerDatesMiseEnService.form.tsx
@@ -23,7 +23,7 @@ export const ImporterDatesMiseEnServiceForm: FC = () => {
       }}
       onValidationError={(validationErrors) => setValidationErrors(validationErrors)}
       successMessage={'dates de mise en service transmises'}
-      actionButtons={<SubmitButton>Importer</SubmitButton>}
+      actions={<SubmitButton>Importer</SubmitButton>}
     >
       <UploadDocument
         label="Fichier des dates de mise en service"

--- a/packages/applications/ssr/src/components/pages/réseau/raccordement/modifier/modifierDemandeComplèteRaccordement/ModifierDemandeComplèteRaccordement.form.tsx
+++ b/packages/applications/ssr/src/components/pages/réseau/raccordement/modifier/modifierDemandeComplèteRaccordement/ModifierDemandeComplèteRaccordement.form.tsx
@@ -64,6 +64,21 @@ export const ModifierDemandeComplèteRaccordementForm: FC<
       heading="Modifier une demande complète de raccordement"
       onSuccess={() => router.push(Routes.Raccordement.détail(identifiantProjet))}
       onValidationError={(validationErrors) => setValidationErrors(validationErrors)}
+      actionButtons={
+        <>
+          <Button
+            priority="secondary"
+            linkProps={{
+              href: Routes.Raccordement.détail(identifiantProjet),
+              prefetch: false,
+            }}
+            iconId="fr-icon-arrow-left-line"
+          >
+            Retour aux dossiers de raccordement
+          </Button>
+          <SubmitButton>Modifier</SubmitButton>
+        </>
+      }
     >
       <input name="identifiantProjet" type="hidden" value={identifiantProjet} />
       <input name="referenceDossierRaccordementActuelle" type="hidden" value={référence.value} />
@@ -142,20 +157,6 @@ export const ModifierDemandeComplèteRaccordementForm: FC<
           required: true,
         }}
       />
-
-      <div className="flex flex-col md:flex-row gap-4 m-auto">
-        <Button
-          priority="secondary"
-          linkProps={{
-            href: Routes.Raccordement.détail(identifiantProjet),
-            prefetch: false,
-          }}
-          iconId="fr-icon-arrow-left-line"
-        >
-          Retour aux dossiers de raccordement
-        </Button>
-        <SubmitButton>Modifier</SubmitButton>
-      </div>
     </Form>
   );
 };

--- a/packages/applications/ssr/src/components/pages/réseau/raccordement/modifier/modifierDemandeComplèteRaccordement/ModifierDemandeComplèteRaccordement.form.tsx
+++ b/packages/applications/ssr/src/components/pages/réseau/raccordement/modifier/modifierDemandeComplèteRaccordement/ModifierDemandeComplèteRaccordement.form.tsx
@@ -64,7 +64,7 @@ export const ModifierDemandeComplèteRaccordementForm: FC<
       heading="Modifier une demande complète de raccordement"
       onSuccess={() => router.push(Routes.Raccordement.détail(identifiantProjet))}
       onValidationError={(validationErrors) => setValidationErrors(validationErrors)}
-      actionButtons={
+      actions={
         <>
           <Button
             priority="secondary"

--- a/packages/applications/ssr/src/components/pages/réseau/raccordement/modifier/modifierGestionnaireRéseauRaccordement/ModifierGestionnaireRéseauRaccordement.form.tsx
+++ b/packages/applications/ssr/src/components/pages/réseau/raccordement/modifier/modifierGestionnaireRéseauRaccordement/ModifierGestionnaireRéseauRaccordement.form.tsx
@@ -39,6 +39,21 @@ export const ModifierGestionnaireRéseauRaccordementForm: FC<
       onSuccess={() => router.push(Routes.Raccordement.détail(identifiantProjet))}
       onValidationError={(validationErrors) => setValidationErrors(validationErrors)}
       heading="Modifier le gestionnaire de réseau du projet"
+      actionButtons={
+        <>
+          <Button
+            priority="secondary"
+            linkProps={{
+              href: Routes.Raccordement.détail(identifiantProjet),
+              prefetch: false,
+            }}
+            iconId="fr-icon-arrow-left-line"
+          >
+            Retour aux dossiers de raccordement
+          </Button>
+          <SubmitButton>Modifier</SubmitButton>
+        </>
+      }
     >
       <input name="identifiantProjet" type="hidden" value={identifiantProjet} />
 
@@ -52,20 +67,6 @@ export const ModifierGestionnaireRéseauRaccordementForm: FC<
             gestionnairesRéseau={listeGestionnairesRéseau}
             identifiantGestionnaireRéseauActuel={gestionnaireActuel?.identifiantGestionnaireRéseau}
           />
-        </div>
-
-        <div className="flex flex-col md:flex-row gap-4 m-auto">
-          <Button
-            priority="secondary"
-            linkProps={{
-              href: Routes.Raccordement.détail(identifiantProjet),
-              prefetch: false,
-            }}
-            iconId="fr-icon-arrow-left-line"
-          >
-            Retour aux dossiers de raccordement
-          </Button>
-          <SubmitButton>Modifier</SubmitButton>
         </div>
       </div>
     </Form>

--- a/packages/applications/ssr/src/components/pages/réseau/raccordement/modifier/modifierGestionnaireRéseauRaccordement/ModifierGestionnaireRéseauRaccordement.form.tsx
+++ b/packages/applications/ssr/src/components/pages/réseau/raccordement/modifier/modifierGestionnaireRéseauRaccordement/ModifierGestionnaireRéseauRaccordement.form.tsx
@@ -39,7 +39,7 @@ export const ModifierGestionnaireRéseauRaccordementForm: FC<
       onSuccess={() => router.push(Routes.Raccordement.détail(identifiantProjet))}
       onValidationError={(validationErrors) => setValidationErrors(validationErrors)}
       heading="Modifier le gestionnaire de réseau du projet"
-      actionButtons={
+      actions={
         <>
           <Button
             priority="secondary"

--- a/packages/applications/ssr/src/components/pages/réseau/raccordement/modifier/modifierPropositionTechniqueEtFinancière/ModifierPropositionTechniqueEtFinancière.form.tsx
+++ b/packages/applications/ssr/src/components/pages/réseau/raccordement/modifier/modifierPropositionTechniqueEtFinancière/ModifierPropositionTechniqueEtFinancière.form.tsx
@@ -45,6 +45,21 @@ export const ModifierPropositionTechniqueEtFinancièreForm: FC<
       onSuccess={() => router.push(Routes.Raccordement.détail(identifiantProjet))}
       heading="Modifier la proposition technique et financière"
       onValidationError={(validationErrors) => setValidationErrors(validationErrors)}
+      actionButtons={
+        <>
+          <Button
+            priority="secondary"
+            linkProps={{
+              href: Routes.Raccordement.détail(identifiantProjet),
+              prefetch: false,
+            }}
+            iconId="fr-icon-arrow-left-line"
+          >
+            Retour aux dossiers de raccordement
+          </Button>
+          <SubmitButton>Modifier</SubmitButton>
+        </>
+      }
     >
       <div>
         Référence du dossier de raccordement : <strong>{reference}</strong>
@@ -74,20 +89,6 @@ export const ModifierPropositionTechniqueEtFinancièreForm: FC<
         }
         documentKey={propositionTechniqueEtFinancièreSignée}
       />
-
-      <div className="flex flex-col md:flex-row gap-4 m-auto">
-        <Button
-          priority="secondary"
-          linkProps={{
-            href: Routes.Raccordement.détail(identifiantProjet),
-            prefetch: false,
-          }}
-          iconId="fr-icon-arrow-left-line"
-        >
-          Retour aux dossiers de raccordement
-        </Button>
-        <SubmitButton>Modifier</SubmitButton>
-      </div>
     </Form>
   );
 };

--- a/packages/applications/ssr/src/components/pages/réseau/raccordement/modifier/modifierPropositionTechniqueEtFinancière/ModifierPropositionTechniqueEtFinancière.form.tsx
+++ b/packages/applications/ssr/src/components/pages/réseau/raccordement/modifier/modifierPropositionTechniqueEtFinancière/ModifierPropositionTechniqueEtFinancière.form.tsx
@@ -45,7 +45,7 @@ export const ModifierPropositionTechniqueEtFinancièreForm: FC<
       onSuccess={() => router.push(Routes.Raccordement.détail(identifiantProjet))}
       heading="Modifier la proposition technique et financière"
       onValidationError={(validationErrors) => setValidationErrors(validationErrors)}
-      actionButtons={
+      actions={
         <>
           <Button
             priority="secondary"

--- a/packages/applications/ssr/src/components/pages/réseau/raccordement/transmettre/transmettreDateMiseEnService/TransmettreDateMiseEnService.form.tsx
+++ b/packages/applications/ssr/src/components/pages/réseau/raccordement/transmettre/transmettreDateMiseEnService/TransmettreDateMiseEnService.form.tsx
@@ -35,6 +35,21 @@ export const TransmettreDateMiseEnServiceForm: FC<TransmettreDateMiseEnServiceFo
       heading="Transmettre la date de mise en service"
       action={transmettreDateMiseEnServiceAction}
       onSuccess={() => router.push(Routes.Raccordement.détail(identifiantProjet))}
+      actionButtons={
+        <>
+          <Button
+            priority="secondary"
+            linkProps={{
+              href: Routes.Raccordement.détail(identifiantProjet),
+              prefetch: false,
+            }}
+            iconId="fr-icon-arrow-left-line"
+          >
+            Retour aux dossiers de raccordement
+          </Button>
+          <SubmitButton>Transmettre</SubmitButton>
+        </>
+      }
     >
       <input type="hidden" name="identifiantProjet" value={identifiantProjet} />
       <input type="hidden" name="referenceDossier" value={référence} />
@@ -52,20 +67,6 @@ export const TransmettreDateMiseEnServiceForm: FC<TransmettreDateMiseEnServiceFo
           'aria-required': true,
         }}
       />
-
-      <div className="flex flex-col md:flex-row gap-4 md:mt-4">
-        <Button
-          priority="secondary"
-          linkProps={{
-            href: Routes.Raccordement.détail(identifiantProjet),
-            prefetch: false,
-          }}
-          iconId="fr-icon-arrow-left-line"
-        >
-          Retour aux dossiers de raccordement
-        </Button>
-        <SubmitButton>Transmettre</SubmitButton>
-      </div>
     </Form>
   );
 };

--- a/packages/applications/ssr/src/components/pages/réseau/raccordement/transmettre/transmettreDateMiseEnService/TransmettreDateMiseEnService.form.tsx
+++ b/packages/applications/ssr/src/components/pages/réseau/raccordement/transmettre/transmettreDateMiseEnService/TransmettreDateMiseEnService.form.tsx
@@ -35,7 +35,7 @@ export const TransmettreDateMiseEnServiceForm: FC<TransmettreDateMiseEnServiceFo
       heading="Transmettre la date de mise en service"
       action={transmettreDateMiseEnServiceAction}
       onSuccess={() => router.push(Routes.Raccordement.détail(identifiantProjet))}
-      actionButtons={
+      actions={
         <>
           <Button
             priority="secondary"

--- a/packages/applications/ssr/src/components/pages/réseau/raccordement/transmettre/transmettreDemandeComplèteRaccordement/TransmettreDemandeComplèteRaccordement.form.tsx
+++ b/packages/applications/ssr/src/components/pages/réseau/raccordement/transmettre/transmettreDemandeComplèteRaccordement/TransmettreDemandeComplèteRaccordement.form.tsx
@@ -57,7 +57,7 @@ export const TransmettreDemandeComplèteRaccordementForm = ({
       heading="Transmettre une demande complète de raccordement"
       onSuccess={() => router.push(Routes.Raccordement.détail(identifiantProjet))}
       onValidationError={(validationErrors) => setValidationErrors(validationErrors)}
-      actionButtons={
+      actions={
         <>
           <Button
             priority="secondary"

--- a/packages/applications/ssr/src/components/pages/réseau/raccordement/transmettre/transmettreDemandeComplèteRaccordement/TransmettreDemandeComplèteRaccordement.form.tsx
+++ b/packages/applications/ssr/src/components/pages/réseau/raccordement/transmettre/transmettreDemandeComplèteRaccordement/TransmettreDemandeComplèteRaccordement.form.tsx
@@ -57,6 +57,21 @@ export const TransmettreDemandeComplèteRaccordementForm = ({
       heading="Transmettre une demande complète de raccordement"
       onSuccess={() => router.push(Routes.Raccordement.détail(identifiantProjet))}
       onValidationError={(validationErrors) => setValidationErrors(validationErrors)}
+      actionButtons={
+        <>
+          <Button
+            priority="secondary"
+            linkProps={{
+              href: Routes.Raccordement.détail(identifiantProjet),
+              prefetch: false,
+            }}
+            iconId="fr-icon-arrow-left-line"
+          >
+            Retour aux dossiers de raccordement
+          </Button>
+          <SubmitButton>Transmettre</SubmitButton>
+        </>
+      }
     >
       <input name="identifiantProjet" type="hidden" value={identifiantProjet} />
 
@@ -110,20 +125,6 @@ export const TransmettreDemandeComplèteRaccordementForm = ({
         required
         state={validationErrors.includes('accuseReception') ? 'error' : 'default'}
       />
-
-      <div className="flex flex-col md:flex-row gap-4 mt-5">
-        <Button
-          priority="secondary"
-          linkProps={{
-            href: Routes.Raccordement.détail(identifiantProjet),
-            prefetch: false,
-          }}
-          iconId="fr-icon-arrow-left-line"
-        >
-          Retour aux dossiers de raccordement
-        </Button>
-        <SubmitButton>Transmettre</SubmitButton>
-      </div>
     </Form>
   );
 };

--- a/packages/applications/ssr/src/components/pages/réseau/raccordement/transmettre/transmettrePropositionTechniqueEtFinancière/TransmettrePropositionTechniqueEtFinancière.form.tsx
+++ b/packages/applications/ssr/src/components/pages/réseau/raccordement/transmettre/transmettrePropositionTechniqueEtFinancière/TransmettrePropositionTechniqueEtFinancière.form.tsx
@@ -32,7 +32,7 @@ export const TransmettrePropositionTechniqueEtFinancièreForm: FC<
       action={transmettrePropositionTechniqueEtFinancièreAction}
       onSuccess={() => router.push(Routes.Raccordement.détail(identifiantProjet))}
       onValidationError={(validationErrors) => setValidationErrors(validationErrors)}
-      actionButtons={
+      actions={
         <>
           <Button
             priority="secondary"

--- a/packages/applications/ssr/src/components/pages/réseau/raccordement/transmettre/transmettrePropositionTechniqueEtFinancière/TransmettrePropositionTechniqueEtFinancière.form.tsx
+++ b/packages/applications/ssr/src/components/pages/réseau/raccordement/transmettre/transmettrePropositionTechniqueEtFinancière/TransmettrePropositionTechniqueEtFinancière.form.tsx
@@ -32,6 +32,21 @@ export const TransmettrePropositionTechniqueEtFinancièreForm: FC<
       action={transmettrePropositionTechniqueEtFinancièreAction}
       onSuccess={() => router.push(Routes.Raccordement.détail(identifiantProjet))}
       onValidationError={(validationErrors) => setValidationErrors(validationErrors)}
+      actionButtons={
+        <>
+          <Button
+            priority="secondary"
+            linkProps={{
+              href: Routes.Raccordement.détail(identifiantProjet),
+              prefetch: false,
+            }}
+            iconId="fr-icon-arrow-left-line"
+          >
+            Retour aux dossiers de raccordement
+          </Button>
+          <SubmitButton>Transmettre</SubmitButton>
+        </>
+      }
     >
       <input type="hidden" name="identifiantProjet" value={identifiantProjet} />
       <input type="hidden" name="referenceDossier" value={referenceDossierRaccordement} />
@@ -56,20 +71,6 @@ export const TransmettrePropositionTechniqueEtFinancièreForm: FC<
           validationErrors.includes('propositionTechniqueEtFinanciereSignee') ? 'error' : 'default'
         }
       />
-
-      <div className="flex flex-col md:flex-row gap-4 mt-5">
-        <Button
-          priority="secondary"
-          linkProps={{
-            href: Routes.Raccordement.détail(identifiantProjet),
-            prefetch: false,
-          }}
-          iconId="fr-icon-arrow-left-line"
-        >
-          Retour aux dossiers de raccordement
-        </Button>
-        <SubmitButton>Transmettre</SubmitButton>
-      </div>
     </Form>
   );
 };


### PR DESCRIPTION
# Description

 ### Problématique 
 On affichait différemment les boutons d'actions des formulaires
 
 ### Solution 
 Ajouter une nouvelle props obligatoire "actionButtons" pour définir le positionnement des boutons dans le composant générique Form.
 
 
 
## Type de changement

- [x] Refacto de code

# Comment cela a-t-il été testé?

Dans le front de l'app