### PR TITLE
🐛 Fix/ raccordement text & alert

### DIFF
--- a/packages/applications/legacy/src/views/pages/projectDetailsPage/ProjectDetails.tsx
+++ b/packages/applications/legacy/src/views/pages/projectDetailsPage/ProjectDetails.tsx
@@ -195,8 +195,9 @@ const AlerteBoxRaccordement: FC<{
         Vous devez déposer une demande de raccordement avant le {afficherDate(dcrDueOn)} auprès de
         votre gestionnaire de réseau.
         <br />
-        L'accusé de réception de cette demande transmis sur Potentiel facilitera vos démarches
-        administratives avec les différents acteurs connectés à Potentiel (DGEC, DREAL,
+        L'accusé de réception de cette demande ainsi que les documents complémentaires (proposition
+        technique et financière…) transmis sur Potentiel faciliteront vos démarches administratives
+        avec les différents acteurs connectés à Potentiel (DGEC, services de l'Etat en région,
         Cocontractant, etc.).
       </p>
     )}

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/raccordements/demande-complete-raccordement:transmettre/page.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/raccordements/demande-complete-raccordement:transmettre/page.tsx
@@ -54,11 +54,20 @@ export default async function Page({ params: { identifiant } }: IdentifiantParam
         data: { identifiantProjetValue: identifiantProjet },
       });
 
+    const raccordements = await mediator.send<Raccordement.ConsulterRaccordementQuery>({
+      type: 'Réseau.Raccordement.Query.ConsulterRaccordement',
+      data: { identifiantProjetValue: identifiantProjet },
+    });
+
+    const aDéjàTransmisUneDemandeComplèteDeRaccordement =
+      Option.isSome(raccordements) && raccordements.dossiers.length > 0;
+
     const props: TransmettreDemandeComplèteRaccordementPageProps = mapToProps({
       gestionnairesRéseau,
       appelOffre,
       gestionnaireRéseau: gestionnaire,
       identifiantProjet: IdentifiantProjet.convertirEnValueType(identifiantProjet),
+      aDéjàTransmisUneDemandeComplèteDeRaccordement,
     });
 
     return <TransmettreDemandeComplèteRaccordementPage {...props} />;
@@ -70,6 +79,7 @@ type MapToProps = (args: {
   appelOffre: AppelOffre.ConsulterAppelOffreReadModel;
   gestionnaireRéseau: Option.Type<Raccordement.ConsulterGestionnaireRéseauRaccordementReadModel>;
   identifiantProjet: IdentifiantProjet.ValueType;
+  aDéjàTransmisUneDemandeComplèteDeRaccordement: boolean;
 }) => TransmettreDemandeComplèteRaccordementPageProps;
 
 const mapToProps: MapToProps = ({
@@ -77,6 +87,7 @@ const mapToProps: MapToProps = ({
   appelOffre,
   gestionnaireRéseau,
   identifiantProjet,
+  aDéjàTransmisUneDemandeComplèteDeRaccordement,
 }) => {
   return {
     delaiDemandeDeRaccordementEnMois: appelOffre.periodes.find(
@@ -97,5 +108,6 @@ const mapToProps: MapToProps = ({
       },
     })),
     identifiantProjet: identifiantProjet.formatter(),
+    aDéjàTransmisUneDemandeComplèteDeRaccordement,
   };
 };

--- a/packages/applications/ssr/src/components/pages/attestation-conformité/AttestationConformité.form.tsx
+++ b/packages/applications/ssr/src/components/pages/attestation-conformité/AttestationConformité.form.tsx
@@ -73,22 +73,6 @@ export const AttestationConformitéForm: FC<AttestationConformitéFormProps> = (
           label="Attestation de conformité"
           state={validationErrors.includes('attestation') ? 'error' : 'default'}
         />
-        <Alert
-          severity="info"
-          small
-          description={
-            <p className="p-3">
-              Vous devez transmettre sur Potentiel la preuve, ainsi que la date de transmission au
-              co-contractant, car d'après les cahiers des charges, l'achèvement ou date d’achèvement
-              est la :
-              <br />
-              <span className="italic">
-                Date de fourniture au cocontractant de l’attestation de conformité mentionnée à
-                l’article R. 311-27-1 du code de l’énergie.
-              </span>
-            </p>
-          }
-        />
 
         <UploadDocument
           name="preuveTransmissionAuCocontractant"

--- a/packages/applications/ssr/src/components/pages/attestation-conformité/InfoAttestationConformité.tsx
+++ b/packages/applications/ssr/src/components/pages/attestation-conformité/InfoAttestationConformité.tsx
@@ -1,0 +1,20 @@
+import Alert from '@codegouvfr/react-dsfr/Alert';
+
+export const InfoBoxAttestationConformitéForm = () => (
+  <Alert
+    severity="info"
+    small
+    description={
+      <p className="p-3">
+        Vous devez transmettre sur Potentiel la preuve, ainsi que la date de transmission au
+        co-contractant, car d'après les cahiers des charges, l'achèvement ou date d’achèvement est
+        la :
+        <br />
+        <span className="italic">
+          Date de fourniture au cocontractant de l’attestation de conformité mentionnée à l’article
+          R. 311-27-1 du code de l’énergie.
+        </span>
+      </p>
+    }
+  />
+);

--- a/packages/applications/ssr/src/components/pages/attestation-conformité/InfoAttestationConformité.tsx
+++ b/packages/applications/ssr/src/components/pages/attestation-conformité/InfoAttestationConformité.tsx
@@ -1,6 +1,6 @@
 import Alert from '@codegouvfr/react-dsfr/Alert';
 
-export const InfoBoxAttestationConformitéForm = () => (
+export const InfoBoxAttestationConformité = () => (
   <Alert
     severity="info"
     small

--- a/packages/applications/ssr/src/components/pages/attestation-conformité/modifier/modifierAttestationConformité.page.tsx
+++ b/packages/applications/ssr/src/components/pages/attestation-conformité/modifier/modifierAttestationConformité.page.tsx
@@ -8,6 +8,7 @@ import {
   AttestationConformitéForm,
   type AttestationConformitéFormProps,
 } from '../AttestationConformité.form';
+import { InfoBoxAttestationConformitéForm } from '../InfoAttestationConformité';
 
 import { modifierAttestationConformitéAction } from './modifierAttestationConformité.action';
 
@@ -22,7 +23,7 @@ export const ModifierAttestationConformitéPage: FC<ModifierAttestationConformit
 }) => (
   <PageTemplate banner={<ProjetBanner {...projet} />}>
     <TitrePageAttestationConformité title="Modifier l'attestation de conformité du projet" />
-
+    <InfoBoxAttestationConformitéForm />
     <AttestationConformitéForm
       identifiantProjet={projet.identifiantProjet}
       action={modifierAttestationConformitéAction}

--- a/packages/applications/ssr/src/components/pages/attestation-conformité/modifier/modifierAttestationConformité.page.tsx
+++ b/packages/applications/ssr/src/components/pages/attestation-conformité/modifier/modifierAttestationConformité.page.tsx
@@ -8,7 +8,7 @@ import {
   AttestationConformitéForm,
   type AttestationConformitéFormProps,
 } from '../AttestationConformité.form';
-import { InfoBoxAttestationConformitéForm } from '../InfoAttestationConformité';
+import { InfoBoxAttestationConformité } from '../InfoAttestationConformité';
 
 import { modifierAttestationConformitéAction } from './modifierAttestationConformité.action';
 
@@ -23,7 +23,7 @@ export const ModifierAttestationConformitéPage: FC<ModifierAttestationConformit
 }) => (
   <PageTemplate banner={<ProjetBanner {...projet} />}>
     <TitrePageAttestationConformité title="Modifier l'attestation de conformité du projet" />
-    <InfoBoxAttestationConformitéForm />
+    <InfoBoxAttestationConformité />
     <AttestationConformitéForm
       identifiantProjet={projet.identifiantProjet}
       action={modifierAttestationConformitéAction}

--- a/packages/applications/ssr/src/components/pages/attestation-conformité/transmettre/transmettreAttestationConformité.action.ts
+++ b/packages/applications/ssr/src/components/pages/attestation-conformité/transmettre/transmettreAttestationConformité.action.ts
@@ -72,9 +72,12 @@ const action: FormAction<FormState, typeof schema> = async (
       },
     });
 
-    const redirectUrl = Option.isSome(raccordement)
+    const aDéjàTransmisUnDossierDeRaccordement =
+      Option.isSome(raccordement) && raccordement.dossiers.length > 1;
+
+    const redirectUrl = aDéjàTransmisUnDossierDeRaccordement
       ? Routes.Projet.details(identifiantProjet)
-      : Routes.Raccordement.détail(identifiantProjet);
+      : Routes.Raccordement.transmettreDemandeComplèteRaccordement(identifiantProjet);
 
     return {
       status: 'success',

--- a/packages/applications/ssr/src/components/pages/attestation-conformité/transmettre/transmettreAttestationConformité.action.ts
+++ b/packages/applications/ssr/src/components/pages/attestation-conformité/transmettre/transmettreAttestationConformité.action.ts
@@ -73,7 +73,7 @@ const action: FormAction<FormState, typeof schema> = async (
     });
 
     const aDéjàTransmisUnDossierDeRaccordement =
-      Option.isSome(raccordement) && raccordement.dossiers.length > 1;
+      Option.isSome(raccordement) && raccordement.dossiers.length > 0;
 
     const redirectUrl = aDéjàTransmisUnDossierDeRaccordement
       ? Routes.Projet.details(identifiantProjet)

--- a/packages/applications/ssr/src/components/pages/attestation-conformité/transmettre/transmettreAttestationConformité.page.tsx
+++ b/packages/applications/ssr/src/components/pages/attestation-conformité/transmettre/transmettreAttestationConformité.page.tsx
@@ -5,6 +5,7 @@ import { ProjetBanner, ProjetBannerProps } from '@/components/molecules/projet/P
 
 import { TitrePageAttestationConformité } from '../TitrePageAttestationConformité';
 import { AttestationConformitéForm } from '../AttestationConformité.form';
+import { InfoBoxAttestationConformitéForm } from '../InfoAttestationConformité';
 
 import { transmettreAttestationConformitéAction } from './transmettreAttestationConformité.action';
 
@@ -19,7 +20,7 @@ export const TransmettreAttestationConformitéPage: FC<
 > = ({ projet, peutDemanderMainlevée, peutVoirMainlevée }) => (
   <PageTemplate banner={<ProjetBanner {...projet} />}>
     <TitrePageAttestationConformité title="Transmettre l'attestation de conformité du projet" />
-
+    <InfoBoxAttestationConformitéForm />
     <AttestationConformitéForm
       identifiantProjet={projet.identifiantProjet}
       action={transmettreAttestationConformitéAction}

--- a/packages/applications/ssr/src/components/pages/attestation-conformité/transmettre/transmettreAttestationConformité.page.tsx
+++ b/packages/applications/ssr/src/components/pages/attestation-conformité/transmettre/transmettreAttestationConformité.page.tsx
@@ -5,7 +5,7 @@ import { ProjetBanner, ProjetBannerProps } from '@/components/molecules/projet/P
 
 import { TitrePageAttestationConformité } from '../TitrePageAttestationConformité';
 import { AttestationConformitéForm } from '../AttestationConformité.form';
-import { InfoBoxAttestationConformitéForm } from '../InfoAttestationConformité';
+import { InfoBoxAttestationConformité } from '../InfoAttestationConformité';
 
 import { transmettreAttestationConformitéAction } from './transmettreAttestationConformité.action';
 
@@ -20,7 +20,7 @@ export const TransmettreAttestationConformitéPage: FC<
 > = ({ projet, peutDemanderMainlevée, peutVoirMainlevée }) => (
   <PageTemplate banner={<ProjetBanner {...projet} />}>
     <TitrePageAttestationConformité title="Transmettre l'attestation de conformité du projet" />
-    <InfoBoxAttestationConformitéForm />
+    <InfoBoxAttestationConformité />
     <AttestationConformitéForm
       identifiantProjet={projet.identifiantProjet}
       action={transmettreAttestationConformitéAction}

--- a/packages/applications/ssr/src/components/pages/réseau/raccordement/détails/AucunDossierDeRaccordementAlert.tsx
+++ b/packages/applications/ssr/src/components/pages/réseau/raccordement/détails/AucunDossierDeRaccordementAlert.tsx
@@ -3,9 +3,9 @@ import Link from 'next/link';
 
 import { Routes } from '@potentiel-applications/routes';
 
-type Props = { identifiantProjet: string };
+type Props = { identifiantProjet: string; showLink?: boolean };
 
-export const AucunDossierDeRaccordementAlert = ({ identifiantProjet }: Props) => (
+export const AucunDossierDeRaccordementAlert = ({ identifiantProjet, showLink = true }: Props) => (
   <Alert
     severity="warning"
     title="Données de raccordement à compléter"
@@ -14,19 +14,18 @@ export const AucunDossierDeRaccordementAlert = ({ identifiantProjet }: Props) =>
         <p>Vous n'avez pas encore transmis votre demande complète de raccordement sur Potentiel.</p>
         <p>
           L'accusé de réception de cette demande ainsi que les documents complémentaires
-          (proposition technique et financière ou convention de raccordement directe, convention de
-          raccordement…) transmis sur Potentiel faciliteront vos démarches administratives avec les
-          différents acteurs connectés à Potentiel (DGEC, DREAL, Cocontractant, etc.).
+          (proposition technique et financière…) transmis sur Potentiel faciliteront vos démarches
+          administratives avec les différents acteurs connectés à Potentiel (DGEC, services de
+          l'Etat en région, Cocontractant, etc.).
         </p>
-        <span>
-          Mettre à jour votre{' '}
+        {showLink && (
           <Link
             href={Routes.Raccordement.transmettreDemandeComplèteRaccordement(identifiantProjet)}
             className="font-semibold"
           >
-            dossier de raccordement
+            Mettre à jour votre dossier de raccordement
           </Link>
-        </span>
+        )}
       </div>
     }
   />

--- a/packages/applications/ssr/src/components/pages/réseau/raccordement/détails/AucunDossierDeRaccordementAlert.tsx
+++ b/packages/applications/ssr/src/components/pages/réseau/raccordement/détails/AucunDossierDeRaccordementAlert.tsx
@@ -21,7 +21,7 @@ export const AucunDossierDeRaccordementAlert = ({ identifiantProjet, showLink = 
         {showLink && (
           <Link
             href={Routes.Raccordement.transmettreDemandeComplèteRaccordement(identifiantProjet)}
-            className="font-semibold"
+            className="font-semibold w-fit"
           >
             Mettre à jour votre dossier de raccordement
           </Link>

--- a/packages/applications/ssr/src/components/pages/réseau/raccordement/transmettre/transmettreDemandeComplèteRaccordement/TransmettreDemandeComplèteRaccordement.page.tsx
+++ b/packages/applications/ssr/src/components/pages/réseau/raccordement/transmettre/transmettreDemandeComplèteRaccordement/TransmettreDemandeComplèteRaccordement.page.tsx
@@ -35,19 +35,21 @@ export const TransmettreDemandeComplèteRaccordementPage: FC<
 }) => (
   <ColumnPageTemplate
     banner={<ProjetBanner identifiantProjet={identifiantProjet} />}
-    heading={<TitrePageRaccordement />}
+    heading={
+      <>
+        <TitrePageRaccordement />
+        {!aDéjàTransmisUneDemandeComplèteDeRaccordement && (
+          <AucunDossierDeRaccordementAlert identifiantProjet={identifiantProjet} showLink={false} />
+        )}
+      </>
+    }
     leftColumn={{
       children: (
-        <>
-          {!aDéjàTransmisUneDemandeComplèteDeRaccordement && (
-            <AucunDossierDeRaccordementAlert identifiantProjet={identifiantProjet} />
-          )}
-          <TransmettreDemandeComplèteRaccordementForm
-            identifiantProjet={identifiantProjet}
-            listeGestionnairesRéseau={listeGestionnairesRéseau}
-            identifiantGestionnaireRéseauActuel={identifiantGestionnaireRéseauActuel}
-          />
-        </>
+        <TransmettreDemandeComplèteRaccordementForm
+          identifiantProjet={identifiantProjet}
+          listeGestionnairesRéseau={listeGestionnairesRéseau}
+          identifiantGestionnaireRéseauActuel={identifiantGestionnaireRéseauActuel}
+        />
       ),
     }}
     rightColumn={{

--- a/packages/applications/ssr/src/components/pages/réseau/raccordement/transmettre/transmettreDemandeComplèteRaccordement/TransmettreDemandeComplèteRaccordement.page.tsx
+++ b/packages/applications/ssr/src/components/pages/réseau/raccordement/transmettre/transmettreDemandeComplèteRaccordement/TransmettreDemandeComplèteRaccordement.page.tsx
@@ -9,6 +9,7 @@ import {
   InformationDemandeComplèteRaccordementProps,
 } from '../../InformationDemandeComplèteRaccordement';
 import { TitrePageRaccordement } from '../../TitrePageRaccordement';
+import { AucunDossierDeRaccordementAlert } from '../../détails/AucunDossierDeRaccordementAlert';
 
 import {
   TransmettreDemandeComplèteRaccordementForm,
@@ -20,6 +21,7 @@ export type TransmettreDemandeComplèteRaccordementPageProps = {
   identifiantGestionnaireRéseauActuel?: TransmettreDemandeComplèteRaccordementFormProps['identifiantGestionnaireRéseauActuel'];
   identifiantProjet: TransmettreDemandeComplèteRaccordementFormProps['identifiantProjet'];
   delaiDemandeDeRaccordementEnMois: InformationDemandeComplèteRaccordementProps['delaiDemandeDeRaccordementEnMois'];
+  aDéjàTransmisUneDemandeComplèteDeRaccordement: boolean;
 };
 
 export const TransmettreDemandeComplèteRaccordementPage: FC<
@@ -29,17 +31,23 @@ export const TransmettreDemandeComplèteRaccordementPage: FC<
   identifiantGestionnaireRéseauActuel,
   identifiantProjet,
   delaiDemandeDeRaccordementEnMois,
+  aDéjàTransmisUneDemandeComplèteDeRaccordement,
 }) => (
   <ColumnPageTemplate
     banner={<ProjetBanner identifiantProjet={identifiantProjet} />}
     heading={<TitrePageRaccordement />}
     leftColumn={{
       children: (
-        <TransmettreDemandeComplèteRaccordementForm
-          identifiantProjet={identifiantProjet}
-          listeGestionnairesRéseau={listeGestionnairesRéseau}
-          identifiantGestionnaireRéseauActuel={identifiantGestionnaireRéseauActuel}
-        />
+        <>
+          {!aDéjàTransmisUneDemandeComplèteDeRaccordement && (
+            <AucunDossierDeRaccordementAlert identifiantProjet={identifiantProjet} />
+          )}
+          <TransmettreDemandeComplèteRaccordementForm
+            identifiantProjet={identifiantProjet}
+            listeGestionnairesRéseau={listeGestionnairesRéseau}
+            identifiantGestionnaireRéseauActuel={identifiantGestionnaireRéseauActuel}
+          />
+        </>
       ),
     }}
     rightColumn={{

--- a/packages/applications/ssr/src/components/pages/réseau/raccordement/transmettre/transmettreDemandeComplèteRaccordement/TransmettreDemandeComplèteRaccordement.stories.tsx
+++ b/packages/applications/ssr/src/components/pages/réseau/raccordement/transmettre/transmettreDemandeComplèteRaccordement/TransmettreDemandeComplèteRaccordement.stories.tsx
@@ -51,5 +51,6 @@ export const Default: Story = {
     identifiantGestionnaireRéseauActuel: 'identifiantGestionnaireRéseau#2',
     identifiantProjet: 'appelOffre#période#famille#numéroCRE',
     delaiDemandeDeRaccordementEnMois: { texte: '3 mois', valeur: 3 },
+    aDéjàTransmisUneDemandeComplèteDeRaccordement: false,
   },
 };


### PR DESCRIPTION
# Description

Petits changements vu avec Matthieu pour la release 👍 
- changement du texte de l'alerte si pas de raccordement,
- Affichage de l'alerte dans la page transmettre (en plus de la page récap) si pas de raccordement

## Type de changement

Veuillez supprimer les options qui ne sont pas pertinentes.

- [x] Correction de bug
- [ ] Nouvelle fonctionnalité
- [ ] Refacto de code
- [ ] Breaking changes (correction ou fonctionnalité qui ferait en sorte que la fonctionnalité existante ne fonctionne pas comme prévu)
- [ ] Ce changement nécessite une mise à jour de la documentation