### PR TITLE
🔧 Mise à jour du header CSP sans 'unsafe-inline'

### DIFF
--- a/packages/applications/legacy/src/server.ts
+++ b/packages/applications/legacy/src/server.ts
@@ -45,7 +45,6 @@ export async function makeServer(port: number, sessionSecret: string) {
               'default-src': ["'self'", 'blob:', 'metabase.potentiel.beta.gouv.fr'],
               'connect-src': [
                 "'self'",
-                "'unsafe-inline'",
                 'analytics.potentiel.beta.gouv.fr',
                 'client.crisp.chat',
                 'wss://client.relay.crisp.chat',
@@ -54,7 +53,6 @@ export async function makeServer(port: number, sessionSecret: string) {
               'font-src': ["'self'", 'data:', 'client.crisp.chat'],
               'style-src': ["'self'", 'data:', "'unsafe-inline'", 'client.crisp.chat'],
               'script-src': [
-                "'unsafe-inline'",
                 "'self'",
                 'metabase.potentiel.beta.gouv.fr',
                 'analytics.potentiel.beta.gouv.fr',


### PR DESCRIPTION
Retiré de `script-src`, `connect-src`, laissé dans `style-src`


je ne vois pas de raison particulière d'avoir cette directive
Crisp ne demande pas ce header dans script-src ou connect-src, mais le demande pour style-src. cf https://docs.crisp.chat/guides/others/whitelisting-our-systems/crisp-domain-names/


NB: je ne touche pas pour l'instant à la directive `data:` qui a l'air utilisée par le DSFR
