### PR TITLE
🐛 Corriger statut lors du réimport des candiatures

### DIFF
--- a/packages/applications/scheduled-tasks/src/candidature/getLocalité.ts
+++ b/packages/applications/scheduled-tasks/src/candidature/getLocalité.ts
@@ -1,0 +1,30 @@
+import { Candidature } from '@potentiel-domain/candidature';
+
+import { CandidatureShape } from '../importer/candidature.schema';
+
+import {
+  DépartementRégion,
+  getRégionAndDépartementFromCodePostal,
+} from './getRégionAndDépartementFromCodePostal';
+
+export const getLocalité = ({
+  code_postaux,
+  adresse1,
+  adresse2,
+  commune,
+}: CandidatureShape): Candidature.ImporterCandidatureUseCase['data']['localitéValue'] => {
+  const départementsRégions = code_postaux
+    .map(getRégionAndDépartementFromCodePostal)
+    .filter((dptRegion): dptRegion is DépartementRégion => !!dptRegion);
+  const departements = Array.from(new Set(départementsRégions.map((x) => x.département)));
+  const régions = Array.from(new Set(départementsRégions.map((x) => x.région)));
+
+  return {
+    adresse1,
+    adresse2,
+    commune,
+    codePostal: code_postaux.join(' / '),
+    département: departements.join(' / '),
+    région: régions.join(' / '),
+  };
+};

--- a/packages/applications/scheduled-tasks/src/candidature/getLocalité.ts
+++ b/packages/applications/scheduled-tasks/src/candidature/getLocalité.ts
@@ -1,11 +1,16 @@
 import { Candidature } from '@potentiel-domain/candidature';
 
-import { CandidatureShape } from '../importer/candidature.schema';
-
 import {
   DépartementRégion,
   getRégionAndDépartementFromCodePostal,
 } from './getRégionAndDépartementFromCodePostal';
+
+type CandidatureShape = {
+  code_postaux: string[];
+  adresse1: string;
+  adresse2: string;
+  commune: string;
+};
 
 export const getLocalité = ({
   code_postaux,

--- a/packages/applications/scheduled-tasks/src/candidature/getRégionAndDépartementFromCodePostal.ts
+++ b/packages/applications/scheduled-tasks/src/candidature/getRégionAndDépartementFromCodePostal.ts
@@ -1,0 +1,152 @@
+export type DépartementRégion = {
+  région: string;
+  département: string;
+};
+
+export const getRégionAndDépartementFromCodePostal = (
+  codePostal: string,
+): DépartementRégion | undefined => {
+  if (codePostal.length > 5) {
+    return undefined;
+  }
+
+  const régionDépartement =
+    référentiel[codePostal] ?? // traiter les exceptions
+    référentiel[codePostal.slice(0, 3)] ?? // traiter les outre-mer
+    référentiel[codePostal.slice(0, 2)]; // corse & métropole
+
+  return régionDépartement
+    ? {
+        région: régionDépartement.région,
+        département: régionDépartement.département,
+      }
+    : undefined;
+};
+
+const auvergneRhôneAlpes = 'Auvergne-Rhône-Alpes';
+const bourgogneFrancheComté = 'Bourgogne-Franche-Comté';
+const bretagne = 'Bretagne';
+const centreValDeLoire = 'Centre-Val de Loire';
+const corse = 'Corse';
+const grandEst = 'Grand Est';
+const occitanie = 'Occitanie';
+const paca = "Provence-Alpes-Côte d'Azur";
+const normandie = 'Normandie';
+const nouvelleAquitaine = 'Nouvelle-Aquitaine';
+const paysDeLaLoire = 'Pays de la Loire';
+const hautsDeFrance = 'Hauts-de-France';
+const idf = 'Île-de-France';
+
+const référentiel: Record<string, DépartementRégion> = {
+  // Métropole
+  '01': { département: 'Ain', région: auvergneRhôneAlpes },
+  '02': { département: 'Aisne', région: hautsDeFrance },
+  '03': { département: 'Allier', région: auvergneRhôneAlpes },
+  '04': { département: 'Alpes-de-Haute-Provence', région: paca },
+  '05': { département: 'Hautes-Alpes', région: paca },
+  '06': { département: 'Alpes-Maritimes', région: paca },
+  '07': { département: 'Ardèche', région: auvergneRhôneAlpes },
+  '08': { département: 'Ardennes', région: grandEst },
+  '09': { département: 'Ariège', région: occitanie },
+  '10': { département: 'Aube', région: grandEst },
+  '11': { département: 'Aude', région: occitanie },
+  '12': { département: 'Aveyron', région: occitanie },
+  '13': { département: 'Bouches-du-Rhône', région: paca },
+  '14': { département: 'Calvados', région: normandie },
+  '15': { département: 'Cantal', région: auvergneRhôneAlpes },
+  '16': { département: 'Charente', région: nouvelleAquitaine },
+  '17': { département: 'Charente-Maritime', région: nouvelleAquitaine },
+  '18': { département: 'Cher', région: centreValDeLoire },
+  '19': { département: 'Corrèze', région: nouvelleAquitaine },
+  '21': { département: "Côte-d'Or", région: bourgogneFrancheComté },
+  '22': { département: "Côtes-d'Armor", région: bretagne },
+  '23': { département: 'Creuse', région: nouvelleAquitaine },
+  '24': { département: 'Dordogne', région: nouvelleAquitaine },
+  '25': { département: 'Doubs', région: bourgogneFrancheComté },
+  '26': { département: 'Drôme', région: auvergneRhôneAlpes },
+  '27': { département: 'Eure', région: normandie },
+  '28': { département: 'Eure-et-Loir', région: centreValDeLoire },
+  '29': { département: 'Finistère', région: bretagne },
+  '30': { département: 'Gard', région: occitanie },
+  '31': { département: 'Haute-Garonne', région: occitanie },
+  '32': { département: 'Gers', région: occitanie },
+  '33': { département: 'Gironde', région: nouvelleAquitaine },
+  '34': { département: 'Hérault', région: occitanie },
+  '35': { département: 'Ille-et-Vilaine', région: bretagne },
+  '36': { département: 'Indre', région: centreValDeLoire },
+  '37': { département: 'Indre-et-Loire', région: centreValDeLoire },
+  '38': { département: 'Isère', région: auvergneRhôneAlpes },
+  '39': { département: 'Jura', région: bourgogneFrancheComté },
+  '40': { département: 'Landes', région: nouvelleAquitaine },
+  '41': { département: 'Loir-et-Cher', région: centreValDeLoire },
+  '42': { département: 'Loire', région: auvergneRhôneAlpes },
+  '43': { département: 'Haute-Loire', région: auvergneRhôneAlpes },
+  '44': { département: 'Loire-Atlantique', région: paysDeLaLoire },
+  '45': { département: 'Loiret', région: centreValDeLoire },
+  '46': { département: 'Lot', région: occitanie },
+  '47': { département: 'Lot-et-Garonne', région: nouvelleAquitaine },
+  '48': { département: 'Lozère', région: occitanie },
+  '49': { département: 'Maine-et-Loire', région: paysDeLaLoire },
+  '50': { département: 'Manche', région: normandie },
+  '51': { département: 'Marne', région: grandEst },
+  '52': { département: 'Haute-Marne', région: grandEst },
+  '53': { département: 'Mayenne', région: paysDeLaLoire },
+  '54': { département: 'Meurthe-et-Moselle', région: grandEst },
+  '55': { département: 'Meuse', région: grandEst },
+  '56': { département: 'Morbihan', région: bretagne },
+  '57': { département: 'Moselle', région: grandEst },
+  '58': { département: 'Nièvre', région: bourgogneFrancheComté },
+  '59': { département: 'Nord', région: hautsDeFrance },
+  '60': { département: 'Oise', région: hautsDeFrance },
+  '61': { département: 'Orne', région: normandie },
+  '62': { département: 'Pas-de-Calais', région: hautsDeFrance },
+  '63': { département: 'Puy-de-Dôme', région: auvergneRhôneAlpes },
+  '64': { département: 'Pyrénées-Atlantiques', région: nouvelleAquitaine },
+  '65': { département: 'Hautes-Pyrénées', région: occitanie },
+  '66': { département: 'Pyrénées-Orientales', région: occitanie },
+  '67': { département: 'Bas-Rhin', région: grandEst },
+  '68': { département: 'Haut-Rhin', région: grandEst },
+  '69': { département: 'Rhône', région: auvergneRhôneAlpes },
+  '70': { département: 'Haute-Saône', région: bourgogneFrancheComté },
+  '71': { département: 'Saône-et-Loire', région: bourgogneFrancheComté },
+  '72': { département: 'Sarthe', région: paysDeLaLoire },
+  '73': { département: 'Savoie', région: auvergneRhôneAlpes },
+  '74': { département: 'Haute-Savoie', région: auvergneRhôneAlpes },
+  '75': { département: 'Paris', région: idf },
+  '76': { département: 'Seine-Maritime', région: normandie },
+  '77': { département: 'Seine-et-Marne', région: idf },
+  '78': { département: 'Yvelines', région: idf },
+  '79': { département: 'Deux-Sèvres', région: nouvelleAquitaine },
+  '80': { département: 'Somme', région: hautsDeFrance },
+  '81': { département: 'Tarn', région: occitanie },
+  '82': { département: 'Tarn-et-Garonne', région: occitanie },
+  '83': { département: 'Var', région: paca },
+  '84': { département: 'Vaucluse', région: paca },
+  '85': { département: 'Vendée', région: paysDeLaLoire },
+  '86': { département: 'Vienne', région: nouvelleAquitaine },
+  '87': { département: 'Haute-Vienne', région: nouvelleAquitaine },
+  '88': { département: 'Vosges', région: grandEst },
+  '89': { département: 'Yonne', région: bourgogneFrancheComté },
+  '90': { département: 'Territoire de Belfort', région: bourgogneFrancheComté },
+  '91': { département: 'Essonne', région: idf },
+  '92': { département: 'Hauts-de-Seine', région: idf },
+  '93': { département: 'Seine-Saint-Denis', région: idf },
+  '94': { département: 'Val-de-Marne', région: idf },
+  '95': { département: "Val-d'Oise", région: idf },
+
+  // Outre mer
+  '971': { département: 'Guadeloupe', région: 'Guadeloupe' },
+  '972': { département: 'Martinique', région: 'Martinique' },
+  '973': { département: 'Guyane', région: 'Guyane' },
+  '974': { département: 'La Réunion', région: 'La Réunion' },
+  '976': { département: 'Mayotte', région: 'Mayotte' },
+
+  // Corse
+  '201': { département: 'Corse-du-Sud', région: corse },
+  '202': { département: 'Haute-Corse', région: corse },
+  // cas particulier Ajaccio, Furiani, Biguglia
+  '20000': { département: 'Corse-du-Sud', région: corse },
+  '20090': { département: 'Corse-du-Sud', région: corse },
+  '20600': { département: 'Haute-Corse', région: corse },
+  '20620': { département: 'Haute-Corse', région: corse },
+};

--- a/packages/applications/scheduled-tasks/src/candidature/migrate-project-import-events.ts
+++ b/packages/applications/scheduled-tasks/src/candidature/migrate-project-import-events.ts
@@ -421,7 +421,9 @@ type ProjectReimported = {
                 ...acc,
                 identifiantProjet:
                   IdentifiantProjet.convertirEnValueType(identifiantProjet).formatter(),
-                statut: payload.data.classe === 'Classé' ? 'classé' : 'éliminé',
+                ...(payload.data.classe && {
+                  statut: payload.data.classe === 'Classé' ? 'classé' : 'éliminé',
+                }),
                 ...(payload.data.nomProjet && { nomProjet: payload.data.nomProjet }),
                 ...(payload.data.actionnaire && { sociétéMère: payload.data.actionnaire }),
                 ...(payload.data.nomCandidat && { nomCandidat: payload.data.nomCandidat }),

--- a/packages/applications/scheduled-tasks/src/candidature/migrate-project-import-events.ts
+++ b/packages/applications/scheduled-tasks/src/candidature/migrate-project-import-events.ts
@@ -278,7 +278,8 @@ type ProjectReimported = {
       .concat(projectImportedEventsPerProjects)
       .concat(projectReimportedEventsPerProjects)
       .reduce((acc, { appel_offre, periode, famille, numero_cre, event_ids }) => {
-        const identifiantProjet: IdentifiantProjet.RawType = `${appel_offre}#${periode}#${famille}#${numero_cre}`;
+        const appelOffre = appel_offre.replace('PPE2 - Bâtiment 2', 'PPE2 - Bâtiment');
+        const identifiantProjet: IdentifiantProjet.RawType = `${appelOffre}#${periode}#${famille}#${numero_cre}`;
 
         const alreadyAddedEventIds = acc.get(identifiantProjet);
         acc.set(identifiantProjet, [...(alreadyAddedEventIds ?? []), ...event_ids]);

--- a/packages/applications/scheduled-tasks/src/candidature/migrate-project-import-events.ts
+++ b/packages/applications/scheduled-tasks/src/candidature/migrate-project-import-events.ts
@@ -1,0 +1,566 @@
+import { Candidature } from '@potentiel-domain/candidature';
+import { DateTime, IdentifiantProjet } from '@potentiel-domain/common';
+import { GarantiesFinancières } from '@potentiel-domain/laureat';
+import { publish } from '@potentiel-infrastructure/pg-event-sourcing';
+import { executeSelect } from '@potentiel-libraries/pg-helpers';
+
+import { getLocalité } from './getLocalité';
+
+type ProjectRawDataImported = {
+  type: 'ProjectRawDataImported';
+  occurredAt: number;
+  payload: {
+    data: {
+      periodeId: string;
+      appelOffreId: string;
+      familleId: string;
+      territoireProjet: string;
+      numeroCRE: string;
+      nomCandidat: string;
+      actionnaire: string;
+      nomProjet: string;
+      puissance: number;
+      prixReference: number;
+      evaluationCarbone: number;
+      note: number;
+      nomRepresentantLegal: string;
+      isFinancementParticipatif: boolean;
+      isInvestissementParticipatif: boolean;
+      engagementFournitureDePuissanceAlaPointe: boolean;
+      email: string;
+      adresseProjet: string;
+      codePostalProjet: string;
+      communeProjet: string;
+      departementProjet: string;
+      regionProjet: string;
+      classe: string;
+      motifsElimination: string;
+      notifiedOn: number;
+      details: Record<string, string>;
+      technologie: string;
+      actionnariat?: 'financement-collectif' | 'gouvernance-partagee';
+      garantiesFinancièresType?: string;
+      garantiesFinancièresDateEchéance?: string;
+      désignationCatégorie?: 'volume-réservé' | 'hors-volume-réservé';
+      historiqueAbandon?:
+        | 'première-candidature'
+        | 'abandon-classique'
+        | 'abandon-avec-recandidature'
+        | 'lauréat-autre-période';
+    };
+  };
+};
+
+type LegacyProjectSourced = {
+  type: 'LegacyProjectSourced';
+  occurredAt: number;
+  payload: {
+    projectId: string;
+    appelOffreId: string;
+    periodeId: string;
+    familleId: string;
+    numeroCRE: string;
+    potentielIdentifier: string;
+    content: {
+      periodeId: string;
+      appelOffreId: string;
+      familleId: string;
+      territoireProjet: string;
+      numeroCRE: string;
+      nomCandidat: string;
+      nomProjet: string;
+      puissance: number;
+      prixReference: number;
+      evaluationCarbone: number;
+      note: number;
+      nomRepresentantLegal: string;
+      isFinancementParticipatif: boolean;
+      isInvestissementParticipatif: boolean;
+      engagementFournitureDePuissanceAlaPointe: boolean;
+      email: string;
+      adresseProjet: string;
+      codePostalProjet: string;
+      communeProjet: string;
+      departementProjet: string;
+      regionProjet: string;
+      fournisseur: string;
+      actionnaire: string;
+      classe: string;
+      motifsElimination: string;
+      notifiedOn: number;
+      details: Record<string, string>;
+    };
+  };
+};
+
+type ProjectImported = {
+  type: 'ProjectImported';
+  occurredAt: number;
+  payload: {
+    projectId: string;
+    appelOffreId: string;
+    periodeId: string;
+    familleId: string;
+    numeroCRE: string;
+    potentielIdentifier: string;
+    importId: string;
+    data: {
+      periodeId: string;
+      appelOffreId: string;
+      familleId: string;
+      territoireProjet: string;
+      numeroCRE: string;
+      nomCandidat: string;
+      actionnaire: string;
+      nomProjet: string;
+      puissance: number;
+      prixReference: number;
+      evaluationCarbone: number;
+      note: number;
+      nomRepresentantLegal: string;
+      isFinancementParticipatif: boolean;
+      isInvestissementParticipatif: boolean;
+      engagementFournitureDePuissanceAlaPointe: boolean;
+      email: string;
+      adresseProjet: string;
+      codePostalProjet: string;
+      communeProjet: string;
+      departementProjet: string;
+      regionProjet: string;
+      classe: string;
+      motifsElimination: string;
+      notifiedOn: number;
+      details: Record<string, string>;
+      technologie: string;
+      actionnariat?: 'financement-collectif' | 'gouvernance-partagee';
+      soumisAuxGF?: true;
+      désignationCatégorie?: 'volume-réservé' | 'hors-volume-réservé';
+      historiqueAbandon?:
+        | 'première-candidature'
+        | 'abandon-classique'
+        | 'abandon-avec-recandidature'
+        | 'lauréat-autre-période';
+    };
+  };
+};
+
+type ProjectReimported = {
+  type: 'ProjectReimported';
+  occurredAt: number;
+  payload: {
+    projectId: string;
+    periodeId: string;
+    appelOffreId: string;
+    familleId?: string;
+    importId: string; // This field was added later
+    data: Partial<{
+      periodeId: string;
+      appelOffreId: string;
+      familleId: string;
+      territoireProjet: string;
+      numeroCRE: string;
+      nomCandidat: string;
+      nomProjet: string;
+      puissance: number;
+      prixReference: number;
+      evaluationCarbone: number;
+      note: number;
+      nomRepresentantLegal: string;
+      isFinancementParticipatif: boolean;
+      isInvestissementParticipatif: boolean;
+      engagementFournitureDePuissanceAlaPointe: boolean;
+      email: string;
+      adresseProjet: string;
+      codePostalProjet: string;
+      communeProjet: string;
+      departementProjet: string;
+      regionProjet: string;
+      actionnaire: string;
+      classe: string;
+      motifsElimination: string;
+      notifiedOn: number;
+      details: Record<string, string>;
+      technologie: string;
+      actionnariat?: 'financement-collectif' | 'gouvernance-partagee';
+    }>;
+  };
+};
+
+(async () => {
+  console.info(`ℹ️ Lancement du script [migrate-project-import-events] ...`);
+
+  const getProjectRawDataImportedEventsQuery = `
+    select payload->'data'->>'appelOffreId' as "appel_offre", 
+           payload->'data'->>'periodeId' as "periode", 
+           payload->'data'->>'familleId' as "famille", 
+           payload->'data'->>'numeroCRE' as "numero_cre", 
+           count(id) as "total_import",
+           array_agg(id) as "event_ids" 
+    from "eventStores" es 
+    where type = 'ProjectRawDataImported'
+    group by payload->'data'->>'appelOffreId', 
+             payload->'data'->>'periodeId', 
+             payload->'data'->>'familleId', 
+             payload->'data'->>'numeroCRE';
+  `;
+
+  const getLegacyProjectSourcedEventsQuery = `
+    select payload->>'appelOffreId' as "appel_offre", 
+           payload->>'periodeId' as "periode", 
+           payload->>'familleId' as "famille",
+           payload->>'numeroCRE' as "numero_cre", 
+           count(id) as "total_import",
+           array_agg(id) as "event_ids" 
+    from "eventStores" es 
+    where type = 'LegacyProjectSourced'
+    group by payload->>'appelOffreId', 
+             payload->>'periodeId', 
+             payload->>'familleId', 
+             payload->>'numeroCRE';
+  `;
+
+  const getProjectImportedEventsQuery = `
+    select payload->>'appelOffreId' as "appel_offre", 
+           payload->>'periodeId' as "periode", 
+           payload->>'familleId' as "famille",
+           payload->>'numeroCRE' as "numero_cre", 
+           count(id) as "total_import",
+           array_agg(id) as "event_ids" 
+    from "eventStores" es 
+    where type = 'ProjectImported'
+    group by payload->>'appelOffreId', 
+             payload->>'periodeId', 
+             payload->>'familleId', 
+             payload->>'numeroCRE';
+  `;
+
+  const getProjectReimportedEventsQuery = `
+    select p."appelOffreId" as "appel_offre", 
+       p."periodeId" as "periode", 
+       p."familleId" as "famille",
+       p."numeroCRE" as "numero_cre", 
+       count(es.id) as "total_import",
+       array_agg(es.id) as "event_ids" 
+    from "eventStores" es 
+    inner join projects p on es.payload->>'projectId' = p.id::text
+    where type = 'ProjectReimported'
+    group by p."appelOffreId", 
+            p."periodeId", 
+            p."familleId",
+            p."numeroCRE";
+
+  `;
+
+  try {
+    type EventIdsPerProject = {
+      appel_offre: string;
+      periode: string;
+      famille: string;
+      numero_cre: string;
+      total_import: number;
+      event_ids: string[];
+    };
+
+    const projectRawDataImportedEventsPerProjects = await executeSelect<EventIdsPerProject>(
+      getProjectRawDataImportedEventsQuery,
+    );
+    const legacyProjectSourcedEventsPerProjects = await executeSelect<EventIdsPerProject>(
+      getLegacyProjectSourcedEventsQuery,
+    );
+    const projectImportedEventsPerProjects = await executeSelect<EventIdsPerProject>(
+      getProjectImportedEventsQuery,
+    );
+    const projectReimportedEventsPerProjects = await executeSelect<EventIdsPerProject>(
+      getProjectReimportedEventsQuery,
+    );
+
+    const allEventsPerProject = projectRawDataImportedEventsPerProjects
+      .concat(legacyProjectSourcedEventsPerProjects)
+      .concat(projectImportedEventsPerProjects)
+      .concat(projectReimportedEventsPerProjects)
+      .reduce((acc, { appel_offre, periode, famille, numero_cre, event_ids }) => {
+        const identifiantProjet: IdentifiantProjet.RawType = `${appel_offre}#${periode}#${famille}#${numero_cre}`;
+
+        const alreadyAddedEventIds = acc.get(identifiantProjet);
+        acc.set(identifiantProjet, [...(alreadyAddedEventIds ?? []), ...event_ids]);
+
+        return acc;
+      }, new Map<IdentifiantProjet.RawType, Array<string>>());
+
+    console.info(`🧐 ${allEventsPerProject.size} projects found to migrate`);
+
+    let current = 0;
+    for (const [identifiantProjet, eventIds] of allEventsPerProject.entries()) {
+      console.info(`Processing project ${identifiantProjet}`);
+      current++;
+
+      const query = `
+        select type, payload, "occurredAt"
+        from "eventStores" es
+        where id = any($1)
+        order by "createdAt" asc;
+      `;
+
+      type Events =
+        | ProjectRawDataImported
+        | LegacyProjectSourced
+        | ProjectImported
+        | ProjectReimported;
+
+      const events = await executeSelect<Events>(query, eventIds);
+
+      const payload: Candidature.CandidatureImportéeEvent['payload'] = events.reduce(
+        (acc, { type, payload, occurredAt }) => {
+          switch (type) {
+            case 'ProjectRawDataImported':
+              const result1: Candidature.CandidatureImportéeEvent['payload'] = {
+                ...acc,
+                identifiantProjet:
+                  IdentifiantProjet.convertirEnValueType(identifiantProjet).formatter(),
+                statut: payload.data.classe === 'Classé' ? 'classé' : 'éliminé',
+                typeGarantiesFinancières: normaliserTypeGarantiesFinancières(
+                  payload.data.garantiesFinancièresType ?? acc.typeGarantiesFinancières,
+                ),
+                historiqueAbandon: normaliserHistoriqueAbandon(
+                  payload.data.historiqueAbandon ?? acc.historiqueAbandon,
+                ),
+                appelOffre: payload.data.appelOffreId,
+                période: payload.data.periodeId,
+                famille: payload.data.familleId,
+                numéroCRE: payload.data.numeroCRE,
+                nomProjet: payload.data.nomProjet,
+                sociétéMère: payload.data.actionnaire,
+                nomCandidat: payload.data.nomCandidat,
+                puissanceProductionAnnuelle: payload.data.puissance,
+                prixReference: payload.data.prixReference,
+                noteTotale: payload.data.note,
+                nomReprésentantLégal: payload.data.nomRepresentantLegal,
+                emailContact: payload.data.email,
+                localité: getLocalité({
+                  code_postaux: [payload.data.codePostalProjet],
+                  adresse1: payload.data.adresseProjet,
+                  adresse2: '',
+                  commune: payload.data.communeProjet,
+                }),
+                motifÉlimination: payload.data.motifsElimination || undefined,
+                puissanceALaPointe: payload.data.engagementFournitureDePuissanceAlaPointe,
+                evaluationCarboneSimplifiée: payload.data.evaluationCarbone,
+                technologie: normaliserTechnologie(payload.data.technologie ?? acc.technologie),
+                actionnariat: normaliserActionnariat(payload.data),
+                dateÉchéanceGf: payload.data.garantiesFinancièresDateEchéance
+                  ? DateTime.convertirEnValueType(
+                      new Date(payload.data.garantiesFinancièresDateEchéance),
+                    ).formatter()
+                  : undefined,
+                territoireProjet: payload.data.territoireProjet,
+                importéPar: 'team@potentiel.beta.gouv.fr',
+                importéLe: DateTime.convertirEnValueType(new Date(occurredAt)).formatter(),
+              };
+
+              return result1;
+
+            case 'LegacyProjectSourced':
+              const result2: Candidature.CandidatureImportéeEvent['payload'] = {
+                ...acc,
+                identifiantProjet:
+                  IdentifiantProjet.convertirEnValueType(identifiantProjet).formatter(),
+                statut: payload.content.classe === 'Classé' ? 'classé' : 'éliminé',
+                appelOffre: payload.appelOffreId,
+                période: payload.periodeId,
+                famille: payload.familleId,
+                numéroCRE: payload.numeroCRE,
+                nomProjet: payload.content.nomProjet,
+                sociétéMère: payload.content.actionnaire,
+                nomCandidat: payload.content.nomCandidat,
+                puissanceProductionAnnuelle: payload.content.puissance,
+                prixReference: payload.content.prixReference,
+                noteTotale: payload.content.note,
+                nomReprésentantLégal: payload.content.nomRepresentantLegal,
+                emailContact: payload.content.email,
+                localité: getLocalité({
+                  code_postaux: [payload.content.codePostalProjet],
+                  adresse1: payload.content.adresseProjet,
+                  adresse2: '',
+                  commune: payload.content.communeProjet,
+                }),
+                motifÉlimination: payload.content.motifsElimination || undefined,
+                puissanceALaPointe: payload.content.engagementFournitureDePuissanceAlaPointe,
+                evaluationCarboneSimplifiée: payload.content.evaluationCarbone,
+                actionnariat: normaliserActionnariat(payload.content),
+                territoireProjet: payload.content.territoireProjet,
+                importéPar: 'team@potentiel.beta.gouv.fr',
+                importéLe: DateTime.convertirEnValueType(new Date(occurredAt)).formatter(),
+              };
+
+              return result2;
+
+            case 'ProjectImported':
+              const result3: Candidature.CandidatureImportéeEvent['payload'] = {
+                ...acc,
+                identifiantProjet:
+                  IdentifiantProjet.convertirEnValueType(identifiantProjet).formatter(),
+                statut: payload.data.classe === 'Classé' ? 'classé' : 'éliminé',
+                appelOffre: payload.appelOffreId,
+                période: payload.periodeId,
+                famille: payload.familleId,
+                numéroCRE: payload.numeroCRE,
+                nomProjet: payload.data.nomProjet,
+                sociétéMère: payload.data.actionnaire,
+                nomCandidat: payload.data.nomCandidat,
+                puissanceProductionAnnuelle: payload.data.puissance,
+                prixReference: payload.data.prixReference,
+                noteTotale: payload.data.note,
+                nomReprésentantLégal: payload.data.nomRepresentantLegal,
+                emailContact: payload.data.email,
+                localité: getLocalité({
+                  code_postaux: [payload.data.codePostalProjet],
+                  adresse1: payload.data.adresseProjet,
+                  adresse2: '',
+                  commune: payload.data.communeProjet,
+                }),
+                motifÉlimination: payload.data.motifsElimination || undefined,
+                puissanceALaPointe: payload.data.engagementFournitureDePuissanceAlaPointe,
+                evaluationCarboneSimplifiée: payload.data.evaluationCarbone,
+                actionnariat: normaliserActionnariat(payload.data),
+                territoireProjet: payload.data.territoireProjet,
+                importéPar: 'team@potentiel.beta.gouv.fr',
+                importéLe: DateTime.convertirEnValueType(new Date(occurredAt)).formatter(),
+              };
+
+              return result3;
+
+            case 'ProjectReimported':
+              const result4: Candidature.CandidatureImportéeEvent['payload'] = {
+                ...acc,
+                identifiantProjet:
+                  IdentifiantProjet.convertirEnValueType(identifiantProjet).formatter(),
+                statut: payload.data.classe === 'Classé' ? 'classé' : 'éliminé',
+                appelOffre: payload.appelOffreId,
+                période: payload.periodeId,
+                ...(payload.familleId && { famille: payload.familleId }),
+                ...(payload.data.numeroCRE && { numéroCRE: payload.data.numeroCRE }),
+                ...(payload.data.nomProjet && { nomProjet: payload.data.nomProjet }),
+                ...(payload.data.actionnaire && { sociétéMère: payload.data.actionnaire }),
+                ...(payload.data.nomCandidat && { nomCandidat: payload.data.nomCandidat }),
+                ...(payload.data.puissance && {
+                  puissanceProductionAnnuelle: payload.data.puissance,
+                }),
+                ...(payload.data.prixReference && { prixReference: payload.data.prixReference }),
+                ...(payload.data.note && { noteTotale: payload.data.note }),
+                ...(payload.data.nomRepresentantLegal && {
+                  nomReprésentantLégal: payload.data.nomRepresentantLegal,
+                }),
+                ...(payload.data.email && { emailContact: payload.data.email }),
+                ...(payload.data.motifsElimination && {
+                  motifÉlimination: payload.data.motifsElimination,
+                }),
+                ...(payload.data.engagementFournitureDePuissanceAlaPointe && {
+                  puissanceALaPointe: payload.data.engagementFournitureDePuissanceAlaPointe,
+                }),
+                ...(payload.data.evaluationCarbone && {
+                  evaluationCarboneSimplifiée: payload.data.evaluationCarbone,
+                }),
+                ...(payload.data.isInvestissementParticipatif && {
+                  financementParticipatif: payload.data.isInvestissementParticipatif,
+                }),
+                ...(payload.data.territoireProjet && {
+                  territoireProjet: payload.data.territoireProjet,
+                }),
+                ...(normaliserActionnariat(payload.data) && {
+                  actionnariat: normaliserActionnariat(payload.data),
+                }),
+                localité: getLocalité({
+                  code_postaux: payload.data.codePostalProjet
+                    ? [payload.data.codePostalProjet]
+                    : [acc.localité?.codePostal ?? ''],
+                  adresse1: payload.data.adresseProjet ?? acc.localité?.adresse1 ?? '',
+                  adresse2: '',
+                  commune: payload.data.communeProjet ?? acc.localité?.commune ?? '',
+                }),
+                importéPar: 'team@potentiel.beta.gouv.fr',
+                importéLe: DateTime.convertirEnValueType(new Date(occurredAt)).formatter(),
+              };
+
+              return result4;
+          }
+        },
+        {
+          technologie: 'N/A',
+          historiqueAbandon: 'première-candidature',
+          typeGarantiesFinancières: 'type-inconnu',
+        } as Candidature.CandidatureImportéeEvent['payload'],
+      );
+
+      console.info(`Publishing event for project ${identifiantProjet}...`);
+
+      await publish(`candidature|${identifiantProjet}`, {
+        type: 'CandidatureImportée-V1',
+        payload,
+      });
+    }
+
+    const getAllProjects = `
+      select count(id) as "total_projects"
+      from projects;
+    `;
+
+    const [{ total_projects }] = await executeSelect<{ total_projects: number }>(getAllProjects);
+    console.info(`${current} events were published for ${total_projects} existant projects`);
+    console.info('\nFin du script ✨');
+  } catch (error) {
+    console.error(error as Error);
+  }
+
+  process.exit(0);
+})();
+
+const normaliserHistoriqueAbandon = (val: string | undefined) =>
+  !val || val === 'N/A'
+    ? Candidature.HistoriqueAbandon.premièreCandidature.type
+    : Candidature.HistoriqueAbandon.convertirEnValueType(val).type;
+
+const normaliserTypeGarantiesFinancières = (
+  val: string | undefined,
+): GarantiesFinancières.TypeGarantiesFinancières.RawType | undefined => {
+  if (!val) return 'type-inconnu';
+  switch (val) {
+    case `Garantie financière jusqu'à 6 mois après la date d'achèvement`:
+      return 'six-mois-après-achèvement';
+    case 'Consignation':
+      return 'consignation';
+    case `Garantie financière avec date d'échéance et à renouveler`:
+      return 'avec-date-échéance';
+    default:
+      try {
+        return GarantiesFinancières.TypeGarantiesFinancières.convertirEnValueType(val).type;
+      } catch {}
+      return 'type-inconnu';
+  }
+};
+
+const normaliserTechnologie = (technologie: string): Candidature.TypeTechnologie.RawType => {
+  return technologie
+    ? Candidature.TypeTechnologie.convertirEnValueType(technologie).type
+    : Candidature.TypeTechnologie.nonApplicable.type;
+};
+
+const normaliserActionnariat = ({
+  actionnariat,
+  isFinancementParticipatif,
+  isInvestissementParticipatif,
+}: Partial<
+  Pick<
+    ProjectRawDataImported['payload']['data'],
+    'actionnariat' | 'isFinancementParticipatif' | 'isInvestissementParticipatif'
+  >
+>) => {
+  return actionnariat === 'financement-collectif'
+    ? 'financement-collectif'
+    : actionnariat === 'gouvernance-partagee'
+      ? 'gouvernance-partagée'
+      : isFinancementParticipatif
+        ? 'financement-participatif'
+        : isInvestissementParticipatif
+          ? 'investissement-participatif'
+          : undefined;
+};

--- a/packages/applications/scheduled-tasks/src/candidature/migrate-project-import-events.ts
+++ b/packages/applications/scheduled-tasks/src/candidature/migrate-project-import-events.ts
@@ -1,6 +1,5 @@
 import { Candidature } from '@potentiel-domain/candidature';
 import { DateTime, IdentifiantProjet } from '@potentiel-domain/common';
-import { GarantiesFinancières } from '@potentiel-domain/laureat';
 import { publish } from '@potentiel-infrastructure/pg-event-sourcing';
 import { executeSelect } from '@potentiel-libraries/pg-helpers';
 
@@ -324,10 +323,6 @@ type ProjectReimported = {
                 historiqueAbandon: normaliserHistoriqueAbandon(
                   payload.data.historiqueAbandon ?? acc.historiqueAbandon,
                 ),
-                appelOffre: payload.data.appelOffreId,
-                période: payload.data.periodeId,
-                famille: payload.data.familleId,
-                numéroCRE: payload.data.numeroCRE,
                 nomProjet: payload.data.nomProjet,
                 sociétéMère: payload.data.actionnaire,
                 nomCandidat: payload.data.nomCandidat,
@@ -365,10 +360,6 @@ type ProjectReimported = {
                 identifiantProjet:
                   IdentifiantProjet.convertirEnValueType(identifiantProjet).formatter(),
                 statut: payload.content.classe === 'Classé' ? 'classé' : 'éliminé',
-                appelOffre: payload.appelOffreId,
-                période: payload.periodeId,
-                famille: payload.familleId,
-                numéroCRE: payload.numeroCRE,
                 nomProjet: payload.content.nomProjet,
                 sociétéMère: payload.content.actionnaire,
                 nomCandidat: payload.content.nomCandidat,
@@ -400,10 +391,6 @@ type ProjectReimported = {
                 identifiantProjet:
                   IdentifiantProjet.convertirEnValueType(identifiantProjet).formatter(),
                 statut: payload.data.classe === 'Classé' ? 'classé' : 'éliminé',
-                appelOffre: payload.appelOffreId,
-                période: payload.periodeId,
-                famille: payload.familleId,
-                numéroCRE: payload.numeroCRE,
                 nomProjet: payload.data.nomProjet,
                 sociétéMère: payload.data.actionnaire,
                 nomCandidat: payload.data.nomCandidat,
@@ -435,10 +422,6 @@ type ProjectReimported = {
                 identifiantProjet:
                   IdentifiantProjet.convertirEnValueType(identifiantProjet).formatter(),
                 statut: payload.data.classe === 'Classé' ? 'classé' : 'éliminé',
-                appelOffre: payload.appelOffreId,
-                période: payload.periodeId,
-                ...(payload.familleId && { famille: payload.familleId }),
-                ...(payload.data.numeroCRE && { numéroCRE: payload.data.numeroCRE }),
                 ...(payload.data.nomProjet && { nomProjet: payload.data.nomProjet }),
                 ...(payload.data.actionnaire && { sociétéMère: payload.data.actionnaire }),
                 ...(payload.data.nomCandidat && { nomCandidat: payload.data.nomCandidat }),
@@ -521,7 +504,7 @@ const normaliserHistoriqueAbandon = (val: string | undefined) =>
 
 const normaliserTypeGarantiesFinancières = (
   val: string | undefined,
-): GarantiesFinancières.TypeGarantiesFinancières.RawType | undefined => {
+): Candidature.TypeGarantiesFinancières.RawType | undefined => {
   if (!val) return 'type-inconnu';
   switch (val) {
     case `Garantie financière jusqu'à 6 mois après la date d'achèvement`:
@@ -532,7 +515,7 @@ const normaliserTypeGarantiesFinancières = (
       return 'avec-date-échéance';
     default:
       try {
-        return GarantiesFinancières.TypeGarantiesFinancières.convertirEnValueType(val).type;
+        return Candidature.TypeGarantiesFinancières.convertirEnValueType(val).type;
       } catch {}
       return 'type-inconnu';
   }


### PR DESCRIPTION
1er commit: le script tel qu'il était à la précédente migration
2e commit: retirer les champs supprimés depuis la migration
autres: les vrais corrections