### PR TITLE
🎨 ETQ PP je suis invite a transmettre mon DCR

### DIFF
--- a/packages/applications/legacy/src/views/pages/projectDetailsPage/ProjectDetails.tsx
+++ b/packages/applications/legacy/src/views/pages/projectDetailsPage/ProjectDetails.tsx
@@ -187,9 +187,10 @@ const AlerteBoxRaccordement: FC<{
         Vous devez déposer une demande de raccordement avant le {afficherDate(dcrDueOn)} auprès de
         votre gestionnaire de réseau.
         <br />
-        L'accusé de réception de cette demande transmis sur Potentiel facilitera vos démarches
-        administratives avec les différents acteurs connectés à Potentiel (DGEC, DREAL,
-        Cocontractant, etc.).
+        L'accusé de réception de cette demande ainsi que les documents complémentaires (proposition
+        technique et financière ou convention de raccordement directe, convention de raccordement…)
+        transmis sur Potentiel faciliteront vos démarches administratives avec les différents
+        acteurs connectés à Potentiel (DGEC, DREAL, Cocontractant, etc.).
       </p>
     )}
     <Link href={Routes.Raccordement.détail(identifiantProjet)}>

--- a/packages/applications/legacy/src/views/pages/projectDetailsPage/ProjectDetails.tsx
+++ b/packages/applications/legacy/src/views/pages/projectDetailsPage/ProjectDetails.tsx
@@ -187,10 +187,9 @@ const AlerteBoxRaccordement: FC<{
         Vous devez déposer une demande de raccordement avant le {afficherDate(dcrDueOn)} auprès de
         votre gestionnaire de réseau.
         <br />
-        L'accusé de réception de cette demande ainsi que les documents complémentaires (proposition
-        technique et financière ou convention de raccordement directe, convention de raccordement…)
-        transmis sur Potentiel faciliteront vos démarches administratives avec les différents
-        acteurs connectés à Potentiel (DGEC, DREAL, Cocontractant, etc.).
+        L'accusé de réception de cette demande transmis sur Potentiel facilitera vos démarches
+        administratives avec les différents acteurs connectés à Potentiel (DGEC, DREAL,
+        Cocontractant, etc.).
       </p>
     )}
     <Link href={Routes.Raccordement.détail(identifiantProjet)}>

--- a/packages/applications/legacy/src/views/pages/projectDetailsPage/ProjectDetails.tsx
+++ b/packages/applications/legacy/src/views/pages/projectDetailsPage/ProjectDetails.tsx
@@ -192,7 +192,7 @@ const AlerteBoxRaccordement: FC<{
         Cocontractant, etc.).
       </p>
     )}
-    <Link href={Routes.Raccordement.détail(identifiantProjet)}>
+    <Link href={Routes.Raccordement.transmettreDemandeComplèteRaccordement(identifiantProjet)}>
       Mettre à jour les données de raccordement de mon projet
     </Link>
   </AlertBox>

--- a/packages/applications/notifications/src/subscribers/période/période.notification.ts
+++ b/packages/applications/notifications/src/subscribers/période/période.notification.ts
@@ -32,12 +32,14 @@ async function getEmailPayloads(
           identifiantAppelOffre: identifiantPériode.appelOffre,
         },
       });
+
       if (Option.isNone(appelOffre)) {
         getLogger().error(
           new Error(`Pas d'appel d'offre trouvé pour ${identifiantPériode.formatter()}`),
         );
         return;
       }
+
       const période = appelOffre.periodes.find((x) => x.id === identifiantPériode.période);
 
       if (!période) {

--- a/packages/applications/ssr/src/components/pages/attestation-conformité/transmettre/transmettreAttestationConformité.action.ts
+++ b/packages/applications/ssr/src/components/pages/attestation-conformité/transmettre/transmettreAttestationConformité.action.ts
@@ -3,9 +3,11 @@
 import * as zod from 'zod';
 import { mediator } from 'mediateur';
 
+import { Option } from '@potentiel-libraries/monads';
 import { Achèvement, GarantiesFinancières } from '@potentiel-domain/laureat';
 import { DateTime } from '@potentiel-domain/common';
 import { Routes } from '@potentiel-applications/routes';
+import { Raccordement } from '@potentiel-domain/reseau';
 
 import { FormAction, FormState, formAction } from '@/utils/formAction';
 import { withUtilisateur } from '@/utils/withUtilisateur';
@@ -63,9 +65,20 @@ const action: FormAction<FormState, typeof schema> = async (
       });
     }
 
+    const raccordement = await mediator.send<Raccordement.ConsulterRaccordementQuery>({
+      type: 'Réseau.Raccordement.Query.ConsulterRaccordement',
+      data: {
+        identifiantProjetValue: identifiantProjet,
+      },
+    });
+
+    const redirectUrl = Option.isSome(raccordement)
+      ? Routes.Projet.details(identifiantProjet)
+      : Routes.Raccordement.détail(identifiantProjet);
+
     return {
       status: 'success',
-      redirectUrl: Routes.Projet.details(identifiantProjet),
+      redirectUrl,
     };
   });
 

--- a/packages/applications/ssr/src/components/pages/réseau/raccordement/détails/AucunDossierDeRaccordement.page.tsx
+++ b/packages/applications/ssr/src/components/pages/réseau/raccordement/détails/AucunDossierDeRaccordement.page.tsx
@@ -1,4 +1,3 @@
-import Link from 'next/link';
 import { FC } from 'react';
 import Button from '@codegouvfr/react-dsfr/Button';
 
@@ -11,6 +10,7 @@ import { TitrePageRaccordement } from '../TitrePageRaccordement';
 
 import { GestionnaireRéseau as GestionnaireRéseauProps } from './type';
 import { ModifierGestionnaireRéseauDuRaccordement } from './components/ModifierGestionnaireRéseauDuRaccordement';
+import { AucunDossierDeRaccordementAlert } from './AucunDossierDeRaccordementAlert';
 
 export type AucunDossierDeRaccordementPageProps = {
   identifiantProjet: string;
@@ -23,7 +23,6 @@ export const AucunDossierDeRaccordementPage: FC<AucunDossierDeRaccordementPagePr
 }) => (
   <PageTemplate banner={<ProjetBanner identifiantProjet={identifiantProjet} />}>
     <TitrePageRaccordement />
-
     <div className="flex flex-col gap-8">
       {gestionnaireRéseau && (
         <ModifierGestionnaireRéseauDuRaccordement
@@ -31,15 +30,7 @@ export const AucunDossierDeRaccordementPage: FC<AucunDossierDeRaccordementPagePr
           identifiantProjet={identifiantProjet}
         />
       )}
-      <p>
-        Aucun dossier de raccordement trouvé pour ce projet, vous devez transmettre un{' '}
-        <Link
-          href={Routes.Raccordement.transmettreDemandeComplèteRaccordement(identifiantProjet)}
-          className="font-semibold"
-        >
-          nouveau dossier de raccordement
-        </Link>
-      </p>
+      <AucunDossierDeRaccordementAlert identifiantProjet={identifiantProjet} />
       <Button
         priority="secondary"
         linkProps={{ href: Routes.Projet.details(identifiantProjet), prefetch: false }}

--- a/packages/applications/ssr/src/components/pages/réseau/raccordement/détails/AucunDossierDeRaccordementAlert.tsx
+++ b/packages/applications/ssr/src/components/pages/réseau/raccordement/détails/AucunDossierDeRaccordementAlert.tsx
@@ -19,7 +19,7 @@ export const AucunDossierDeRaccordementAlert = ({ identifiantProjet }: Props) =>
           différents acteurs connectés à Potentiel (DGEC, DREAL, Cocontractant, etc.).
         </p>
         <span>
-          Vous devez transmettre un{' '}
+          Mettre à jour votre{' '}
           <Link
             href={Routes.Raccordement.transmettreDemandeComplèteRaccordement(identifiantProjet)}
             className="font-semibold"

--- a/packages/applications/ssr/src/components/pages/réseau/raccordement/détails/AucunDossierDeRaccordementAlert.tsx
+++ b/packages/applications/ssr/src/components/pages/réseau/raccordement/détails/AucunDossierDeRaccordementAlert.tsx
@@ -1,0 +1,33 @@
+import Alert from '@codegouvfr/react-dsfr/Alert';
+import Link from 'next/link';
+
+import { Routes } from '@potentiel-applications/routes';
+
+type Props = { identifiantProjet: string };
+
+export const AucunDossierDeRaccordementAlert = ({ identifiantProjet }: Props) => (
+  <Alert
+    severity="warning"
+    title="Données de raccordement à compléter"
+    description={
+      <div className="flex flex-col gap-3 mt-3">
+        <p>Vous n'avez pas encore transmis votre demande complète de raccordement sur Potentiel.</p>
+        <p>
+          L'accusé de réception de cette demande ainsi que les documents complémentaires
+          (proposition technique et financière ou convention de raccordement directe, convention de
+          raccordement…) transmis sur Potentiel faciliteront vos démarches administratives avec les
+          différents acteurs connectés à Potentiel (DGEC, DREAL, Cocontractant, etc.).
+        </p>
+        <span>
+          Vous devez transmettre un{' '}
+          <Link
+            href={Routes.Raccordement.transmettreDemandeComplèteRaccordement(identifiantProjet)}
+            className="font-semibold"
+          >
+            dossier de raccordement
+          </Link>
+        </span>
+      </div>
+    }
+  />
+);


### PR DESCRIPTION
# Description

- Alerte plus claire si pas de dossier de raccordement sur la page détail
- Suite à la transmission d'une attestation de conformité, je suis renvoyé vers la page détail de raccordement si je n'ai pas de dossier de raccordement

[Ticket](https://linear.app/startup-potentiel/issue/POT-528/etq-equipe-potentiel-nous-souhaitons-avoir-un-maximum-de-projets-en)

## Type de changement

Veuillez supprimer les options qui ne sont pas pertinentes.

- [x] Front

# Comment cela a-t-il été testé?

Visuel & scénario

- Nouvelle alerte

<img width="997" alt="Capture d’écran 2024-09-24 à 11 31 04" src="https://github.com/user-attachments/assets/e221ef02-c797-4342-9f01-bd16c990349d">

- Test du redirect
