### PR TITLE
🎨 Ajout d'un gardefou si l'app est en mode maintenance (pas d'envoi d'email)

### DIFF
--- a/packages/infrastructure/email/src/sendEmail.ts
+++ b/packages/infrastructure/email/src/sendEmail.ts
@@ -24,11 +24,16 @@ const formatRecipients = (recipients: Array<Receipt>) =>
   }));
 
 export const sendEmail: SendEmail = async (sendEmailArgs) => {
-  const { SEND_EMAILS_FROM, SEND_EMAILS_FROM_NAME, SEND_EMAIL_MODE = 'logging-only' } = process.env;
+  const {
+    SEND_EMAILS_FROM,
+    SEND_EMAILS_FROM_NAME,
+    SEND_EMAIL_MODE = 'logging-only',
+    MAINTENANCE_MODE,
+  } = process.env;
 
   const mode = mapToSendEmailMode(SEND_EMAIL_MODE);
 
-  if (mode !== 'logging-only') {
+  if (mode !== 'logging-only' && !MAINTENANCE_MODE) {
     const { templateId, messageSubject, recipients, cc, bcc, variables } = sendEmailArgs;
 
     await getMailjetClient()


### PR DESCRIPTION
# Description

Suite au problème d'envoi d'email en prod pendant la maintenance, on ajout cette condition pour éviter quoi qu'il arrive qu'en mode maintenance des emails partent

## Type de changement
- [x] Correction de bug