### PR TITLE
💄 Affichage différent si 1 ou plusieurs dossiers de raccordement

### DIFF
--- a/packages/applications/ssr/src/components/pages/réseau/raccordement/détails/DétailsRaccordement.page.tsx
+++ b/packages/applications/ssr/src/components/pages/réseau/raccordement/détails/DétailsRaccordement.page.tsx
@@ -68,14 +68,18 @@ export const DétailsRaccordementPage: FC<DétailsRaccordementPageProps> = ({
         />
 
         <div className={`my-8 flex flex-col gap-8 md:gap-3 ${fr.cx('fr-accordions-group')}`}>
-          {dossiers.map((dossier) => (
-            <Accordion
-              label={`Dossier avec la référence ${dossier.référence}`}
-              key={dossier.référence}
-            >
-              <DossierRaccordement {...dossier} isGestionnaireInconnu={isGestionnaireInconnu} />
-            </Accordion>
-          ))}
+          {dossiers.length === 1 ? (
+            <DossierRaccordement {...dossiers[0]} isGestionnaireInconnu={isGestionnaireInconnu} />
+          ) : (
+            dossiers.map((dossier) => (
+              <Accordion
+                label={`Dossier avec la référence ${dossier.référence}`}
+                key={dossier.référence}
+              >
+                <DossierRaccordement {...dossier} isGestionnaireInconnu={isGestionnaireInconnu} />
+              </Accordion>
+            ))
+          )}
         </div>
       </div>
 


### PR DESCRIPTION
1 dossier : 
<img width="1496" alt="1dossier" src="https://github.com/user-attachments/assets/3c82e0c0-6bd8-4e5b-be9f-6170cc7d6b4d">

X dossiers : 
<img width="1477" alt="Capture d’écran 2024-09-03 à 16 37 15" src="https://github.com/user-attachments/assets/0e371484-7ab4-4b7c-af93-055a409e8eb8">
