### PR TITLE
🐛 Corriger la preview d'attestation quand on filtre par période

### DIFF
--- a/packages/applications/ssr/src/components/molecules/UserBasedRoleNavigation.tsx
+++ b/packages/applications/ssr/src/components/molecules/UserBasedRoleNavigation.tsx
@@ -92,12 +92,6 @@ const getNavigationItemsBasedOnRole = (
               },
             },
             {
-              text: 'Régénérer des attestations',
-              linkProps: {
-                href: '/admin/regenerer-attestations.html',
-              },
-            },
-            {
               text: 'Tous les candidats',
               linkProps: {
                 href: Routes.Candidature.lister(),


### PR DESCRIPTION
et retirer le lien "régénérer des attestations" dans le ssr (déjà fait dans le legacy)