### PR TITLE
🐛 Corriger la maj des Dossier de Raccordement après changement de gestionnaire

### DIFF
--- a/packages/applications/projectors/src/infrastructure/updateManyProjection.spec.ts
+++ b/packages/applications/projectors/src/infrastructure/updateManyProjection.spec.ts
@@ -1,0 +1,42 @@
+import { describe, test } from 'node:test';
+
+import { expect } from 'chai';
+
+import { Entity } from '@potentiel-domain/entity';
+
+import { getUpdateProjectionQuery } from './updateManyProjections';
+
+type TestEntity = Entity<
+  'test',
+  {
+    id: string;
+    foo: string;
+    bar: string;
+  }
+>;
+
+describe('updateManyProjections', () => {
+  test('single key', () => {
+    const [query, values] = getUpdateProjectionQuery<TestEntity>(
+      'test',
+      { id: { operator: 'equal', value: 'abcd' } },
+      { foo: 'hello' },
+    );
+    expect(query).to.eq(
+      "update domain_views.projection set value=jsonb_set(value,'{foo}',$3) where key like $1 and value->>'id' = $2",
+    );
+    expect(values).to.deep.eq(['test|%', 'abcd', '"hello"']);
+  });
+
+  test('multiple keys', () => {
+    const [query, values] = getUpdateProjectionQuery<TestEntity>(
+      'test',
+      { id: { operator: 'equal', value: 'abcd' } },
+      { foo: 'hello', bar: 'world' },
+    );
+    expect(query).to.eq(
+      "update domain_views.projection set value=jsonb_set(jsonb_set(value,'{foo}',$3),'{bar}',$4) where key like $1 and value->>'id' = $2",
+    );
+    expect(values).to.deep.eq(['test|%', 'abcd', '"hello"', '"world"']);
+  });
+});

--- a/packages/applications/projectors/src/infrastructure/updateManyProjections.ts
+++ b/packages/applications/projectors/src/infrastructure/updateManyProjections.ts
@@ -1,0 +1,49 @@
+import format from 'pg-format';
+
+import { Entity, WhereOptions } from '@potentiel-domain/entity';
+import { flatten } from '@potentiel-libraries/flat';
+import { executeQuery } from '@potentiel-libraries/pg-helpers';
+import { getWhereClause } from '@potentiel-infrastructure/pg-projections';
+
+type AtLeastOne<T, U = { [K in keyof T]: Pick<T, K> }> = Partial<T> & U[keyof U];
+
+/** */
+export const updateManyProjections = async <TEntity extends Entity>(
+  category: TEntity['type'],
+  where: WhereOptions<Omit<TEntity, 'type'>>,
+  update: AtLeastOne<Omit<TEntity, 'type'>>,
+): Promise<void> => {
+  const [updateQuery, values] = getUpdateProjectionQuery(category, where, update);
+  console.log({ updateQuery, values });
+  await executeQuery(updateQuery, ...values);
+};
+
+export const getUpdateProjectionQuery = <TEntity extends Entity>(
+  category: TEntity['type'],
+  where: WhereOptions<Omit<TEntity, 'type'>>,
+  update: AtLeastOne<Omit<TEntity, 'type'>>,
+): [string, Array<unknown>] => {
+  const flatReadModel = flatten(update) as Record<string, unknown>;
+
+  const [whereClause, whereValues] = where ? getWhereClause(where) : ['', []];
+
+  /*
+    The following generates a recursive update similar to this:
+    select jsonb_set(jsonb_set(data,'{field1}','"new_value1"'), '{field2}', '"new_value2"')
+    from (select '{"field1": "a", "field2":"b"}'::jsonb as data ) a
+
+    the `i+2` operation is due to `i` starting at 0, and $1 being the key
+   */
+  const jsonb_set = Object.keys(flatReadModel).reduce(
+    (acc, curr, i) => `jsonb_set(${acc},'{${format('%I', curr)}}',$${i + 2 + whereValues.length})`,
+    'value',
+  );
+  const values = Object.values(flatReadModel).map((value) =>
+    typeof value === 'string' ? `"${value}"` : value,
+  );
+
+  return [
+    `update domain_views.projection set value=${jsonb_set} where key like $1 ${whereClause}`,
+    [`${category}|%`, ...whereValues, ...values],
+  ];
+};

--- a/packages/applications/projectors/src/infrastructure/updateManyProjections.ts
+++ b/packages/applications/projectors/src/infrastructure/updateManyProjections.ts
@@ -13,7 +13,6 @@ export const updateManyProjections = async <TEntity extends Entity>(
   update: AtLeastOne<Omit<TEntity, 'type'>>,
 ): Promise<void> => {
   const [updateQuery, values] = getUpdateProjectionQuery(category, where, update);
-  console.log({ updateQuery, values });
   await executeQuery(updateQuery, ...values);
 };
 

--- a/packages/applications/projectors/src/infrastructure/updateOneProjection.spec.ts
+++ b/packages/applications/projectors/src/infrastructure/updateOneProjection.spec.ts
@@ -4,7 +4,7 @@ import { expect } from 'chai';
 
 import { Entity } from '@potentiel-domain/entity';
 
-import { prepareUpdateProjectionQuery } from './updateProjection';
+import { prepareUpdateProjectionQuery } from './updateOneProjection';
 
 type TestEntity = Entity<
   'test',
@@ -15,7 +15,7 @@ type TestEntity = Entity<
   }
 >;
 
-describe('updateProjection', () => {
+describe('updateOneProjection', () => {
   test(`single string key`, () => {
     const [query, values] = prepareUpdateProjectionQuery<TestEntity>({ foo: 'hello' });
     expect(query).to.eq(

--- a/packages/applications/projectors/src/infrastructure/updateOneProjection.spec.ts
+++ b/packages/applications/projectors/src/infrastructure/updateOneProjection.spec.ts
@@ -4,7 +4,7 @@ import { expect } from 'chai';
 
 import { Entity } from '@potentiel-domain/entity';
 
-import { prepareUpdateProjectionQuery } from './updateOneProjection';
+import { getUpdateClause } from './updateOneProjection';
 
 type TestEntity = Entity<
   'test',
@@ -17,37 +17,34 @@ type TestEntity = Entity<
 
 describe('updateOneProjection', () => {
   test(`single string key`, () => {
-    const [query, values] = prepareUpdateProjectionQuery<TestEntity>({ foo: 'hello' });
-    expect(query).to.eq(
-      "update domain_views.projection set value=jsonb_set(value,'{foo}',$2) where key = $1",
-    );
+    const [query, values] = getUpdateClause<TestEntity>({ foo: 'hello' }, 1);
+    expect(query).to.eq("update domain_views.projection set value=jsonb_set(value,'{foo}',$2)");
     expect(values).to.deep.eq(['"hello"']);
   });
 
   test(`single number key`, () => {
-    const [query, values] = prepareUpdateProjectionQuery<TestEntity>({ bar: 1 });
-    expect(query).to.eq(
-      "update domain_views.projection set value=jsonb_set(value,'{bar}',$2) where key = $1",
-    );
+    const [query, values] = getUpdateClause<TestEntity>({ bar: 1 }, 1);
+    expect(query).to.eq("update domain_views.projection set value=jsonb_set(value,'{bar}',$2)");
     expect(values).to.deep.eq([1]);
   });
 
   test(`single boolean key`, () => {
-    const [query, values] = prepareUpdateProjectionQuery<TestEntity>({ baz: true });
-    expect(query).to.eq(
-      "update domain_views.projection set value=jsonb_set(value,'{baz}',$2) where key = $1",
-    );
+    const [query, values] = getUpdateClause<TestEntity>({ baz: true }, 1);
+    expect(query).to.eq("update domain_views.projection set value=jsonb_set(value,'{baz}',$2)");
     expect(values).to.deep.eq([true]);
   });
 
   test(`multiple keys`, () => {
-    const [query, values] = prepareUpdateProjectionQuery<TestEntity>({
-      foo: '',
-      bar: -1,
-      baz: false,
-    });
+    const [query, values] = getUpdateClause<TestEntity>(
+      {
+        foo: '',
+        bar: -1,
+        baz: false,
+      },
+      1,
+    );
     expect(query).to.eq(
-      "update domain_views.projection set value=jsonb_set(jsonb_set(jsonb_set(value,'{foo}',$2),'{bar}',$3),'{baz}',$4) where key = $1",
+      "update domain_views.projection set value=jsonb_set(jsonb_set(jsonb_set(value,'{foo}',$2),'{bar}',$3),'{baz}',$4)",
     );
     expect(values).to.deep.eq(['""', -1, false]);
   });

--- a/packages/applications/projectors/src/infrastructure/updateOneProjection.ts
+++ b/packages/applications/projectors/src/infrastructure/updateOneProjection.ts
@@ -7,7 +7,7 @@ import { executeQuery } from '@potentiel-libraries/pg-helpers';
 type AtLeastOne<T, U = { [K in keyof T]: Pick<T, K> }> = Partial<T> & U[keyof U];
 
 /** */
-export const updateProjection = async <TProjection extends Entity>(
+export const updateOneProjection = async <TProjection extends Entity>(
   id: `${TProjection['type']}|${string}`,
   readModel: AtLeastOne<Omit<TProjection, 'type'>>,
 ): Promise<void> => {

--- a/packages/applications/projectors/src/subscribers/candidature/candidature.projector.ts
+++ b/packages/applications/projectors/src/subscribers/candidature/candidature.projector.ts
@@ -8,7 +8,7 @@ import { Option } from '@potentiel-libraries/monads';
 
 import { removeProjection } from '../../infrastructure/removeProjection';
 import { upsertProjection } from '../../infrastructure/upsertProjection';
-import { updateProjection } from '../../infrastructure/updateProjection';
+import { updateOneProjection } from '../../infrastructure/updateOneProjection';
 
 export type SubscriptionEvent = (Candidature.CandidatureEvent & Event) | RebuildTriggered;
 
@@ -100,7 +100,7 @@ export const register = () => {
           );
           break;
         case 'CandidatureNotifiée-V1':
-          await updateProjection<Candidature.CandidatureEntity>(
+          await updateOneProjection<Candidature.CandidatureEntity>(
             `candidature|${payload.identifiantProjet}`,
             {
               estNotifiée: true,
@@ -113,7 +113,7 @@ export const register = () => {
           );
           break;
         case 'CandidatureNotifiée-V2':
-          await updateProjection<Candidature.CandidatureEntity>(
+          await updateOneProjection<Candidature.CandidatureEntity>(
             `candidature|${payload.identifiantProjet}`,
             {
               estNotifiée: true,

--- a/packages/applications/ssr/src/components/pages/réseau/raccordement/lister/DossierRaccordementList.page.tsx
+++ b/packages/applications/ssr/src/components/pages/réseau/raccordement/lister/DossierRaccordementList.page.tsx
@@ -7,10 +7,15 @@ import { IdentifiantProjet } from '@potentiel-domain/common';
 import { mapToPagination } from '@/utils/pagination';
 import { ListPageTemplate, ListPageTemplateProps } from '@/components/templates/ListPage.template';
 
-import { DossierRaccordementListItem } from './DossierRaccordementListItem';
+import {
+  DossierRaccordementListItem,
+  DossierRaccordementListItemProps,
+} from './DossierRaccordementListItem';
 
 export type DossierRaccordementListPageProps = PlainType<{
-  list: Raccordement.ListerDossierRaccordementReadModel;
+  list: Omit<Raccordement.ListerDossierRaccordementReadModel, 'items'> & {
+    items: DossierRaccordementListItemProps[];
+  };
   filters: ListPageTemplateProps<typeof DossierRaccordementListItem>['filters'];
 }>;
 

--- a/packages/applications/ssr/src/components/pages/réseau/raccordement/lister/DossierRaccordementList.stories.tsx
+++ b/packages/applications/ssr/src/components/pages/réseau/raccordement/lister/DossierRaccordementList.stories.tsx
@@ -72,6 +72,8 @@ export const Default: Story = {
         référenceDossier: {
           référence: `référence${i}`,
         },
+        identifiantGestionnaireRéseau: { codeEIC: 'codeEIC' },
+        gestionnaireRéseau: 'gestionnaireRéseau',
         statutDGEC: i % 2 === 0 ? 'classé' : 'abandonné',
         dateMiseEnService:
           i % 2 === 0

--- a/packages/applications/ssr/src/components/pages/réseau/raccordement/lister/DossierRaccordementListItem.tsx
+++ b/packages/applications/ssr/src/components/pages/réseau/raccordement/lister/DossierRaccordementListItem.tsx
@@ -12,7 +12,9 @@ import { FormattedDate } from '@/components/atoms/FormattedDate';
 
 export type DossierRaccordementListItemProps = PlainType<
   Raccordement.ListerDossierRaccordementReadModel['items'][number]
->;
+> & {
+  gestionnaireRéseau: string;
+};
 
 export const DossierRaccordementListItem: FC<DossierRaccordementListItemProps> = ({
   identifiantProjet,
@@ -24,6 +26,7 @@ export const DossierRaccordementListItem: FC<DossierRaccordementListItemProps> =
   référenceDossier,
   statutDGEC,
   dateMiseEnService,
+  gestionnaireRéseau,
 }) => (
   <ListItem
     heading={
@@ -37,12 +40,15 @@ export const DossierRaccordementListItem: FC<DossierRaccordementListItemProps> =
     actions={<></>}
   >
     <div className="mt-4">
-      <Icon id="fr-icon-map-pin-2-line" title="Date de mise en service" size="sm" />{' '}
+      <Icon id="fr-icon-map-pin-2-line" title="Commune du site de production" size="sm" />{' '}
       <span className="italic">
         {codePostal} {commune}, {département}, {région}
       </span>
     </div>
     <div className="mt-4">
+      <Icon id="fr-icon-building-line" title="Gestionnaire Réseau" size="sm" /> Gestionnaire Réseau
+      : <span className="font-bold">{gestionnaireRéseau}</span>
+      <div></div>
       <Icon id="ri-price-tag-3-line" title="Date de mise en service" size="sm" /> Référence du
       dossier : <span className="font-bold">{référenceDossier.référence}</span>
       <div>

--- a/packages/applications/ssr/src/components/pages/réseau/raccordement/lister/DossierRaccordementListItem.tsx
+++ b/packages/applications/ssr/src/components/pages/réseau/raccordement/lister/DossierRaccordementListItem.tsx
@@ -46,11 +46,16 @@ export const DossierRaccordementListItem: FC<DossierRaccordementListItemProps> =
       </span>
     </div>
     <div className="mt-4">
-      <Icon id="fr-icon-building-line" title="Gestionnaire Réseau" size="sm" /> Gestionnaire Réseau
-      : <span className="font-bold">{gestionnaireRéseau}</span>
-      <div></div>
-      <Icon id="ri-price-tag-3-line" title="Date de mise en service" size="sm" /> Référence du
-      dossier : <span className="font-bold">{référenceDossier.référence}</span>
+      {gestionnaireRéseau && (
+        <div>
+          <Icon id="fr-icon-building-line" title="Gestionnaire Réseau" size="sm" /> Gestionnaire
+          Réseau : <span className="font-bold">{gestionnaireRéseau}</span>
+        </div>
+      )}
+      <div>
+        <Icon id="ri-price-tag-3-line" title="Date de mise en service" size="sm" /> Référence du
+        dossier : <span className="font-bold">{référenceDossier.référence}</span>
+      </div>
       <div>
         <Icon id="fr-icon-calendar-line" title="Date de mise en service" size="sm" /> Date de mise
         en service :{' '}

--- a/packages/domain/réseau/src/raccordement/lister/listerDossierRaccordement.query.ts
+++ b/packages/domain/réseau/src/raccordement/lister/listerDossierRaccordement.query.ts
@@ -9,6 +9,7 @@ import { Abandon } from '@potentiel-domain/laureat';
 
 import { RéférenceDossierRaccordement } from '..';
 import { DossierRaccordementEntity } from '../raccordement.entity';
+import { IdentifiantGestionnaireRéseau } from '../../gestionnaire';
 
 type DossierRaccordement = {
   nomProjet: string;
@@ -24,6 +25,7 @@ type DossierRaccordement = {
   référenceDossier: RéférenceDossierRaccordement.ValueType;
   statutDGEC: Lauréat.StatutLauréat.RawType;
   dateMiseEnService?: DateTime.ValueType;
+  identifiantGestionnaireRéseau: IdentifiantGestionnaireRéseau.ValueType;
 };
 
 export type ListerDossierRaccordementReadModel = {
@@ -112,7 +114,12 @@ export const registerListerDossierRaccordementQuery = ({
 };
 
 export const toReadModel = (
-  { identifiantProjet, référence, miseEnService }: DossierRaccordementEntity,
+  {
+    identifiantProjet,
+    référence,
+    miseEnService,
+    identifiantGestionnaireRéseau,
+  }: DossierRaccordementEntity,
   candidatures: ReadonlyArray<Candidature.CandidatureEntity>,
   abandons: ReadonlyArray<Abandon.AbandonEntity>,
 ): DossierRaccordement => {
@@ -157,5 +164,8 @@ export const toReadModel = (
     dateMiseEnService: miseEnService
       ? DateTime.convertirEnValueType(miseEnService.dateMiseEnService)
       : undefined,
+    identifiantGestionnaireRéseau: IdentifiantGestionnaireRéseau.convertirEnValueType(
+      identifiantGestionnaireRéseau,
+    ),
   };
 };

--- a/packages/infrastructure/pg-projections/src/index.ts
+++ b/packages/infrastructure/pg-projections/src/index.ts
@@ -1,3 +1,4 @@
 export { countProjection } from './countProjection';
 export { findProjection } from './findProjection';
 export { listProjection } from './listProjection';
+export { getWhereClause } from './getWhereClause';


### PR DESCRIPTION
Reprend la correction de #2383 avec optimisation pour ne faire qu'une seule query

Bonus (optionnel, ca m'a servi pour tester mais je peux le retirer): ajout de la raison sociale du gestionnaire réseau dans le list item