### PR TITLE
🐛 Rendre obligatoire le document lors de la correction de réponse de mainlevée

### DIFF
--- a/packages/applications/ssr/src/components/pages/garanties-financières/mainlevée/corrigerRéponseSignée/CorrigerRéponseSignée.form.tsx
+++ b/packages/applications/ssr/src/components/pages/garanties-financières/mainlevée/corrigerRéponseSignée/CorrigerRéponseSignée.form.tsx
@@ -48,6 +48,7 @@ export const CorrigerRéponseSignée = ({
               <UploadDocument
                 name="documentCorrige"
                 id="documentCorrige"
+                required
                 label="Nouvelle réponse signée"
               />
 

--- a/packages/applications/ssr/src/components/pages/garanties-financières/mainlevée/corrigerRéponseSignée/corrigerRéponseSignée.action.ts
+++ b/packages/applications/ssr/src/components/pages/garanties-financières/mainlevée/corrigerRéponseSignée/corrigerRéponseSignée.action.ts
@@ -8,7 +8,7 @@ import { CorrigerDocumentProjetCommand } from '@potentiel-domain/document';
 import { FormAction, formAction, FormState } from '@/utils/formAction';
 
 const schema = zod.object({
-  documentCorrige: zod.instanceof(Blob),
+  documentCorrige: zod.instanceof(Blob).refine((file) => file.size > 0),
   courrierReponseACorriger: zod.string().min(1),
 });
 


### PR DESCRIPTION
# Description

easy

## Type de changement

Veuillez supprimer les options qui ne sont pas pertinentes.

- [x] Correction de bug
