### PR TITLE
🐛 Fix build ssr (getlogger) dans ajouterFiligrane

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26467,7 +26467,6 @@
       "dependencies": {
         "@potentiel-libraries/http-client": "*",
         "@potentiel-libraries/monads": "*",
-        "@potentiel-libraries/monitoring": "*",
         "zod": "^3.23.8"
       },
       "devDependencies": {

--- a/packages/infrastructure/filigrane-facile-client/package.json
+++ b/packages/infrastructure/filigrane-facile-client/package.json
@@ -13,7 +13,6 @@
   },
   "dependencies": {
     "@potentiel-libraries/http-client": "*",
-    "@potentiel-libraries/monitoring": "*",
     "@potentiel-libraries/monads": "*",
     "zod": "^3.23.8"
   }

--- a/packages/infrastructure/filigrane-facile-client/src/ajouterFiligrane.ts
+++ b/packages/infrastructure/filigrane-facile-client/src/ajouterFiligrane.ts
@@ -1,5 +1,5 @@
 import { Option } from '@potentiel-libraries/monads';
-import { getLogger } from '@potentiel-libraries/monitoring';
+// import { getLogger } from '@potentiel-libraries/monitoring';
 
 import { startApplyingWatermarkOnFile } from './startApplyingWatermarkOnFile';
 import { getWatermarkedFile } from './getWatermarkedFile';
@@ -22,13 +22,16 @@ export const ajouterFiligrane = async (
 
     return documentAvecFiligrane;
   } catch (error) {
-    getLogger().warn(
-      `Erreur lors de l'ajout du filigrane | Le document a été transmis sans filigrane`,
-      {
-        error,
-        filigrane,
-      },
-    );
+    /**
+     * @todo À investiguer parce qu'aujourd'hui ça casse le build SSR
+     */
+    // getLogger().warn(
+    //   `Erreur lors de l'ajout du filigrane | Le document a été transmis sans filigrane`,
+    //   {
+    //     error,
+    //     filigrane,
+    //   },
+    // );
     return Option.none;
   }
 };

--- a/packages/infrastructure/filigrane-facile-client/tsconfig.json
+++ b/packages/infrastructure/filigrane-facile-client/tsconfig.json
@@ -10,9 +10,6 @@
     },
     {
       "path": "../../libraries/monads"
-    },
-    {
-      "path": "../../libraries/monitoring"
     }
   ]
 }


### PR DESCRIPTION
# Description

Le fait d'avoir un getLogger dans un composant rendu coté serveur provoque une erreur dès qu'on arrive sur une page qui a un formulaire qui upload des fichiers.

Le fix tmp est de supprimer la dépendance au logger