### PR TITLE
🐛 Page non trouvée en l'absence de dossier de raccordement

### DIFF
--- a/packages/applications/legacy/src/controllers/project/getProjectPage.ts
+++ b/packages/applications/legacy/src/controllers/project/getProjectPage.ts
@@ -270,7 +270,7 @@ const getAlertesRaccordement = async ({
     data: { identifiantProjetValue: identifiantProjet.formatter() },
   });
 
-  if (Option.isSome(dossiersRaccordement)) {
+  if (Option.isSome(dossiersRaccordement) && !!dossiersRaccordement.dossiers[0]) {
     if (
       CDC2022Choisi &&
       dossiersRaccordement.dossiers[0].référence.estÉgaleÀ(


### PR DESCRIPTION
Ex: https://potentiel-staging.osc-fr1.scalingo.io/projet/c1644a65-9a6c-465a-baab-2dcca8907d12/details.html

la page envoie une erreur, ce qui cause "page non trouvée"
c'est dû au fait que `dossiersRaccordement.dossiers[0]` est undefined