### PR TITLE
🧑‍💻 Attendre que minio soit up avant de créer le bucket

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,8 +39,12 @@ services:
     image: minio/mc
     depends_on:
       - s3
-    entrypoint: >
-      /bin/sh -c " /usr/bin/mc alias set myminio http://s3:9000 minioadmin minioadmin; /usr/bin/mc mb myminio/potentiel; exit 0; "
+    entrypoint: /bin/sh -c
+    command:
+      - |
+        mc alias set myminio http://s3:9000 minioadmin minioadmin
+        mc ping myminio -c 1
+        mc mb myminio/potentiel
     profiles: ['app']
   auth:
     container_name: potentiel_auth


### PR DESCRIPTION
Dans de rare cas, le bucket n'est pas créé sur minio car celui-ci n'est pas encore joignable. l'ajout de `mc ping -c 1`  permet d'attendre un ping successful avant de continuer. 

Au passage, mini changement de la config docker compose pour plus de lisibilité