### PR TITLE
🐛 Correction de l'affichage des Statistiques

### DIFF
--- a/packages/applications/legacy/src/views/components/UI/organisms/MetabaseStats.tsx
+++ b/packages/applications/legacy/src/views/components/UI/organisms/MetabaseStats.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+type MetabaseStatsProps = {
+  iframeUrl: string;
+};
+
+export const MetabaseStats: React.FC<MetabaseStatsProps> = ({ iframeUrl }) => {
+  const iframeRef = React.useRef<HTMLIFrameElement>(null);
+
+  React.useEffect(() => {
+    if (!iframeRef.current) return;
+    const onLoad = function () {
+      (window as any).iFrameResize({}, this);
+    };
+    iframeRef.current.addEventListener('load', onLoad);
+    return () => {
+      iframeRef.current?.removeEventListener('load', onLoad);
+    };
+  }, []);
+
+  return (
+    <div>
+      <iframe ref={iframeRef} src={iframeUrl} width="100%" frameBorder="0" allowTransparency />
+    </div>
+  );
+};

--- a/packages/applications/legacy/src/views/components/UI/organisms/index.ts
+++ b/packages/applications/legacy/src/views/components/UI/organisms/index.ts
@@ -3,4 +3,5 @@ export * from './ProjectList';
 export * from './UserNavigation';
 export * from './Header';
 export * from './Footer';
+export * from './MetabaseStats';
 export { Pagination } from './Pagination';

--- a/packages/applications/legacy/src/views/pages/AcheteurObligeStatistiquesPage.tsx
+++ b/packages/applications/legacy/src/views/pages/AcheteurObligeStatistiquesPage.tsx
@@ -1,6 +1,6 @@
 import type { Request } from 'express';
 import React from 'react';
-import { Heading1, LegacyPageTemplate } from '../components';
+import { Heading1, LegacyPageTemplate, MetabaseStats } from '../components';
 import { hydrateOnClient } from '../helpers';
 
 type AcheteurObligeStatistiquesProps = {
@@ -18,17 +18,7 @@ export const AcheteurObligeStatistiques = ({
         <Heading1>Tableau de bord</Heading1>
         <section>
           <script src="https://metabase.potentiel.beta.gouv.fr/app/iframeResizer.js"></script>
-          <div
-            dangerouslySetInnerHTML={{
-              __html: `<iframe
-            src="${iframeUrl}"
-            frameBorder="0"
-            width="100%"
-            allowTransparency
-            onload="iFrameResize({}, this)"
-          ></iframe>`,
-            }}
-          />
+          <MetabaseStats iframeUrl={iframeUrl} />
         </section>
       </div>
     </LegacyPageTemplate>

--- a/packages/applications/legacy/src/views/pages/AdemeStatistiquesPage.tsx
+++ b/packages/applications/legacy/src/views/pages/AdemeStatistiquesPage.tsx
@@ -1,6 +1,6 @@
 import type { Request } from 'express';
 import React from 'react';
-import { Heading1, LegacyPageTemplate } from '../components';
+import { Heading1, LegacyPageTemplate, MetabaseStats } from '../components';
 import { hydrateOnClient } from '../helpers';
 
 type AdemeStatistiquesProps = {
@@ -14,17 +14,7 @@ export const AdemeStatistiques = ({ iframeUrl, request }: AdemeStatistiquesProps
       <Heading1>Tableau de bord</Heading1>
       <section>
         <script src="https://metabase.potentiel.beta.gouv.fr/app/iframeResizer.js"></script>
-        <div
-          dangerouslySetInnerHTML={{
-            __html: `<iframe
-            src="${iframeUrl}"
-            frameBorder="0"
-            width="100%"
-            allowTransparency
-            onload="iFrameResize({}, this)"
-          ></iframe>`,
-          }}
-        />
+        <MetabaseStats iframeUrl={iframeUrl} />
       </section>
     </LegacyPageTemplate>
   );

--- a/packages/applications/legacy/src/views/pages/AdminStatistiquesPage.tsx
+++ b/packages/applications/legacy/src/views/pages/AdminStatistiquesPage.tsx
@@ -1,6 +1,6 @@
 import type { Request } from 'express';
 import React from 'react';
-import { Heading1, LegacyPageTemplate } from '../components';
+import { Heading1, LegacyPageTemplate, MetabaseStats } from '../components';
 import { hydrateOnClient } from '../helpers';
 
 type AdminStatistiquesProps = {
@@ -14,17 +14,7 @@ export const AdminStatistiques = ({ iframeUrl, request }: AdminStatistiquesProps
       <Heading1>Tableau de bord</Heading1>
       <section>
         <script src="https://metabase.potentiel.beta.gouv.fr/app/iframeResizer.js"></script>
-        <div
-          dangerouslySetInnerHTML={{
-            __html: `<iframe
-            src="${iframeUrl}"
-            frameBorder="0"
-            width="100%"
-            allowTransparency
-            onload="iFrameResize({}, this)"
-          ></iframe>`,
-          }}
-        />
+        <MetabaseStats iframeUrl={iframeUrl} />
       </section>
     </LegacyPageTemplate>
   );

--- a/packages/applications/legacy/src/views/pages/CreStatistiquesPage.tsx
+++ b/packages/applications/legacy/src/views/pages/CreStatistiquesPage.tsx
@@ -1,6 +1,6 @@
 import type { Request } from 'express';
 import React from 'react';
-import { Heading1, LegacyPageTemplate } from '../components';
+import { Heading1, LegacyPageTemplate, MetabaseStats } from '../components';
 import { hydrateOnClient } from '../helpers';
 
 type CreStatistiquesPageProps = {
@@ -13,18 +13,8 @@ export const CreStatistiques = ({ iframeUrl, request }: CreStatistiquesPageProps
     <LegacyPageTemplate user={request.user} currentPage="cre-statistiques">
       <Heading1>Tableau de bord</Heading1>
       <section>
-        <script src="https://metabase.potentiel.beta.gouv.fr/app/iframeResizer.js" />
-        <div
-          dangerouslySetInnerHTML={{
-            __html: `<iframe
-            src="${iframeUrl}"
-            frameBorder="0"
-            width="100%"
-            allowTransparency
-            onload="iFrameResize({}, this)"
-          ></iframe>`,
-          }}
-        />
+        <script src="https://metabase.potentiel.beta.gouv.fr/app/iframeResizer.js"></script>
+        <MetabaseStats iframeUrl={iframeUrl} />
       </section>
     </LegacyPageTemplate>
   );

--- a/packages/applications/legacy/src/views/pages/StatistiquesPage.tsx
+++ b/packages/applications/legacy/src/views/pages/StatistiquesPage.tsx
@@ -1,6 +1,6 @@
 import type { Request } from 'express';
 import React from 'react';
-import { Heading1, LegacyPageTemplate } from '../components';
+import { Heading1, LegacyPageTemplate, MetabaseStats } from '../components';
 import { hydrateOnClient } from '../helpers';
 
 type StatistiquesProps = {
@@ -20,28 +20,8 @@ export const Statistiques = ({ mapIframeUrl, mainIframeUrl, request }: Statistiq
       </section>
       <section>
         <script src="https://metabase.potentiel.beta.gouv.fr/app/iframeResizer.js"></script>
-        <div
-          dangerouslySetInnerHTML={{
-            __html: `<iframe
-            src="${mainIframeUrl}"
-            frameBorder="0"
-            width="100%"
-            allowTransparency
-            onload="iFrameResize({}, this)"
-          ></iframe>`,
-          }}
-        ></div>
-        <div
-          dangerouslySetInnerHTML={{
-            __html: `<iframe
-            src="${mapIframeUrl}"
-            frameBorder="0"
-            width="100%"
-            allowTransparency
-            onload="iFrameResize({}, this)"
-          ></iframe>`,
-          }}
-        ></div>
+        <MetabaseStats iframeUrl={mainIframeUrl} />
+        <MetabaseStats iframeUrl={mapIframeUrl} />
       </section>
     </LegacyPageTemplate>
   );


### PR DESCRIPTION
les CSP empêchent l'execution du script inline `onload`, et l'iframe n'est pas resize correctement. En passant tout en react, on a plus le problème. 
En local, j'ai un soucis de scintillement, j'aimerais tester en dev si ca fait pareil.