### PR TITLE
🐛 Fix : uniformisation bouton "à notifier"

### DIFF
--- a/packages/applications/legacy/src/views/components/UI/atoms/Badge.tsx
+++ b/packages/applications/legacy/src/views/components/UI/atoms/Badge.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from 'react';
 
-export type BadgeType = 'success' | 'error' | 'info' | 'warning';
+export type BadgeType = 'success' | 'error' | 'info' | 'warning' | 'new';
 
 type BadgeProps = {
   className?: string;
@@ -31,6 +31,11 @@ const badgeColorsByType: Record<
     borderColor: 'border-warning-950-base',
     textColor: 'text-warning-425-base',
   },
+  new: {
+    backgroundColor: 'bg-new-950-base',
+    borderColor: 'border-new-950-base',
+    textColor: 'text-new-425-base',
+  },
 };
 
 export const Badge: FC<BadgeProps & { children: React.ReactNode }> = ({
@@ -41,7 +46,7 @@ export const Badge: FC<BadgeProps & { children: React.ReactNode }> = ({
   const { backgroundColor, textColor, borderColor } = badgeColorsByType[type];
   return (
     <span
-      className={`inline-block self-start px-2 py-0.5 rounded-md text-sm font-bold uppercase ${backgroundColor} ${textColor} print:border-solid print:border-2 print:${borderColor} ${className}`}
+      className={`inline-bloc text-nowrap self-start px-2 py-0.5 rounded-md text-sm font-bold uppercase ${backgroundColor} ${textColor} print:border-solid print:border-2 print:${borderColor} ${className}`}
     >
       {children}
     </span>

--- a/packages/applications/legacy/src/views/components/UI/atoms/Badge.tsx
+++ b/packages/applications/legacy/src/views/components/UI/atoms/Badge.tsx
@@ -46,7 +46,7 @@ export const Badge: FC<BadgeProps & { children: React.ReactNode }> = ({
   const { backgroundColor, textColor, borderColor } = badgeColorsByType[type];
   return (
     <span
-      className={`inline-bloc text-nowrap self-start px-2 py-0.5 rounded-md text-sm font-bold uppercase ${backgroundColor} ${textColor} print:border-solid print:border-2 print:${borderColor} ${className}`}
+      className={`inline-block text-nowrap self-start px-2 py-0.5 rounded-md text-sm font-bold uppercase ${backgroundColor} ${textColor} print:border-solid print:border-2 print:${borderColor} ${className}`}
     >
       {children}
     </span>

--- a/packages/applications/legacy/src/views/components/UI/templates/PageProjetTemplate.tsx
+++ b/packages/applications/legacy/src/views/components/UI/templates/PageProjetTemplate.tsx
@@ -73,7 +73,7 @@ const getBadgeType = (statut: Candidature.ConsulterProjetReadModel['statut']): B
 };
 
 const getBadgeLabel = (statut: Candidature.ConsulterProjetReadModel['statut']): string => {
-  if (statut === 'non-notifié') return 'à-notifier';
+  if (statut === 'non-notifié') return 'à notifier';
   return statut;
 };
 

--- a/packages/applications/legacy/src/views/components/UI/templates/PageProjetTemplate.tsx
+++ b/packages/applications/legacy/src/views/components/UI/templates/PageProjetTemplate.tsx
@@ -68,14 +68,19 @@ const getBadgeType = (statut: Candidature.ConsulterProjetReadModel['statut']): B
     case 'éliminé':
       return 'error';
     case 'non-notifié':
-      return 'info';
+      return 'new';
   }
+};
+
+const getBadgeLabel = (statut: Candidature.ConsulterProjetReadModel['statut']): string => {
+  if (statut === 'non-notifié') return 'à-notifier';
+  return statut;
 };
 
 const StatutProjet: FC<{
   statut: Candidature.ConsulterProjetReadModel['statut'];
 }> = ({ statut }) => (
   <Badge type={getBadgeType(statut)} className="ml-2 self-center">
-    {statut}
+    {getBadgeLabel(statut)}
   </Badge>
 );

--- a/packages/applications/legacy/src/views/pages/projectDetailsPage/components/ProjectHeaderBadge.tsx
+++ b/packages/applications/legacy/src/views/pages/projectDetailsPage/components/ProjectHeaderBadge.tsx
@@ -12,7 +12,7 @@ export const ProjectHeaderBadge = ({ project }: ProjectHeaderBadgeProps) => (
       <Badge type="warning">Abandonné</Badge>
     ) : (
       <>
-        {!project.notifiedOn && <Badge type="info">Non-notifié</Badge>}
+        {!project.notifiedOn && <Badge type="new">à-notifier</Badge>}
         {project.isClasse ? (
           <Badge type="success">Classé</Badge>
         ) : (

--- a/packages/applications/legacy/src/views/pages/projectDetailsPage/components/ProjectHeaderBadge.tsx
+++ b/packages/applications/legacy/src/views/pages/projectDetailsPage/components/ProjectHeaderBadge.tsx
@@ -12,7 +12,7 @@ export const ProjectHeaderBadge = ({ project }: ProjectHeaderBadgeProps) => (
       <Badge type="warning">Abandonné</Badge>
     ) : (
       <>
-        {!project.notifiedOn && <Badge type="new">à-notifier</Badge>}
+        {!project.notifiedOn && <Badge type="new">à notifier</Badge>}
         {project.isClasse ? (
           <Badge type="success">Classé</Badge>
         ) : (

--- a/packages/applications/legacy/tailwind.config.js
+++ b/packages/applications/legacy/tailwind.config.js
@@ -101,6 +101,16 @@ module.exports = {
         'warning-975': {
           base: '#fff4f3',
         },
+        'new-425': {
+          base: '#695240',
+          hover: '#9b7b61',
+          active: '#b58f72',
+        },
+        'new-950': {
+          base: '#feebd0',
+          hover: '#fdcd6d',
+          active: '#f4be30',
+        },
         'info-425': {
           base: '#0063cb',
           hover: '#3b87ff',

--- a/packages/applications/ssr/src/components/molecules/candidature/NotificationBadge.tsx
+++ b/packages/applications/ssr/src/components/molecules/candidature/NotificationBadge.tsx
@@ -8,7 +8,7 @@ type NotificationBadgeProps = {
 export const NotificationBadge: React.FC<NotificationBadgeProps> = ({ estNotifié }) => {
   return (
     <Badge small noIcon severity={estNotifié ? 'info' : 'new'}>
-      {estNotifié ? 'Notifié' : 'À Notifier'}
+      {estNotifié ? 'notifié' : 'à notifier'}
     </Badge>
   );
 };

--- a/packages/applications/ssr/src/components/molecules/projet/StatutProjetBadge.tsx
+++ b/packages/applications/ssr/src/components/molecules/projet/StatutProjetBadge.tsx
@@ -11,8 +11,13 @@ const convertStatutProjetToBadgeSeverity: Record<StatutProjet, AlertProps.Severi
   éliminé: 'error',
 };
 
+const getStatutProjetBadgeLabel = (statut: StatutProjet): string => {
+  if (statut === 'non-notifié') return 'à-notifier';
+  return statut;
+};
+
 export const StatutProjetBadge: FC<{ statut: StatutProjet }> = ({ statut }) => (
   <Badge small noIcon severity={convertStatutProjetToBadgeSeverity[statut]}>
-    {statut}
+    {getStatutProjetBadgeLabel(statut)}
   </Badge>
 );

--- a/packages/applications/ssr/src/components/molecules/projet/StatutProjetBadge.tsx
+++ b/packages/applications/ssr/src/components/molecules/projet/StatutProjetBadge.tsx
@@ -12,7 +12,7 @@ const convertStatutProjetToBadgeSeverity: Record<StatutProjet, AlertProps.Severi
 };
 
 const getStatutProjetBadgeLabel = (statut: StatutProjet): string => {
-  if (statut === 'non-notifié') return 'à-notifier';
+  if (statut === 'non-notifié') return 'à notifier';
   return statut;
 };
 


### PR DESCRIPTION
# Description

- legacy et ssr
- J'ai préféré faire un quick fix de transformation plutôt que de changer le valuetype de project statut (ainsi que les queries...)

## Type de changement

Veuillez supprimer les options qui ne sont pas pertinentes.

- [x] Correction de bug

<img width="537" alt="Capture d’écran 2024-11-05 à 16 40 03" src="https://github.com/user-attachments/assets/d5a9b36c-7578-4ebf-bdba-d61083fad905">

