### PR TITLE
🧪 Ajout d'un appel d'offre "Test" nécessaire à la phase de tests d'intrusion

### DIFF
--- a/.demo/Tests-Intrusions-EY.csv
+++ b/.demo/Tests-Intrusions-EY.csv
@@ -1,0 +1,205 @@
+N°CRE;Appel d'offres;Période;Famille;Candidat;Nom projet;"1. Garantie financière jusqu'à 6 mois après la date d'achèvement
+2. Garantie financière avec date d'échéance et à renouveler
+3. Consignation";Date d'échéance au format JJ/MM/AAAA;"1. Lauréat d'aucun AO
+2. Abandon classique
+3. Abandon avec recandidature
+4. Lauréat d'un AO";puissance_production_annuelle;prix_reference;Evaluation carbone simplifiée indiquée au C. du formulaire de candidature et arrondie (kg eq CO2/kWc);Note prix;Note carbone;Note environnementale;Note totale;Nom (personne physique) ou raison sociale (personne morale) :;Nature du candidat;Numéro SIREN ou SIRET*;Code NACE;Type entreprise;Société mère;Région d'implantation;Adresse;Nom et prénom du représentant légal;Titre du représentant légal;Nom et prénom du contact;Société du contact;Titre du contact;Adresse postale du contact;Adresse électronique du contact;Téléphone;Nom du projet;Famille de candidature;Numéro SIRET de l'installation;N°, voie, lieu-dit 1;CP;Commune;Département;Région;Deuxième commune si le projet est implanté sur deux communes;Puissance installée (MWc);Coordonnées géodésiques WGS84 du barycentre de l’Installation : Latitude (degrés);Coordonnées géodésiques WGS84 du barycentre de l’Installation : Latitude (minutes);Coordonnées géodésiques WGS84 du barycentre de l’Installation : Latitude (secondes);"Coordonnées géodésiques WGS84du barycentre de l’Installation : Longitude
+(degrés)";"Coordonnées géodésiques WGS84du barycentre de l’Installation : Longitude
+(minutes)";"Coordonnées géodésiques WGS84du barycentre de l’Installation : Longitude
+(secondes)";Prix de référence (€/MWh);Valeur de l’évaluation carbone des modules (kg eq CO2/kWc);Financement collectif (Oui/Non);Part minimale du financement collectif (%);Origine du financement collectif;Gouvernance partagée (Oui/Non);Niveau d'engagement gouvernance partagée (%);Type d'utorisation d'Urbanisme (pièce n°3);Numéro de l'autorisation d'urbanisme;Date d'obtention de l'autorisation d'urbanisme;Commentaire si plusieurs autorisation d'urbanisme;Dépôt 1ère périodes précédentes ? 1;Dépôt 1ère périodes précédentes ? 2;Dépôt 1ère périodes précédentes ? 3;Date d'obtention du CETI;"Type de terrain d'implantation 
+(pièce n°3)";"Types Cas 3 
+(pièce n°3)";Surface projetée au sol de l’ensemble des Capteurs solaires (ha);Surface du Terrain d’implantation (ha);Typologie de projet;Ensoleillement de référence (kWh/m²/an);"Nb d'aérogénérateurs
+(AO éolien)";Puissance unitaire des aérogénérateurs (AO éolien);"Diamètre du rotor (m)
+(AO éolien)";"Hauteur bout de pâle (m)
+(AO éolien)";Technologie (AO éolien);Installation renouvellée (AO éolien);Référence du dossier de raccordement*;Date de mise en service du raccordement attendue (mm/aaaa);Capacité du raccordement (kW);"Type de consommateur associé
+(AO autoconsommation)";"Nature et nombre du ou des consommateur(s)
+(AO autoconsommation)";Nom et prénom du signataire du formulaire;"date
+(candidature)";"heure
+(candidature)";"Reference Pli
+(candidature)";Respect de toutes les conditions d'admissibilité ?;;Suspicion de doublon ? Colonnes DL à DP;Vérif précédentes périodes (colonnes BC à BE);Suspicion de 250m ? Colonnes DL à DP;Avis admissibilité du projet;Identification du candidat (pièce n°1);Comm identification du candidat;Avis identification du candidat;Comm 1 formulaire de candidature;Comm2 formulaire de candidature;Avis formulaire de candidature;;;;;;Comm 1 garanties financières (Pièce n°5);Montant garanties financières (Pièce n°5);Vérification montant garanties financières (Pièce n°5);Date d'effet garanties financières (Pièce n°5);Avis garanties financières (Pièce n°5);;;;;;;;;;;;;;;;;Classé ?;;;;;;;;;;"Technologie
+(dispositif de production)";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;Technologie (Modules ou films);"Référence commerciale 
+(Modules ou films)";"Nom du fabricant 
+(Modules ou films) 1";"Nom du fabricant 
+(Modules ou films) 2";"Nom du fabricant 
+(Modules ou films) 3";"Nom du fabricant 
+(Modules ou films) 4";"Nom du fabricant 
+(Modules ou films) 5";"Lieu(x) de fabrication 
+(Modules ou films) 1";"Lieu(x) de fabrication 
+(Modules ou films) 2";"Lieu(x) de fabrication 
+(Modules ou films) 3";"Lieu(x) de fabrication 
+(Modules ou films) 4";"Lieu(x) de fabrication 
+(Modules ou films) 5";"Puissance crête (Wc) 
+(Modules ou films)";"Rendement nominal 
+(Modules ou films)";Nom du fabricant (Cellules) 1;Nom du fabricant (Cellules) 2;Nom du fabricant (Cellules) 3;Nom du fabricant (Cellules) 4;Nom du fabricant (Cellules) 5;Lieu(x) de fabrication (Cellules) 1;Lieu(x) de fabrication (Cellules) 2;Lieu(x) de fabrication (Cellules) 3;Lieu(x) de fabrication (Cellules) 4;Lieu(x) de fabrication (Cellules) 5;"Nom du fabricant 
+(Plaquettes de silicium (wafers)) 1";"Nom du fabricant 
+(Plaquettes de silicium (wafers)) 2";"Nom du fabricant 
+(Plaquettes de silicium (wafers)) 3";"Nom du fabricant 
+(Plaquettes de silicium (wafers)) 4";"Nom du fabricant 
+(Plaquettes de silicium (wafers)) 5";"Lieu(x) de fabrication 
+(Plaquettes de silicium (wafers)) 1";"Lieu(x) de fabrication 
+(Plaquettes de silicium (wafers)) 2";"Lieu(x) de fabrication 
+(Plaquettes de silicium (wafers)) 3";"Lieu(x) de fabrication 
+(Plaquettes de silicium (wafers)) 4";"Lieu(x) de fabrication 
+(Plaquettes de silicium (wafers)) 5";"Nom du fabricant 
+(Polysilicium) 1";"Nom du fabricant 
+(Polysilicium) 2";"Nom du fabricant 
+(Polysilicium) 3";"Nom du fabricant 
+(Polysilicium) 4";"Nom du fabricant 
+(Polysilicium) 5";"Lieu(x) de fabrication 
+(Polysilicium) 1";"Lieu(x) de fabrication 
+(Polysilicium) 2";"Lieu(x) de fabrication 
+(Polysilicium) 3";"Lieu(x) de fabrication 
+(Polysilicium) 4";"Lieu(x) de fabrication 
+(Polysilicium) 5";"Nom du fabricant 
+(Postes de conversion) 1";"Nom du fabricant 
+(Postes de conversion) 2";"Nom du fabricant 
+(Postes de conversion) 3";"Nom du fabricant 
+(Postes de conversion) 4";"Nom du fabricant 
+(Postes de conversion) 5";"Lieu(x) de fabrication 
+(Postes de conversion) 1";"Lieu(x) de fabrication 
+(Postes de conversion) 2";"Lieu(x) de fabrication 
+(Postes de conversion) 3";"Lieu(x) de fabrication 
+(Postes de conversion) 4";"Lieu(x) de fabrication 
+(Postes de conversion) 5";"Technologie 
+(Dispositifs de stockage de l’énergie *)";"Nom du fabricant 
+(Dispositifs de stockage de l’énergie *) 1";"Nom du fabricant 
+(Dispositifs de stockage de l’énergie *) 2";"Nom du fabricant 
+(Dispositifs de stockage de l’énergie *) 3";"Nom du fabricant 
+(Dispositifs de stockage de l’énergie *) 4";"Nom du fabricant 
+(Dispositifs de stockage de l’énergie *) 5";"Lieu(x) de fabrication 
+(Dispositifs de stockage de l’énergie *) 1";"Lieu(x) de fabrication 
+(Dispositifs de stockage de l’énergie *) 2";"Lieu(x) de fabrication 
+(Dispositifs de stockage de l’énergie *) 3";"Lieu(x) de fabrication 
+(Dispositifs de stockage de l’énergie *) 4";"Lieu(x) de fabrication 
+(Dispositifs de stockage de l’énergie *) 5";"Technologie 
+(Dispositifs de suivi de la course du soleil *)";"Nom du fabricant 
+(Dispositifs de suivi de la course du soleil *) 1";"Nom du fabricant 
+(Dispositifs de suivi de la course du soleil *) 2";"Nom du fabricant 
+(Dispositifs de suivi de la course du soleil *) 3";"Nom du fabricant 
+(Dispositifs de suivi de la course du soleil *) 4";"Nom du fabricant 
+(Dispositifs de suivi de la course du soleil *) 5";"Lieu(x) de fabrication 
+(Dispositifs de suivi de la course du soleil *) 1";"Lieu(x) de fabrication 
+(Dispositifs de suivi de la course du soleil *) 2";"Lieu(x) de fabrication 
+(Dispositifs de suivi de la course du soleil *) 3";"Lieu(x) de fabrication 
+(Dispositifs de suivi de la course du soleil *) 4";"Lieu(x) de fabrication 
+(Dispositifs de suivi de la course du soleil *) 5";"Référence commerciale 
+(Autres technologies)";"Nom du fabricant 
+(Autres technologies) 1";"Nom du fabricant 
+(Autres technologies) 2";"Nom du fabricant 
+(Autres technologies) 3";"Nom du fabricant 
+(Autres technologies) 4";"Nom du fabricant 
+(Autres technologies) 5";"Lieu(x) de fabrication 
+(Autres technologies) 1";"Lieu(x) de fabrication 
+(Autres technologies) 2";"Lieu(x) de fabrication 
+(Autres technologies) 3";"Lieu(x) de fabrication 
+(Autres technologies) 4";"Lieu(x) de fabrication 
+(Autres technologies) 5";;;;;;;;;;;;;;"Coût total du lot (M€)
+(Développement)";"Coût total du lot (M€)
+(Modules ou films)";"Coût total du lot (M€)
+(Cellules)";"Coût total du lot (M€)
+(Plaquettes de silicium (wafers))";"Coût total du lot (M€)
+(Polysilicium)";"Coût total du lot (M€)
+(Postes de conversion)";"Coût total du lot (M€)
+(Structure)";"Coût total du lot (M€)
+(Dispositifs de stockage de l’énergie *)";"Coût total du lot (M€)
+(Dispositifs de suivi de la course du soleil *)";"Coût total du lot (M€)
+(Autres technologies)";"Coût total du lot (M€)
+(Installation et mise en service )";"Coût total du lot (M€)
+(raccordement)";"Contenu local français (%)
+(Développement)";"Contenu local français (%)
+(Modules ou films)";"Contenu local français (%)
+(Cellules)";"Contenu local français (%)
+(Plaquettes de silicium (wafers))";"Contenu local français (%)
+(Polysilicium)";"Contenu local français (%)
+(Postes de conversion)";"Contenu local français (%)
+(Structure)";"Contenu local français (%)
+(Dispositifs de stockage de l’énergie *)";"Contenu local français (%)
+(Dispositifs de suivi de la course du soleil *)";"Contenu local français (%)
+(Autres technologies)";"Contenu local français (%)
+(Installation et mise en service) ";"Contenu local français (%)
+(raccordement)";"Contenu local européen (%)
+(Développement)";"Contenu local européen (%)
+(Modules ou films)";"Contenu local européen (%)
+(Cellules)";"Contenu local européen (%)
+(Plaquettes de silicium (wafers))";"Contenu local européen (%)
+(Polysilicium)";"Contenu local européen (%)
+(Postes de conversion)";"Contenu local européen (%)
+(Structure)";"Contenu local européen (%)
+(Dispositifs de stockage de l’énergie *)";"Contenu local européen (%)
+(Dispositifs de suivi de la course du soleil *)";"Contenu local européen (%)
+(Autres technologies)";"Contenu local européen (%)
+(Installation et mise en service)";"Contenu local européen (%)
+(raccordement)";"Contenu local développement :
+Commentaires";Puissance cumulée;Motif d'élimination;"Territoire
+(AO ZNI)";"Note innovation
+(AO innovation)";Coordonnées géodésiques WGS84 du barycentre de l’Installation : Latitude (cardinal);"Coordonnées géodésiques WGS84du barycentre de l’Installation : Longitude
+(cardinal)";"Taux occupation toiture
+(AO autoconsommation)";"Engagement de fourniture de puissance à la pointe
+(AO ZNI)";Terrain d’implantation bénéficie de la dérogation sur le c) du Cas 2 du 2.6;"Contenu local Fabrication de composants et assemblage :
+Commentaires";Coût des modules €/Wc;"Nom du fabricant 
+(Structure)";"Lieu(x) de fabrication 
+(Structure)";"Commentaires contenu local
+(Installation et mise en service)";"Contenu local TOTAL :
+coût total (M€)";Contenu local TOTAL français (%);Contenu local TOTAL européen (%);"Contenu local TOTAL :
+Commentaires";Productible annuel (MWh/an);Facteur de charges (kWh/kWc);Montant estimé du raccordement (k€);Raccordement € / kWc;Investissement total (k€); dont quantité de fonds propres (k€) ;dont quantité d'endettement  (k€);dont quantité de subventions à l'investissement  (k€);dont quantité d'autres avantages financiers  (k€);Location (€/an/MWc);"CAPEX Moyen
+(k€ / MWc)";"Condition d'admissibilité ?
+(AO éolien)";Financement collectif (Oui/Non);Gouvernance partagée (Oui/Non);€/MWh bonus participatif;"Note degré d’innovation (/20pt)
+(AO innovation)";"Commentaire final sur note degré d’innovation
+(AO innovation)";"Nom de l'innovation (ADEME)
+(AO innovation)";"Type de l'innovation (ADEME)
+(AO innovation)";"Note synergie avec l'usage agricole (/10pt)
+(AO Innovation)";"Commentaire final sur note synergie avec l'usage agricole 
+(AO Innovation)";"Note positionnement sur le marché (/10pt)
+(AO innovation)";"Commentaire final sur note positionnement sur le marché 
+(AO innovation)";"Note qualité technique (/5pt)
+(AO innovation)";"Commentaire final sur note qualité technique
+(AO innovation)";"Note adéquation du projet avec les ambitions industrielles (/5pt)
+(AO innovation)";"Commentaire final sur note adéquation du projet avec les ambitions industrielles
+(AO innovation)";"Note aspects environnementaux et sociaux (/5pt)
+(AO innovation)";"Commentaire final sur note aspects environnementaux et sociaux
+(AO innovation)";Respect de toutes les conditions d'admissibilité ?;Suspicion de doublon ? ;Oui projet ;Suspicion de 500m inter-famille ? ;Avis admissibilité;"Comm 1 
+(pièce n°1)";"Comm 2 
+(pièce n°1)";"Avis 
+(pièce n°1)";"Comm 1 
+(pièce n°2)";"Comm 2 
+(pièce n°2)";"Avis 
+(pièce n°2)";"Période visée par certificat d'éligibilité du terrain 
+(pièce n°3)";"Comm 1 
+(pièce n°3)";"Comm 2
+(pièce n°3)";"Avis 
+(pièce n°3)";"Comm 1
+(pièce n°4 AO innovation)";"Comm 2
+(pièce n°4 AO innovation)";"Avis
+(pièce n°4 AO innovation)";"Comm 1
+(pièce n°5 AO innovation)";"Comm 2
+(pièce n°5 AO innovation)";"Avis
+(pièce n°5 AO innovation)";"Date 
+(pièce n°4)";"Comm 2 
+(pièce n°4)";"Avis 
+(pièce n°4)";"Comm 1 
+(pièce n°6)";"Comm 2 
+(pièce n°6)";"Avis 
+(pièce n°6)";"Oui/non ? 
+(pièce n°7)";"Comm 1 
+(pièce n°7)";"Comm 2 
+(pièce n°7)";"Avis 
+(pièce n°7)";"Comm 1 
+(Délégation de signature)";"Comm 2 
+(Délégation de signature)";"Avis 
+(Délégation de signature)";Commentaire final;Avis final;Avis final CRE + ADEME;Prix Majoré;"Codes cas
+(AO sol)";"Codes cas
+(AO sol)";"Codes cas
+(AO sol)";Nom projet (doublon);CP (doublon);Commune (doublon);Modifications;Statut;Commentaires;;Type de modification 1;Date de modification 1;Colonne concernée 1;Ancienne valeur 1;Type de modification 2;Date de modification 2;Colonne concernée 2;Ancienne valeur 2;Type de modification 3;Date de modification 3;Colonne concernée 3;Ancienne valeur 3;Type de modification 4;Date de modification 4;Colonne concernée 4;Ancienne valeur 4;Type de modification 5;Date de modification 5;Colonne concernée 5;Ancienne valeur 5
+Test-1;Test;1;;SD3B;Test 1;1;;1;2.615;1;500;63.91;3.57;;67.48;E&Y;Personne morale;;;PME;E&Y;Hauts-de-France;27bis rue du Vieux Faubourg 59000 Lille;E&Y;Gérant;E&Y;E&Y;Directeur du développement;27bis rue du Vieux Faubourg;eypentest4@eycyberlab.fr;;Test 1;;;27bis rue du Vieux Faubourg;59000;LILLE;Nord;Hauts-De-France;;2.615;;;;;;;1;500;Non;;;Non;;Déclaration préalable de travaux;;;;;;;;;;;;Bâtiment;1025;;;;;;;;;;;;;;;;oui;Bâtiment;;;;Favorable;Kbis;;Favorable;;;Favorable;Déclaration préalable de travaux;;;AMD;Favorable;GPD;78455;30001.91205;21/10/2021;Favorable;;Favorable;Non;0%;0;;Non;0%;;Favorable;oui;Favorable;;Favorable;;Retenu;Classé;;1;1;1;1;1;;;;N/A;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;;;;;;;;;;;;;;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;#N/A;2.615;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;Oui;Non;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+Test-2;Test;1;;SD3B;Test 2;1;;1;1.589;1;424;51.8;9;;62.8;E&Y;Personne morale;;;PME;E&Y;Hauts-de-France;27bis rue du Vieux Faubourg 59000 Lille;E&Y;Président;E&Y;E&Y;Directeur du développement;27bis rue du Vieux Faubourg;eypentest4@eycyberlab.fr;;Test 2;;;27bis rue du Vieux Faubourg;59000;LILLE;Nord;Hauts-De-France;;1.589;;;;;;;1;424;Oui;10%;Au moins 20 personnes physiques;Non;;Permis de construire;;;;;;;; ;;;;Ombrière de parking;1384;;;;;;;;;;;;;;;;oui;Ombrière de parking;;;;Favorable;Kbis;;Favorable;;;Favorable;Permis de construire;;;AMD;Favorable;GPD;47670;30000;21/01/2022;Favorable;;Favorable;Oui;10%;Au moins 20 personnes physiques;;Non;0%;;Favorable;s.o.;Favorable;;Favorable;;Retenu;Classé;;3;1;1;1;1;;;;N/A;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;Silicium monocristallin;123;MODULE PV;0;0;0;0;Chine;0;0;0;0;405;0.211;CELLULE PV;0;0;0;0;Chine;0;0;0;0;PLAQUETTE PV;0;0;0;0;Allemagne;0;0;0;0;POLYSI PV;0;0;0;0;Norvège;0;0;0;0;CONVERT PV;0;0;0;0;Chine;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;;;;;;;;;;;;;;0.021;0.446203;0;0;0;0.05;0.563728;0;0;0;0.0556664;0.104194;1;0;0;0;0;0;0;0;0;0;1;1;1;0;0;0;0;0;1;0;0;0;1;1;"Ces montants sont donnés avec les données disponibles à ce jour pour le porteur de projet. Toutes les informations ne sont pas disponibles.
+
+Le prix des modules comprend l'ensemble des sous-lots (pas de détails disponible pour le candidat)";4.204;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;Non;Non;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+Test-3;Test;1;;SD3B;Test 3;1;;1;1.7;1;474;54.81;5.43;;62.24;E&Y;Personne morale;;;PME;E&Y;Hauts-de-France;27bis rue du Vieux Faubourg 59000 Lille;E&Y;Président;E&Y;E&Y;Directeur du développement;27bis rue du Vieux Faubourg;eypentest4@eycyberlab.fr;;Test 3;;;27bis rue du Vieux Faubourg;59000;LILLE;Nord;Hauts-De-France;;1.7;;;;;;;1;474;Oui;10%;Au moins 20 personnes physiques;Non;;Permis de construire;;;;;;;; ;;;;Ombrière de parking;1789;;;;;;;;;;;;;;;;;Ombrière de parking;;;;Favorable;Kbis;;Favorable;;;Favorable;Permis de construire;;;;Favorable;GPD;51000;30000;;Favorable;;Favorable;Oui;10%;Au moins 20 personnes physiques;;Non;0%;;Favorable;oui;Favorable;;Favorable;;Retenu;Classé;;2;1;1;1;1;;;;N/A;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;Silicium monocristallin;456;MODULE PV;0;0;0;0;Corée du Sud;0;0;0;0;385;0.196;CELLULE PV;0;0;0;0;Corée du Sud;0;0;0;0;PLAQUETTE PV;0;0;0;0;Corée du Sud;0;0;0;0;POLYSI PV;0;0;0;0;Corée du Sud;0;0;0;0;CONVERT PV;0;0;0;0;Chine;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;;;;;;;;;;;;;;0;442000;0;0;0;44200;487000;0;0;0;817111;294275;0;0;0;0;0;0;1;0;0;0;1;1;0;0;0;0;0;0;0;0;0;0;0;0;0;5.904;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;Oui;Non;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+Test-4;Test;1;;SD3B;Test 4;2;12/12/2028;1;3.05;1;500;57.83;3.57;;61.4;E&Y;Personne morale;;;PME;E&Y;Hauts-de-France;27bis rue du Vieux Faubourg 59000 Lille;E&Y;Gérant;E&Y;E&Y;Directeur du développement;27bis rue du Vieux Faubourg;eypentest4@eycyberlab.fr;;Test 4;;;27bis rue du Vieux Faubourg;59000;LILLE;Nord;Hauts-De-France;;3.05;;;;;;;1;500;;;;;;Permis de construire;;;;;;;; ;;;;Serre;1250;;;;;;;;;;;;;;;;oui;Serre;;;;Favorable;Kbis;;Favorable;;;Favorable;Permis de construire;;;AMD;Favorable;CDC;91500;30000;12/10/2021;Favorable;;Favorable;0;0%;0;;0;0%;;Favorable;oui;Favorable;;Favorable;;Retenu;Classé;;1;1;1;1;1;;;;N/A;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;Silicium monocristallin;789;MODULE PV;0;0;0;0;Thaïlande;Chine;0;0;0;410;0.21;CELLULE PV;0;0;0;0;Thaïlande;Chine;0;0;0;PLAQUETTE PV;0;0;0;0;Chine;0;0;0;0;POLYSI PV;0;0;0;0;Allemagne;0;0;0;0;CONVERT PV;0;0;0;0;Chine;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;;;;;;;;;;;;;;0.126;1.078;0;0;0;0.086;0.012;0;0;0;0.622;0.6;1;0;0;0;0;0;0;0;0;0;1;1;1;0.34;0;0;1;0;0.1;0;0;0;1;1;0;8.954;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;Non;Oui;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+Test-5;Test;1;;SD3B;Test 5;2;12/12/2028;1;12.849;1;450;50.52;7.14;;59.66;E&Y;Personne morale;;;PME;E&Y;Hauts-de-France;27bis rue du Vieux Faubourg 59000 Lille;E&Y;Président;E&Y;E&Y;Directeur du développement;27bis rue du Vieux Faubourg;eypentest4@eycyberlab.fr;;Test 5;;;27bis rue du Vieux Faubourg;59000;LILLE;Nord;Hauts-De-France;;12.849;;;;;;;1;450;Oui;10%;Au moins 20 personnes physiques;Non;;Permis de construire;;;;;;;; ;;;;Bâtiment;1163;;;;;;;;;;;;;;;;oui;Bâtiment;;;;Favorable;Kbis;;Favorable;;;Favorable;Permis de construire;;;;Favorable;GPD;387000;30119.07541;21/01/2022;Favorable;;Favorable;Oui;10%;Au moins 20 personnes physiques;;Non;0%;;Favorable;s.o.;Favorable;;Favorable;;Retenu;Classé;;7;1;1;1;1;;;;N/A;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;Silicium monocristallin;789;MODULE PV;0;0;0;0;Chine;0;0;0;0;380;0.2086;CELLULE PV;0;0;0;0;Chine;0;0;0;0;PLAQUETTE PV;0;0;0;0;Chine;0;0;0;0;POLYSI PV;0;0;0;0;Etats-Unis;Chine;0;0;0;CONVERT PV;0;0;0;0;Chine;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;;;;;;;;;;;;;;0.08;0.4381;0.4381;0.65715;2.84765;0.36;1.49;0;0;0;2;1.82;1;0;0;0;0;0;1;0;0;0;0;1;1;0;0;0;0;0;1;0;0;0;1;1;0;21.803;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;Oui;Non;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+Test-6;Test;1;;SD3B;Test 6;2;12/12/2028;1;1.795;1;450;50.25;7.14;;59.39;E&Y;Personne morale;;;PME;E&Y;Hauts-de-France;27bis rue du Vieux Faubourg 59000 Lille;E&Y;Gérante;E&Y;E&Y;Directeur du développement;27bis rue du Vieux Faubourg;eypentest4@eycyberlab.fr;;Test 6;;;27bis rue du Vieux Faubourg;59000;LILLE;Nord;Hauts-De-France;;1.79452;;;;;;;1;450;Oui;10%;Au moins 20 personnes physiques;Non;;Déclaration préalable de travaux;;;;;;;; ;;;;Bâtiment;1514;;;;;;;;;;;;;;;;oui;Bâtiment;;;;Favorable;Kbis;;Favorable;;;Favorable;Déclaration préalable de travaux;;;;Favorable;GF1 : Annexe 3 non-servie;;0;;Défavorable;;Favorable;Oui;10%;Au moins 20 personnes physiques;;Non;0%;;Favorable;s.o.;Favorable;;Défavorable;;Eliminé;Eliminé;;4;1;1;2;1;;;;N/A;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;Silicium monocristallin;789;MODULE PV;0;0;0;0;Thaïlande;0;0;0;0;455;0.2059;CELLULE PV;0;0;0;0;Thaïlande;0;0;0;0;PLAQUETTE PV;0;0;0;0;Thaïlande;0;0;0;0;POLYSI PV;0;0;0;0;Norvège;0;0;0;0;CONVERT PV;0;0;0;0;Chine;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;;;;;;;;;;;;;;0.125616;0.088649;0.132974;0.05901;0.099889;0.062808;0.44863;0;0;0;0.125616;0.05;1;0;0;0;0;0;1;0;0;0;1;1;1;0;0;0.2;0;0;1;0;0;0;1;1;0;21.803;Le candidat n’a pas fourni le document relatif à la garantie financière. L'offre a donc été éliminée en application des prescriptions du paragraphe 3.2.4 du cahier des charges;;;;;;;;;;;;;;;;;;;;;;;;;;;;;Non;Oui;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+Test-7;Test;1;;SD3B;Test 7;2;12/12/2028;2;0.75;1;450;50.25;7.14;;59.39;E&Y;Personne morale;;;PME;E&Y;Hauts-de-France;27bis rue du Vieux Faubourg 59000 Lille;E&Y;Président;E&Y;E&Y;Directeur du développement;27bis rue du Vieux Faubourg;eypentest4@eycyberlab.fr;;Test 7;;;27bis rue du Vieux Faubourg;59000;LILLE;Nord;Hauts-De-France;;0.75016;;;;;;;1;450;Oui;10%;Au moins 20 personnes physiques;Non;;Permis de construire;;;;;;;; ;;;;Bâtiment;1703;;;;;;;;;;;;;;;;oui;Bâtiment;;;;Favorable;Kbis;;Favorable;;;Favorable;Permis de construire;;;AMD;Favorable;GF1 : Annexe 3 non-servie;;0;;Défavorable;;Favorable;Oui;10%;Au moins 20 personnes physiques;;Non;0%;;Favorable;oui;Favorable;;Défavorable;;Eliminé;Eliminé;;4;3;1;3;3;;;;N/A;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;Silicium monocristallin;789;MODULE PV;0;0;0;0;Thaïlande;0;0;0;0;455;0.2059;CELLULE PV;0;0;0;0;Thaïlande;0;0;0;0;PLAQUETTE PV;0;0;0;0;Thaïlande;0;0;0;0;POLYSI PV;0;0;0;0;Norvège;0;0;0;0;CONVERT PV;0;0;0;0;Chine;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;;;;;;;;;;;;;;0.052553;0.0339339;0.05090085;0.05090085;0.0339339;0.02627625;0.135135;0;0;0;0.0525525;0.05;1;0;0;0;0;0;1;0;0;0;1;1;1;0;0;0.2;0;0;1;0;0;0;1;1;0;21.803;Le candidat n’a pas fourni le document relatif à la garantie financière. L'offre a donc été éliminée en application des prescriptions du paragraphe 3.2.4 du cahier des charges;;;;;;;;;;;;;;;;;;;;;;;;;;;;;Oui;Non;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+Test-8;Test;1;;SD3B;Test 8;3;;3;1.103;1;450;50.25;7.14;;59.39;E&Y;Personne morale;;;PME;E&Y;Hauts-de-France;27bis rue du Vieux Faubourg 59000 Lille;E&Y;Président;E&Y;E&Y;Directeur du développement;27bis rue du Vieux Faubourg;eypentest4@eycyberlab.fr;;Test 8;;;27bis rue du Vieux Faubourg;59000;LILLE;Nord;Hauts-De-France;;1.10292;;;;;;;1;450;Oui;10%;Au moins 20 personnes physiques;Non;;Permis de construire;;;;;;;; ;;;;Bâtiment;1687;;;;;;;;;;;;;;;;oui;Bâtiment;;;;Favorable;Kbis;;Favorable;;;Favorable;Permis de construire;;;AMD;Favorable;GF1 : Annexe 3 non-servie;;0;;Défavorable;;Favorable;Oui;10%;Au moins 20 personnes physiques;;Non;0%;;Favorable;oui;Favorable;;Défavorable;;Eliminé;Eliminé;;4;3;1;3;3;;;;N/A;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;Silicium monocristallin;789;MODULE PV;0;0;0;0;Thaïlande;0;0;0;0;455;0.2059;CELLULE PV;0;0;0;0;Thaïlande;0;0;0;0;PLAQUETTE PV;0;0;0;0;Thaïlande;0;0;0;0;POLYSI PV;0;0;0;0;Norvège;0;0;0;0;CONVERT PV;0;0;0;0;Chine;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;;;;;;;;;;;;;;0.10313;0.066592708;0.099889062;0.099889062;0.066592708;0.05156515;0.2651922;0;0;0;0.1031303;0.05;1;0;0;0;0;0;1;0;0;0;1;1;1;0;0;0.2;0;0;1;0;0;0;1;1;0;21.803;Le candidat n’a pas fourni le document relatif à la garantie financière. L'offre a donc été éliminée en application des prescriptions du paragraphe 3.2.4 du cahier des charges;;;;;;;;;;;;;;;;;;;;;;;;;;;;;Non;Non;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+Test-9;Test;1;;SD3B;Test 9;3;;1;3.59;1;450;50.22;7.14;;59.36;E&Y;Personne morale;;;PME;E&Y;Hauts-de-France;27bis rue du Vieux Faubourg 59000 Lille;E&Y;Président;E&Y;E&Y;Directeur du développement;27bis rue du Vieux Faubourg;eypentest4@eycyberlab.fr;;Test 9;;;27bis rue du Vieux Faubourg;59000;LILLE;Nord;Hauts-De-France;;3.59;;;;;;;1;450;Oui;10%;Au moins 20 personnes physiques;Non;;Permis de construire;;;;;;;; ;;;;Ombrière de parking;1414;;;;;;;;;;;;;;;;oui;Ombrière de parking;;;;Favorable;Kbis;;Favorable;;;Favorable;Permis de construire;;;AMD;Favorable;GPD;108000;30083.56546;21/01/2022;Favorable;;Favorable;Oui;10%;Au moins 20 personnes physiques;;Non;0%;;Favorable;s.o.;Favorable;;Favorable;;Retenu;Classé;;7;1;1;1;1;;;;N/A;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;Silicium monocristallin;789;MODULE PV;0;0;0;0;Chine;0;0;0;0;380;0.2086;CELLULE PV;0;0;0;0;Chine;0;0;0;0;PLAQUETTE PV;0;0;0;0;Chine;0;0;0;0;POLYSI PV;0;0;0;0;Etats-Unis;Chine;0;0;0;CONVERT PV;0;0;0;0;Chine;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;;;;;;;;;;;;;;0.048;0.11752;0.11752;0.17628;0.76388;0.09;0.28;0;0;0;1.01;0.3;1;0;0;0;0;0;0;0;0;0;0;1;1;0;0;0;0;0;1;0;0;0;1;1;0;25.393;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;Oui;Non;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+Test-10;Test;1;;SD3B;Test 10;3;;4;1.103;1;450;50.22;7.14;;59.36;E&Y;Personne morale;;;PME;E&Y;Hauts-de-France;27bis rue du Vieux Faubourg 59000 Lille;E&Y;Président;E&Y;E&Y;Directeur du développement;27bis rue du Vieux Faubourg;eypentest4@eycyberlab.fr;;Test 10;;;27bis rue du Vieux Faubourg;59000;LILLE;Nord;Hauts-De-France;;1.10292;;;;;;;1;450;Oui;10%;Au moins 20 personnes physiques;Non;;Permis de construire;;;;;;;; ;;;;Bâtiment;1709;;;;;;;;;;;;;;;;oui;Bâtiment;;;;Favorable;Kbis;;Favorable;;;Favorable;Permis de construire;;;;Favorable;GF1 : Annexe 3 non-servie;;0;;Défavorable;;Favorable;Oui;10%;Au moins 20 personnes physiques;;Non;0%;;Favorable;oui;Favorable;;Défavorable;;Eliminé;Eliminé;;4;3;1;3;3;;;;N/A;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;Silicium monocristallin;789;MODULE PV;0;0;0;0;Thaïlande;0;0;0;0;455;0.2059;CELLULE PV;0;0;0;0;Thaïlande;0;0;0;0;PLAQUETTE PV;0;0;0;0;Thaïlande;0;0;0;0;POLYSI PV;0;0;0;0;Norvège;0;0;0;0;CONVERT PV;0;0;0;0;Chine;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;;;;;;;;;;;;;;0.077204;0.049851984;0.074777976;0.074777976;0.049851984;0.0386022;0.1985256;0;0;0;0.0772044;0.05;1;0;0;0;0;0;1;0;0;0;1;1;1;0;0;0.2;0;0;1;0;0;0;1;1;0;25.393;Le candidat n’a pas fourni le document relatif à la garantie financière. L'offre a donc été éliminée en application des prescriptions du paragraphe 3.2.4 du cahier des charges;;;;;;;;;;;;;;;;;;;;;;;;;;;;;Non;Oui;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+Test-11;Test;1;;SD3B;Test 11;3;;4;1.103;1;450;50.22;7.14;;59.36;E&Y;Personne morale;;;PME;E&Y;Hauts-de-France;27bis rue du Vieux Faubourg 59000 Lille;E&Y;Président;E&Y;E&Y;Directeur du développement;27bis rue du Vieux Faubourg;eypentest4@eycyberlab.fr;;Test 11;;;27bis rue du Vieux Faubourg;59000;LILLE;Nord;Hauts-De-France;;1.10292;;;;;;;1;450;Oui;10%;Au moins 20 personnes physiques;Non;;Permis de construire;;;;;;;; ;;;;Bâtiment;1709;;;;;;;;;;;;;;;;oui;Bâtiment;;;;Favorable;Kbis;;Favorable;;;Favorable;Permis de construire;;;;Favorable;GF1 : Annexe 3 non-servie;;0;;Défavorable;;Favorable;Oui;10%;Au moins 20 personnes physiques;;Non;0%;;Favorable;oui;Favorable;;Défavorable;;Eliminé;Eliminé;;4;3;1;3;3;;;;N/A;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;Silicium monocristallin;789;MODULE PV;0;0;0;0;Thaïlande;0;0;0;0;455;0.2059;CELLULE PV;0;0;0;0;Thaïlande;0;0;0;0;PLAQUETTE PV;0;0;0;0;Thaïlande;0;0;0;0;POLYSI PV;0;0;0;0;Norvège;0;0;0;0;CONVERT PV;0;0;0;0;Chine;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;;;;;;;;;;;;;;0.077204;0.049851984;0.074777976;0.074777976;0.049851984;0.0386022;0.1985256;0;0;0;0.0772044;0.05;1;0;0;0;0;0;1;0;0;0;1;1;1;0;0;0.2;0;0;1;0;0;0;1;1;0;25.393;Le candidat n’a pas fourni le document relatif à la garantie financière. L'offre a donc été éliminée en application des prescriptions du paragraphe 3.2.4 du cahier des charges;;;;;;;;;;;;;;;;;;;;;;;;;;;;;Non;Oui;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/packages/domain/inmemory-referential/src/appelOffre/test.ts
+++ b/packages/domain/inmemory-referential/src/appelOffre/test.ts
@@ -1,0 +1,135 @@
+import { AppelOffre } from '@potentiel-domain/appel-offre';
+
+import { validateurParDéfaut } from '../validateurParDéfaut';
+
+const CDCModifié30082022: AppelOffre.CahierDesChargesModifié = {
+  type: 'modifié',
+  paruLe: '30/08/2022',
+  numéroGestionnaireRequis: true,
+  donnéesCourriersRéponse: {
+    texteChangementDePuissance: {
+      référenceParagraphe: '5.7',
+      dispositions: `Les modifications de la Puissance installée avant l’Achèvement sont autorisées, sous réserve que la Puissance de l’Installation modifiée soit comprise entre quatre-vingts pourcents (80 %) et cent vingt pourcents (120 %) de la Puissance indiquée dans l’offre. Elles doivent faire l’objet d’une information au Préfet.
+    Pour les projets dont soit l'achèvement, soit la mise en service est antérieur au 31 décembre 2024, cette augmentation de puissance peut être portée à 140% de la Puissance formulée dans l’offre, à condition qu’elle soit permise par l’autorisation environnementale de l’Installation, y compris si celle-ci a été modifiée.
+    Les modifications après l’Achèvement ou hors de cette fourchette ne sont pas autorisées.
+    Par dérogation, les modifications à la baisse de la Puissance installée qui seraient imposées soit par une décision de l’Etat dans le cadre de la procédure d’autorisation, ou par une décision de justice concernant l’autorisation sont acceptées. Elles doivent faire l’objet d’une information au Préfet.`,
+    },
+    texteDélaisDAchèvement: {
+      référenceParagraphe: '6.3',
+      dispositions: `
+          Le  Candidat  dont  l’offre  a  été  retenue  s’engage  à  ce  que  l’Achèvement  de  son  Installation  intervienne avant une limite définie par la date la plus tardive des deux dates suivantes : 
+-trente-six (36) mois à compter de la Date de désignation. 
+-deux mois à compter de la fin des travaux de raccordement, sous réserve que le Producteur ait mis en œuvre toutes les démarches dans le respect des exigences du gestionnaire de réseau pour que les travaux de raccordement soient réalisés dans les délais. Dans ce cas, l’attestation de conformité doit être transmise au cocontractant dans un délai de 2 mois à compter de la fin des travaux de raccordement matérialisée par la date de la facture de solde à acquitter par  le producteur pour sa contribution au coût du raccordement. 
+Pour les installations dont la mise en service a lieu entre le 1er septembre 2022 et le 31 décembre 2024 inclus, cette date limite est repoussée de dix-huit (18) mois supplémentaires.
+En cas de dépassement de ce délai, la durée de contrat mentionnée au 7.1 est réduite de la durée de dépassement. 
+Des  dérogations  au  délai  d’Achèvement  sont  toutefois  possibles  dans  le  cas  où  des  contentieux  administratifs  effectués  à  l’encontre  de  toute autorisation  administrative  nécessaire  à  la  réalisation  du     projet     ont     pour     effet     de     retarder     la     construction     de     l’installation.     Dans     ce     cas,  un  délai  supplémentaire  égal  à  la  durée  entre  la  date  du  recours  initial  et  la  date  de  la  décision  définitive attestée par la décision ayant autorité de la chose jugée est alors accordé. 
+ Ces retards sont réputés autorisés sous réserve de pouvoir les justifier auprès de l’acheteur obligé. 
+Des délais supplémentaires pour l’Achèvement ou, pour ce qui concerne l’échéance du 31 décembre 2024 mentionnée au présent 6.3 et au 7.1, pour la mise en service peuvent être accordés par le Préfet, à  son  appréciation,  en  cas  d’événement  imprévisible  à  la  Date  de  désignation  et  extérieur  au  Producteur, dûment justifié.
+    `,
+    },
+  },
+};
+
+export const eolienPPE2: AppelOffre.AppelOffreReadModel = {
+  id: 'Test',
+  typeAppelOffre: 'eolien',
+  title:
+    'portant sur la réalisation et l’exploitation d’Installations de production d’électricité à partir de l’énergie mécanique du vent implantées à terre',
+  shortTitle: 'Test',
+  dossierSuiviPar: 'aoeolien@developpement-durable.gouv.fr',
+  launchDate: 'Octobre 2024',
+  cahiersDesChargesUrl:
+    'https://www.cre.fr/documents/Appels-d-offres/appel-d-offres-portant-sur-la-realisation-et-l-exploitation-d-installations-de-production-d-electricite-a-partir-de-l-energie-mecanique-du-vent-imp',
+  unitePuissance: 'MW',
+  autoritéCompétenteDemandesDélai: 'dreal',
+  tarifOuPrimeRetenue: 'le prix de référence T de l’électricité retenu',
+  tarifOuPrimeRetenueAlt: 'ce prix de référence',
+  paragraphePrixReference: '7',
+  affichageParagrapheECS: false,
+  paragrapheEngagementIPFPGPFC: '3.3.7, 4.3 et 6.5.2',
+  renvoiEngagementIPFPGPFC: '3.3.7',
+  renvoiDemandeCompleteRaccordement: '6.1',
+  renvoiRetraitDesignationGarantieFinancieres: '5.1',
+  soumisAuxGarantiesFinancieres: 'à la candidature',
+  paragrapheDelaiDerogatoire: '6.3',
+  delaiRealisationEnMois: 36,
+  delaiRealisationTexte: 'trente-six (36) mois',
+  decoupageParTechnologie: false,
+  paragrapheAttestationConformite: '6.5',
+  afficherParagrapheInstallationMiseEnServiceModification: true,
+  renvoiModification: '5.2',
+  paragrapheClauseCompetitivite: '2.11',
+  afficherPhraseRegionImplantation: false,
+  afficherValeurEvaluationCarbone: true,
+  doitPouvoirChoisirCDCInitial: true,
+  changementPuissance: {
+    ratios: {
+      min: 0.8,
+      max: 1.2,
+    },
+  },
+  changementProducteurPossibleAvantAchèvement: true,
+  donnéesCourriersRéponse: {
+    texteEngagementRéalisationEtModalitésAbandon: {
+      référenceParagraphe: '6.2',
+      dispositions: `Le Candidat dont l’offre a été retenue réalise l’Installation dans les conditions du présent cahier des charges et conformément aux éléments du dossier de candidature (les possibilités et modalités de modification sont indiquées au 5.2).
+Par exception, le Candidat est délié de cette obligation :
+- en cas de retrait de l’autorisation environnementale par l’autorité compétente ou d’annulation de cette autorisation à la suite d’un contentieux. Les retraits gracieux sur demande du candidat ne sont pas concernés.
+- en cas de non obtention ou de retrait de toute autre autorisation administrative ou dérogation nécessaire à la réalisation du projet.
+Il en informe dans ce cas le Préfet en joignant les pièces justificatives. La garantie financière est alors levée.
+Le Candidat peut également être délié de cette obligation selon l’appréciation du ministre chargé de l’énergie à la suite d’une demande dûment justifiée. Le Ministre peut accompagner son accord de conditions ou du prélèvement d’une part de la garantie financière. Ni l’accord du Ministre, ni les conditions imposées, ni le prélèvement de la garantie financière ne limitent la possibilité de recours de l’Etat aux sanctions du 8.2. 
+`,
+    },
+    texteChangementDePuissance: {
+      référenceParagraphe: '5.7',
+      dispositions: `Les modifications de la Puissance installée avant l’Achèvement sont autorisées, sous réserve que la Puissance de l’Installation modifiée soit comprise entre quatre-vingts pourcents (80 %) et cent vingt pourcents (120 %) de la Puissance indiquée dans l’offre. Elles doivent faire l’objet d’une information au Préfet.
+ Les modifications après l’Achèvement ou hors de cette fourchette ne sont pas autorisées.
+ Par dérogation, les modifications à la baisse de la Puissance installée qui seraient imposées soit par une décision de l’Etat dans le cadre de la procédure d’autorisation, ou par une décision de justice concernant l’autorisation sont acceptées. Elles doivent faire l’objet d’une information au Préfet.`,
+    },
+    texteDélaisDAchèvement: {
+      référenceParagraphe: '6.3',
+      dispositions: `Le Candidat dont l’offre a été retenue s’engage à ce que l’Achèvement de son Installation intervienne avant une limite définie par la date la plus tardive des deux dates suivantes :
+- trente-six (36) mois à compter de la Date de désignation.
+- deux mois à compter de la fin des travaux de raccordement, sous réserve que le Producteur ait mis en oeuvre toutes les démarches dans le respect des exigences du gestionnaire de réseau pour que les travaux de raccordement soient réalisés dans les délais. Dans ce cas, l’attestation  de conformité doit être transmise au cocontractant dans un délai de 2 mois à compter de la fin des travaux de raccordement matérialisée par la date de la facture de solde à acquitter par le producteur pour sa contribution au coût du raccordement.
+En cas de dépassement de ce délai, la durée de contrat mentionnée au 7.1 est réduite de la  durée de dépassement.
+Des dérogations au délai d’Achèvement sont toutefois possibles dans le cas où des contentieux administratifs effectués à l’encontre de toute autorisation administrative nécessaire à la réalisation du projet ont pour effet de retarder la construction de l’installation ou sa mise en service. Dans ce cas, un délai supplémentaire égal à la durée entre la date du recours initial et la date de la décision définitive attestée par la décision ayant autorité de la chose jugée est alors accordé.
+Ces retards sont réputés autorisés sous réserve de pouvoir les justifier auprès de l’acheteur obligé.
+Des délais supplémentaires peuvent être accordés par le Préfet, à son appréciation, en cas d’événement imprévisible à la Date de désignation et extérieur au Producteur, dûment justifié.`,
+    },
+  },
+  periodes: [
+    {
+      id: '1',
+      title: 'première',
+      certificateTemplate: 'ppe2.v1',
+      validateurParDéfaut: validateurParDéfaut.ghislain,
+      noteThreshold: 0.68,
+      cahierDesCharges: {
+        référence: '2024/test-9999999',
+      },
+      delaiDcrEnMois: { valeur: 3, texte: 'trois' },
+      familles: [],
+      dossierSuiviPar: 'violaine.tarizzo@developpement-durable.gouv.fr',
+      cahiersDesChargesModifiésDisponibles: [
+        {
+          ...CDCModifié30082022,
+          délaiApplicable: {
+            délaiEnMois: 18,
+            intervaleDateMiseEnService: {
+              min: new Date('2022-06-01').toISOString(),
+              max: new Date('2024-09-30').toISOString(),
+            },
+          },
+          seuilSupplémentaireChangementPuissance: {
+            ratios: {
+              min: 0.8,
+              max: 1.4,
+            },
+            paragrapheAlerte: `Pour les projets dont soit l'achèvement, soit la mise en service est antérieur au 31 décembre 2024, cette augmentation de puissance peut être portée à 140% de la Puissance formulée dans l’offre, à condition qu’elle soit permise par l’autorisation environnementale de l’Installation, y compris si celle-ci a été modifiée.`,
+          },
+        },
+      ],
+      abandonAvecRecandidature: true,
+    },
+  ],
+};


### PR DESCRIPTION
# Description

Afin que les tests d'intrusion soient le plus exhaustif possible et ne pas perturber les données de production
Nous devons créer un appel d'offre "Test" pour lequel il sera possible d'importer des projets de tests

Les tests ayant lieu dans 3 jours il est nécessaire de l'avoir rapidement en production d'où l'utilisation de la `release/3.31` qui est celle actuellement en production