### PR TITLE
🐛 Aggrégat GF toujours redéfinit lorsqu'un évènement est ajouté

### DIFF
--- a/packages/domain/lauréat/src/garantiesFinancières/garantiesFinancièresActuelles/enregistrer/enregistrerGarantiesFinancières.behavior.ts
+++ b/packages/domain/lauréat/src/garantiesFinancières/garantiesFinancièresActuelles/enregistrer/enregistrerGarantiesFinancières.behavior.ts
@@ -79,24 +79,14 @@ export function applyEnregistrerGarantiesFinancières(
     payload: { type, dateÉchéance, dateConstitution, attestation },
   }: GarantiesFinancièresEnregistréesEvent,
 ) {
-  if (!this.actuelles) {
-    this.actuelles = {
-      statut: StatutGarantiesFinancières.validé,
-      type: Candidature.TypeGarantiesFinancières.convertirEnValueType(type),
-      dateÉchéance: dateÉchéance && DateTime.convertirEnValueType(dateÉchéance),
-      dateConstitution: DateTime.convertirEnValueType(dateConstitution),
-      attestation,
-    };
-    return;
-  }
-
-  Object.assign(this.actuelles, {
+  this.actuelles = {
+    ...this.actuelles,
     statut: StatutGarantiesFinancières.validé,
     type: Candidature.TypeGarantiesFinancières.convertirEnValueType(type),
     dateÉchéance: dateÉchéance && DateTime.convertirEnValueType(dateÉchéance),
     dateConstitution: DateTime.convertirEnValueType(dateConstitution),
     attestation,
-  });
+  };
 }
 
 class GarantiesFinancièresDéjàEnregistréesError extends InvalidOperationError {

--- a/packages/domain/lauréat/src/garantiesFinancières/garantiesFinancièresActuelles/enregistrer/enregistrerGarantiesFinancières.behavior.ts
+++ b/packages/domain/lauréat/src/garantiesFinancières/garantiesFinancièresActuelles/enregistrer/enregistrerGarantiesFinancières.behavior.ts
@@ -79,13 +79,24 @@ export function applyEnregistrerGarantiesFinancières(
     payload: { type, dateÉchéance, dateConstitution, attestation },
   }: GarantiesFinancièresEnregistréesEvent,
 ) {
-  this.actuelles = {
+  if (!this.actuelles) {
+    this.actuelles = {
+      statut: StatutGarantiesFinancières.validé,
+      type: Candidature.TypeGarantiesFinancières.convertirEnValueType(type),
+      dateÉchéance: dateÉchéance && DateTime.convertirEnValueType(dateÉchéance),
+      dateConstitution: DateTime.convertirEnValueType(dateConstitution),
+      attestation,
+    };
+    return;
+  }
+
+  Object.assign(this.actuelles, {
     statut: StatutGarantiesFinancières.validé,
     type: Candidature.TypeGarantiesFinancières.convertirEnValueType(type),
     dateÉchéance: dateÉchéance && DateTime.convertirEnValueType(dateÉchéance),
     dateConstitution: DateTime.convertirEnValueType(dateConstitution),
     attestation,
-  };
+  });
 }
 
 class GarantiesFinancièresDéjàEnregistréesError extends InvalidOperationError {

--- a/packages/domain/lauréat/src/garantiesFinancières/garantiesFinancièresActuelles/enregistrerAttestation/enregistrerAttestationGarantiesFinancières.behavior.ts
+++ b/packages/domain/lauréat/src/garantiesFinancières/garantiesFinancièresActuelles/enregistrerAttestation/enregistrerAttestationGarantiesFinancières.behavior.ts
@@ -2,9 +2,11 @@ import { DateTime, IdentifiantProjet } from '@potentiel-domain/common';
 import { DomainEvent, InvalidOperationError } from '@potentiel-domain/core';
 import { IdentifiantUtilisateur } from '@potentiel-domain/utilisateur';
 import { DocumentProjet } from '@potentiel-domain/document';
+import { Candidature } from '@potentiel-domain/candidature';
 
 import { DateConstitutionDansLeFuturError } from '../../dateConstitutionDansLeFutur.error';
 import { GarantiesFinancièresAggregate } from '../../garantiesFinancières.aggregate';
+import { StatutGarantiesFinancières } from '../..';
 
 export type AttestationGarantiesFinancièresEnregistréeEvent = DomainEvent<
   'AttestationGarantiesFinancièresEnregistrée-V1',
@@ -57,10 +59,20 @@ export function applyEnregistrerAttestationGarantiesFinancières(
   this: GarantiesFinancièresAggregate,
   { payload: { dateConstitution, attestation } }: AttestationGarantiesFinancièresEnregistréeEvent,
 ) {
-  if (this.actuelles) {
-    this.actuelles.dateConstitution = DateTime.convertirEnValueType(dateConstitution);
-    this.actuelles.attestation = attestation;
+  if (!this.actuelles) {
+    this.actuelles = {
+      statut: StatutGarantiesFinancières.validé,
+      type: Candidature.TypeGarantiesFinancières.typeInconnu,
+      dateConstitution: DateTime.convertirEnValueType(dateConstitution),
+      attestation,
+    };
+    return;
   }
+
+  Object.assign(this.actuelles, {
+    dateConstitution: DateTime.convertirEnValueType(dateConstitution),
+    attestation,
+  });
 }
 
 class AucunesGarantiesFinancièresActuelles extends InvalidOperationError {

--- a/packages/domain/lauréat/src/garantiesFinancières/garantiesFinancièresActuelles/enregistrerAttestation/enregistrerAttestationGarantiesFinancières.behavior.ts
+++ b/packages/domain/lauréat/src/garantiesFinancières/garantiesFinancièresActuelles/enregistrerAttestation/enregistrerAttestationGarantiesFinancières.behavior.ts
@@ -2,11 +2,9 @@ import { DateTime, IdentifiantProjet } from '@potentiel-domain/common';
 import { DomainEvent, InvalidOperationError } from '@potentiel-domain/core';
 import { IdentifiantUtilisateur } from '@potentiel-domain/utilisateur';
 import { DocumentProjet } from '@potentiel-domain/document';
-import { Candidature } from '@potentiel-domain/candidature';
 
 import { DateConstitutionDansLeFuturError } from '../../dateConstitutionDansLeFutur.error';
 import { GarantiesFinancièresAggregate } from '../../garantiesFinancières.aggregate';
-import { StatutGarantiesFinancières } from '../..';
 
 export type AttestationGarantiesFinancièresEnregistréeEvent = DomainEvent<
   'AttestationGarantiesFinancièresEnregistrée-V1',
@@ -59,20 +57,11 @@ export function applyEnregistrerAttestationGarantiesFinancières(
   this: GarantiesFinancièresAggregate,
   { payload: { dateConstitution, attestation } }: AttestationGarantiesFinancièresEnregistréeEvent,
 ) {
-  if (!this.actuelles) {
-    this.actuelles = {
-      statut: StatutGarantiesFinancières.validé,
-      type: Candidature.TypeGarantiesFinancières.typeInconnu,
-      dateConstitution: DateTime.convertirEnValueType(dateConstitution),
-      attestation,
-    };
-    return;
-  }
-
-  Object.assign(this.actuelles, {
+  this.actuelles = {
+    ...this.actuelles!,
     dateConstitution: DateTime.convertirEnValueType(dateConstitution),
     attestation,
-  });
+  };
 }
 
 class AucunesGarantiesFinancièresActuelles extends InvalidOperationError {

--- a/packages/domain/lauréat/src/garantiesFinancières/garantiesFinancièresActuelles/importer/importerTypeGarantiesFinancières.behavior.ts
+++ b/packages/domain/lauréat/src/garantiesFinancières/garantiesFinancièresActuelles/importer/importerTypeGarantiesFinancières.behavior.ts
@@ -51,10 +51,20 @@ export function applyTypeGarantiesFinancièresImporté(
   this: GarantiesFinancièresAggregate,
   { payload: { type, dateÉchéance, importéLe } }: TypeGarantiesFinancièresImportéEvent,
 ) {
-  this.actuelles = {
+  if (!this.actuelles) {
+    this.actuelles = {
+      statut: StatutGarantiesFinancières.validé,
+      type: Candidature.TypeGarantiesFinancières.convertirEnValueType(type),
+      dateÉchéance: dateÉchéance && DateTime.convertirEnValueType(dateÉchéance),
+      importéLe: DateTime.convertirEnValueType(importéLe),
+    };
+    return;
+  }
+
+  Object.assign(this.actuelles, {
     statut: StatutGarantiesFinancières.validé,
     type: Candidature.TypeGarantiesFinancières.convertirEnValueType(type),
     dateÉchéance: dateÉchéance && DateTime.convertirEnValueType(dateÉchéance),
     importéLe: DateTime.convertirEnValueType(importéLe),
-  };
+  });
 }

--- a/packages/domain/lauréat/src/garantiesFinancières/garantiesFinancièresActuelles/importer/importerTypeGarantiesFinancières.behavior.ts
+++ b/packages/domain/lauréat/src/garantiesFinancières/garantiesFinancièresActuelles/importer/importerTypeGarantiesFinancières.behavior.ts
@@ -51,20 +51,11 @@ export function applyTypeGarantiesFinancièresImporté(
   this: GarantiesFinancièresAggregate,
   { payload: { type, dateÉchéance, importéLe } }: TypeGarantiesFinancièresImportéEvent,
 ) {
-  if (!this.actuelles) {
-    this.actuelles = {
-      statut: StatutGarantiesFinancières.validé,
-      type: Candidature.TypeGarantiesFinancières.convertirEnValueType(type),
-      dateÉchéance: dateÉchéance && DateTime.convertirEnValueType(dateÉchéance),
-      importéLe: DateTime.convertirEnValueType(importéLe),
-    };
-    return;
-  }
-
-  Object.assign(this.actuelles, {
+  this.actuelles = {
+    ...this.actuelles,
     statut: StatutGarantiesFinancières.validé,
     type: Candidature.TypeGarantiesFinancières.convertirEnValueType(type),
     dateÉchéance: dateÉchéance && DateTime.convertirEnValueType(dateÉchéance),
     importéLe: DateTime.convertirEnValueType(importéLe),
-  });
+  };
 }


### PR DESCRIPTION
## Hotfix 

On devrait toujours maj l'aggregat gf sans écraser son état avant l'insertion de l'event

prévoir un rebuild gf
