### PR TITLE
✨  Regénérer attestation quand correction

### DIFF
--- a/packages/applications/bootstrap/src/bootstrap.ts
+++ b/packages/applications/bootstrap/src/bootstrap.ts
@@ -38,6 +38,7 @@ export const bootstrap = async ({
     mediator.use({
       middlewares: [logMiddleware, ...middlewares],
     });
+
     if (!sendEmail) {
       sendEmail = sendEmailMailjet;
     }
@@ -45,7 +46,7 @@ export const bootstrap = async ({
     setupUtilisateur();
     await setupAppelOffre();
     const unsetupPériode = await setupPériode({ sendEmail });
-    const unsetupCandidature = await setupCandidature();
+    const unsetupCandidature = await setupCandidature({ sendEmail });
     setupDocumentProjet();
     AttestationSaga.register();
 

--- a/packages/applications/bootstrap/src/setupEliminé.ts
+++ b/packages/applications/bootstrap/src/setupEliminé.ts
@@ -10,11 +10,11 @@ import {
 import { RecoursProjector, ÉliminéProjector } from '@potentiel-applications/projectors';
 import { RecoursNotification, SendEmail } from '@potentiel-applications/notifications';
 
-type SetupÉliminéDependenices = {
+type SetupÉliminéDependencies = {
   sendEmail: SendEmail;
 };
 
-export const setupEliminé = async ({ sendEmail }: SetupÉliminéDependenices) => {
+export const setupEliminé = async ({ sendEmail }: SetupÉliminéDependencies) => {
   registerEliminéUseCases({
     loadAggregate,
   });

--- a/packages/applications/bootstrap/src/setupLauréat.ts
+++ b/packages/applications/bootstrap/src/setupLauréat.ts
@@ -25,10 +25,10 @@ import {
 } from '@potentiel-infrastructure/domain-adapters';
 import { SendEmail } from '@potentiel-applications/notifications';
 
-type SetupLauréatDependenices = {
+type SetupLauréatDependencies = {
   sendEmail: SendEmail;
 };
-export const setupLauréat = async ({ sendEmail }: SetupLauréatDependenices) => {
+export const setupLauréat = async ({ sendEmail }: SetupLauréatDependencies) => {
   registerLauréatUseCases({
     loadAggregate,
   });
@@ -47,7 +47,7 @@ export const setupLauréat = async ({ sendEmail }: SetupLauréatDependenices) =>
   AchèvementProjector.register();
   AchèvementNotification.register({ sendEmail });
 
-  // Notfications
+  // Notifications
   AbandonNotification.register({ sendEmail });
   GarantiesFinancièresNotification.register({ sendEmail });
 

--- a/packages/applications/bootstrap/src/setupPériode.ts
+++ b/packages/applications/bootstrap/src/setupPériode.ts
@@ -6,11 +6,11 @@ import { findProjection, listProjection } from '@potentiel-infrastructure/pg-pro
 import { loadAggregate, subscribe } from '@potentiel-infrastructure/pg-event-sourcing';
 import { PériodeNotification, SendEmail } from '@potentiel-applications/notifications';
 
-type SetupPériodeDependenices = {
+type SetupPériodeDependencies = {
   sendEmail: SendEmail;
 };
 
-export const setupPériode = async ({ sendEmail }: SetupPériodeDependenices) => {
+export const setupPériode = async ({ sendEmail }: SetupPériodeDependencies) => {
   Période.registerPériodeQueries({
     find: findProjection,
     list: listProjection,

--- a/packages/applications/document-builder/src/candidature/attestation/attestation.saga.ts
+++ b/packages/applications/document-builder/src/candidature/attestation/attestation.saga.ts
@@ -1,6 +1,10 @@
 import { Message, MessageHandler, mediator } from 'mediateur';
 
-import { DocumentProjet, EnregistrerDocumentProjetCommand } from '@potentiel-domain/document';
+import {
+  CorrigerDocumentProjetCommand,
+  DocumentProjet,
+  EnregistrerDocumentProjetCommand,
+} from '@potentiel-domain/document';
 import { getLogger } from '@potentiel-libraries/monitoring';
 import { Candidature } from '@potentiel-domain/candidature';
 import { Option } from '@potentiel-libraries/monads';
@@ -9,54 +13,60 @@ import { ConsulterUtilisateurQuery } from '@potentiel-domain/utilisateur';
 
 import { buildCertificate } from './buildCertificate';
 
-export type SubscriptionEvent = Candidature.CandidatureNotifiéeEvent;
+export type SubscriptionEvent =
+  | Candidature.CandidatureNotifiéeEvent
+  | Candidature.CandidatureCorrigéeEvent;
 
 export type Execute = Message<'System.Candidature.Attestation.Saga.Execute', SubscriptionEvent>;
 
 export const register = () => {
   const handler: MessageHandler<Execute> = async (event) => {
     const logger = getLogger('System.Candidature.Attestation.Saga.Execute');
+
     const {
-      payload: {
-        identifiantProjet,
-        attestation: { format },
-        notifiéeLe,
-        notifiéePar,
-      },
+      payload: { identifiantProjet },
     } = event;
+
+    const candidature = await mediator.send<Candidature.ConsulterCandidatureQuery>({
+      type: 'Candidature.Query.ConsulterCandidature',
+      data: {
+        identifiantProjet,
+      },
+    });
+
+    if (Option.isNone(candidature)) {
+      logger.warn(`Candidature non trouvée`, { identifiantProjet });
+      return;
+    }
+
+    const appelOffres = await mediator.send<AppelOffre.ConsulterAppelOffreQuery>({
+      type: 'AppelOffre.Query.ConsulterAppelOffre',
+      data: { identifiantAppelOffre: candidature.identifiantProjet.appelOffre },
+    });
+
+    if (Option.isNone(appelOffres)) {
+      logger.warn(`Appel d'offres non trouvé`, { identifiantProjet });
+      return;
+    }
+
+    const période = appelOffres.periodes.find(
+      (x) => x.id === candidature.identifiantProjet.période,
+    );
+
+    if (!période) {
+      logger.warn(`Période non trouvée`, { identifiantProjet });
+      return;
+    }
 
     switch (event.type) {
       case 'CandidatureNotifiée-V1':
-        const candidature = await mediator.send<Candidature.ConsulterCandidatureQuery>({
-          type: 'Candidature.Query.ConsulterCandidature',
-          data: {
-            identifiantProjet,
+        const {
+          payload: {
+            attestation: { format },
+            notifiéeLe,
+            notifiéePar,
           },
-        });
-
-        if (Option.isNone(candidature)) {
-          logger.warn(`Candidature non trouvée`, { identifiantProjet });
-          return;
-        }
-
-        const appelOffres = await mediator.send<AppelOffre.ConsulterAppelOffreQuery>({
-          type: 'AppelOffre.Query.ConsulterAppelOffre',
-          data: { identifiantAppelOffre: candidature.identifiantProjet.appelOffre },
-        });
-
-        if (Option.isNone(appelOffres)) {
-          logger.warn(`Appel d'offres non trouvé`, { identifiantProjet });
-          return;
-        }
-
-        const période = appelOffres.periodes.find(
-          (x) => x.id === candidature.identifiantProjet.période,
-        );
-
-        if (!période) {
-          logger.warn(`Période non trouvée`, { identifiantProjet });
-          return;
-        }
+        } = event;
 
         const modèleAttestationNonDisponible = période.type === 'legacy';
 
@@ -110,6 +120,54 @@ export const register = () => {
             documentProjet: attestation,
           },
         });
+
+        break;
+
+      case 'CandidatureCorrigée-V1':
+        if (!candidature.notification?.notifiéeLe) {
+          logger.info(`L'attestation ne sera pas regénérée car la candidature n'est pas notifiée`, {
+            identifiantProjet,
+          });
+          return;
+        } else {
+          const utilisateur = await mediator.send<ConsulterUtilisateurQuery>({
+            type: 'Utilisateur.Query.ConsulterUtilisateur',
+            data: {
+              identifiantUtilisateur: candidature.notification.notifiéePar.formatter(),
+            },
+          });
+
+          if (Option.isNone(utilisateur)) {
+            logger.warn(`Utilisateur non trouvé`, {
+              identifiantProjet,
+              identifiantUtilisateur: candidature.notification.notifiéePar.formatter(),
+            });
+            return;
+          }
+
+          // prendre candidature de l'événement
+
+          const certificate = await buildCertificate({
+            appelOffre: appelOffres,
+            période,
+            utilisateur,
+            candidature,
+            notifiéLe: candidature.notification.notifiéeLe.formatter(),
+          });
+
+          if (!certificate) {
+            logger.warn(`Impossible de regénérer l'attestation du projet ${identifiantProjet}`);
+            return;
+          }
+
+          await mediator.send<CorrigerDocumentProjetCommand>({
+            type: 'Document.Command.CorrigerDocumentProjet',
+            data: {
+              content: certificate,
+              documentProjetKey: candidature.notification.attestation.formatter(),
+            },
+          });
+        }
 
         break;
     }

--- a/packages/applications/document-builder/src/candidature/attestation/attestation.saga.ts
+++ b/packages/applications/document-builder/src/candidature/attestation/attestation.saga.ts
@@ -125,13 +125,14 @@ export const register = () => {
         break;
 
       case 'CandidatureCorrigée-V1':
+        // la correction d'une candidature ne peut pas modifier le champs notification
+        // on peut donc sans crainte utiliser cette vérification
         if (!candidature.notification?.notifiéeLe) {
           logger.info(`L'attestation ne sera pas regénérée car la candidature n'est pas notifiée`, {
             identifiantProjet,
           });
           return;
-        }
-        if (event.payload.doitRégénérerAttestation !== true) {
+        } else if (event.payload.doitRégénérerAttestation !== true) {
           logger.info(`L'attestation ne sera pas regénérée`, {
             identifiantProjet,
           });
@@ -165,7 +166,7 @@ export const register = () => {
             ),
             dateÉchéanceGf: event.payload.dateÉchéanceGf
               ? DateTime.convertirEnValueType(event.payload.dateÉchéanceGf)
-              : candidature.dateÉchéanceGf,
+              : undefined,
             historiqueAbandon: Candidature.HistoriqueAbandon.convertirEnValueType(
               event.payload.historiqueAbandon,
             ),
@@ -173,10 +174,10 @@ export const register = () => {
               ? Candidature.TypeGarantiesFinancières.convertirEnValueType(
                   event.payload.typeGarantiesFinancières,
                 )
-              : candidature.typeGarantiesFinancières,
+              : undefined,
             actionnariat: event.payload.actionnariat
               ? Candidature.TypeActionnariat.convertirEnValueType(event.payload.actionnariat)
-              : candidature.actionnariat,
+              : undefined,
           };
 
           const certificate = await buildCertificate({
@@ -200,7 +201,6 @@ export const register = () => {
             },
           });
         }
-
         break;
     }
   };

--- a/packages/applications/document-builder/src/candidature/attestation/attestation.saga.ts
+++ b/packages/applications/document-builder/src/candidature/attestation/attestation.saga.ts
@@ -9,7 +9,6 @@ import { getLogger } from '@potentiel-libraries/monitoring';
 import { Candidature } from '@potentiel-domain/candidature';
 import { Option } from '@potentiel-libraries/monads';
 import { AppelOffre } from '@potentiel-domain/appel-offre';
-import { ConsulterUtilisateurQuery } from '@potentiel-domain/utilisateur';
 import { DateTime, IdentifiantProjet } from '@potentiel-domain/common';
 
 import { buildCertificate } from './buildCertificate';
@@ -65,7 +64,6 @@ export const register = () => {
           payload: {
             attestation: { format },
             notifiéeLe,
-            notifiéePar,
           },
         } = event;
 
@@ -79,25 +77,10 @@ export const register = () => {
           return;
         }
 
-        const utilisateur = await mediator.send<ConsulterUtilisateurQuery>({
-          type: 'Utilisateur.Query.ConsulterUtilisateur',
-          data: {
-            identifiantUtilisateur: notifiéePar,
-          },
-        });
-
-        if (Option.isNone(utilisateur)) {
-          logger.warn(`Utilisateur non trouvé`, {
-            identifiantProjet,
-            identifiantUtilisateur: notifiéePar,
-          });
-          return;
-        }
-
         const certificate = await buildCertificate({
           appelOffre: appelOffres,
           période,
-          validateur: { fonction: utilisateur.fonction, fullName: utilisateur.nomComplet },
+          validateur: event.payload.validateur,
           candidature,
           notifiéLe: notifiéeLe,
         });

--- a/packages/applications/document-builder/src/candidature/attestation/attestation.stories.tsx
+++ b/packages/applications/document-builder/src/candidature/attestation/attestation.stories.tsx
@@ -79,7 +79,7 @@ const fakeProject = (appelOffreId: string, périodeId?: string): AttestationCand
 };
 
 const validateur = {
-  fullName: 'Nom du signataire',
+  nomComplet: 'Nom du signataire',
   fonction: 'fonction du signataire',
 } as AppelOffre.Validateur;
 

--- a/packages/applications/document-builder/src/candidature/attestation/buildCertificate.ts
+++ b/packages/applications/document-builder/src/candidature/attestation/buildCertificate.ts
@@ -5,7 +5,6 @@ import ReactPDF, { Font } from '@react-pdf/renderer';
 import { AppelOffre } from '@potentiel-domain/appel-offre';
 import { DateTime } from '@potentiel-domain/common';
 import { Candidature } from '@potentiel-domain/candidature';
-import { ConsulterUtilisateurReadModel } from '@potentiel-domain/utilisateur';
 
 import { fontsFolderPath, imagesFolderPath } from '../../assets';
 import { mapToReadableStream } from '../../mapToReadableStream';
@@ -36,7 +35,7 @@ Font.register({
 type BuildCertificateProps = {
   appelOffre: AppelOffre.AppelOffreReadModel;
   période: AppelOffre.Periode;
-  utilisateur: ConsulterUtilisateurReadModel;
+  validateur: AppelOffre.Validateur;
   candidature: Candidature.ConsulterCandidatureReadModel;
   notifiéLe: DateTime.RawType;
 };
@@ -44,14 +43,13 @@ type BuildCertificateProps = {
 export const buildCertificate = async ({
   appelOffre,
   période,
-  utilisateur,
+  validateur,
   candidature,
   notifiéLe,
 }: BuildCertificateProps): Promise<ReadableStream | void> => {
-  const { data, validateur } = mapToCertificateData({
+  const { data } = mapToCertificateData({
     appelOffre,
     période,
-    utilisateur,
     candidature,
     notifiéLe,
   });
@@ -71,16 +69,14 @@ export const buildCertificate = async ({
 
 type CertificateData = {
   data?: AttestationCandidatureOptions;
-  validateur?: AppelOffre.Validateur;
 };
 
 const mapToCertificateData = ({
   appelOffre,
   période,
-  utilisateur,
   candidature,
   notifiéLe,
-}: BuildCertificateProps): CertificateData => {
+}: Omit<BuildCertificateProps, 'validateur'>): CertificateData => {
   const famille = période.familles.find((x) => x.id === candidature.identifiantProjet.famille);
 
   const financementEtTemplate = getFinancementEtTemplate({
@@ -95,10 +91,6 @@ const mapToCertificateData = ({
   const potentielId = formatPotentielId(candidature.identifiantProjet);
 
   return {
-    validateur: {
-      fullName: utilisateur.nomComplet,
-      fonction: utilisateur.fonction,
-    },
     data: {
       appelOffre,
       période,

--- a/packages/applications/document-builder/src/candidature/attestation/cre4/v0/attestation.stories.tsx
+++ b/packages/applications/document-builder/src/candidature/attestation/cre4/v0/attestation.stories.tsx
@@ -13,7 +13,7 @@ const meta = {
     return makeCertificate(
       projet,
       {
-        fullName: 'Nom du signataire',
+        nomComplet: 'Nom du signataire',
         fonction: 'fonction du signataire',
       },
       '/images',

--- a/packages/applications/document-builder/src/candidature/attestation/cre4/v0/makeCertificate.tsx
+++ b/packages/applications/document-builder/src/candidature/attestation/cre4/v0/makeCertificate.tsx
@@ -399,7 +399,7 @@ const Certificate = ({
               }}
             >
               <Text style={{ fontSize: 10, marginTop: 30, textAlign: 'center' }}>
-                {validateur.fullName}
+                {validateur.nomComplet}
               </Text>
               <Text
                 style={{ fontSize: 10, fontWeight: 'bold', marginTop: 10, textAlign: 'center' }}

--- a/packages/applications/document-builder/src/candidature/attestation/cre4/v1/attestation.stories.tsx
+++ b/packages/applications/document-builder/src/candidature/attestation/cre4/v1/attestation.stories.tsx
@@ -13,7 +13,7 @@ const meta = {
     return makeCertificate(
       projet,
       {
-        fullName: 'Nom du signataire',
+        nomComplet: 'Nom du signataire',
         fonction: 'fonction du signataire',
       },
       '/images',

--- a/packages/applications/document-builder/src/candidature/attestation/cre4/v1/makeCertificate.tsx
+++ b/packages/applications/document-builder/src/candidature/attestation/cre4/v1/makeCertificate.tsx
@@ -402,7 +402,7 @@ const Certificate = ({
               }}
             >
               <Text style={{ fontSize: 10, marginTop: 30, textAlign: 'center' }}>
-                {validateur.fullName}
+                {validateur.nomComplet}
               </Text>
               <Text
                 style={{ fontSize: 10, fontWeight: 'bold', marginTop: 10, textAlign: 'center' }}

--- a/packages/applications/document-builder/src/candidature/attestation/ppe2/components/Signature.tsx
+++ b/packages/applications/document-builder/src/candidature/attestation/ppe2/components/Signature.tsx
@@ -24,7 +24,7 @@ export const Signature = ({ validateur }: SignatureProps) => (
       wrap={false}
     >
       <Text style={{ fontSize: 10, marginTop: 30, textAlign: 'center' }}>
-        {validateur.fullName}
+        {validateur.nomComplet}
       </Text>
       <Text style={{ fontSize: 10, fontWeight: 'bold', marginTop: 10, textAlign: 'center' }}>
         {validateur.fonction}

--- a/packages/applications/document-builder/src/candidature/attestation/ppe2/v1/ppe2.elimine.stories.tsx
+++ b/packages/applications/document-builder/src/candidature/attestation/ppe2/v1/ppe2.elimine.stories.tsx
@@ -17,7 +17,7 @@ const meta = {
     return makeCertificate(
       projet,
       {
-        fullName: 'Nom du signataire',
+        nomComplet: 'Nom du signataire',
         fonction: 'fonction du signataire',
       },
       '/images',

--- a/packages/applications/document-builder/src/candidature/attestation/ppe2/v1/ppe2.laureat.stories.tsx
+++ b/packages/applications/document-builder/src/candidature/attestation/ppe2/v1/ppe2.laureat.stories.tsx
@@ -21,7 +21,7 @@ const meta = {
     return makeCertificate(
       projet,
       {
-        fullName: 'Nom du signataire',
+        nomComplet: 'Nom du signataire',
         fonction: 'fonction du signataire',
       },
       '/images',

--- a/packages/applications/document-builder/src/candidature/attestation/ppe2/v2/ppe2.elimine.stories.tsx
+++ b/packages/applications/document-builder/src/candidature/attestation/ppe2/v2/ppe2.elimine.stories.tsx
@@ -17,7 +17,7 @@ const meta = {
     return makeCertificate(
       projet,
       {
-        fullName: 'Nom du signataire',
+        nomComplet: 'Nom du signataire',
         fonction: 'fonction du signataire',
       },
       '/images',

--- a/packages/applications/document-builder/src/candidature/attestation/ppe2/v2/ppe2.laureat.stories.tsx
+++ b/packages/applications/document-builder/src/candidature/attestation/ppe2/v2/ppe2.laureat.stories.tsx
@@ -20,7 +20,7 @@ const meta = {
     return makeCertificate(
       projet,
       {
-        fullName: 'Nom du signataire',
+        nomComplet: 'Nom du signataire',
         fonction: 'fonction du signataire',
       },
       '/images',

--- a/packages/applications/legacy/src/infra/mail/mailjet.ts
+++ b/packages/applications/legacy/src/infra/mail/mailjet.ts
@@ -14,7 +14,6 @@ const TEMPLATE_ID_BY_TYPE: Record<NotificationProps['type'], number> = {
   'pp-gf-notification': 1463065,
   'dreal-gf-déposée-notification': 1528696,
   'dreal-gf-enregistrée-notification': 5685924,
-  'pp-certificate-updated': 1765851,
   'modification-request-status-update': 2046625,
   'pp-délai-accordé-corrigé': 4554290,
   'user-invitation': 2814281,

--- a/packages/applications/legacy/src/modules/notification/Notification.ts
+++ b/packages/applications/legacy/src/modules/notification/Notification.ts
@@ -71,19 +71,6 @@ type PP_GF_Notification = {
   };
 };
 
-type PP_CertificateUpdated = {
-  type: 'pp-certificate-updated';
-  context: {
-    projectId: string;
-    userId: string;
-  };
-  variables: {
-    nomProjet: string;
-    raison?: string;
-    urlRedirection: string;
-  };
-};
-
 type DREAL_GF_déposée_Notification = {
   type: 'dreal-gf-déposée-notification';
   context: {
@@ -341,7 +328,6 @@ type NotificationVariants =
   | PP_GF_Notification
   | DREAL_GF_déposée_Notification
   | DREAL_GF_enregistrée_Notification
-  | PP_CertificateUpdated
   | ModificationRequestStatusUpdate
   | ModificationRequestConfirmedByPP
   | ModificationRequestCancelled

--- a/packages/applications/notifications/src/index.ts
+++ b/packages/applications/notifications/src/index.ts
@@ -4,5 +4,6 @@ export * as AchèvementNotification from './subscribers/lauréat/achèvement.not
 export * as TâchePlanifiéeNotification from './subscribers/lauréat/tâchePlanifiée.notification';
 export * as PériodeNotification from './subscribers/période/période.notification';
 export * as RecoursNotification from './subscribers/éliminé/recours.notification';
+export * as CandidatureNotification from './subscribers/candidature/candidature.notification';
 
 export { SendEmail, EmailPayload } from './sendEmail';

--- a/packages/applications/notifications/src/subscribers/candidature/candidature.notification.ts
+++ b/packages/applications/notifications/src/subscribers/candidature/candidature.notification.ts
@@ -42,11 +42,9 @@ export const register = ({ sendEmail }: RegisterCandidatureNotificationDependenc
           return;
         }
 
-        const attestationHasBeenRegenerated = candidature.notification !== undefined;
-
         const { BASE_URL } = process.env;
 
-        if (attestationHasBeenRegenerated) {
+        if (event.payload.doitRégénérerAttestation) {
           await sendEmail({
             templateId: templateId.attestationRegénéréePorteur,
             messageSubject: `Potentiel - Une nouvelle attestation est disponible pour le projet ${candidature.nomProjet}`,

--- a/packages/applications/notifications/src/subscribers/candidature/candidature.notification.ts
+++ b/packages/applications/notifications/src/subscribers/candidature/candidature.notification.ts
@@ -1,0 +1,66 @@
+import { Message, MessageHandler, mediator } from 'mediateur';
+
+import { Option } from '@potentiel-libraries/monads';
+import { Event } from '@potentiel-infrastructure/pg-event-sourcing';
+import { getLogger } from '@potentiel-libraries/monitoring';
+import { Candidature } from '@potentiel-domain/candidature';
+import { Routes } from '@potentiel-applications/routes';
+
+import { SendEmail } from '../../sendEmail';
+
+export type SubscriptionEvent = Candidature.CandidatureCorrigéeEvent & Event;
+
+export type Execute = Message<'System.Notification.Candidature', SubscriptionEvent>;
+
+const templateId = {
+  attestationRegénéréePorteur: 1765851,
+};
+
+export type RegisterCandidatureNotificationDependencies = {
+  sendEmail: SendEmail;
+};
+
+export const register = ({ sendEmail }: RegisterCandidatureNotificationDependencies) => {
+  const handler: MessageHandler<Execute> = async (event) => {
+    const logger = getLogger();
+
+    const {
+      payload: { identifiantProjet },
+    } = event;
+
+    switch (event.type) {
+      case 'CandidatureCorrigée-V1':
+        const candidature = await mediator.send<Candidature.ConsulterCandidatureQuery>({
+          type: 'Candidature.Query.ConsulterCandidature',
+          data: {
+            identifiantProjet,
+          },
+        });
+
+        if (Option.isNone(candidature)) {
+          logger.warn(`Candidature non trouvée`, { identifiantProjet });
+          return;
+        }
+
+        const attestationHasBeenRegenerated = candidature.notification !== undefined;
+
+        const { BASE_URL } = process.env;
+
+        if (attestationHasBeenRegenerated) {
+          await sendEmail({
+            templateId: templateId.attestationRegénéréePorteur,
+            messageSubject: `Potentiel - Une nouvelle attestation est disponible pour le projet ${candidature.nomProjet}`,
+            recipients: [
+              { email: candidature.emailContact, fullName: candidature.nomReprésentantLégal },
+            ],
+            variables: {
+              nom_projet: candidature.nomProjet,
+              raison: 'Votre candidature a été modifiée',
+              redirect_url: `${BASE_URL}${Routes.Projet.details(identifiantProjet)}`,
+            },
+          });
+        }
+    }
+  };
+  mediator.register('System.Notification.Candidature', handler);
+};

--- a/packages/applications/projectors/src/subscribers/candidature/candidature.projector.ts
+++ b/packages/applications/projectors/src/subscribers/candidature/candidature.projector.ts
@@ -73,10 +73,7 @@ export const register = () => {
                 estNotifiée: true,
                 notifiéeLe: payload.notifiéeLe,
                 notifiéePar: payload.notifiéePar,
-                validateur: {
-                  fonction: payload.validateur.fonction,
-                  nomComplet: payload.validateur.nomComplet,
-                },
+                validateur: payload.validateur,
               },
             },
           );

--- a/packages/applications/scheduled-tasks/src/candidature/create-events-candidature-notifiée.ts
+++ b/packages/applications/scheduled-tasks/src/candidature/create-events-candidature-notifiée.ts
@@ -31,14 +31,9 @@ AppelOffre.registerAppelOffreQueries({
   find: findProjection,
 });
 
-type Validateur = {
-  fonction: string;
-  nomComplet: string;
-};
-
 const validateurInconnu = {
   fonction: 'fonction inconnue',
-  nomComplet: 'nom inconnu',
+  fullName: 'nom inconnu',
 };
 
 let compteurValidateurInconnu = 0;
@@ -49,7 +44,7 @@ let anomalies = 0;
 const findValidateur = async (
   notifiéPar: Email.RawType,
   identifiantProjet: IdentifiantProjet.RawType,
-): Promise<Validateur> => {
+): Promise<AppelOffre.Validateur> => {
   const utilisateur = await mediator.send<ConsulterUtilisateurQuery>({
     type: 'Utilisateur.Query.ConsulterUtilisateur',
     data: {
@@ -67,7 +62,7 @@ const findValidateur = async (
     compteurValidateurIdentifié++;
     return {
       fonction: utilisateur.fonction,
-      nomComplet: utilisateur.nomComplet,
+      fullName: utilisateur.nomComplet,
     };
   }
 
@@ -104,7 +99,7 @@ const findValidateur = async (
     compteurValidateurParDéfault++;
     return {
       fonction: période.validateurParDéfaut.fonction,
-      nomComplet: période.validateurParDéfaut.fullName,
+      fullName: période.validateurParDéfaut.fullName,
     };
   }
 

--- a/packages/applications/scheduled-tasks/src/candidature/create-events-candidature-notifiée.ts
+++ b/packages/applications/scheduled-tasks/src/candidature/create-events-candidature-notifiée.ts
@@ -33,7 +33,7 @@ AppelOffre.registerAppelOffreQueries({
 
 const validateurInconnu = {
   fonction: 'fonction inconnue',
-  fullName: 'nom inconnu',
+  nomComplet: 'nom inconnu',
 };
 
 let compteurValidateurInconnu = 0;
@@ -62,7 +62,7 @@ const findValidateur = async (
     compteurValidateurIdentifié++;
     return {
       fonction: utilisateur.fonction,
-      fullName: utilisateur.nomComplet,
+      nomComplet: utilisateur.nomComplet,
     };
   }
 
@@ -99,7 +99,7 @@ const findValidateur = async (
     compteurValidateurParDéfault++;
     return {
       fonction: période.validateurParDéfaut.fonction,
-      fullName: période.validateurParDéfaut.fullName,
+      nomComplet: période.validateurParDéfaut.nomComplet,
     };
   }
 

--- a/packages/applications/ssr/src/app/candidatures/[identifiant]/previsualiser-attestation/route.ts
+++ b/packages/applications/ssr/src/app/candidatures/[identifiant]/previsualiser-attestation/route.ts
@@ -85,10 +85,15 @@ export const GET = async (_: Request, { params: { identifiant } }: IdentifiantPa
       return notFound();
     }
 
+    const validateur = candidature.notification?.validateur ?? {
+      fonction: user.fonction,
+      fullName: user.nomComplet,
+    };
+
     const certificate = await buildCertificate({
       appelOffre: appelOffres,
       période,
-      utilisateur: user,
+      validateur,
       candidature,
       notifiéLe: notifiéLe.formatter(),
     });

--- a/packages/applications/ssr/src/app/candidatures/[identifiant]/previsualiser-attestation/route.ts
+++ b/packages/applications/ssr/src/app/candidatures/[identifiant]/previsualiser-attestation/route.ts
@@ -87,7 +87,7 @@ export const GET = async (_: Request, { params: { identifiant } }: IdentifiantPa
 
     const validateur = candidature.notification?.validateur ?? {
       fonction: user.fonction,
-      fullName: user.nomComplet,
+      nomComplet: user.nomComplet,
     };
 
     const certificate = await buildCertificate({

--- a/packages/applications/ssr/src/components/pages/période/notifier/notifierPériode.action.ts
+++ b/packages/applications/ssr/src/components/pages/période/notifier/notifierPériode.action.ts
@@ -52,7 +52,7 @@ const action: FormAction<FormState, typeof schema> = async (_, { appelOffre, per
         notifiéeParValue: utilisateur.identifiantUtilisateur.formatter(),
         validateurValue: {
           fonction: utilisateurDetails.fonction,
-          fullName: utilisateurDetails.nomComplet,
+          nomComplet: utilisateurDetails.nomComplet,
         },
         identifiantCandidatureValues: candidatures.items.map((candidatures) =>
           candidatures.identifiantProjet.formatter(),

--- a/packages/applications/ssr/src/components/pages/période/notifier/notifierPériode.action.ts
+++ b/packages/applications/ssr/src/components/pages/période/notifier/notifierPériode.action.ts
@@ -52,7 +52,7 @@ const action: FormAction<FormState, typeof schema> = async (_, { appelOffre, per
         notifiéeParValue: utilisateur.identifiantUtilisateur.formatter(),
         validateurValue: {
           fonction: utilisateurDetails.fonction,
-          nomComplet: utilisateurDetails.nomComplet,
+          fullName: utilisateurDetails.nomComplet,
         },
         identifiantCandidatureValues: candidatures.items.map((candidatures) =>
           candidatures.identifiantProjet.formatter(),

--- a/packages/domain/appel-offre/src/appelOffre.entity.ts
+++ b/packages/domain/appel-offre/src/appelOffre.entity.ts
@@ -135,7 +135,7 @@ type NoteThresholdByCategory = {
 };
 
 export type Validateur = {
-  fullName: string;
+  nomComplet: string;
   fonction: string;
 };
 

--- a/packages/domain/candidature/src/attestationNonGénérée.error.ts
+++ b/packages/domain/candidature/src/attestationNonGénérée.error.ts
@@ -1,0 +1,7 @@
+import { InvalidOperationError } from '@potentiel-domain/core';
+
+export class AttestationNonGénéréeError extends InvalidOperationError {
+  constructor() {
+    super(`L'attestation d'une candidature non notifiée ne peut pas être régénérée`);
+  }
+}

--- a/packages/domain/candidature/src/candidature.aggregate.ts
+++ b/packages/domain/candidature/src/candidature.aggregate.ts
@@ -25,7 +25,11 @@ import {
   FamillePériodeAppelOffreInexistanteError,
   PériodeAppelOffreInexistanteError,
 } from './appelOffreInexistant.error';
-import { CandidatureNotifiéeEvent, notifier } from './notifier/notifierCandidature.behavior';
+import {
+  applyCandidatureNotifiée,
+  CandidatureNotifiéeEvent,
+  notifier,
+} from './notifier/notifierCandidature.behavior';
 
 export type CandidatureEvent =
   | CandidatureImportéeEvent
@@ -104,6 +108,9 @@ function apply(this: CandidatureAggregate, event: CandidatureEvent) {
   switch (event.type) {
     case 'CandidatureImportée-V1':
       applyCandidatureImportée.bind(this)(event);
+      break;
+    case 'CandidatureNotifiée-V1':
+      applyCandidatureNotifiée.bind(this)(event);
       break;
     case 'CandidatureCorrigée-V1':
       applyCandidatureCorrigée.bind(this)(event);

--- a/packages/domain/candidature/src/candidature.entity.ts
+++ b/packages/domain/candidature/src/candidature.entity.ts
@@ -44,7 +44,7 @@ export type CandidatureEntity = Entity<
       notifiéePar: Email.RawType;
       validateur: {
         fonction: string;
-        nomComplet: string;
+        fullName: string;
       };
     };
   }

--- a/packages/domain/candidature/src/candidature.entity.ts
+++ b/packages/domain/candidature/src/candidature.entity.ts
@@ -1,5 +1,6 @@
 import { DateTime, Email, IdentifiantProjet, StatutProjet } from '@potentiel-domain/common';
 import { Entity } from '@potentiel-domain/entity';
+import { AppelOffre } from '@potentiel-domain/appel-offre';
 
 import * as TypeGarantiesFinancières from './typeGarantiesFinancières.valueType';
 import { HistoriqueAbandon, TypeTechnologie, TypeActionnariat } from './candidature';
@@ -42,10 +43,7 @@ export type CandidatureEntity = Entity<
       estNotifiée: true;
       notifiéeLe: DateTime.RawType;
       notifiéePar: Email.RawType;
-      validateur: {
-        fonction: string;
-        fullName: string;
-      };
+      validateur: AppelOffre.Validateur;
     };
   }
 >;

--- a/packages/domain/candidature/src/consulter/consulterCandidature.query.ts
+++ b/packages/domain/candidature/src/consulter/consulterCandidature.query.ts
@@ -40,7 +40,7 @@ export type ConsulterCandidatureReadModel = {
   territoireProjet: string;
   misÀJourLe: DateTime.ValueType;
 
-  détails: DocumentProjet.ValueType;
+  détailsImport: DocumentProjet.ValueType;
 
   notification?: {
     notifiéeLe: DateTime.ValueType;
@@ -49,6 +49,7 @@ export type ConsulterCandidatureReadModel = {
       fonction: string;
       nomComplet: string;
     };
+    attestation: DocumentProjet.ValueType;
   };
 };
 
@@ -125,7 +126,7 @@ export const mapToReadModel = ({
   evaluationCarboneSimplifiée,
   actionnariat: actionnariat ? TypeActionnariat.convertirEnValueType(actionnariat) : undefined,
   territoireProjet,
-  détails: DocumentProjet.convertirEnValueType(
+  détailsImport: DocumentProjet.convertirEnValueType(
     identifiantProjet,
     'candidature/import',
     misÀJourLe,
@@ -138,5 +139,11 @@ export const mapToReadModel = ({
       fonction: notification.validateur.fonction,
       nomComplet: notification.validateur.nomComplet,
     },
+    attestation: DocumentProjet.convertirEnValueType(
+      identifiantProjet,
+      'attestation',
+      notification.notifiéeLe,
+      'application/pdf',
+    ),
   },
 });

--- a/packages/domain/candidature/src/consulter/consulterCandidature.query.ts
+++ b/packages/domain/candidature/src/consulter/consulterCandidature.query.ts
@@ -4,6 +4,7 @@ import { Option } from '@potentiel-libraries/monads';
 import { DateTime, Email, IdentifiantProjet } from '@potentiel-domain/common';
 import { Find } from '@potentiel-domain/entity';
 import { DocumentProjet } from '@potentiel-domain/document';
+import { AppelOffre } from '@potentiel-domain/appel-offre';
 
 import * as StatutCandidature from '../statutCandidature.valueType';
 import { CandidatureEntity } from '../candidature.entity';
@@ -45,10 +46,7 @@ export type ConsulterCandidatureReadModel = {
   notification?: {
     notifiéeLe: DateTime.ValueType;
     notifiéePar: Email.ValueType;
-    validateur: {
-      fonction: string;
-      nomComplet: string;
-    };
+    validateur: AppelOffre.Validateur;
     attestation: DocumentProjet.ValueType;
   };
 };
@@ -135,10 +133,7 @@ export const mapToReadModel = ({
   notification: notification && {
     notifiéeLe: DateTime.convertirEnValueType(notification.notifiéeLe),
     notifiéePar: Email.convertirEnValueType(notification.notifiéePar),
-    validateur: {
-      fonction: notification.validateur.fonction,
-      nomComplet: notification.validateur.nomComplet,
-    },
+    validateur: notification.validateur,
     attestation: DocumentProjet.convertirEnValueType(
       identifiantProjet,
       'attestation',

--- a/packages/domain/candidature/src/corriger/corrigerCandidature.command.ts
+++ b/packages/domain/candidature/src/corriger/corrigerCandidature.command.ts
@@ -10,6 +10,7 @@ import { ImporterCandidatureCommandCommonOptions } from '../importer/importerCan
 type CorrigerCandidatureCommandOptions = ImporterCandidatureCommandCommonOptions & {
   corrigéLe: DateTime.ValueType;
   corrigéPar: Email.ValueType;
+  doitRégénérerAttestation?: true;
 };
 
 export type CorrigerCandidatureCommand = Message<

--- a/packages/domain/candidature/src/corriger/corrigerCandidature.usecase.ts
+++ b/packages/domain/candidature/src/corriger/corrigerCandidature.usecase.ts
@@ -13,6 +13,7 @@ import { CorrigerCandidatureCommand } from './corrigerCandidature.command';
 type CorrigerCandidatureUseCasePayload = ImporterCandidatureUseCaseCommonPayload & {
   corrigéLe: string;
   corrigéPar: string;
+  doitRégénérerAttestation?: true;
 };
 
 export type CorrigerCandidatureUseCase = Message<
@@ -49,6 +50,7 @@ export const registerCorrigerCandidatureUseCase = () => {
         ...mapPayloadForCommand(payload),
         corrigéLe: DateTime.convertirEnValueType(payload.corrigéLe),
         corrigéPar: Email.convertirEnValueType(payload.corrigéPar),
+        doitRégénérerAttestation: payload.doitRégénérerAttestation,
       },
     });
   };

--- a/packages/domain/candidature/src/lister/listerCandidatures.query.ts
+++ b/packages/domain/candidature/src/lister/listerCandidatures.query.ts
@@ -23,8 +23,9 @@ export type CandidaturesListItemReadModel = {
     département: ConsulterCandidatureReadModel['localité']['département'];
     région: ConsulterCandidatureReadModel['localité']['région'];
   };
-  détails: ConsulterCandidatureReadModel['détails'];
+  détailsImport: ConsulterCandidatureReadModel['détailsImport'];
   estNotifiée: boolean;
+  attestation?: DocumentProjet.ValueType;
 };
 
 export type ListerCandidaturesReadModel = Readonly<{
@@ -120,11 +121,19 @@ export const mapToReadModel = ({
     département,
     région,
   },
-  détails: DocumentProjet.convertirEnValueType(
+  détailsImport: DocumentProjet.convertirEnValueType(
     identifiantProjet,
     'candidature/import',
     misÀJourLe,
     'application/json',
   ),
   estNotifiée: notification?.estNotifiée ?? false,
+  ...(notification?.estNotifiée && {
+    attestation: DocumentProjet.convertirEnValueType(
+      identifiantProjet,
+      'attestation',
+      notification.notifiéeLe,
+      'application/pdf',
+    ),
+  }),
 });

--- a/packages/domain/candidature/src/notifier/notifierCandidature.behavior.ts
+++ b/packages/domain/candidature/src/notifier/notifierCandidature.behavior.ts
@@ -9,7 +9,7 @@ export type NotifierOptions = {
   notifiéePar: Email.ValueType;
   validateur: {
     fonction: string;
-    nomComplet: string;
+    fullName: string;
   };
   attestation: {
     format: string;
@@ -24,7 +24,7 @@ export type CandidatureNotifiéeEvent = DomainEvent<
     notifiéePar: Email.RawType;
     validateur: {
       fonction: string;
-      nomComplet: string;
+      fullName: string;
     };
     attestation: {
       format: string;

--- a/packages/domain/candidature/src/notifier/notifierCandidature.behavior.ts
+++ b/packages/domain/candidature/src/notifier/notifierCandidature.behavior.ts
@@ -62,7 +62,7 @@ export async function notifier(
   await this.publish(event);
 }
 
-export function applyCandidatureNotifié(
+export function applyCandidatureNotifiée(
   this: CandidatureAggregate,
   _event: CandidatureNotifiéeEvent,
 ) {

--- a/packages/domain/candidature/src/notifier/notifierCandidature.behavior.ts
+++ b/packages/domain/candidature/src/notifier/notifierCandidature.behavior.ts
@@ -1,5 +1,6 @@
 import { DomainEvent, InvalidOperationError } from '@potentiel-domain/core';
 import { DateTime, Email, IdentifiantProjet } from '@potentiel-domain/common';
+import { AppelOffre } from '@potentiel-domain/appel-offre';
 
 import { CandidatureAggregate } from '../candidature.aggregate';
 
@@ -7,10 +8,7 @@ export type NotifierOptions = {
   identifiantProjet: IdentifiantProjet.ValueType;
   notifiéeLe: DateTime.ValueType;
   notifiéePar: Email.ValueType;
-  validateur: {
-    fonction: string;
-    fullName: string;
-  };
+  validateur: AppelOffre.Validateur;
   attestation: {
     format: string;
   };
@@ -22,10 +20,7 @@ export type CandidatureNotifiéeEvent = DomainEvent<
     identifiantProjet: IdentifiantProjet.RawType;
     notifiéeLe: DateTime.RawType;
     notifiéePar: Email.RawType;
-    validateur: {
-      fonction: string;
-      fullName: string;
-    };
+    validateur: AppelOffre.Validateur;
     attestation: {
       format: string;
     };

--- a/packages/domain/candidature/src/notifier/notifierCandidature.command.ts
+++ b/packages/domain/candidature/src/notifier/notifierCandidature.command.ts
@@ -2,6 +2,7 @@ import { Message, MessageHandler, mediator } from 'mediateur';
 
 import { LoadAggregate } from '@potentiel-domain/core';
 import { DateTime, Email, IdentifiantProjet } from '@potentiel-domain/common';
+import { AppelOffre } from '@potentiel-domain/appel-offre';
 
 import { loadCandidatureFactory } from '../candidature.aggregate';
 
@@ -11,10 +12,7 @@ export type NotifierCandidatureCommand = Message<
     identifiantProjet: IdentifiantProjet.ValueType;
     notifiéeLe: DateTime.ValueType;
     notifiéePar: Email.ValueType;
-    validateur: {
-      fonction: string;
-      fullName: string;
-    };
+    validateur: AppelOffre.Validateur;
     attestation: { format: string };
   }
 >;

--- a/packages/domain/candidature/src/notifier/notifierCandidature.command.ts
+++ b/packages/domain/candidature/src/notifier/notifierCandidature.command.ts
@@ -13,7 +13,7 @@ export type NotifierCandidatureCommand = Message<
     notifiéePar: Email.ValueType;
     validateur: {
       fonction: string;
-      nomComplet: string;
+      fullName: string;
     };
     attestation: { format: string };
   }

--- a/packages/domain/candidature/src/notifier/notifierCandidature.usecase.ts
+++ b/packages/domain/candidature/src/notifier/notifierCandidature.usecase.ts
@@ -1,6 +1,7 @@
 import { Message, MessageHandler, mediator } from 'mediateur';
 
 import { DateTime, Email, IdentifiantProjet } from '@potentiel-domain/common';
+import { AppelOffre } from '@potentiel-domain/appel-offre';
 
 import { NotifierCandidatureCommand } from './notifierCandidature.command';
 
@@ -10,10 +11,7 @@ export type NotifierCandidatureUseCase = Message<
     identifiantProjetValue: string;
     notifiéeLeValue: string;
     notifiéeParValue: string;
-    validateurValue: {
-      fonction: string;
-      fullName: string;
-    };
+    validateurValue: AppelOffre.Validateur;
     attestationValue: {
       format: string;
     };

--- a/packages/domain/candidature/src/notifier/notifierCandidature.usecase.ts
+++ b/packages/domain/candidature/src/notifier/notifierCandidature.usecase.ts
@@ -12,7 +12,7 @@ export type NotifierCandidatureUseCase = Message<
     notifiéeParValue: string;
     validateurValue: {
       fonction: string;
-      nomComplet: string;
+      fullName: string;
     };
     attestationValue: {
       format: string;

--- a/packages/domain/inmemory-referential/src/validateurParDéfaut/index.ts
+++ b/packages/domain/inmemory-referential/src/validateurParDéfaut/index.ts
@@ -2,19 +2,19 @@ import { AppelOffre } from '@potentiel-domain/appel-offre';
 
 export const validateurParDéfaut = {
   sd2: {
-    fullName: 'Sous-directeur bureau SD2',
+    nomComplet: 'Sous-directeur bureau SD2',
     fonction: 'Sous-directrice du système électrique et des énergies renouvelables',
   } satisfies AppelOffre.Validateur,
   hermine: {
-    fullName: 'Hermine DURAND',
+    nomComplet: 'Hermine DURAND',
     fonction: `Sous-directrice du système électrique et des énergies renouvelables`,
   } satisfies AppelOffre.Validateur,
   nicolas: {
-    fullName: 'Nicolas CLAUSSET',
+    nomComplet: 'Nicolas CLAUSSET',
     fonction: `Le sous-directeur du système électrique et des énergies renouvelables`,
   } satisfies AppelOffre.Validateur,
   ghislain: {
-    fullName: 'Ghislain FERRAN',
+    nomComplet: 'Ghislain FERRAN',
     fonction: `L’adjoint au sous-directeur du système électrique et des énergies renouvelables`,
   } satisfies AppelOffre.Validateur,
 };

--- a/packages/domain/lauréat/src/notifier/notifierLauréat.usecase.ts
+++ b/packages/domain/lauréat/src/notifier/notifierLauréat.usecase.ts
@@ -2,6 +2,7 @@ import { Message, MessageHandler, mediator } from 'mediateur';
 
 import { DateTime, Email, IdentifiantProjet } from '@potentiel-domain/common';
 import { Candidature } from '@potentiel-domain/candidature';
+import { AppelOffre } from '@potentiel-domain/appel-offre';
 
 import { NotifierLauréatCommand } from './notifierLauréat.command';
 
@@ -11,10 +12,7 @@ export type NotifierLauréatUseCase = Message<
     identifiantProjetValue: string;
     notifiéLeValue: string;
     notifiéParValue: string;
-    validateurValue: {
-      fonction: string;
-      fullName: string;
-    };
+    validateurValue: AppelOffre.Validateur;
     attestationValue: {
       format: string;
     };

--- a/packages/domain/lauréat/src/notifier/notifierLauréat.usecase.ts
+++ b/packages/domain/lauréat/src/notifier/notifierLauréat.usecase.ts
@@ -13,7 +13,7 @@ export type NotifierLauréatUseCase = Message<
     notifiéParValue: string;
     validateurValue: {
       fonction: string;
-      nomComplet: string;
+      fullName: string;
     };
     attestationValue: {
       format: string;

--- a/packages/domain/période/src/notifier/notifierPériode.command.ts
+++ b/packages/domain/période/src/notifier/notifierPériode.command.ts
@@ -6,6 +6,7 @@ import { LoadAggregate } from '@potentiel-domain/core';
 import { Candidature } from '@potentiel-domain/candidature';
 import { Lauréat } from '@potentiel-domain/laureat';
 import { Éliminé } from '@potentiel-domain/elimine';
+import { AppelOffre } from '@potentiel-domain/appel-offre';
 
 import { loadPériodeFactory } from '../période.aggregate';
 import * as IdentifiantPériode from '../identifiantPériode.valueType';
@@ -16,10 +17,7 @@ export type NotifierPériodeCommand = Message<
     identifiantPériode: IdentifiantPériode.ValueType;
     notifiéeLe: DateTime.ValueType;
     notifiéePar: Email.ValueType;
-    validateur: {
-      fonction: string;
-      fullName: string;
-    };
+    validateur: AppelOffre.Validateur;
     identifiantCandidatures: ReadonlyArray<IdentifiantProjet.ValueType>;
   }
 >;

--- a/packages/domain/période/src/notifier/notifierPériode.command.ts
+++ b/packages/domain/période/src/notifier/notifierPériode.command.ts
@@ -18,7 +18,7 @@ export type NotifierPériodeCommand = Message<
     notifiéePar: Email.ValueType;
     validateur: {
       fonction: string;
-      nomComplet: string;
+      fullName: string;
     };
     identifiantCandidatures: ReadonlyArray<IdentifiantProjet.ValueType>;
   }

--- a/packages/domain/période/src/notifier/notifierPériode.usecase.ts
+++ b/packages/domain/période/src/notifier/notifierPériode.usecase.ts
@@ -1,6 +1,7 @@
 import { Message, MessageHandler, mediator } from 'mediateur';
 
 import { DateTime, Email, IdentifiantProjet } from '@potentiel-domain/common';
+import { AppelOffre } from '@potentiel-domain/appel-offre';
 
 import * as IdentifiantPériode from '../identifiantPériode.valueType';
 
@@ -12,10 +13,7 @@ export type NotifierPériodeUseCase = Message<
     identifiantPériodeValue: IdentifiantPériode.RawType;
     notifiéeLeValue: DateTime.RawType;
     notifiéeParValue: Email.RawType;
-    validateurValue: {
-      fonction: string;
-      fullName: string;
-    };
+    validateurValue: AppelOffre.Validateur;
     identifiantCandidatureValues: ReadonlyArray<IdentifiantProjet.RawType>;
   }
 >;

--- a/packages/domain/période/src/notifier/notifierPériode.usecase.ts
+++ b/packages/domain/période/src/notifier/notifierPériode.usecase.ts
@@ -14,7 +14,7 @@ export type NotifierPériodeUseCase = Message<
     notifiéeParValue: Email.RawType;
     validateurValue: {
       fonction: string;
-      nomComplet: string;
+      fullName: string;
     };
     identifiantCandidatureValues: ReadonlyArray<IdentifiantProjet.RawType>;
   }

--- a/packages/domain/éliminé/src/notifier/notifierÉliminé.usecase.ts
+++ b/packages/domain/éliminé/src/notifier/notifierÉliminé.usecase.ts
@@ -2,6 +2,7 @@ import { Message, MessageHandler, mediator } from 'mediateur';
 
 import { DateTime, Email, IdentifiantProjet } from '@potentiel-domain/common';
 import { Candidature } from '@potentiel-domain/candidature';
+import { AppelOffre } from '@potentiel-domain/appel-offre';
 
 import { NotifierÉliminéCommand } from './notifierÉliminé.command';
 
@@ -11,10 +12,7 @@ export type NotifierÉliminéUseCase = Message<
     identifiantProjetValue: string;
     notifiéLeValue: string;
     notifiéParValue: string;
-    validateurValue: {
-      fonction: string;
-      fullName: string;
-    };
+    validateurValue: AppelOffre.Validateur;
     attestationValue: {
       format: string;
     };

--- a/packages/domain/éliminé/src/notifier/notifierÉliminé.usecase.ts
+++ b/packages/domain/éliminé/src/notifier/notifierÉliminé.usecase.ts
@@ -13,7 +13,7 @@ export type NotifierÉliminéUseCase = Message<
     notifiéParValue: string;
     validateurValue: {
       fonction: string;
-      nomComplet: string;
+      fullName: string;
     };
     attestationValue: {
       format: string;

--- a/packages/specifications/src/candidature/candidature.world.ts
+++ b/packages/specifications/src/candidature/candidature.world.ts
@@ -105,7 +105,7 @@ export class CandidatureWorld {
       actionnariat: expectedValues.actionnariatValue
         ? Candidature.TypeActionnariat.convertirEnValueType(expectedValues.actionnariatValue)
         : undefined,
-      détails: DocumentProjet.convertirEnValueType(
+      détailsImport: DocumentProjet.convertirEnValueType(
         this.importerCandidature.identifiantProjet,
         'candidature/import',
         misÀJourLe,

--- a/packages/specifications/src/candidature/corrigerCandidature.feature
+++ b/packages/specifications/src/candidature/corrigerCandidature.feature
@@ -12,12 +12,20 @@ Fonctionnalité: Corriger une candidature
         Et le porteur n'a pas été prévenu que son attestation a été modifiée
 
     Scénario: Corriger une candidature notifiée en regénérant l'attestation
-        Quand le DGEC validateur notifie la candidature comme lauréate
+        Etant donné la candidature lauréate notifiée "Du boulodrome de Marseille #2"
         Quand un administrateur corrige la candidature avec :
             | nom candidat               | abcd |
             | doit régénérer attestation | oui  |
         Alors la candidature devrait être consultable
         Et le porteur a été prévenu que son attestation a été modifiée
+
+    Scénario: Corriger une candidature notifiée sans régénérer l'attestation
+        Etant donné la candidature lauréate notifiée "Du boulodrome de Marseille #2"
+        Quand un administrateur corrige la candidature avec :
+            | nom candidat               | abcd |
+            | doit régénérer attestation | non  |
+        Alors la candidature devrait être consultable
+        Et le porteur n'a pas été prévenu que son attestation a été modifiée
 
     Scénario: Impossible de régénérer l'attestation d'une candidature non notifiée
         Quand un administrateur corrige la candidature avec :

--- a/packages/specifications/src/candidature/corrigerCandidature.feature
+++ b/packages/specifications/src/candidature/corrigerCandidature.feature
@@ -5,17 +5,25 @@ Fonctionnalité: Corriger une candidature
         Etant donné le DGEC validateur "Robert Robichet"
         Et la candidature lauréate "Du boulodrome de Marseille"
 
-    Scénario: Corriger une candidature
+    Scénario: Corriger une candidature sans régénérer l'attestation
         Quand un administrateur corrige la candidature avec :
             | nom candidat | abcd |
         Alors la candidature devrait être consultable
+        Et le porteur n'a pas été prévenu que son attestation a été modifiée
 
-    Scénario: Corriger une candidature notifiée
+    Scénario: Corriger une candidature notifiée en regénérant l'attestation
         Quand le DGEC validateur notifie la candidature comme lauréate
-        Et un administrateur corrige la candidature avec :
-            | nom candidat | abcd |
+        Quand un administrateur corrige la candidature avec :
+            | nom candidat               | abcd |
+            | doit régénérer attestation | oui  |
         Alors la candidature devrait être consultable
         Et le porteur a été prévenu que son attestation a été modifiée
+
+    Scénario: Impossible de régénérer l'attestation d'une candidature non notifiée
+        Quand un administrateur corrige la candidature avec :
+            | nom candidat               | abcd |
+            | doit régénérer attestation | oui  |
+        Alors l'administrateur devrait être informé que "L'attestation d'une candidature non notifiée ne peut pas être régénérée"
 
     Scénario: Impossible de changer l'AO d'une candidature
         Quand un administrateur corrige la candidature avec :

--- a/packages/specifications/src/candidature/corrigerCandidature.feature
+++ b/packages/specifications/src/candidature/corrigerCandidature.feature
@@ -10,6 +10,13 @@ Fonctionnalité: Corriger une candidature
             | nom candidat | abcd |
         Alors la candidature devrait être consultable
 
+    Scénario: Corriger une candidature notifiée
+        Quand le DGEC validateur notifie la candidature comme lauréate
+        Et un administrateur corrige la candidature avec :
+            | nom candidat | abcd |
+        Alors la candidature devrait être consultable
+        Et le porteur a été prévenu que son attestation a été modifiée
+
     Scénario: Impossible de changer l'AO d'une candidature
         Quand un administrateur corrige la candidature avec :
             | appel d'offre | x |

--- a/packages/specifications/src/candidature/stepDefinitions/candidature.given.ts
+++ b/packages/specifications/src/candidature/stepDefinitions/candidature.given.ts
@@ -58,7 +58,7 @@ EtantDonné(
         notifiéParValue: this.utilisateurWorld.validateurFixture.email,
         validateurValue: {
           fonction: this.utilisateurWorld.validateurFixture.fonction,
-          fullName: this.utilisateurWorld.validateurFixture.nom,
+          nomComplet: this.utilisateurWorld.validateurFixture.nom,
         },
         attestationValue: {
           format: `text/plain`,

--- a/packages/specifications/src/candidature/stepDefinitions/candidature.given.ts
+++ b/packages/specifications/src/candidature/stepDefinitions/candidature.given.ts
@@ -2,6 +2,8 @@ import { DataTable, Given as EtantDonné } from '@cucumber/cucumber';
 import { mediator } from 'mediateur';
 
 import { Candidature } from '@potentiel-domain/candidature';
+import { Lauréat } from '@potentiel-domain/laureat';
+import { DateTime } from '@potentiel-domain/common';
 
 import { PotentielWorld } from '../../potentiel.world';
 import { DeepPartial } from '../../fixture';
@@ -30,6 +32,35 @@ EtantDonné(
   `la candidature lauréate {string}`,
   async function (this: PotentielWorld, nomProjet: string) {
     await importerCandidature.call(this, nomProjet, 'classé');
+  },
+);
+
+EtantDonné(
+  'la candidature lauréate notifiée {string}',
+  async function (this: PotentielWorld, nomProjet: string) {
+    await importerCandidature.call(this, nomProjet, 'classé');
+
+    const identifiantProjet = this.candidatureWorld.importerCandidature.identifiantProjet;
+
+    this.lauréatWorld.notifierLauréatFixture.créer({
+      identifiantProjet,
+    });
+
+    this.utilisateurWorld.porteurFixture.créer({
+      email: this.candidatureWorld.importerCandidature.values.emailContactValue,
+    });
+
+    await mediator.send<Lauréat.NotifierLauréatUseCase>({
+      type: 'Lauréat.UseCase.NotifierLauréat',
+      data: {
+        identifiantProjetValue: identifiantProjet,
+        notifiéLeValue: DateTime.now().formatter(),
+        notifiéParValue: this.utilisateurWorld.validateurFixture.email,
+        attestationValue: {
+          format: `text/plain`,
+        },
+      },
+    });
   },
 );
 

--- a/packages/specifications/src/candidature/stepDefinitions/candidature.given.ts
+++ b/packages/specifications/src/candidature/stepDefinitions/candidature.given.ts
@@ -56,6 +56,10 @@ EtantDonné(
         identifiantProjetValue: identifiantProjet,
         notifiéLeValue: DateTime.now().formatter(),
         notifiéParValue: this.utilisateurWorld.validateurFixture.email,
+        validateurValue: {
+          fonction: this.utilisateurWorld.validateurFixture.fonction,
+          fullName: this.utilisateurWorld.validateurFixture.nom,
+        },
         attestationValue: {
           format: `text/plain`,
         },

--- a/packages/specifications/src/candidature/stepDefinitions/candidature.then.ts
+++ b/packages/specifications/src/candidature/stepDefinitions/candidature.then.ts
@@ -10,6 +10,7 @@ import { ConsulterDocumentProjetQuery } from '@potentiel-domain/document';
 
 import { PotentielWorld } from '../../potentiel.world';
 import { convertReadableStreamToString } from '../../helpers/convertReadableToString';
+import { sleep } from '../../helpers/sleep';
 
 Alors(`la candidature devrait être consultable`, async function (this: PotentielWorld) {
   const { identifiantProjet, values: expectedValues } = this.candidatureWorld.importerCandidature;
@@ -65,6 +66,21 @@ Alors(
         /Potentiel - Une nouvelle attestation est disponible pour le projet .*/,
       );
     });
+  },
+);
+
+Alors(
+  "le porteur n'a pas été prévenu que son attestation a été modifiée",
+  async function (this: PotentielWorld) {
+    // edge case because we want to wait for a notification that should not be sent
+    await sleep(400);
+    try {
+      this.notificationWorld.récupérerNotification(
+        this.candidatureWorld.importerCandidature.values.emailContactValue,
+      );
+    } catch (error) {
+      expect((error as Error).message).to.equal('Pas de notification');
+    }
   },
 );
 

--- a/packages/specifications/src/candidature/stepDefinitions/candidature.then.ts
+++ b/packages/specifications/src/candidature/stepDefinitions/candidature.then.ts
@@ -102,37 +102,6 @@ Alors(
 );
 
 Alors(
-  'les attestations de désignation des candidatures de la période notifiée devraient être consultables',
-  async function (this: PotentielWorld) {
-    const { identifiantPériode } = this.périodeWorld;
-    const candidatures = await mediator.send<Candidature.ListerCandidaturesQuery>({
-      type: 'Candidature.Query.ListerCandidatures',
-      data: {
-        appelOffre: identifiantPériode.appelOffre,
-        période: identifiantPériode.période,
-      },
-    });
-
-    for (const candidature of candidatures.items) {
-      expect(candidature.attestation, "La candidature n'a pas d'attestation").not.to.be.undefined;
-      await waitForExpect(async () => {
-        if (candidature.attestation) {
-          const { content, format } = await mediator.send<ConsulterDocumentProjetQuery>({
-            type: 'Document.Query.ConsulterDocumentProjet',
-            data: {
-              documentKey: candidature.attestation.formatter(),
-            },
-          });
-
-          expect(await convertReadableStreamToString(content)).to.have.length.gt(1);
-          format.should.be.equal('application/pdf');
-        }
-      });
-    }
-  },
-);
-
-Alors(
   "l'attestation de désignation de la candidature devrait être consultable",
   async function (this: PotentielWorld) {
     const { identifiantProjet } = this.candidatureWorld.importerCandidature;

--- a/packages/specifications/src/candidature/stepDefinitions/candidature.when.ts
+++ b/packages/specifications/src/candidature/stepDefinitions/candidature.when.ts
@@ -65,6 +65,9 @@ async function corrigerCandidature(this: PotentielWorld, exemple?: Record<string
     corrigéPar: this.utilisateurWorld.validateurFixture.email,
   });
 
+  const doitRégénérerAttestation =
+    exemple?.['doit régénérer attestation'] === 'oui' ? true : undefined;
+
   try {
     await mediator.send<Candidature.CorrigerCandidatureUseCase>({
       type: 'Candidature.UseCase.CorrigerCandidature',
@@ -72,6 +75,7 @@ async function corrigerCandidature(this: PotentielWorld, exemple?: Record<string
         ...values,
         corrigéLe,
         corrigéPar,
+        doitRégénérerAttestation,
       },
     });
   } catch (error) {

--- a/packages/specifications/src/période/notifierPériode.feature
+++ b/packages/specifications/src/période/notifierPériode.feature
@@ -9,6 +9,7 @@ Fonctionnalité: Notifier une période d'un appel d'offres
         Quand un DGEC validateur notifie la période d'un appel d'offres
         Alors la période devrait être notifiée avec les lauréats et les éliminés
         Et les candidatures de la période notifiée devraient être notifiées
+        Et les attestations de désignation des candidatures de la période notifiée devraient être consultables
         Et le porteur a été prévenu que sa candidature a été notifiée
         Et les lauréats et éliminés devraient être consultables
 
@@ -18,4 +19,5 @@ Fonctionnalité: Notifier une période d'un appel d'offres
         Quand un DGEC validateur notifie la période d'un appel d'offres
         Alors la période devrait être notifiée avec les lauréats et les éliminés
         Et les candidatures de la période notifiée devraient être notifiées
+        Et les attestations de désignation des candidatures de la période notifiée devraient être consultables
         Et les lauréats et éliminés devraient être consultables

--- a/packages/specifications/src/période/stepDefinitions/période.when.ts
+++ b/packages/specifications/src/période/stepDefinitions/période.when.ts
@@ -35,7 +35,7 @@ export async function notifierPériode(this: PotentielWorld) {
         notifiéeParValue: this.périodeWorld.notifierPériodeFixture.notifiéePar,
         validateurValue: {
           fonction: this.utilisateurWorld.validateurFixture.fonction,
-          nomComplet: this.utilisateurWorld.validateurFixture.nom,
+          fullName: this.utilisateurWorld.validateurFixture.nom,
         },
         identifiantCandidatureValues: [...lauréats, ...éliminés],
       },

--- a/packages/specifications/src/période/stepDefinitions/période.when.ts
+++ b/packages/specifications/src/période/stepDefinitions/période.when.ts
@@ -17,7 +17,9 @@ export async function notifierPériode(this: PotentielWorld) {
   try {
     const identifiantPériode = this.périodeWorld.identifiantPériode.formatter();
 
-    const { lauréats, éliminés } = this.périodeWorld.notifierPériodeFixture.créer();
+    const { lauréats, éliminés } = this.périodeWorld.notifierPériodeFixture.créer({
+      notifiéePar: this.utilisateurWorld.validateurFixture.email,
+    });
 
     this.utilisateurWorld.porteurFixture.créer({
       email: this.candidatureWorld.importerCandidature.values.emailContactValue,

--- a/packages/specifications/src/période/stepDefinitions/période.when.ts
+++ b/packages/specifications/src/période/stepDefinitions/période.when.ts
@@ -35,7 +35,7 @@ export async function notifierPériode(this: PotentielWorld) {
         notifiéeParValue: this.périodeWorld.notifierPériodeFixture.notifiéePar,
         validateurValue: {
           fonction: this.utilisateurWorld.validateurFixture.fonction,
-          fullName: this.utilisateurWorld.validateurFixture.nom,
+          nomComplet: this.utilisateurWorld.validateurFixture.nom,
         },
         identifiantCandidatureValues: [...lauréats, ...éliminés],
       },

--- a/packages/specifications/src/setup.ts
+++ b/packages/specifications/src/setup.ts
@@ -128,6 +128,7 @@ After(async () => {
       Bucket: bucketName,
     }),
   );
+
   if (unsetup) {
     await unsetup();
   }


### PR DESCRIPTION
# Description

### Regénérer attestation si correction des candidatures && candidature déjà notifiée
- mise à jour saga attestation
- ajout test pour l'attestation de désignation


### Notification
- notification du porteur
- ajout test

## Type de changement

Veuillez supprimer les options qui ne sont pas pertinentes.

- [ ] Correction de bug
- [x] Nouvelle fonctionnalité
- [ ] Refacto de code
- [ ] Breaking changes (correction ou fonctionnalité qui ferait en sorte que la fonctionnalité existante ne fonctionne pas comme prévu)
- [ ] Ce changement nécessite une mise à jour de la documentation

# Comment cela a-t-il été testé?

Test ajouté

# Check-up :

- [ ] Mon code [suit les directives de style](../docs/contributing//DEVELOPMENT_FLOW.md) de ce projet
- [ ] J'ai effectué une auto-revue de mon code
- [ ] J'ai commenté mon code, en particulier dans les zones difficiles à comprendre
- [ ] J'ai apporté des modifications correspondantes à la documentation
- [ ] Mes modifications ne génèrent aucun warning
- [ ] J'ai ajouté des tests qui prouvent l'efficacité de ma correction ou que ma fonctionnalité fonctionne
- [ ] Les nouveaux tests unitaires et les tests existants passent en local / dans la CI avec mes modifications
