### PR TITLE
✅ Fix flaky test dans corriger candidature

### DIFF
--- a/packages/specifications/src/candidature/corrigerCandidature.feature
+++ b/packages/specifications/src/candidature/corrigerCandidature.feature
@@ -12,7 +12,7 @@ Fonctionnalité: Corriger une candidature
 
     Scénario: Impossible de changer l'AO d'une candidature
         Quand un administrateur corrige la candidature avec :
-            | appel d'offre | PPE2 - Neutre |
+            | appel d'offre | x |
         Alors l'administrateur devrait être informé que "La candidature n'existe pas"
 
     Scénario: Impossible de changer la période d'une candidature


### PR DESCRIPTION
les tests utilisant désormais des valeurs aléatoires, on peut avoir le cas où l'appel d'offre est déjà `PPE2 - Neutre`