### PR TITLE
🐛 Annuler tâches 'échoir' GF pour abandonnés et éliminés

### DIFF
--- a/packages/applications/scheduled-tasks/package.json
+++ b/packages/applications/scheduled-tasks/package.json
@@ -11,7 +11,8 @@
     "start:créer-backup": "node ./dist/backup/créer-backup",
     "start:mettre-à-jour-gestionnaire-réseau": "node ./dist/gestionnaireRéseau",
     "start:migrate-project-import-events": "node ./dist/candidature/migrate-project-import-events",
-    "start:supprimer-raccordement": "node ./dist/raccordement/supprimer-raccordement"
+    "start:supprimer-raccordement": "node ./dist/raccordement/supprimer-raccordement",
+    "start:annuler-echoir-gf-abandonnés-ou-éliminés": "node ./dist/annuler-echoir-gf-abandonnés-ou-éliminés"
   },
   "dependencies": {
     "@potentiel-libraries/monads": "*",

--- a/packages/applications/scheduled-tasks/src/annuler-echoir-gf-abandonnés-ou-éliminés.ts
+++ b/packages/applications/scheduled-tasks/src/annuler-echoir-gf-abandonnés-ou-éliminés.ts
@@ -11,7 +11,7 @@ import { loadAggregate } from '@potentiel-infrastructure/pg-event-sourcing';
 import { Candidature } from '@potentiel-domain/candidature';
 import { CandidatureAdapter } from '@potentiel-infrastructure/domain-adapters';
 import { Option } from '@potentiel-libraries/monads';
-import { Abandon } from '@potentiel-domain/laureat';
+import { Abandon, GarantiesFinancières } from '@potentiel-domain/laureat';
 import { IdentifiantProjet, StatutProjet } from '@potentiel-domain/common';
 
 registerTâchePlanifiéeUseCases({
@@ -44,11 +44,19 @@ Abandon.registerAbandonQueries({
       data: { catégorieTâche: 'garanties-financières' },
     });
 
-    let tâchesAnnulées = 0;
+    let nombreDeTâchesAnnulées = 0;
 
     const projetIds = new Set<IdentifiantProjet.RawType>();
 
     for (const { identifiantProjet, typeTâchePlanifiée } of tâchesPlanifiées.items) {
+      if (
+        GarantiesFinancières.TypeTâchePlanifiéeGarantiesFinancières.convertirEnValueType(
+          typeTâchePlanifiée,
+        ).estInconnu()
+      ) {
+        continue;
+      }
+
       const projet = await mediator.send<Candidature.ConsulterProjetQuery>({
         type: 'Candidature.Query.ConsulterProjet',
         data: { identifiantProjet: identifiantProjet.formatter() },
@@ -73,14 +81,16 @@ Abandon.registerAbandonQueries({
           typeTâchePlanifiée,
         },
       });
-      console.log(`📨 Tâche échoir annulée pour le projet ${identifiantProjet.formatter()}`);
-      tâchesAnnulées++;
+      console.log(
+        `📨 Tâche ${typeTâchePlanifiée} annulée pour le projet ${identifiantProjet.formatter()}`,
+      );
+      nombreDeTâchesAnnulées++;
     }
 
     console.log(`\n📊 Statistiques`);
     console.log(`\n${projetIds.size} projets concernés`);
     console.log(`\n${tâchesPlanifiées.items.length} tâches échoir trouvées pour : `);
-    console.log(`\n🥁 ${tâchesAnnulées} tâches annulées`);
+    console.log(`\n🥁 ${nombreDeTâchesAnnulées} tâches annulées`);
 
     console.info('\nFin du script ✨');
   } catch (error) {

--- a/packages/applications/scheduled-tasks/src/annuler-echoir-gf.ts
+++ b/packages/applications/scheduled-tasks/src/annuler-echoir-gf.ts
@@ -1,0 +1,92 @@
+import { mediator } from 'mediateur';
+
+import {
+  AnnulerTâchePlanifiéeCommand,
+  ListerTâchesPlanifiéesQuery,
+  registerTâchePlanifiéeQuery,
+  registerTâchePlanifiéeUseCases,
+} from '@potentiel-domain/tache-planifiee';
+import { findProjection, listProjection } from '@potentiel-infrastructure/pg-projections';
+import { loadAggregate } from '@potentiel-infrastructure/pg-event-sourcing';
+import { Candidature } from '@potentiel-domain/candidature';
+import { CandidatureAdapter } from '@potentiel-infrastructure/domain-adapters';
+import { Option } from '@potentiel-libraries/monads';
+import { Abandon } from '@potentiel-domain/laureat';
+
+registerTâchePlanifiéeUseCases({
+  loadAggregate,
+});
+
+registerTâchePlanifiéeQuery({
+  list: listProjection,
+});
+
+Candidature.registerCandidatureQueries({
+  find: findProjection,
+  récupérerProjet: CandidatureAdapter.récupérerProjetAdapter,
+  récupérerProjetsEligiblesPreuveRecanditure:
+    CandidatureAdapter.récupérerProjetsEligiblesPreuveRecanditureAdapter,
+  récupérerProjets: CandidatureAdapter.récupérerProjetsAdapter,
+  list: listProjection,
+});
+
+Abandon.registerAbandonQueries({
+  find: findProjection,
+  list: listProjection,
+  récupérerIdentifiantsProjetParEmailPorteur: async () => [],
+});
+
+(async () => {
+  try {
+    const tâchesPlanifiées = await mediator.send<ListerTâchesPlanifiéesQuery>({
+      type: 'Tâche.Query.ListerTâchesPlanifiées',
+      data: { catégorieTâche: 'garanties-financières' },
+    });
+
+    console.info(`🧐 ${tâchesPlanifiées.total} tâches found`);
+
+    let tâchesAnnulées = 0;
+
+    for (const { identifiantProjet, typeTâchePlanifiée } of tâchesPlanifiées.items) {
+      const projet = await mediator.send<Candidature.ConsulterProjetQuery>({
+        type: 'Candidature.Query.ConsulterProjet',
+        data: { identifiantProjet: identifiantProjet.formatter() },
+      });
+      if (Option.isNone(projet)) {
+        console.warn(`❌ Projet ${identifiantProjet.formatter()} non trouvé`);
+        continue;
+      }
+      if (projet.statut === 'classé') {
+        const abandon = await mediator.send<Abandon.ConsulterAbandonQuery>({
+          type: 'Lauréat.Abandon.Query.ConsulterAbandon',
+          data: {
+            identifiantProjetValue: identifiantProjet.formatter(),
+          },
+        });
+        if (Option.isNone(abandon) || !abandon.statut.estConfirmé()) {
+          console.info(`🤫 Skipping project ${identifiantProjet.formatter()}...`);
+
+          continue;
+        }
+      }
+      console.info(`📨 Publishing event for project ${identifiantProjet.formatter()}...`);
+
+      await mediator.send<AnnulerTâchePlanifiéeCommand>({
+        type: 'System.TâchePlanifiée.Command.AnnulerTâchePlanifiée',
+        data: {
+          identifiantProjet,
+          typeTâchePlanifiée,
+        },
+      });
+      tâchesAnnulées++;
+    }
+
+    console.log(`🚀 ${tâchesAnnulées} tâches annulées`);
+
+    console.info('\nFin du script ✨');
+  } catch (error) {
+    console.error(error as Error);
+  }
+
+  process.exit(0);
+})();

--- a/packages/domain/lauréat/src/garantiesFinancières/typeTâchePlanifiéeGarantiesFinancières.valueType.ts
+++ b/packages/domain/lauréat/src/garantiesFinancières/typeTâchePlanifiéeGarantiesFinancières.valueType.ts
@@ -11,13 +11,29 @@ export type RawType = (typeof types)[number];
 
 export type ValueType = ReadonlyValueType<{
   type: RawType;
+  estInconnu: () => boolean;
+  estÉchoir: () => boolean;
+  estRappelÉchéanceUnMois: () => boolean;
+  estRappelÉchéanceDeuxMois: () => boolean;
 }>;
 
 export const bind = ({ type }: PlainType<ValueType>): ValueType => {
   return {
     type,
-    estÉgaleÀ: function ({ type }) {
+    estÉgaleÀ({ type }) {
       return this.type === type;
+    },
+    estInconnu() {
+      return this.type === 'garanties-financières.inconnue';
+    },
+    estÉchoir() {
+      return this.type === 'garanties-financières.échoir';
+    },
+    estRappelÉchéanceUnMois() {
+      return this.type === 'garanties-financières.rappel-échéance-un-mois';
+    },
+    estRappelÉchéanceDeuxMois() {
+      return this.type === 'garanties-financières.rappel-échéance-deux-mois';
     },
   };
 };


### PR DESCRIPTION
script temporaire pour annuler les tâches planifiées pour les projets abandonnés et éliminés

Cela ne remplace pas l'implémentation nécessaire pour gérer les cas futurs, mais permet d'annuler les tâches insérées par erreur.

