### PR TITLE
✨  Tri de la liste des périodes

### DIFF
--- a/packages/applications/ssr/src/app/periodes/page.tsx
+++ b/packages/applications/ssr/src/app/periodes/page.tsx
@@ -116,8 +116,8 @@ const mapToProps = async ({
         peutÊtreNotifiée: période.estNotifiée
           ? false
           : utilisateur.role.aLaPermission('période.notifier'),
-        notifiéLe: période.estNotifiée ? période.notifiéeLe.formatter() : undefined,
-        notifiéPar: période.estNotifiée ? période.notifiéePar.formatter() : undefined,
+        notifiéLe: période.estNotifiée ? période.notifiéeLe?.formatter() : undefined,
+        notifiéPar: période.estNotifiée ? période.notifiéePar?.formatter() : undefined,
         totalÉliminés,
         totalLauréats,
         totalCandidatures,

--- a/packages/domain/entity/src/orderByOptions.ts
+++ b/packages/domain/entity/src/orderByOptions.ts
@@ -1,7 +1,7 @@
 export type Order = 'ascending' | 'descending';
 
 export type OrderByOptions<T> = {
-  [P in keyof T]?: T[P] extends string | boolean | number
+  [P in keyof T]?: T[P] extends string | boolean | number | undefined
     ? Order
     : T[P] extends Record<string, unknown>
       ? OrderByOptions<T[P]>

--- a/packages/domain/période/src/consulter/consulterPériode.query.ts
+++ b/packages/domain/période/src/consulter/consulterPériode.query.ts
@@ -18,8 +18,8 @@ type PériodeNotifiée = {
   identifiantPériode: IdentifiantPériode.ValueType;
   estNotifiée: true;
 
-  notifiéeLe: DateTime.ValueType;
-  notifiéePar: Email.ValueType;
+  notifiéeLe?: DateTime.ValueType;
+  notifiéePar?: Email.ValueType;
 
   identifiantLauréats: ReadonlyArray<IdentifiantProjet.ValueType>;
   identifiantÉliminés: ReadonlyArray<IdentifiantProjet.ValueType>;

--- a/packages/domain/période/src/consulter/consulterPériode.query.ts
+++ b/packages/domain/période/src/consulter/consulterPériode.query.ts
@@ -52,7 +52,7 @@ export const mapToReadModel = (période: PériodeEntity): ConsulterPériodeReadM
     période.identifiantPériode,
   );
 
-  if (période.estNotifiée) {
+  if (période.estNotifiée && période.notifiéeLe && période.notifiéePar) {
     return {
       identifiantPériode,
       estNotifiée: true,

--- a/packages/domain/période/src/lister/listerPériodesNonNotifiées.ts
+++ b/packages/domain/période/src/lister/listerPériodesNonNotifiées.ts
@@ -28,12 +28,14 @@ export const listerPériodesNonNotifiées = async (
     return [...acc, ...periodes];
   }, [] as Array<ConsulterPériodeReadModel>);
 
-  const allWithoutNotifiées = all.filter(
-    (période) =>
-      notifiées.items.find(
-        (notifiée) => notifiée.identifiantPériode === période.identifiantPériode.formatter(),
-      ) === undefined,
-  );
+  const allWithoutNotifiées = all
+    .filter(
+      (période) =>
+        notifiées.items.find(
+          (notifiée) => notifiée.identifiantPériode === période.identifiantPériode.formatter(),
+        ) === undefined,
+    )
+    .sort((a, b) => a.identifiantPériode.appelOffre.localeCompare(b.identifiantPériode.appelOffre));
 
   return {
     items: range

--- a/packages/domain/période/src/lister/listerPériodesNotifiées.ts
+++ b/packages/domain/période/src/lister/listerPériodesNotifiées.ts
@@ -13,6 +13,9 @@ export const listerPériodesNotifiées = async (
     where: {
       appelOffre: Where.equal(appelOffre),
     },
+    orderBy: {
+      notifiéeLe: 'descending',
+    },
   });
 
   return {

--- a/packages/domain/période/src/lister/listerToutesLesPériodes.ts
+++ b/packages/domain/période/src/lister/listerToutesLesPériodes.ts
@@ -26,25 +26,28 @@ export const listerToutesLesPériodes = async (
         `${current.id}#${periode.id}`,
       );
 
-      const notifiée = notifiées.items.find(
+      const périodeNotifiée = notifiées.items.find(
         (notifiée) => notifiée.identifiantPériode === identifiantPériode.formatter(),
       );
 
+      if (périodeNotifiée?.estNotifiée) {
+        return {
+          identifiantPériode,
+          estNotifiée: true,
+          identifiantLauréats: périodeNotifiée.identifiantLauréats.map(
+            IdentifiantProjet.convertirEnValueType,
+          ),
+          identifiantÉliminés: périodeNotifiée.identifiantÉliminés.map(
+            IdentifiantProjet.convertirEnValueType,
+          ),
+          notifiéeLe: DateTime.convertirEnValueType(périodeNotifiée.notifiéeLe),
+          notifiéePar: Email.convertirEnValueType(périodeNotifiée.notifiéePar),
+        };
+      }
+
       return {
         identifiantPériode,
-        ...(notifiée?.estNotifiée
-          ? {
-              estNotifiée: true,
-              identifiantLauréats: notifiée.identifiantLauréats.map(
-                IdentifiantProjet.convertirEnValueType,
-              ),
-              identifiantÉliminés: notifiée.identifiantÉliminés.map(
-                IdentifiantProjet.convertirEnValueType,
-              ),
-              notifiéeLe: DateTime.convertirEnValueType(notifiée.notifiéeLe),
-              notifiéePar: Email.convertirEnValueType(notifiée.notifiéePar),
-            }
-          : { estNotifiée: false }),
+        estNotifiée: false,
       };
     });
 

--- a/packages/domain/période/src/lister/listerToutesLesPériodes.ts
+++ b/packages/domain/période/src/lister/listerToutesLesPériodes.ts
@@ -41,8 +41,12 @@ export const listerToutesLesPériodes = async (
             identifiantÉliminés: périodeNotifiée.identifiantÉliminés.map(
               IdentifiantProjet.convertirEnValueType,
             ),
-            notifiéeLe: DateTime.convertirEnValueType(périodeNotifiée.notifiéeLe),
-            notifiéePar: Email.convertirEnValueType(périodeNotifiée.notifiéePar),
+            notifiéeLe: périodeNotifiée.notifiéeLe
+              ? DateTime.convertirEnValueType(périodeNotifiée.notifiéeLe)
+              : undefined,
+            notifiéePar: périodeNotifiée.notifiéePar
+              ? Email.convertirEnValueType(périodeNotifiée.notifiéePar)
+              : undefined,
           };
         }
 

--- a/packages/domain/période/src/période.entity.ts
+++ b/packages/domain/période/src/période.entity.ts
@@ -11,8 +11,8 @@ export type PériodeEntity = Entity<
     période: string;
     estNotifiée: boolean;
 
-    notifiéeLe: DateTime.RawType;
-    notifiéePar: Email.RawType;
+    notifiéeLe?: DateTime.RawType;
+    notifiéePar?: Email.RawType;
 
     identifiantLauréats: ReadonlyArray<IdentifiantProjet.RawType>;
     identifiantÉliminés: ReadonlyArray<IdentifiantProjet.RawType>;

--- a/packages/domain/période/src/période.entity.ts
+++ b/packages/domain/période/src/période.entity.ts
@@ -9,19 +9,12 @@ export type PériodeEntity = Entity<
     identifiantPériode: IdentifiantPériode.RawType;
     appelOffre: string;
     période: string;
-  } & (PériodeNotifiée | PériodeNonNotifiée)
+    estNotifiée: boolean;
+
+    notifiéeLe: DateTime.RawType;
+    notifiéePar: Email.RawType;
+
+    identifiantLauréats: ReadonlyArray<IdentifiantProjet.RawType>;
+    identifiantÉliminés: ReadonlyArray<IdentifiantProjet.RawType>;
+  }
 >;
-
-type PériodeNonNotifiée = {
-  estNotifiée: false;
-};
-
-type PériodeNotifiée = {
-  estNotifiée: true;
-
-  notifiéeLe: DateTime.RawType;
-  notifiéePar: Email.RawType;
-
-  identifiantLauréats: ReadonlyArray<IdentifiantProjet.RawType>;
-  identifiantÉliminés: ReadonlyArray<IdentifiantProjet.RawType>;
-};

--- a/packages/domain/période/tsconfig.json
+++ b/packages/domain/période/tsconfig.json
@@ -9,6 +9,9 @@
       "path": "../../libraries/monads"
     },
     {
+      "path": "../../domain/entity"
+    },
+    {
       "path": "../common"
     },
     {


### PR DESCRIPTION
# Description

Afin d'avoir une liste ordonnée des périodes, il faut trier automatiquement la liste des périodes selon les filtres appliqués :
- Toutes les périodes : tri par appel d'offres
- À notifier : tri par appel d'offres
- Notifiées : tri par date de notification

## Type de changement

Veuillez supprimer les options qui ne sont pas pertinentes.

- Nouvelle fonctionnalité