### PR TITLE
♻️ Candidature notifiée

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29371,8 +29371,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@potentiel-domain/appel-offre": "*",
-        "@potentiel-domain/elimine": "*",
-        "@potentiel-domain/laureat": "*",
+        "@potentiel-domain/candidature": "*",
         "@react-pdf/renderer": "^3.1.14",
         "docxtemplater": "^3.42.3",
         "pizzip": "^3.1.4"
@@ -29875,6 +29874,7 @@
       "name": "@potentiel-domain/periode",
       "version": "0.0.0",
       "dependencies": {
+        "@potentiel-domain/candidature": "*",
         "@potentiel-domain/common": "*",
         "@potentiel-domain/core": "*",
         "@potentiel-domain/elimine": "*",

--- a/packages/applications/bootstrap/src/setupCandidature.ts
+++ b/packages/applications/bootstrap/src/setupCandidature.ts
@@ -2,9 +2,10 @@ import { mediator } from 'mediateur';
 
 import { Candidature } from '@potentiel-domain/candidature';
 import { CandidatureAdapter } from '@potentiel-infrastructure/domain-adapters';
-import { loadAggregate, subscribe } from '@potentiel-infrastructure/pg-event-sourcing';
+import { Event, loadAggregate, subscribe } from '@potentiel-infrastructure/pg-event-sourcing';
 import { CandidatureProjector } from '@potentiel-applications/projectors';
 import { findProjection, listProjection } from '@potentiel-infrastructure/pg-projections';
+import { AttestationSaga } from '@potentiel-applications/document-builder';
 
 export const setupCandidature = async () => {
   Candidature.registerCandidaturesUseCases({ loadAggregate });
@@ -22,7 +23,12 @@ export const setupCandidature = async () => {
 
   const unsubscribeCandidatureProjector = await subscribe<CandidatureProjector.SubscriptionEvent>({
     name: 'projector',
-    eventType: ['RebuildTriggered', 'CandidatureImportée-V1', 'CandidatureCorrigée-V1'],
+    eventType: [
+      'RebuildTriggered',
+      'CandidatureImportée-V1',
+      'CandidatureCorrigée-V1',
+      'CandidatureNotifiée-V1',
+    ],
     eventHandler: async (event) => {
       await mediator.send<CandidatureProjector.Execute>({
         type: 'System.Projector.Candidature',
@@ -32,7 +38,20 @@ export const setupCandidature = async () => {
     streamCategory: 'candidature',
   });
 
+  const unsubscribeAttestationSaga = await subscribe<AttestationSaga.SubscriptionEvent & Event>({
+    name: 'attestation-saga',
+    streamCategory: 'candidature',
+    eventType: ['CandidatureNotifiée-V1'],
+    eventHandler: async (event) => {
+      await mediator.publish<AttestationSaga.Execute>({
+        type: 'System.Candidature.Attestation.Saga.Execute',
+        data: event,
+      });
+    },
+  });
+
   return async () => {
     await unsubscribeCandidatureProjector();
+    await unsubscribeAttestationSaga();
   };
 };

--- a/packages/applications/bootstrap/src/setupLauréat.ts
+++ b/packages/applications/bootstrap/src/setupLauréat.ts
@@ -24,7 +24,6 @@ import {
   récupérerIdentifiantsProjetParEmailPorteurAdapter,
 } from '@potentiel-infrastructure/domain-adapters';
 import { SendEmail } from '@potentiel-applications/notifications';
-import { AttestationSaga } from '@potentiel-applications/document-builder';
 
 type SetupLauréatDependenices = {
   sendEmail: SendEmail;
@@ -66,18 +65,6 @@ export const setupLauréat = async ({ sendEmail }: SetupLauréatDependenices) =>
       });
     },
     streamCategory: 'lauréat',
-  });
-
-  const unsubscribeAttestationSaga = await subscribe<AttestationSaga.SubscriptionEvent & Event>({
-    name: 'attestation-saga',
-    streamCategory: 'lauréat',
-    eventType: ['LauréatNotifié-V1'],
-    eventHandler: async (event) => {
-      await mediator.publish<AttestationSaga.Execute>({
-        type: 'System.Candidature.Attestation.Saga.Execute',
-        data: event,
-      });
-    },
   });
 
   const unsubscribeLauréatSaga = await subscribe<Lauréat.LauréatSaga.SubscriptionEvent & Event>({
@@ -237,7 +224,6 @@ export const setupLauréat = async ({ sendEmail }: SetupLauréatDependenices) =>
 
   return async () => {
     await unsubscribeLauréatProjector();
-    await unsubscribeAttestationSaga();
     await unsubscribeAbandonNotification();
     await unsubscribeAbandonProjector();
     await unsubscribeGarantiesFinancièresProjector();

--- a/packages/applications/document-builder/package.json
+++ b/packages/applications/document-builder/package.json
@@ -11,8 +11,7 @@
   },
   "dependencies": {
     "@potentiel-domain/appel-offre": "*",
-    "@potentiel-domain/laureat": "*",
-    "@potentiel-domain/elimine": "*",
+    "@potentiel-domain/candidature": "*",
     "@react-pdf/renderer": "^3.1.14",
     "docxtemplater": "^3.42.3",
     "pizzip": "^3.1.4"

--- a/packages/applications/document-builder/tsconfig.json
+++ b/packages/applications/document-builder/tsconfig.json
@@ -13,10 +13,7 @@
       "path": "../../domain/appel-offre"
     },
     {
-      "path": "../../domain/lauréat"
-    },
-    {
-      "path": "../../domain/éliminé"
+      "path": "../../domain/candidature"
     },
     {
       "path": "../../libraries/monitoring"

--- a/packages/applications/projectors/src/subscribers/candidature/candidature.projector.ts
+++ b/packages/applications/projectors/src/subscribers/candidature/candidature.projector.ts
@@ -6,6 +6,7 @@ import { DateTime, IdentifiantProjet } from '@potentiel-domain/common';
 
 import { removeProjection } from '../../infrastructure/removeProjection';
 import { upsertProjection } from '../../infrastructure/upsertProjection';
+import { updateProjection } from '../../infrastructure/updateProjection';
 
 export type SubscriptionEvent = (Candidature.CandidatureEvent & Event) | RebuildTriggered;
 
@@ -57,6 +58,7 @@ export const register = () => {
               : undefined,
             technologie: Candidature.TypeTechnologie.convertirEnValueType(payload.technologie).type,
             misÀJourLe: type === 'CandidatureCorrigée-V1' ? payload.corrigéLe : payload.importéLe,
+            estNotifiée: false,
           };
 
           await upsertProjection<Candidature.CandidatureEntity>(
@@ -64,6 +66,11 @@ export const register = () => {
             candidature,
           );
           break;
+        case 'CandidatureNotifiée-V1':
+          await updateProjection<Candidature.CandidatureEntity>(
+            `candidature|${payload.identifiantProjet}`,
+            { estNotifiée: true },
+          );
       }
     }
   };

--- a/packages/domain/candidature/src/candidature.aggregate.ts
+++ b/packages/domain/candidature/src/candidature.aggregate.ts
@@ -35,7 +35,7 @@ export type CandidatureEvent =
 export type CandidatureAggregate = Aggregate<CandidatureEvent> & {
   statut?: StatutCandidature.ValueType;
   importé?: true;
-  estNotifiée?: true;
+  estNotifiée: boolean;
   payloadHash: string;
   importer: typeof importer;
   corriger: typeof corriger;
@@ -60,6 +60,7 @@ export const getDefaultCandidatureAggregate: GetDefaultAggregateState<
 > = () => ({
   identifiantProjet: IdentifiantProjet.inconnu,
   payloadHash: '',
+  estNotifiée: false,
   apply,
   importer,
   corriger,

--- a/packages/domain/candidature/src/candidature.aggregate.ts
+++ b/packages/domain/candidature/src/candidature.aggregate.ts
@@ -25,15 +25,21 @@ import {
   FamillePériodeAppelOffreInexistanteError,
   PériodeAppelOffreInexistanteError,
 } from './appelOffreInexistant.error';
+import { CandidatureNotifiéeEvent, notifier } from './notifier/notifierCandidature.behavior';
 
-export type CandidatureEvent = CandidatureImportéeEvent | CandidatureCorrigéeEvent;
+export type CandidatureEvent =
+  | CandidatureImportéeEvent
+  | CandidatureCorrigéeEvent
+  | CandidatureNotifiéeEvent;
 
 export type CandidatureAggregate = Aggregate<CandidatureEvent> & {
   statut?: StatutCandidature.ValueType;
   importé?: true;
+  estNotifiée?: true;
   payloadHash: string;
   importer: typeof importer;
   corriger: typeof corriger;
+  notifier: typeof notifier;
   calculerHash(payload: CandidatureEvent['payload']): string;
   estIdentiqueÀ(payload: CandidatureEvent['payload']): boolean;
 
@@ -57,6 +63,7 @@ export const getDefaultCandidatureAggregate: GetDefaultAggregateState<
   apply,
   importer,
   corriger,
+  notifier,
   calculerHash(payload) {
     const copy = { ...payload } as Partial<
       CandidatureImportéeEvent['payload'] & CandidatureCorrigéeEvent['payload']

--- a/packages/domain/candidature/src/candidature.entity.ts
+++ b/packages/domain/candidature/src/candidature.entity.ts
@@ -37,5 +37,7 @@ export type CandidatureEntity = Entity<
     dateÉchéanceGf?: DateTime.RawType;
     territoireProjet: string;
     misÀJourLe: DateTime.RawType;
+
+    estNotifiée: boolean;
   }
 >;

--- a/packages/domain/candidature/src/candidature.ts
+++ b/packages/domain/candidature/src/candidature.ts
@@ -26,6 +26,8 @@ import {
   ListerCandidaturesQuery,
   ListerCandidaturesReadModel,
 } from './lister/listerCandidatures.query';
+import { NotifierCandidatureUseCase } from './notifier/notifierCandidature.usecase';
+import { CandidatureNotifiéeEvent } from './notifier/notifierCandidature.behavior';
 
 // Query
 export type CandidatureQuery =
@@ -49,13 +51,19 @@ export {
 };
 
 // UseCases
-export type CandidatureUseCase = ImporterCandidatureUseCase | CorrigerCandidatureUseCase;
-export { ImporterCandidatureUseCase, CorrigerCandidatureUseCase };
+export type CandidatureUseCase =
+  | ImporterCandidatureUseCase
+  | CorrigerCandidatureUseCase
+  | NotifierCandidatureUseCase;
+export { ImporterCandidatureUseCase, CorrigerCandidatureUseCase, NotifierCandidatureUseCase };
 
 // Events
-export type CandidatureEvent = CandidatureImportéeEvent | CandidatureCorrigéeEvent;
+export type CandidatureEvent =
+  | CandidatureImportéeEvent
+  | CandidatureCorrigéeEvent
+  | CandidatureNotifiéeEvent;
 
-export { CandidatureImportéeEvent, CandidatureCorrigéeEvent };
+export { CandidatureImportéeEvent, CandidatureCorrigéeEvent, CandidatureNotifiéeEvent };
 
 // Register
 export * from './register';

--- a/packages/domain/candidature/src/consulter/consulterCandidature.query.ts
+++ b/packages/domain/candidature/src/consulter/consulterCandidature.query.ts
@@ -41,6 +41,8 @@ export type ConsulterCandidatureReadModel = {
   misÀJourLe: DateTime.ValueType;
 
   détails: DocumentProjet.ValueType;
+
+  estNotifiée: boolean;
 };
 
 export type ConsulterCandidatureQuery = Message<
@@ -91,6 +93,7 @@ export const mapToReadModel = ({
   actionnariat,
   territoireProjet,
   misÀJourLe,
+  estNotifiée,
 }: CandidatureEntity): ConsulterCandidatureReadModel => ({
   identifiantProjet: IdentifiantProjet.convertirEnValueType(identifiantProjet),
   statut: StatutCandidature.convertirEnValueType(statut),
@@ -121,4 +124,5 @@ export const mapToReadModel = ({
     misÀJourLe,
     'application/json',
   ),
+  estNotifiée,
 });

--- a/packages/domain/candidature/src/lister/listerCandidatures.query.ts
+++ b/packages/domain/candidature/src/lister/listerCandidatures.query.ts
@@ -24,6 +24,7 @@ export type CandidaturesListItemReadModel = {
     région: ConsulterCandidatureReadModel['localité']['région'];
   };
   détails: ConsulterCandidatureReadModel['détails'];
+  estNotifiée: boolean;
 };
 
 export type ListerCandidaturesReadModel = Readonly<{
@@ -42,6 +43,7 @@ export type ListerCandidaturesQuery = Message<
     statut?: StatutCandidature.RawType;
     identifiantProjets?: Array<IdentifiantProjet.RawType>;
     excludedIdentifiantProjets?: Array<IdentifiantProjet.RawType>;
+    estNotifiée?: boolean;
   },
   ListerCandidaturesReadModel
 >;
@@ -59,6 +61,7 @@ export const registerListerCandidaturesQuery = ({ list }: ListerCandidaturesQuer
     statut,
     excludedIdentifiantProjets,
     identifiantProjets,
+    estNotifiée,
   }) => {
     const {
       items,
@@ -70,6 +73,7 @@ export const registerListerCandidaturesQuery = ({ list }: ListerCandidaturesQuer
         période: Where.equal(période),
         nomProjet: Where.contains(nomProjet),
         statut: Where.equal(statut),
+        estNotifiée: Where.equal(estNotifiée),
         identifiantProjet: identifiantProjets?.length
           ? Where.include(identifiantProjets)
           : Where.notInclude(excludedIdentifiantProjets),
@@ -101,6 +105,7 @@ export const mapToReadModel = ({
   localité: { commune, département, région },
   evaluationCarboneSimplifiée,
   misÀJourLe,
+  estNotifiée,
 }: CandidatureEntity): CandidaturesListItemReadModel => ({
   identifiantProjet: IdentifiantProjet.convertirEnValueType(identifiantProjet),
   statut: StatutCandidature.convertirEnValueType(statut),
@@ -122,4 +127,5 @@ export const mapToReadModel = ({
     misÀJourLe,
     'application/json',
   ),
+  estNotifiée,
 });

--- a/packages/domain/candidature/src/notifier/notifierCandidature.behavior.ts
+++ b/packages/domain/candidature/src/notifier/notifierCandidature.behavior.ts
@@ -1,0 +1,61 @@
+import { DomainEvent, InvalidOperationError } from '@potentiel-domain/core';
+import { DateTime, Email, IdentifiantProjet } from '@potentiel-domain/common';
+
+import { CandidatureAggregate } from '../candidature.aggregate';
+
+export type NotifierOptions = {
+  identifiantProjet: IdentifiantProjet.ValueType;
+  notifiéLe: DateTime.ValueType;
+  notifiéPar: Email.ValueType;
+  attestation: {
+    format: string;
+  };
+};
+
+export type CandidatureNotifiéeEvent = DomainEvent<
+  'CandidatureNotifiée-V1',
+  {
+    identifiantProjet: IdentifiantProjet.RawType;
+    notifiéeLe: DateTime.RawType;
+    notifiéePar: Email.RawType;
+
+    attestation: {
+      format: string;
+    };
+  }
+>;
+
+export async function notifier(
+  this: CandidatureAggregate,
+  { identifiantProjet, notifiéLe, notifiéPar, attestation: { format } }: NotifierOptions,
+) {
+  if (this.estNotifiée) {
+    throw new CandidatureDéjàNotifiéeError(identifiantProjet);
+  }
+  const event: CandidatureNotifiéeEvent = {
+    type: 'CandidatureNotifiée-V1',
+    payload: {
+      identifiantProjet: identifiantProjet.formatter(),
+      notifiéeLe: notifiéLe.formatter(),
+      notifiéePar: notifiéPar.formatter(),
+      attestation: {
+        format,
+      },
+    },
+  };
+
+  await this.publish(event);
+}
+
+export function applyCandidatureNotifié(
+  this: CandidatureAggregate,
+  _event: CandidatureNotifiéeEvent,
+) {
+  this.estNotifiée = true;
+}
+
+class CandidatureDéjàNotifiéeError extends InvalidOperationError {
+  constructor(identifiantProjet: IdentifiantProjet.ValueType) {
+    super(`La candidature est déjà notifiée`, { identifiantProjet });
+  }
+}

--- a/packages/domain/candidature/src/notifier/notifierCandidature.behavior.ts
+++ b/packages/domain/candidature/src/notifier/notifierCandidature.behavior.ts
@@ -5,8 +5,8 @@ import { CandidatureAggregate } from '../candidature.aggregate';
 
 export type NotifierOptions = {
   identifiantProjet: IdentifiantProjet.ValueType;
-  notifiéLe: DateTime.ValueType;
-  notifiéPar: Email.ValueType;
+  notifiéeLe: DateTime.ValueType;
+  notifiéePar: Email.ValueType;
   attestation: {
     format: string;
   };
@@ -27,7 +27,7 @@ export type CandidatureNotifiéeEvent = DomainEvent<
 
 export async function notifier(
   this: CandidatureAggregate,
-  { identifiantProjet, notifiéLe, notifiéPar, attestation: { format } }: NotifierOptions,
+  { identifiantProjet, notifiéeLe, notifiéePar, attestation: { format } }: NotifierOptions,
 ) {
   if (this.estNotifiée) {
     throw new CandidatureDéjàNotifiéeError(identifiantProjet);
@@ -36,8 +36,8 @@ export async function notifier(
     type: 'CandidatureNotifiée-V1',
     payload: {
       identifiantProjet: identifiantProjet.formatter(),
-      notifiéeLe: notifiéLe.formatter(),
-      notifiéePar: notifiéPar.formatter(),
+      notifiéeLe: notifiéeLe.formatter(),
+      notifiéePar: notifiéePar.formatter(),
       attestation: {
         format,
       },

--- a/packages/domain/candidature/src/notifier/notifierCandidature.command.ts
+++ b/packages/domain/candidature/src/notifier/notifierCandidature.command.ts
@@ -1,0 +1,26 @@
+import { Message, MessageHandler, mediator } from 'mediateur';
+
+import { LoadAggregate } from '@potentiel-domain/core';
+import { DateTime, Email, IdentifiantProjet } from '@potentiel-domain/common';
+
+import { loadCandidatureFactory } from '../candidature.aggregate';
+
+export type NotifierCandidatureCommand = Message<
+  'Candidature.Command.NotifierCandidature',
+  {
+    identifiantProjet: IdentifiantProjet.ValueType;
+    notifiéLe: DateTime.ValueType;
+    notifiéPar: Email.ValueType;
+    attestation: { format: string };
+  }
+>;
+
+export const registerNotifierCandidatureCommand = (loadAggregate: LoadAggregate) => {
+  const loadCandidatureAggregate = loadCandidatureFactory(loadAggregate);
+  const handler: MessageHandler<NotifierCandidatureCommand> = async (payload) => {
+    const candidature = await loadCandidatureAggregate(payload.identifiantProjet, false);
+    await candidature.notifier(payload);
+  };
+
+  mediator.register('Candidature.Command.NotifierCandidature', handler);
+};

--- a/packages/domain/candidature/src/notifier/notifierCandidature.command.ts
+++ b/packages/domain/candidature/src/notifier/notifierCandidature.command.ts
@@ -9,8 +9,8 @@ export type NotifierCandidatureCommand = Message<
   'Candidature.Command.NotifierCandidature',
   {
     identifiantProjet: IdentifiantProjet.ValueType;
-    notifiéLe: DateTime.ValueType;
-    notifiéPar: Email.ValueType;
+    notifiéeLe: DateTime.ValueType;
+    notifiéePar: Email.ValueType;
     attestation: { format: string };
   }
 >;

--- a/packages/domain/candidature/src/notifier/notifierCandidature.usecase.ts
+++ b/packages/domain/candidature/src/notifier/notifierCandidature.usecase.ts
@@ -8,8 +8,8 @@ export type NotifierCandidatureUseCase = Message<
   'Candidature.UseCase.NotifierCandidature',
   {
     identifiantProjetValue: string;
-    notifiéLeValue: string;
-    notifiéParValue: string;
+    notifiéeLeValue: string;
+    notifiéeParValue: string;
     attestationValue: {
       format: string;
     };
@@ -19,16 +19,16 @@ export type NotifierCandidatureUseCase = Message<
 export const registerNotifierCandidatureUseCase = () => {
   const handler: MessageHandler<NotifierCandidatureUseCase> = async ({
     identifiantProjetValue,
-    notifiéParValue,
-    notifiéLeValue,
+    notifiéeParValue,
+    notifiéeLeValue,
     attestationValue: { format },
   }) => {
     await mediator.send<NotifierCandidatureCommand>({
       type: 'Candidature.Command.NotifierCandidature',
       data: {
         identifiantProjet: IdentifiantProjet.convertirEnValueType(identifiantProjetValue),
-        notifiéLe: DateTime.convertirEnValueType(notifiéLeValue),
-        notifiéPar: Email.convertirEnValueType(notifiéParValue),
+        notifiéeLe: DateTime.convertirEnValueType(notifiéeLeValue),
+        notifiéePar: Email.convertirEnValueType(notifiéeParValue),
         attestation: { format },
       },
     });

--- a/packages/domain/candidature/src/notifier/notifierCandidature.usecase.ts
+++ b/packages/domain/candidature/src/notifier/notifierCandidature.usecase.ts
@@ -1,0 +1,38 @@
+import { Message, MessageHandler, mediator } from 'mediateur';
+
+import { DateTime, Email, IdentifiantProjet } from '@potentiel-domain/common';
+
+import { NotifierCandidatureCommand } from './notifierCandidature.command';
+
+export type NotifierCandidatureUseCase = Message<
+  'Candidature.UseCase.NotifierCandidature',
+  {
+    identifiantProjetValue: string;
+    notifiéLeValue: string;
+    notifiéParValue: string;
+    attestationValue: {
+      format: string;
+    };
+  }
+>;
+
+export const registerNotifierCandidatureUseCase = () => {
+  const handler: MessageHandler<NotifierCandidatureUseCase> = async ({
+    identifiantProjetValue,
+    notifiéParValue,
+    notifiéLeValue,
+    attestationValue: { format },
+  }) => {
+    await mediator.send<NotifierCandidatureCommand>({
+      type: 'Candidature.Command.NotifierCandidature',
+      data: {
+        identifiantProjet: IdentifiantProjet.convertirEnValueType(identifiantProjetValue),
+        notifiéLe: DateTime.convertirEnValueType(notifiéLeValue),
+        notifiéPar: Email.convertirEnValueType(notifiéParValue),
+        attestation: { format },
+      },
+    });
+  };
+
+  mediator.register('Candidature.UseCase.NotifierCandidature', handler);
+};

--- a/packages/domain/candidature/src/register.ts
+++ b/packages/domain/candidature/src/register.ts
@@ -21,6 +21,8 @@ import {
   ListerCandidaturesQueryDependencies,
   registerListerCandidaturesQuery,
 } from './lister/listerCandidatures.query';
+import { registerNotifierCandidatureCommand } from './notifier/notifierCandidature.command';
+import { registerNotifierCandidatureUseCase } from './notifier/notifierCandidature.usecase';
 
 type CandidatureQueryDependencies = ConsulterProjetDependencies &
   ListerProjetsEligiblesPreuveRecanditureDependencies &
@@ -43,7 +45,9 @@ export const registerCandidatureQueries = (dependencies: CandidatureQueryDepende
 export const registerCandidaturesUseCases = ({ loadAggregate }: CandiatureUseCasesDependencies) => {
   registerImporterCandidatureCommand(loadAggregate);
   registerCorrigerCandidatureCommand(loadAggregate);
+  registerNotifierCandidatureCommand(loadAggregate);
 
   registerImporterCandidatureUseCase();
   registerCorrigerCandidatureUseCase();
+  registerNotifierCandidatureUseCase();
 };

--- a/packages/domain/lauréat/src/lauréat.aggregate.ts
+++ b/packages/domain/lauréat/src/lauréat.aggregate.ts
@@ -16,7 +16,6 @@ export type LauréatEvent = LauréatNotifiéEvent;
 
 export type LauréatAggregate = Aggregate<LauréatEvent> & {
   identifiantProjet: IdentifiantProjet.ValueType;
-  estNotifié?: true;
   notifier: typeof notifier;
 };
 

--- a/packages/domain/lauréat/src/notifier/notifierLauréat.behavior.ts
+++ b/packages/domain/lauréat/src/notifier/notifierLauréat.behavior.ts
@@ -44,6 +44,4 @@ export async function notifier(
   await this.publish(event);
 }
 
-export function applyLauréatNotifié(this: LauréatAggregate, _event: LauréatNotifiéEvent) {
-  this.estNotifié = true;
-}
+export function applyLauréatNotifié(this: LauréatAggregate, _event: LauréatNotifiéEvent) {}

--- a/packages/domain/période/package.json
+++ b/packages/domain/période/package.json
@@ -14,7 +14,8 @@
     "@potentiel-domain/core": "*",
     "@potentiel-domain/utilisateur": "*",
     "@potentiel-domain/laureat": "*",
-    "@potentiel-domain/elimine": "*"
+    "@potentiel-domain/elimine": "*",
+    "@potentiel-domain/candidature": "*"
   },
   "devDependencies": {
     "@potentiel-config/tsconfig": "*"

--- a/packages/domain/période/src/notifier/notifierPériode.command.ts
+++ b/packages/domain/période/src/notifier/notifierPériode.command.ts
@@ -37,6 +37,18 @@ export const registerNotifierPériodeCommand = (loadAggregate: LoadAggregate) =>
       const candidature = await loadCandidature(identifiantCandidature);
 
       try {
+        await mediator.send<Candidature.NotifierCandidatureUseCase>({
+          type: 'Candidature.UseCase.NotifierCandidature',
+          data: {
+            identifiantProjetValue: identifiantCandidature.formatter(),
+            notifiéLeValue: notifiéeLe.formatter(),
+            notifiéParValue: notifiéePar.formatter(),
+            attestationValue: {
+              format: 'application/pdf',
+            },
+          },
+        });
+
         if (candidature.statut?.estClassé()) {
           await mediator.send<Lauréat.NotifierLauréatUseCase>({
             type: 'Lauréat.UseCase.NotifierLauréat',

--- a/packages/domain/période/src/notifier/notifierPériode.command.ts
+++ b/packages/domain/période/src/notifier/notifierPériode.command.ts
@@ -41,8 +41,8 @@ export const registerNotifierPériodeCommand = (loadAggregate: LoadAggregate) =>
           type: 'Candidature.UseCase.NotifierCandidature',
           data: {
             identifiantProjetValue: identifiantCandidature.formatter(),
-            notifiéLeValue: notifiéeLe.formatter(),
-            notifiéParValue: notifiéePar.formatter(),
+            notifiéeLeValue: notifiéeLe.formatter(),
+            notifiéeParValue: notifiéePar.formatter(),
             attestationValue: {
               format: 'application/pdf',
             },

--- a/packages/domain/période/tsconfig.json
+++ b/packages/domain/période/tsconfig.json
@@ -16,6 +16,15 @@
     },
     {
       "path": "../core"
+    },
+    {
+      "path": "../lauréat"
+    },
+    {
+      "path": "../éliminé"
+    },
+    {
+      "path": "../candidature"
     }
   ]
 }

--- a/packages/domain/utilisateur/src/role.valueType.ts
+++ b/packages/domain/utilisateur/src/role.valueType.ts
@@ -247,10 +247,12 @@ const référencielPermissions = {
     usecase: {
       importer: 'Candidature.UseCase.ImporterCandidature',
       corriger: 'Candidature.UseCase.CorrigerCandidature',
+      notifier: 'Candidature.UseCase.NotifierCandidature',
     },
     command: {
       importer: 'Candidature.Command.ImporterCandidature',
       corriger: 'Candidature.Command.CorrigerCandidature',
+      notifier: 'Candidature.Command.NotifierCandidature',
     },
   },
   période: {

--- a/packages/domain/éliminé/src/notifier/notifierÉliminé.behavior.ts
+++ b/packages/domain/éliminé/src/notifier/notifierÉliminé.behavior.ts
@@ -43,6 +43,4 @@ export async function notifier(
   await this.publish(event);
 }
 
-export function applyÉliminéNotifié(this: ÉliminéAggregate, _event: ÉliminéNotifiéEvent) {
-  this.estNotifié = true;
-}
+export function applyÉliminéNotifié(this: ÉliminéAggregate, _event: ÉliminéNotifiéEvent) {}

--- a/packages/domain/éliminé/src/éliminé.aggregate.ts
+++ b/packages/domain/éliminé/src/éliminé.aggregate.ts
@@ -21,7 +21,6 @@ export type ÉliminéEvent = ÉliminéNotifiéEvent | ÉliminéArchivéEvent;
 
 export type ÉliminéAggregate = Aggregate<ÉliminéEvent> & {
   identifiantProjet: IdentifiantProjet.ValueType;
-  estNotifié?: true;
   estArchivé: boolean;
   archiver: typeof archiver;
   notifier: typeof notifier;

--- a/packages/specifications/src/candidature/candidature.world.ts
+++ b/packages/specifications/src/candidature/candidature.world.ts
@@ -110,6 +110,7 @@ export class CandidatureWorld {
       ),
 
       misÀJourLe: DateTime.convertirEnValueType(misÀJourLe),
+      estNotifiée: false,
     };
   }
 }

--- a/packages/specifications/src/candidature/stepDefinitions/candidature.then.ts
+++ b/packages/specifications/src/candidature/stepDefinitions/candidature.then.ts
@@ -52,3 +52,20 @@ Alors(
     });
   },
 );
+
+Alors(
+  'les candidatures de la période notifiée devraient être notifiées',
+  async function (this: PotentielWorld) {
+    const { identifiantPériode } = this.périodeWorld;
+    const candidatures = await mediator.send<Candidature.ListerCandidaturesQuery>({
+      type: 'Candidature.Query.ListerCandidatures',
+      data: {
+        appelOffre: identifiantPériode.appelOffre,
+        période: identifiantPériode.période,
+      },
+    });
+    for (const candidature of candidatures.items) {
+      expect(candidature.estNotifiée, "La candidature n'est pas notifiée").to.be.true;
+    }
+  },
+);

--- a/packages/specifications/src/période/notifierPériode.feature
+++ b/packages/specifications/src/période/notifierPériode.feature
@@ -8,5 +8,6 @@ Fonctionnalité: Notifier une période d'un appel d'offres
     Scénario: Notifier les candidats d'une période d'un appel d'offres
         Quand un DGEC validateur notifie la période d'un appel d'offres
         Alors la période devrait être notifiée avec les lauréats et les éliminés
+        Et les candidatures de la période notifiée devraient être notifiées
         Et le porteur a été prévenu que sa candidature a été notifiée
         Et les lauréats et éliminés devraient être consultables


### PR DESCRIPTION
Un nouvel évenement CandidatureNotifiée est ajouté. Il est redondant avec `LauréatNotifié` et `ÉliminéNotifié`, mais permet:
- de simplifier la saga attestation en réaction à ces deux événements
- d'avoir l'information `estNotifiée` sur une candidature, afin de permettre un filtre et la fonctionalité "notifier des candidats oubliés d'une période"
- de simplifier le téléchargement de l'attestation (on peut retrouver l'attestation en 1 query, plutot que vérifier lauréat et éliminé). Non implémenté dans cette PR
