### PR TITLE
✨ Filtrer les candidatures par période d'un appel d'offres

### DIFF
--- a/packages/applications/projectors/src/subscribers/candidature/candidature.projector.ts
+++ b/packages/applications/projectors/src/subscribers/candidature/candidature.projector.ts
@@ -25,6 +25,7 @@ export const register = () => {
           const candidature: Omit<Candidature.CandidatureEntity, 'type'> = {
             identifiantProjet: payload.identifiantProjet,
             appelOffre: payload.appelOffre,
+            période: payload.période,
             nomProjet: payload.nomProjet,
             sociétéMère: payload.sociétéMère,
             nomCandidat: payload.nomCandidat,

--- a/packages/applications/ssr/src/app/candidatures/page.tsx
+++ b/packages/applications/ssr/src/app/candidatures/page.tsx
@@ -13,7 +13,7 @@ import { CandidatureListPage } from '@/components/pages/candidature/lister/Candi
 import { CandidatureListItemProps } from '@/components/pages/candidature/lister/CandidatureListItem';
 import { ListFilterItem } from '@/components/molecules/ListFilters';
 
-type SearchParams = 'page' | 'appelOffre' | 'statut' | 'nomProjet';
+type SearchParams = 'page' | 'appelOffre' | 'periode' | 'statut' | 'nomProjet';
 
 type PageProps = {
   searchParams?: Record<SearchParams, string>;
@@ -27,6 +27,7 @@ export const metadata: Metadata = {
 export default async function Page({ searchParams }: PageProps) {
   return PageWithErrorHandling(async () => {
     const appelOffre = searchParams?.appelOffre;
+    const periode = searchParams?.periode;
     const nomProjet = searchParams?.nomProjet;
     const statut = searchParams?.statut;
     const page = searchParams?.page ? parseInt(searchParams.page) : 1;
@@ -40,6 +41,7 @@ export default async function Page({ searchParams }: PageProps) {
         }),
         nomProjet,
         appelOffre,
+        période: periode,
         statut: statut ? StatutProjet.convertirEnValueType(statut).statut : undefined,
       },
     });
@@ -48,6 +50,14 @@ export default async function Page({ searchParams }: PageProps) {
       type: 'AppelOffre.Query.ListerAppelOffre',
       data: {},
     });
+
+    const périodes =
+      appelOffres.items
+        .find((ao) => ao.id === appelOffre)
+        ?.periodes.map((p) => ({
+          label: p.title,
+          value: p.id,
+        })) ?? [];
 
     const filters: ListFilterItem<SearchParams>[] = [
       {
@@ -58,6 +68,12 @@ export default async function Page({ searchParams }: PageProps) {
           label: appelOffre.id,
           value: appelOffre.id,
         })),
+      },
+      {
+        label: `Période`,
+        searchParamKey: 'periode',
+        defaultValue: periode,
+        options: périodes,
       },
       {
         label: 'Statut',

--- a/packages/domain/candidature/src/candidature.entity.ts
+++ b/packages/domain/candidature/src/candidature.entity.ts
@@ -9,6 +9,7 @@ export type CandidatureEntity = Entity<
   {
     identifiantProjet: IdentifiantProjet.RawType;
     appelOffre: string;
+    période: string;
     statut: StatutProjet.RawType;
     nomProjet: string;
     typeGarantiesFinancières?: GarantiesFinancières.TypeGarantiesFinancières.RawType;

--- a/packages/domain/candidature/src/lister/listerCandidatures.query.ts
+++ b/packages/domain/candidature/src/lister/listerCandidatures.query.ts
@@ -37,6 +37,7 @@ export type ListerCandidaturesQuery = Message<
   {
     range?: RangeOptions;
     appelOffre?: string;
+    période?: string;
     nomProjet?: string;
     statut?: StatutProjet.RawType;
   },
@@ -52,6 +53,7 @@ export const registerListerCandidaturesQuery = ({ list }: ListerCandidaturesQuer
     range,
     nomProjet,
     appelOffre,
+    période,
     statut,
   }) => {
     const {
@@ -61,6 +63,9 @@ export const registerListerCandidaturesQuery = ({ list }: ListerCandidaturesQuer
     } = await list<CandidatureEntity>('candidature', {
       where: {
         appelOffre: match(appelOffre)
+          .with(Pattern.nullish, () => undefined)
+          .otherwise((value) => ({ operator: 'equal', value })),
+        période: match(période)
           .with(Pattern.nullish, () => undefined)
           .otherwise((value) => ({ operator: 'equal', value })),
         nomProjet: match(nomProjet)


### PR DESCRIPTION
# Description

Ajout du filtre sur les périodes de l'appel d'offres sélectionné dans la liste des candidatures

## Type de changement

- Nouvelle fonctionnalité