### PR TITLE
🔍️ Ajout d'une page `robots.txt` et d'un tag `description`

### DIFF
--- a/packages/applications/legacy/src/views/index.html.tsx
+++ b/packages/applications/legacy/src/views/index.html.tsx
@@ -44,6 +44,10 @@ export const makeHtml = <T extends {}>(args: PageProps<T>) => {
         <meta charset="utf-8" />
         <meta http-equiv="x-ua-compatible" content="ie=edge" />
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+        <meta
+          name="description"
+          content="Facilite le parcours des producteurs d'énergies renouvelables électriques"
+        />
 
         <title>${`${title} - Potentiel`}</title>
 

--- a/packages/applications/ssr/src/app/layout.tsx
+++ b/packages/applications/ssr/src/app/layout.tsx
@@ -16,6 +16,7 @@ import { StartDsfr } from './StartDsfr';
 
 export const metadata: Metadata = {
   title: 'Potentiel',
+  description: "Facilite le parcours des producteurs d'énergies renouvelables électriques",
 };
 
 export const dynamic = 'force-dynamic';

--- a/packages/applications/ssr/src/app/robots.ts
+++ b/packages/applications/ssr/src/app/robots.ts
@@ -1,0 +1,11 @@
+import type { MetadataRoute } from 'next';
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/$',
+      disallow: '/',
+    },
+  };
+}

--- a/packages/applications/ssr/src/middleware.ts
+++ b/packages/applications/ssr/src/middleware.ts
@@ -3,3 +3,8 @@ import { withAuth } from 'next-auth/middleware';
 export default withAuth({
   pages: { signIn: '/auth/signIn' },
 });
+
+export const config = {
+  // do not run middleware for paths matching one of following
+  matcher: ['/((?!api|_next/static|_next/image|auth|favicon.ico|robots.txt|images|$).*)'],
+};


### PR DESCRIPTION
Ajout d'une page robots.txt, qui n'autorise que l'indexation de la home page, afin d'améliorer le score [lighthouse pour le SEO](https://dashlord.mte.incubateur.net/report/aHR0cHM6Ly9wb3RlbnRpZWwuYmV0YS5nb3V2LmZy/lhr-aHR0cHM6Ly9wb3RlbnRpZWwuYmV0YS5nb3V2LmZyLw==.html)

Ajout d'un tag `description`  ([docs](https://developer.chrome.com/docs/lighthouse/seo/meta-description))