### PR TITLE
🔒️ Redefine CSP

### DIFF
--- a/packages/applications/legacy/src/server.ts
+++ b/packages/applications/legacy/src/server.ts
@@ -42,25 +42,18 @@ export async function makeServer(port: number, sessionSecret: string) {
           contentSecurityPolicy: {
             useDefaults: false,
             directives: {
-              'default-src': ["'self'", 'blob:', 'metabase.potentiel.beta.gouv.fr'],
+              'default-src': ["'none'"],
               'connect-src': [
                 "'self'",
-                "'unsafe-inline'",
                 'analytics.potentiel.beta.gouv.fr',
+                'potentiel.beta.gouv.fr',
+
                 'client.crisp.chat',
                 'wss://client.relay.crisp.chat',
               ],
-              'img-src': ["'self'", 'data:', 'client.crisp.chat', 'image.crisp.chat'],
-              'font-src': ["'self'", 'data:', 'client.crisp.chat'],
-              'style-src': ["'self'", 'data:', "'unsafe-inline'", 'client.crisp.chat'],
-              'script-src': [
-                "'unsafe-inline'",
-                "'self'",
-                'metabase.potentiel.beta.gouv.fr',
-                'analytics.potentiel.beta.gouv.fr',
-                'client.crisp.chat',
-              ],
-              'object-src': ["'none'"],
+              'font-src': ["'self'", 'client.crisp.chat'],
+              'frame-src': ['metabase.potentiel.beta.gouv.fr'],
+              'img-src': ["'self'", 'data:', 'image.crisp.chat'],
             },
           },
         }),


### PR DESCRIPTION
# Description

Le [dashlord](https://dashlord.mte.incubateur.net/url/potentiel-beta-gouv-fr/securite/) nous donne un mauvais score suite à l'analyse faite par [Mozilla Observatory](https://observatory.mozilla.org/analyze/potentiel.beta.gouv.fr), notamment au niveau des CSP

Pour les redéfinir les CSP j'ai utilisé l'extension [Laboratory](https://addons.mozilla.org/en-US/firefox/addon/laboratory-by-mozilla/) qui permet de générer des CSP par rapport au besoin d'un site. Je suis repassé ainsi sur toutes les pages de la production.

Le contenu de cette PR est les CSP générés, ça devrait fixer nos soucis normalement.

**Avant**
![avant](https://github.com/user-attachments/assets/1063798a-a470-4736-9cac-192479e66127)

**Après**
![après](https://github.com/user-attachments/assets/1b96a0ce-0833-4666-80de-ddee69d05ced)




## Type de changement


- [x] Correction de bug