### PR TITLE
Revert "🔧 Mise à jour du header CSP sans 'unsafe-inline'"

### DIFF
--- a/packages/applications/legacy/src/server.ts
+++ b/packages/applications/legacy/src/server.ts
@@ -45,6 +45,7 @@ export async function makeServer(port: number, sessionSecret: string) {
               'default-src': ["'self'", 'blob:', 'metabase.potentiel.beta.gouv.fr'],
               'connect-src': [
                 "'self'",
+                "'unsafe-inline'",
                 'analytics.potentiel.beta.gouv.fr',
                 'client.crisp.chat',
                 'wss://client.relay.crisp.chat',
@@ -53,6 +54,7 @@ export async function makeServer(port: number, sessionSecret: string) {
               'font-src': ["'self'", 'data:', 'client.crisp.chat'],
               'style-src': ["'self'", 'data:', "'unsafe-inline'", 'client.crisp.chat'],
               'script-src': [
+                "'unsafe-inline'",
                 "'self'",
                 'metabase.potentiel.beta.gouv.fr',
                 'analytics.potentiel.beta.gouv.fr',


### PR DESCRIPTION
Reverts MTES-MCT/potentiel#2143