### PR TITLE
✨ Supprimer le raccordement d'un projet lorsque celui-ci a son abandon accordé

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32095,6 +32095,7 @@
         "@potentiel-domain/core": "*",
         "@potentiel-domain/document": "*",
         "@potentiel-domain/entity": "*",
+        "@potentiel-domain/laureat": "*",
         "@potentiel-libraries/monads": "*",
         "@potentiel-libraries/monitoring": "*"
       },

--- a/packages/applications/bootstrap/src/setupLauréat.ts
+++ b/packages/applications/bootstrap/src/setupLauréat.ts
@@ -40,15 +40,20 @@ export const setupLauréat = async ({ sendEmail }: SetupLauréatDependenices) =>
     consulterCahierDesChargesAdapter: consulterCahierDesChargesChoisiAdapter,
   });
 
+  // Projectors
   LauréatProjector.register();
   LauréatNotification.register({ sendEmail });
   AbandonProjector.register();
-  AbandonNotification.register({ sendEmail });
   GarantiesFinancièreProjector.register();
-  GarantiesFinancièresNotification.register({ sendEmail });
-  GarantiesFinancières.GarantiesFinancièresSaga.register();
   AchèvementProjector.register();
   AchèvementNotification.register({ sendEmail });
+
+  // Notfications
+  AbandonNotification.register({ sendEmail });
+  GarantiesFinancièresNotification.register({ sendEmail });
+
+  // Sagas
+  GarantiesFinancières.GarantiesFinancièresSaga.register();
 
   const unsubscribeLauréatNotification = await subscribe<LauréatNotification.SubscriptionEvent>({
     name: 'notifications',

--- a/packages/applications/projectors/src/subscribers/réseau/raccordement.projector.ts
+++ b/packages/applications/projectors/src/subscribers/réseau/raccordement.projector.ts
@@ -118,6 +118,25 @@ export const register = () => {
             `dossier-raccordement|${identifiantProjet}#${référenceDossier}`,
           );
         }
+      } else if (event.type === 'RaccordementSupprimé-V1') {
+        const { identifiantProjet } = event.payload;
+
+        const raccordement = await findProjection<Raccordement.RaccordementEntity>(
+          `raccordement|${identifiantProjet}`,
+        );
+
+        if (Option.isSome(raccordement)) {
+          const référencesDossiers = raccordement.dossiers.map((d) => d.référence);
+
+          for (const référence of référencesDossiers) {
+            await removeProjection<Raccordement.DossierRaccordementEntity>(
+              `dossier-raccordement|${identifiantProjet}#${référence}`,
+            );
+          }
+          await removeProjection<Raccordement.RaccordementEntity>(
+            `raccordement|${identifiantProjet}`,
+          );
+        }
       } else {
         const référence =
           event.type === 'DemandeComplèteRaccordementModifiée-V1'

--- a/packages/domain/lauréat/src/abandon/index.ts
+++ b/packages/domain/lauréat/src/abandon/index.ts
@@ -57,6 +57,7 @@ export type { AbandonAnnuléEvent } from './annuler/annulerAbandon.behavior';
 export type { ConfirmationAbandonDemandéeEvent } from './demanderConfirmation/demanderConfirmationAbandon.behavior';
 export type { AbandonConfirméEvent } from './confirmer/confirmerAbandon.behavior';
 export type { AbandonRejetéEvent } from './rejeter/rejeterAbandon.behavior';
+export type { AbandonAccordéEvent } from './accorder/accorderAbandon.behavior';
 export type { PreuveRecandidatureDemandéeEvent } from './demanderPreuveRecandidature/demanderPreuveRecandidatureAbandon.behavior';
 export type { PreuveRecandidatureTransmiseEvent } from './transmettre/transmettrePreuveRecandidatureAbandon.behavior';
 

--- a/packages/domain/réseau/package.json
+++ b/packages/domain/réseau/package.json
@@ -14,7 +14,8 @@
     "@potentiel-domain/document": "*",
     "@potentiel-domain/common": "*",
     "@potentiel-domain/core": "*",
-    "@potentiel-domain/entity": "*"
+    "@potentiel-domain/entity": "*",
+    "@potentiel-domain/laureat": "*"
   },
   "devDependencies": {
     "@potentiel-config/tsconfig": "*"

--- a/packages/domain/réseau/src/raccordement/index.ts
+++ b/packages/domain/réseau/src/raccordement/index.ts
@@ -123,3 +123,6 @@ export * as TypeDocumentRaccordement from './typeDocumentRaccordement.valueType'
 
 // Entities
 export * from './raccordement.entity';
+
+// Saga
+export * as RaccordementSaga from './raccordement.saga';

--- a/packages/domain/réseau/src/raccordement/raccordement.aggregate.ts
+++ b/packages/domain/réseau/src/raccordement/raccordement.aggregate.ts
@@ -72,6 +72,11 @@ import {
   DossierDuRaccordementSuppriméEvent,
   supprimerDossier,
 } from './dossier/supprimer/supprimerDossierDuRaccordement.behavior';
+import {
+  applyRaccordementSuppriméEventV1,
+  RaccordementSuppriméEvent,
+  supprimerRaccordement,
+} from './supprimer/supprimerRaccordement.behavior';
 
 export type DeprecateEvent =
   | DemandeComplèteRaccordementTransmiseEventV1
@@ -93,7 +98,8 @@ export type RaccordementEvent =
   | GestionnaireRéseauRaccordementModifiéEvent
   | GestionnaireRéseauInconnuAttribuéEvent
   | GestionnaireRéseauAttribuéEvent
-  | DossierDuRaccordementSuppriméEvent;
+  | DossierDuRaccordementSuppriméEvent
+  | RaccordementSuppriméEvent;
 
 type DossierRaccordement = {
   référence: RéférenceDossierRaccordement.ValueType;
@@ -126,6 +132,7 @@ export type RaccordementAggregate = Aggregate<RaccordementEvent> & {
   readonly aUneDateDeMiseEnService: () => boolean;
   readonly attribuerGestionnaireRéseau: typeof attribuerGestionnaireRéseau;
   readonly supprimerDossier: typeof supprimerDossier;
+  readonly supprimerRaccordement: typeof supprimerRaccordement;
   readonly dateModifiée: (
     référence: RéférenceDossierRaccordement.ValueType,
     nouvelleDate: DateTime.ValueType,
@@ -149,6 +156,7 @@ export const getDefaultRaccordementAggregate: GetDefaultAggregateState<
   modifierGestionnaireRéseau,
   attribuerGestionnaireRéseau,
   supprimerDossier,
+  supprimerRaccordement,
   contientLeDossier({ référence }) {
     return this.dossiers.has(référence);
   },
@@ -233,6 +241,9 @@ function apply(this: RaccordementAggregate, event: RaccordementEvent) {
       break;
     case 'DossierDuRaccordementSupprimé-V1':
       applyDossierDuRaccordementSuppriméEventV1.bind(this)(event);
+      break;
+    case 'RaccordementSupprimé-V1':
+      applyRaccordementSuppriméEventV1.bind(this)(event);
       break;
   }
 }

--- a/packages/domain/réseau/src/raccordement/raccordement.register.ts
+++ b/packages/domain/réseau/src/raccordement/raccordement.register.ts
@@ -42,6 +42,7 @@ import {
 } from './consulter/consulterNombreRaccordement';
 import { registerSupprimerDossierDuRaccordementUseCase } from './dossier/supprimer/supprimerDossierDuRaccordement.usecase';
 import { registerSupprimerDossierDuRaccordementCommand } from './dossier/supprimer/supprimerDossierDuRaccordement.command';
+import { registerSupprimerRaccordementCommand } from './supprimer/supprimerRaccordement.command';
 
 export type RaccordementQueryDependencies = ConsulterDossierRaccordementDependencies &
   ConsulterGestionnaireRéseauRaccordementDependencies &
@@ -75,6 +76,7 @@ export const registerRaccordementUseCases = ({
   registerTransmettrePropositionTechniqueEtFinancièreCommand(loadAggregate);
   registerAttribuerGestionnaireCommand(loadAggregate);
   registerSupprimerDossierDuRaccordementCommand(loadAggregate);
+  registerSupprimerRaccordementCommand(loadAggregate);
 
   registerModifierDemandeComplèteRaccordementUseCase();
   registerModifierGestionnaireRéseauRaccordementUseCase();

--- a/packages/domain/réseau/src/raccordement/raccordement.saga.ts
+++ b/packages/domain/réseau/src/raccordement/raccordement.saga.ts
@@ -1,0 +1,29 @@
+import { Message, MessageHandler, mediator } from 'mediateur';
+
+import { IdentifiantProjet } from '@potentiel-domain/common';
+import { Abandon } from '@potentiel-domain/laureat';
+
+import { SupprimerRaccordementCommand } from './supprimer/supprimerRaccordement.command';
+
+export type SubscriptionEvent = Abandon.AbandonAccordéEvent;
+
+export type Execute = Message<'System.Réseau.Raccordement.Saga.Execute', SubscriptionEvent>;
+
+export const register = () => {
+  const handler: MessageHandler<Execute> = async (event) => {
+    const {
+      payload: { identifiantProjet },
+    } = event;
+    switch (event.type) {
+      case 'AbandonAccordé-V1':
+        await mediator.send<SupprimerRaccordementCommand>({
+          type: 'Réseau.Raccordement.Command.SupprimerRaccordement',
+          data: {
+            identifiantProjet: IdentifiantProjet.convertirEnValueType(identifiantProjet),
+          },
+        });
+        break;
+    }
+  };
+  mediator.register('System.Réseau.Raccordement.Saga.Execute', handler);
+};

--- a/packages/domain/réseau/src/raccordement/supprimer/supprimerRaccordement.behavior.ts
+++ b/packages/domain/réseau/src/raccordement/supprimer/supprimerRaccordement.behavior.ts
@@ -1,0 +1,39 @@
+import { IdentifiantProjet } from '@potentiel-domain/common';
+import { DomainEvent } from '@potentiel-domain/core';
+
+import { RaccordementAggregate } from '../raccordement.aggregate';
+import { IdentifiantGestionnaireRéseau } from '../../gestionnaire';
+
+export type RaccordementSuppriméEvent = DomainEvent<
+  'RaccordementSupprimé-V1',
+  {
+    identifiantProjet: IdentifiantProjet.RawType;
+  }
+>;
+
+type SupprimerRaccordementOptions = {
+  identifiantProjet: IdentifiantProjet.ValueType;
+};
+
+export async function supprimerRaccordement(
+  this: RaccordementAggregate,
+  { identifiantProjet }: SupprimerRaccordementOptions,
+) {
+  const raccordementSupprimé: RaccordementSuppriméEvent = {
+    type: 'RaccordementSupprimé-V1',
+    payload: {
+      identifiantProjet: identifiantProjet.formatter(),
+    },
+  };
+
+  await this.publish(raccordementSupprimé);
+}
+
+export function applyRaccordementSuppriméEventV1(
+  this: RaccordementAggregate,
+  event: RaccordementSuppriméEvent,
+) {
+  this.identifiantProjet = IdentifiantProjet.convertirEnValueType(event.payload.identifiantProjet);
+  this.identifiantGestionnaireRéseau = IdentifiantGestionnaireRéseau.inconnu;
+  this.dossiers = new Map();
+}

--- a/packages/domain/réseau/src/raccordement/supprimer/supprimerRaccordement.command.ts
+++ b/packages/domain/réseau/src/raccordement/supprimer/supprimerRaccordement.command.ts
@@ -1,0 +1,26 @@
+import { Message, MessageHandler, mediator } from 'mediateur';
+
+import { IdentifiantProjet } from '@potentiel-domain/common';
+import { LoadAggregate } from '@potentiel-domain/core';
+
+import { loadRaccordementAggregateFactory } from '../raccordement.aggregate';
+
+export type SupprimerRaccordementCommand = Message<
+  'Réseau.Raccordement.Command.SupprimerRaccordement',
+  {
+    identifiantProjet: IdentifiantProjet.ValueType;
+  }
+>;
+
+export const registerSupprimerRaccordementCommand = (loadAggregate: LoadAggregate) => {
+  const loadRaccordement = loadRaccordementAggregateFactory(loadAggregate);
+
+  const handler: MessageHandler<SupprimerRaccordementCommand> = async ({ identifiantProjet }) => {
+    const raccordement = await loadRaccordement(identifiantProjet);
+    await raccordement.supprimerRaccordement({
+      identifiantProjet,
+    });
+  };
+
+  mediator.register('Réseau.Raccordement.Command.SupprimerRaccordement', handler);
+};

--- a/packages/infrastructure/domain-adapters/src/projet/listerProjetForOre.adapter.ts
+++ b/packages/infrastructure/domain-adapters/src/projet/listerProjetForOre.adapter.ts
@@ -36,7 +36,7 @@ export const listerProjetForOreAdapter = async ({ limit, offset }: Props) => {
   ) as value
   FROM "projects"
   WHERE "classe" = 'Classé'
-  AND "abandonedOn" <> '0'
+  AND "abandonedOn" = '0'
   ${limit !== undefined ? `LIMIT ${limit}` : ''}
   ${offset !== undefined ? `OFFSET ${limit}` : ''}
 `);

--- a/packages/infrastructure/domain-adapters/src/projet/listerProjetForOre.adapter.ts
+++ b/packages/infrastructure/domain-adapters/src/projet/listerProjetForOre.adapter.ts
@@ -36,6 +36,7 @@ export const listerProjetForOreAdapter = async ({ limit, offset }: Props) => {
   ) as value
   FROM "projects"
   WHERE "classe" = 'Classé'
+  AND "abandonedOn" <> '0'
   ${limit !== undefined ? `LIMIT ${limit}` : ''}
   ${offset !== undefined ? `OFFSET ${limit}` : ''}
 `);

--- a/packages/specifications/src/raccordement/stepDefinitions/raccordement.then.ts
+++ b/packages/specifications/src/raccordement/stepDefinitions/raccordement.then.ts
@@ -262,7 +262,7 @@ Alors(
 );
 
 Alors(
-  `le dossier de raccordement {string} ne devrait plus être consultable dans le raccordement du projet lauréat {string}`,
+  `le dossier ayant comme référence {string} ne devrait plus être consultable dans le raccordement du projet lauréat {string}`,
   async function (this: PotentielWorld, référenceDossier: string, nomProjet: string) {
     const { identifiantProjet } = this.lauréatWorld.rechercherLauréatFixture(nomProjet);
     await waitForExpect(async () => {

--- a/packages/specifications/src/raccordement/stepDefinitions/raccordement.then.ts
+++ b/packages/specifications/src/raccordement/stepDefinitions/raccordement.then.ts
@@ -260,3 +260,32 @@ Alors(
     });
   },
 );
+
+Alors(
+  `le dossier de raccordement {string} ne devrait plus être consultable dans le raccordement du projet lauréat {string}`,
+  async function (this: PotentielWorld, référenceDossier: string, nomProjet: string) {
+    const { identifiantProjet } = this.lauréatWorld.rechercherLauréatFixture(nomProjet);
+    await waitForExpect(async () => {
+      const raccordement = await mediator.send<Raccordement.ConsulterRaccordementQuery>({
+        type: 'Réseau.Raccordement.Query.ConsulterRaccordement',
+        data: {
+          identifiantProjetValue: identifiantProjet.formatter(),
+        },
+      });
+
+      expect(raccordement.identifiantGestionnaireRéseau).to.be.undefined;
+      expect(raccordement.dossiers).to.be.empty;
+
+      const dossierRaccordement =
+        await mediator.send<Raccordement.ConsulterDossierRaccordementQuery>({
+          type: 'Réseau.Raccordement.Query.ConsulterDossierRaccordement',
+          data: {
+            identifiantProjetValue: identifiantProjet.formatter(),
+            référenceDossierRaccordementValue: référenceDossier,
+          },
+        });
+
+      expect(Option.isNone(dossierRaccordement)).to.be.true;
+    });
+  },
+);

--- a/packages/specifications/src/raccordement/supprimerRaccordement.feature
+++ b/packages/specifications/src/raccordement/supprimerRaccordement.feature
@@ -1,7 +1,6 @@
 # language: fr
 Fonctionnalité: Supprimer le raccordement d'un projet
 
-    @select
     Scénario: Le système supprime le raccordement d'un projet si celui-ci a un abandon accordé
         Etant donné le projet lauréat "Du boulodrome de Marseille"
         Et le porteur "Barbara Gordon" ayant accés au projet lauréat "Du boulodrome de Marseille"
@@ -21,4 +20,4 @@ Fonctionnalité: Supprimer le raccordement d'un projet
             | Le contenu de proposition technique et financière   | contenu         |
         Et une date de mise en service "2024-01-01" pour le dossier ayant comme référence "OUE-RP-2022-000033" du raccordement pour le projet lauréat "Du boulodrome de Marseille"
         Et un abandon accordé pour le projet lauréat
-        Alors le dossier de raccordement "OUE-RP-2022-000033" ne devrait plus être consultable dans le raccordement du projet lauréat "Du boulodrome de Marseille"
+        Alors le dossier ayant comme référence "OUE-RP-2022-000033" ne devrait plus être consultable dans le raccordement du projet lauréat "Du boulodrome de Marseille"

--- a/packages/specifications/src/raccordement/supprimerRaccordement.feature
+++ b/packages/specifications/src/raccordement/supprimerRaccordement.feature
@@ -1,4 +1,5 @@
 # language: fr
+@select
 Fonctionnalité: Supprimer le raccordement d'un projet
 
     Scénario: Le système supprime le raccordement d'un projet si celui-ci a un abandon accordé
@@ -19,5 +20,6 @@ Fonctionnalité: Supprimer le raccordement d'un projet
             | Le format de la proposition technique et financière | application/pdf |
             | Le contenu de proposition technique et financière   | contenu         |
         Et une date de mise en service "2024-01-01" pour le dossier ayant comme référence "OUE-RP-2022-000033" du raccordement pour le projet lauréat "Du boulodrome de Marseille"
-        Et un abandon accordé pour le projet lauréat
+        Et une demande d'abandon en cours pour le projet lauréat
+        Quand le DGEC validateur accorde l'abandon pour le projet lauréat
         Alors le dossier ayant comme référence "OUE-RP-2022-000033" ne devrait plus être consultable dans le raccordement du projet lauréat "Du boulodrome de Marseille"

--- a/packages/specifications/src/raccordement/supprimerRaccordement.feature
+++ b/packages/specifications/src/raccordement/supprimerRaccordement.feature
@@ -1,0 +1,24 @@
+# language: fr
+Fonctionnalité: Supprimer le raccordement d'un projet
+
+    @select
+    Scénario: Le système supprime le raccordement d'un projet si celui-ci a un abandon accordé
+        Etant donné le projet lauréat "Du boulodrome de Marseille"
+        Et le porteur "Barbara Gordon" ayant accés au projet lauréat "Du boulodrome de Marseille"
+        Et le DGEC validateur "Bruce Wayne"
+        Et un gestionnaire de réseau
+            | Code EIC       | 17X0000009352859       |
+            | Raison sociale | Arc Energies Maurienne |
+        Et le gestionnaire de réseau "Arc Energies Maurienne" attribué au raccordement du projet lauréat "Du boulodrome de Marseille"
+        Et une demande complète de raccordement pour le projet lauréat "Du boulodrome de Marseille" transmise auprès du gestionnaire de réseau "Arc Energies Maurienne" avec :
+            | La date de qualification                | 2022-10-28         |
+            | La référence du dossier de raccordement | OUE-RP-2022-000033 |
+            | Le format de l'accusé de réception      | application/pdf    |
+            | Le contenu de l'accusé de réception     | contenu            |
+        Et une proposition technique et financière pour le dossier ayant comme référence "OUE-RP-2022-000033" du raccordement pour le projet lauréat "Du boulodrome de Marseille" avec :
+            | La date de signature                                | 2023-01-10      |
+            | Le format de la proposition technique et financière | application/pdf |
+            | Le contenu de proposition technique et financière   | contenu         |
+        Et une date de mise en service "2024-01-01" pour le dossier ayant comme référence "OUE-RP-2022-000033" du raccordement pour le projet lauréat "Du boulodrome de Marseille"
+        Et un abandon accordé pour le projet lauréat
+        Alors le dossier de raccordement "OUE-RP-2022-000033" ne devrait plus être consultable dans le raccordement du projet lauréat "Du boulodrome de Marseille"

--- a/packages/specifications/src/raccordement/supprimerRaccordement.feature
+++ b/packages/specifications/src/raccordement/supprimerRaccordement.feature
@@ -1,5 +1,4 @@
 # language: fr
-@select
 Fonctionnalité: Supprimer le raccordement d'un projet
 
     Scénario: Le système supprime le raccordement d'un projet si celui-ci a un abandon accordé


### PR DESCRIPTION
# Description

- Réaction via une saga à l'évènement AbandonAccordé
- Suppression du raccordement et des dossiers associés

## Type de changement

- [x] Nouvelle fonctionnalité

# Comment cela a-t-il été testé?

TDD
