### PR TITLE
✨ Améliorations de l'import CRE

### DIFF
--- a/packages/applications/ssr/src/components/pages/candidature/corriger-par-lot/corrigerCandidatures.action.ts
+++ b/packages/applications/ssr/src/components/pages/candidature/corriger-par-lot/corrigerCandidatures.action.ts
@@ -80,8 +80,8 @@ const mapLineToUseCaseData = (
   line: CandidatureShape,
   rawLine: Record<string, string>,
 ): Omit<Candidature.ImporterCandidatureUseCase['data'], 'importéLe' | 'importéPar'> => ({
-  typeGarantiesFinancièresValue: line.type_gf,
-  historiqueAbandonValue: line.historique_abandon,
+  typeGarantiesFinancièresValue: line.typeGf,
+  historiqueAbandonValue: line.historiqueAbandon,
   appelOffreValue: line.appelOffre,
   périodeValue: line.période,
   familleValue: line.famille,

--- a/packages/applications/ssr/src/components/pages/candidature/importer/candidature.schema.test.ts
+++ b/packages/applications/ssr/src/components/pages/candidature/importer/candidature.schema.test.ts
@@ -57,33 +57,33 @@ describe('Schema candidature', () => {
     });
     assertNoError(result);
     expect(result.data).to.deep.equal({
-      appel_offre: "appel d'offre",
+      appelOffre: "appel d'offre",
       période: 'période',
       famille: '',
-      num_cre: 'numéro cre',
-      nom_projet: 'nom projet',
-      société_mère: '',
-      nom_candidat: 'candidat',
-      puissance_production_annuelle: 1,
-      prix_reference: 1,
-      note_totale: 1,
-      nom_représentant_légal: 'valentin cognito',
-      email_contact: 'porteur@test.com',
+      numéroCRE: 'numéro cre',
+      nomProjet: 'nom projet',
+      sociétéMère: '',
+      nomCandidat: 'candidat',
+      puissanceProductionAnnuelle: 1,
+      prixRéférence: 1,
+      noteTotale: 1,
+      nomReprésentantLégal: 'valentin cognito',
+      emailContact: 'porteur@test.com',
       adresse1: 'adresse',
       adresse2: '',
-      code_postaux: ['12345'],
+      codePostaux: ['12345'],
       commune: 'MARSEILLE',
       statut: 'éliminé',
-      motif_élimination: 'motif',
-      puissance_a_la_pointe: false,
-      evaluation_carbone_simplifiée: 0,
+      motifÉlimination: 'motif',
+      puissanceÀLaPointe: false,
+      evaluationCarboneSimplifiée: 0,
       technologie: 'N/A',
-      type_gf: undefined,
-      financement_collectif: false,
-      gouvernance_partagée: true,
-      date_échéance_gf: undefined,
-      historique_abandon: 'première-candidature',
-      territoire_projet: '',
+      typeGf: undefined,
+      financementCollectif: false,
+      gouvernancePartagée: true,
+      dateÉchéanceGf: undefined,
+      historiqueAbandon: 'première-candidature',
+      territoireProjet: '',
     });
   });
 
@@ -95,33 +95,33 @@ describe('Schema candidature', () => {
     });
     assertNoError(result);
     expect(result.data).to.deep.equal({
-      appel_offre: "appel d'offre",
+      appelOffre: "appel d'offre",
       période: 'période',
       famille: '',
-      num_cre: 'numéro cre',
-      nom_projet: 'nom projet',
-      société_mère: '',
-      nom_candidat: 'candidat',
-      puissance_production_annuelle: 1,
-      prix_reference: 1,
-      note_totale: 1,
-      nom_représentant_légal: 'valentin cognito',
-      email_contact: 'porteur@test.com',
+      numéroCRE: 'numéro cre',
+      nomProjet: 'nom projet',
+      sociétéMère: '',
+      nomCandidat: 'candidat',
+      puissanceProductionAnnuelle: 1,
+      prixRéférence: 1,
+      noteTotale: 1,
+      nomReprésentantLégal: 'valentin cognito',
+      emailContact: 'porteur@test.com',
       adresse1: 'adresse',
       adresse2: '',
-      code_postaux: ['12345'],
+      codePostaux: ['12345'],
       commune: 'MARSEILLE',
       statut: 'classé',
-      motif_élimination: undefined,
-      puissance_a_la_pointe: true,
-      evaluation_carbone_simplifiée: 0,
+      motifÉlimination: undefined,
+      puissanceÀLaPointe: true,
+      evaluationCarboneSimplifiée: 0,
       technologie: 'eolien',
-      type_gf: 'avec-date-échéance',
-      financement_collectif: false,
-      gouvernance_partagée: true,
-      date_échéance_gf: new Date('2024-12-01T00:00:00.000Z'),
-      historique_abandon: 'première-candidature',
-      territoire_projet: '',
+      typeGf: 'avec-date-échéance',
+      financementCollectif: false,
+      gouvernancePartagée: true,
+      dateÉchéanceGf: new Date('2024-12-01T00:00:00.000Z'),
+      historiqueAbandon: 'première-candidature',
+      territoireProjet: '',
     });
   });
 
@@ -170,7 +170,7 @@ describe('Schema candidature', () => {
       });
     });
 
-    test('nombre avec charactères', () => {
+    test('nombre avec caractères', () => {
       const result = candidatureCsvSchema.safeParse({
         ...minimumValuesEliminé,
         puissance_production_annuelle: 'abcd',
@@ -294,7 +294,7 @@ describe('Schema candidature', () => {
           '',
       });
       assert(result.success);
-      expect(result.data.type_gf).to.be.undefined;
+      expect(result.data.typeGf).to.be.undefined;
     });
 
     test('Enum avec N/A', () => {
@@ -304,7 +304,7 @@ describe('Schema candidature', () => {
           'N/A',
       });
       assert(result.success);
-      expect(result.data.type_gf).to.be.undefined;
+      expect(result.data.typeGf).to.be.undefined;
     });
 
     test('Email non valide', () => {

--- a/packages/applications/ssr/src/components/pages/candidature/importer/candidature.schema.test.ts
+++ b/packages/applications/ssr/src/components/pages/candidature/importer/candidature.schema.test.ts
@@ -464,8 +464,6 @@ describe('Schema candidature', () => {
           CP: '33100',
         });
         assertNoError(result);
-
-        assert(result.success);
       });
 
       test("n'accepte pas un code postal invalide", () => {
@@ -480,6 +478,28 @@ describe('Schema candidature', () => {
           path: ['CP'],
           message: 'Le code postal ne correspond à aucune région / département',
         });
+      });
+    });
+    describe('Adresse', () => {
+      test('au minimum un champs doit être spécifiée', () => {
+        const result = candidatureCsvSchema.safeParse({
+          ...minimumValuesClassé,
+          'N°, voie, lieu-dit 1': undefined,
+        });
+        assert(!result.success, 'should be error');
+        expect(result.error.errors[0]).to.deep.eq({
+          code: 'custom',
+          path: ['N°, voie, lieu-dit 1', 'N°, voie, lieu-dit 2'],
+          message: `Au moins l'une des deux colonnes "N°, voie, lieu-dit 1" et "N°, voie, lieu-dit 2" doit être précisée`,
+        });
+      });
+      test('soit adresse 1 soit adresse 2 peut être spécifiée', () => {
+        const result = candidatureCsvSchema.safeParse({
+          ...minimumValuesClassé,
+          'N°, voie, lieu-dit 1': undefined,
+          'N°, voie, lieu-dit 2': 'adresse',
+        });
+        assertNoError(result);
       });
     });
   });

--- a/packages/applications/ssr/src/components/pages/candidature/importer/candidature.schema.test.ts
+++ b/packages/applications/ssr/src/components/pages/candidature/importer/candidature.schema.test.ts
@@ -426,7 +426,15 @@ describe('Schema candidature', () => {
           'Evaluation carbone simplifiée indiquée au C. du formulaire de candidature et arrondie (kg eq CO2/kWc)':
             'N/A',
         });
-        assert(result.success);
+        assertNoError(result);
+      });
+      test('accepte vide', () => {
+        const result = candidatureCsvSchema.safeParse({
+          ...minimumValuesEliminé,
+          'Evaluation carbone simplifiée indiquée au C. du formulaire de candidature et arrondie (kg eq CO2/kWc)':
+            '',
+        });
+        assertNoError(result);
       });
 
       test('accepte un nombre positif', () => {

--- a/packages/applications/ssr/src/components/pages/candidature/importer/candidature.schema.test.ts
+++ b/packages/applications/ssr/src/components/pages/candidature/importer/candidature.schema.test.ts
@@ -498,7 +498,7 @@ describe('Schema candidature', () => {
         expect(result.error.errors[0]).to.deep.eq({
           code: 'custom',
           path: ['N°, voie, lieu-dit 1', 'N°, voie, lieu-dit 2'],
-          message: `Au moins l'une des deux colonnes "N°, voie, lieu-dit 1" et "N°, voie, lieu-dit 2" doit être précisée`,
+          message: `Au moins l'une des deux colonnes "N°, voie, lieu-dit 1" et "N°, voie, lieu-dit 2" doit être renseignée`,
         });
       });
       test('soit adresse 1 soit adresse 2 peut être spécifiée', () => {

--- a/packages/applications/ssr/src/components/pages/candidature/importer/candidature.schema.ts
+++ b/packages/applications/ssr/src/components/pages/candidature/importer/candidature.schema.ts
@@ -241,8 +241,8 @@ export const candidatureCsvSchema = candidatureCsvRowSchema
   .transform((val) => {
     return {
       ...val,
-      type_gf: val.typeGf ? typeGf[Number(val.typeGf) - 1] : undefined,
-      historique_abandon: historiqueAbandon[Number(val.historiqueAbandon) - 1],
+      typeGf: val.typeGf ? typeGf[Number(val.typeGf) - 1] : undefined,
+      historiqueAbandon: historiqueAbandon[Number(val.historiqueAbandon) - 1],
       statut: statut[val.statut],
       technologie: technologie[val.technologie],
     };

--- a/packages/applications/ssr/src/components/pages/candidature/importer/candidature.schema.ts
+++ b/packages/applications/ssr/src/components/pages/candidature/importer/candidature.schema.ts
@@ -177,8 +177,8 @@ const candidatureCsvRowSchema = z
       .pipe(z.enum(['eliminé', 'éliminé', 'classé', 'retenu'])),
     [colonnes.puissanceÀLaPointe]: optionalOuiNonSchema,
     [colonnes.evaluationCarboneSimplifiée]: z
-      .union([z.enum(['N/A']), strictlyPositiveNumberSchema])
-      .transform((val) => (val === 'N/A' ? 0 : val)),
+      .union([z.literal('N/A'), z.literal(''), strictlyPositiveNumberSchema])
+      .transform((val) => (val === 'N/A' || val === '' ? 0 : val)),
     [colonnes.technologie]: z
       .enum(['N/A', 'Eolien', 'Hydraulique', 'PV'])
       .optional()

--- a/packages/applications/ssr/src/components/pages/candidature/importer/candidature.schema.ts
+++ b/packages/applications/ssr/src/components/pages/candidature/importer/candidature.schema.ts
@@ -73,29 +73,17 @@ const optionalEnum = <TEnumSchema extends [string, ...string[]]>(
  * @param referenceField Le champs dont dépend la validation de `field`
  * @param expectedValue la valeur de `referenceField` pour laquelle `field` est requis
  */
-const requiredFieldIfReferenceFieldEquals = <
-  T,
-  TField extends keyof T,
-  TReferenceField extends keyof T,
->(
-  field: TField,
-  referenceField: TReferenceField,
-  expectedValue: T[TReferenceField],
-): ((arg: T, ctx: z.RefinementCtx) => unknown | Promise<unknown>) => {
-  return (val, ctx) => {
-    if (val[referenceField] === expectedValue && !val[field]) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.invalid_type,
-        expected: z.ZodParsedType.string,
-        received: z.ZodParsedType.undefined,
-        path: [String(field)],
-        message: `"${String(field)}" est requis lorsque "${String(referenceField)}" a la valeur "${expectedValue}"`,
-      });
-      return false;
-    }
-    return true;
-  };
-};
+const conditionalRequiredError = (
+  field: string,
+  referenceField: string,
+  expectedValue: string,
+) => ({
+  code: z.ZodIssueCode.invalid_type,
+  expected: z.ZodParsedType.string,
+  received: z.ZodParsedType.undefined,
+  path: [field],
+  message: `"${field}" est requis lorsque "${referenceField}" a la valeur "${expectedValue}"`,
+});
 
 // Les colonnes du fichier CSV
 const colonnes = {
@@ -146,7 +134,12 @@ const historiqueAbandon = [
   'lauréat-autre-période',
 ] as const;
 
-const statut = { Eliminé: 'éliminé', Classé: 'classé' } as const;
+const statut = {
+  éliminé: 'éliminé',
+  eliminé: 'éliminé',
+  classé: 'classé',
+  retenu: 'classé',
+} as const;
 
 const technologie = {
   Eolien: 'eolien',
@@ -178,7 +171,10 @@ const candidatureCsvRowSchema = z
         'Le code postal ne correspond à aucune région / département',
       ),
     [colonnes.commune]: requiredStringSchema,
-    [colonnes.statut]: z.string().pipe(z.enum(['Eliminé', 'Classé'])),
+    [colonnes.statut]: z
+      .string()
+      .toLowerCase()
+      .pipe(z.enum(['eliminé', 'éliminé', 'classé', 'retenu'])),
     [colonnes.puissanceÀLaPointe]: optionalOuiNonSchema,
     [colonnes.evaluationCarboneSimplifiée]: z
       .union([z.enum(['N/A']), strictlyPositiveNumberSchema])
@@ -200,27 +196,42 @@ const candidatureCsvRowSchema = z
     }),
   })
   // le motif d'élimination est obligatoire si la candidature est éliminée
-  .superRefine(
-    requiredFieldIfReferenceFieldEquals(colonnes.motifÉlimination, colonnes.statut, 'Eliminé'),
-  )
+  .superRefine((obj, ctx) => {
+    const actualStatut = statut[obj[colonnes.statut]];
+    if (actualStatut === 'éliminé' && !obj[colonnes.motifÉlimination]) {
+      ctx.addIssue(
+        conditionalRequiredError(colonnes.motifÉlimination, colonnes.statut, actualStatut),
+      );
+    }
+  })
   // le type de GF est obligatoire si la candidature est classée
-  .superRefine(requiredFieldIfReferenceFieldEquals(colonnes.typeGf, colonnes.statut, 'Classé'))
+  .superRefine((obj, ctx) => {
+    const actualStatut = statut[obj[colonnes.statut]];
+    if (actualStatut === 'classé' && !obj[colonnes.typeGf]) {
+      ctx.addIssue(conditionalRequiredError(colonnes.typeGf, colonnes.statut, actualStatut));
+    }
+  })
   // la date d'échéance est obligatoire si les GF sont de type "avec date d'échéance"
-  .superRefine(requiredFieldIfReferenceFieldEquals(colonnes.dateÉchéanceGf, colonnes.typeGf, '2'))
-  .superRefine(
-    requiredFieldIfReferenceFieldEquals(
-      colonnes.territoireProjet,
-      colonnes.appelOffre,
-      'CRE4 - ZNI',
-    ),
-  )
-  .superRefine(
-    requiredFieldIfReferenceFieldEquals(
-      colonnes.territoireProjet,
-      colonnes.appelOffre,
-      'CRE4 - ZNI 2017',
-    ),
-  )
+  .superRefine((obj, ctx) => {
+    const actualStatut = statut[obj[colonnes.statut]];
+    if (actualStatut === 'éliminé') return;
+    const actualTypeGf = obj[colonnes.typeGf]
+      ? typeGf[Number(obj[colonnes.typeGf]) - 1]
+      : undefined;
+    if (actualTypeGf === 'avec-date-échéance' && !obj[colonnes.dateÉchéanceGf]) {
+      ctx.addIssue(conditionalRequiredError(colonnes.dateÉchéanceGf, colonnes.typeGf, '2'));
+    }
+  })
+  // les CRE4 - ZNI nécessitent un territoire projet
+  .superRefine((obj, ctx) => {
+    const isZNI =
+      obj[colonnes.appelOffre] === 'CRE4 - ZNI' || obj[colonnes.appelOffre] === 'CRE4 - ZNI 2017';
+    if (isZNI && !obj[colonnes.territoireProjet]) {
+      ctx.addIssue(
+        conditionalRequiredError(colonnes.territoireProjet, colonnes.appelOffre, 'CRE4 - ZNI'),
+      );
+    }
+  })
   .refine((val) => !(val[colonnes.financementCollectif] && val[colonnes.gouvernancePartagée]), {
     message: `Seule l'une des deux colonnes "${colonnes.financementCollectif}" et "${colonnes.gouvernancePartagée}" peut avoir la valeur "Oui"`,
     path: [colonnes.financementCollectif, colonnes.gouvernancePartagée],
@@ -293,14 +304,29 @@ export const candidatureSchema = z
     // historiqueAbandon: z.enum(Candidature.HistoriqueAbandon.types),
   })
   // le motif d'élimination est obligatoire si la candidature est éliminée
-  .superRefine(requiredFieldIfReferenceFieldEquals('motifElimination', 'statut', 'éliminé'))
+  .superRefine((obj, ctx) => {
+    if (obj.statut === 'éliminé' && !obj.motifElimination) {
+      ctx.addIssue(conditionalRequiredError('motifElimination', 'statut', 'éliminé'));
+    }
+  })
   // le type de GF est obligatoire si la candidature est classée
-  .superRefine(requiredFieldIfReferenceFieldEquals('typeGarantiesFinancieres', 'statut', 'classé'))
+  .superRefine((obj, ctx) => {
+    if (obj.statut === 'classé' && !obj.typeGarantiesFinancieres) {
+      ctx.addIssue(conditionalRequiredError('typeGarantiesFinancieres', 'statut', 'classé'));
+    }
+  })
   // la date d'échéance est obligatoire si les GF sont de type "avec date d'échéance"
-  .superRefine(
-    requiredFieldIfReferenceFieldEquals(
-      'dateEcheanceGf',
-      'typeGarantiesFinancieres',
-      'avec-date-échéance',
-    ),
-  );
+  .superRefine((obj, ctx) => {
+    const actualTypeGf = obj.typeGarantiesFinancieres
+      ? typeGf[Number(obj.typeGarantiesFinancieres)]
+      : undefined;
+    if (obj.statut === 'classé' && actualTypeGf === 'avec-date-échéance' && !obj.motifElimination) {
+      ctx.addIssue(
+        conditionalRequiredError(
+          'dateEcheanceGf',
+          'typeGarantiesFinancieres',
+          'avec-date-échéance',
+        ),
+      );
+    }
+  });

--- a/packages/applications/ssr/src/components/pages/candidature/importer/candidature.schema.ts
+++ b/packages/applications/ssr/src/components/pages/candidature/importer/candidature.schema.ts
@@ -162,7 +162,7 @@ const candidatureCsvRowSchema = z
     [colonnes.noteTotale]: numberSchema,
     [colonnes.nomReprésentantLégal]: requiredStringSchema,
     [colonnes.emailContact]: requiredStringSchema.email(),
-    [colonnes.adresse1]: optionalStringSchema,
+    [colonnes.adresse1]: optionalStringSchema, // see refine below
     [colonnes.adresse2]: optionalStringSchema,
     [colonnes.codePostaux]: requiredStringSchema
       .transform((val) => val.split('/').map((str) => str.trim()))
@@ -232,10 +232,12 @@ const candidatureCsvRowSchema = z
       );
     }
   })
+  // on ne peut pas avoir financement collectif ET gouvernance partagée
   .refine((val) => !(val[colonnes.financementCollectif] && val[colonnes.gouvernancePartagée]), {
     message: `Seule l'une des deux colonnes "${colonnes.financementCollectif}" et "${colonnes.gouvernancePartagée}" peut avoir la valeur "Oui"`,
     path: [colonnes.financementCollectif, colonnes.gouvernancePartagée],
   })
+  // on doit avoir au minimum adresse1 ou adresse2
   .refine((val) => !!val[colonnes.adresse1] || !!val[colonnes.adresse2], {
     message: `Au moins l'une des deux colonnes "${colonnes.adresse1}" et "${colonnes.adresse2}" doit être précisée`,
     path: [colonnes.adresse1, colonnes.adresse2],

--- a/packages/applications/ssr/src/components/pages/candidature/importer/candidature.schema.ts
+++ b/packages/applications/ssr/src/components/pages/candidature/importer/candidature.schema.ts
@@ -239,7 +239,7 @@ const candidatureCsvRowSchema = z
   })
   // on doit avoir au minimum adresse1 ou adresse2
   .refine((val) => !!val[colonnes.adresse1] || !!val[colonnes.adresse2], {
-    message: `Au moins l'une des deux colonnes "${colonnes.adresse1}" et "${colonnes.adresse2}" doit être précisée`,
+    message: `Au moins l'une des deux colonnes "${colonnes.adresse1}" et "${colonnes.adresse2}" doit être renseignée`,
     path: [colonnes.adresse1, colonnes.adresse2],
   });
 

--- a/packages/applications/ssr/src/components/pages/candidature/importer/candidature.schema.ts
+++ b/packages/applications/ssr/src/components/pages/candidature/importer/candidature.schema.ts
@@ -162,7 +162,7 @@ const candidatureCsvRowSchema = z
     [colonnes.noteTotale]: numberSchema,
     [colonnes.nomReprésentantLégal]: requiredStringSchema,
     [colonnes.emailContact]: requiredStringSchema.email(),
-    [colonnes.adresse1]: requiredStringSchema,
+    [colonnes.adresse1]: optionalStringSchema,
     [colonnes.adresse2]: optionalStringSchema,
     [colonnes.codePostaux]: requiredStringSchema
       .transform((val) => val.split('/').map((str) => str.trim()))
@@ -235,6 +235,10 @@ const candidatureCsvRowSchema = z
   .refine((val) => !(val[colonnes.financementCollectif] && val[colonnes.gouvernancePartagée]), {
     message: `Seule l'une des deux colonnes "${colonnes.financementCollectif}" et "${colonnes.gouvernancePartagée}" peut avoir la valeur "Oui"`,
     path: [colonnes.financementCollectif, colonnes.gouvernancePartagée],
+  })
+  .refine((val) => !!val[colonnes.adresse1] || !!val[colonnes.adresse2], {
+    message: `Au moins l'une des deux colonnes "${colonnes.adresse1}" et "${colonnes.adresse2}" doit être précisée`,
+    path: [colonnes.adresse1, colonnes.adresse2],
   });
 
 export const candidatureCsvSchema = candidatureCsvRowSchema

--- a/packages/applications/ssr/src/components/pages/candidature/importer/importerCandidatures.action.ts
+++ b/packages/applications/ssr/src/components/pages/candidature/importer/importerCandidatures.action.ts
@@ -92,8 +92,8 @@ const mapLineToUseCaseData = (
   line: CandidatureShape,
   rawLine: Record<string, string>,
 ): Omit<Candidature.ImporterCandidatureUseCase['data'], 'importéLe' | 'importéPar'> => ({
-  typeGarantiesFinancièresValue: line.type_gf,
-  historiqueAbandonValue: line.historique_abandon,
+  typeGarantiesFinancièresValue: line.typeGf,
+  historiqueAbandonValue: line.historiqueAbandon,
   appelOffreValue: line.appelOffre,
   périodeValue: line.période,
   familleValue: line.famille,

--- a/packages/applications/ssr/src/components/pages/candidature/importer/importerCandidatures.action.ts
+++ b/packages/applications/ssr/src/components/pages/candidature/importer/importerCandidatures.action.ts
@@ -56,13 +56,13 @@ const action: FormAction<FormState, typeof schema> = async (_, { fichierImportCa
       } catch (error) {
         if (error instanceof DomainError) {
           errors.push({
-            key: line.nomProjet,
+            key: `${line.numéroCRE} - ${line.nomProjet}`,
             reason: error.message,
           });
           continue;
         }
         errors.push({
-          key: line.nomProjet,
+          key: `${line.numéroCRE} - ${line.nomProjet}`,
           reason: `Une erreur inconnue empêche l'import des candidatures`,
         });
       }

--- a/packages/domain/candidature/src/candidature.aggregate.ts
+++ b/packages/domain/candidature/src/candidature.aggregate.ts
@@ -97,6 +97,7 @@ export const getDefaultCandidatureAggregate: GetDefaultAggregateState<
     delete copy.importéLe;
     delete copy.importéPar;
     delete copy.doitRégénérerAttestation;
+    delete copy.détailsMisÀJour;
 
     return createHash('md5')
       .update(JSON.stringify(copy, getDeepKeys(copy).sort()))

--- a/packages/domain/candidature/src/corriger/corrigerCandidature.behavior.ts
+++ b/packages/domain/candidature/src/corriger/corrigerCandidature.behavior.ts
@@ -68,6 +68,7 @@ export async function corriger(
   }
 
   if (
+    candidature.statut.estClassé() &&
     candidature.typeGarantiesFinancières &&
     candidature.typeGarantiesFinancières.estAvecDateÉchéance() &&
     !candidature.dateÉchéanceGf

--- a/packages/domain/candidature/src/importer/importerCandidature.behavior.ts
+++ b/packages/domain/candidature/src/importer/importerCandidature.behavior.ts
@@ -129,6 +129,7 @@ export async function importer(
   }
 
   if (
+    candidature.statut.estClassé() &&
     candidature.typeGarantiesFinancières &&
     candidature.typeGarantiesFinancières.estAvecDateÉchéance() &&
     !candidature.dateÉchéanceGf

--- a/packages/specifications/src/candidature/corrigerCandidature.feature
+++ b/packages/specifications/src/candidature/corrigerCandidature.feature
@@ -76,7 +76,7 @@ Fonctionnalité: Corriger une candidature
             | type GF |  |
         Alors l'administrateur devrait être informé que "Les garanties financières sont requises pour cet appel d'offre ou famille"
 
-    Scénario: Impossible de corriger une candidature classée avec des GF "avec date d'échéance" si la date d'échéance est maquante
+    Scénario: Impossible de corriger une candidature classée avec des GF "avec date d'échéance" si la date d'échéance est manquante
         Quand un administrateur corrige la candidature avec :
             | type GF | avec-date-échéance |
         Alors l'administrateur devrait être informé que "La date d'échéance des garanties financières est requise"

--- a/packages/specifications/src/candidature/corrigerCandidature.feature
+++ b/packages/specifications/src/candidature/corrigerCandidature.feature
@@ -76,7 +76,7 @@ Fonctionnalité: Corriger une candidature
             | type GF |  |
         Alors l'administrateur devrait être informé que "Les garanties financières sont requises pour cet appel d'offre ou famille"
 
-    Scénario: Impossible de corriger une candidature avec des GF "avec date d'échéance" si la date d'échéance est maquante
+    Scénario: Impossible de corriger une candidature classée avec des GF "avec date d'échéance" si la date d'échéance est maquante
         Quand un administrateur corrige la candidature avec :
             | type GF | avec-date-échéance |
         Alors l'administrateur devrait être informé que "La date d'échéance des garanties financières est requise"

--- a/packages/specifications/src/candidature/importerCandidature.feature
+++ b/packages/specifications/src/candidature/importerCandidature.feature
@@ -47,7 +47,7 @@ Fonctionnalité: Importer une candidature
             | type GF       |                 |
         Alors l'administrateur devrait être informé que "Les garanties financières sont requises pour cet appel d'offre ou famille"
 
-    Scénario: Impossible d'importer une candidature avec des GF "avec date d'échéance" si la date d'échéance est maquante
+    Scénario: Impossible d'importer une candidature classée avec des GF "avec date d'échéance" si la date d'échéance est maquante
         Quand un administrateur importe la candidature "Du boulodrome de Marseille" avec :
             | statut        | classé             |
             | appel d'offre | PPE2 - Bâtiment    |

--- a/packages/specifications/src/candidature/importerCandidature.feature
+++ b/packages/specifications/src/candidature/importerCandidature.feature
@@ -47,7 +47,7 @@ Fonctionnalité: Importer une candidature
             | type GF       |                 |
         Alors l'administrateur devrait être informé que "Les garanties financières sont requises pour cet appel d'offre ou famille"
 
-    Scénario: Impossible d'importer une candidature classée avec des GF "avec date d'échéance" si la date d'échéance est maquante
+    Scénario: Impossible d'importer une candidature classée avec des GF "avec date d'échéance" si la date d'échéance est manquante
         Quand un administrateur importe la candidature "Du boulodrome de Marseille" avec :
             | statut        | classé             |
             | appel d'offre | PPE2 - Bâtiment    |


### PR DESCRIPTION
Afin de réduire les manipulations manuelles avant un import de fichier CRE:
- support de "Retenu" dans la colonne "Classé ?", qui vaut "Classé"
- la colonne "voie... 1" peut-être vide si "voie... 2" ne l'est pas
- les projets éliminés peuvent avoir un type de GF, auquel cas on ne doit pas valider la date d'échéance
- support de "" (vide) au même titre que "N/A" pour les colonnes optionnelles (je n'ai identifié que évaluation carbone qui manquait)

Pour simplifier la gestion des erreurs
- ajout du numéro CRE dans les erreurs (métier uniquement, pas CSV)


Bonus:
- les tests ne passaient plus suite au renommage des colonnes en camelCase
- certains champs n'avaient pas été renommés en camelCase
- petit fix d'un bug si import via CSV: on doit ignorer `détailsMisÀJour` pour comparer l'ancienne valeur et la nouvelle. Ce bug n'apparait que lors d'une correction via CSV