### PR TITLE
🔊 Amélioration du log des erreurs

### DIFF
--- a/packages/infrastructure/pg-event-sourcing/src/subscribe/errors/DomainEventHandlingFailed.error.ts
+++ b/packages/infrastructure/pg-event-sourcing/src/subscribe/errors/DomainEventHandlingFailed.error.ts
@@ -1,5 +1,5 @@
 export class DomainEventHandlingFailedError extends Error {
-  constructor() {
-    super('Handling domain event failed');
+  constructor(cause: unknown) {
+    super('Handling domain event failed', { cause });
   }
 }

--- a/packages/infrastructure/pg-event-sourcing/src/subscribe/errors/NotificationPayloadParse.error.ts
+++ b/packages/infrastructure/pg-event-sourcing/src/subscribe/errors/NotificationPayloadParse.error.ts
@@ -1,5 +1,5 @@
 export class NotificationPayloadParseError extends Error {
-  constructor() {
-    super('Notification payload parse error');
+  constructor(cause: unknown) {
+    super('Notification payload parse error', { cause });
   }
 }

--- a/packages/infrastructure/pg-event-sourcing/src/subscribe/errors/RebuildFailed.error.ts
+++ b/packages/infrastructure/pg-event-sourcing/src/subscribe/errors/RebuildFailed.error.ts
@@ -1,5 +1,5 @@
 export class RebuildFailedError extends Error {
-  constructor() {
-    super('Rebuild failed');
+  constructor(cause: unknown) {
+    super('Rebuild failed', { cause });
   }
 }

--- a/packages/infrastructure/pg-event-sourcing/src/subscribe/errors/UnknownEventHandlingFailed.error.ts
+++ b/packages/infrastructure/pg-event-sourcing/src/subscribe/errors/UnknownEventHandlingFailed.error.ts
@@ -1,5 +1,5 @@
 export class UnknownEventHandlingFailedError extends Error {
-  constructor() {
-    super('Handling unknow event failed');
+  constructor(cause: unknown) {
+    super('Handling unknow event failed', { cause });
   }
 }

--- a/packages/infrastructure/pg-event-sourcing/src/subscribe/eventStreamEmitter.ts
+++ b/packages/infrastructure/pg-event-sourcing/src/subscribe/eventStreamEmitter.ts
@@ -136,8 +136,7 @@ export class EventStreamEmitter extends EventEmitter {
           version: event.version,
         });
       } catch (error) {
-        getLogger().error(new DomainEventHandlingFailedError(), {
-          error,
+        getLogger().error(new DomainEventHandlingFailedError(error), {
           event,
           subscriber: this.#subscriber,
         });

--- a/packages/infrastructure/pg-event-sourcing/src/subscribe/eventStreamEmitter.ts
+++ b/packages/infrastructure/pg-event-sourcing/src/subscribe/eventStreamEmitter.ts
@@ -61,9 +61,7 @@ export class EventStreamEmitter extends EventEmitter {
           this.emit(this.#getChannelName(event.type), event);
         }
       } catch (error) {
-        getLogger().error(new NotificationPayloadParseError(), {
-          error,
-        });
+        getLogger().error(new NotificationPayloadParseError(error));
       }
     });
 
@@ -107,8 +105,7 @@ export class EventStreamEmitter extends EventEmitter {
           subscriber: this.#subscriber,
         });
       } catch (error) {
-        getLogger().error(new RebuildFailedError(), {
-          error,
+        getLogger().error(new RebuildFailedError(error), {
           event,
           subscriber: this.#subscriber,
         });
@@ -169,8 +166,7 @@ export class EventStreamEmitter extends EventEmitter {
           version: event.version,
         });
       } catch (error) {
-        getLogger().error(new UnknownEventHandlingFailedError(), {
-          error,
+        getLogger().error(new UnknownEventHandlingFailedError(error), {
           event,
           subscriber: this.#subscriber,
         });

--- a/packages/libraries/monitoring/src/logger.ts
+++ b/packages/libraries/monitoring/src/logger.ts
@@ -40,6 +40,9 @@ let logger: Logger | undefined;
  * In the futur, we can switch to logstash if beta.gouv.fr setup something like ELK
  */
 const customFormat = winston.format((info) => {
+  if ('error' in info && info.error instanceof Error && info.error.cause) {
+    info.meta.cause = String(info.error.cause);
+  }
   const meta = Object.keys(info.meta)
     .map((k) => `{${k}=${JSON.stringify(info.meta[k])}}`)
     .join(' ');


### PR DESCRIPTION
les erreurs `Handling domain event failed ` ne loggent pas de cause, car `JSON.stringify(new Error("hello"))` => 
`'{}'`. 

Ce fix passe  l'erreur d'origine en cause de `DomainEventHandlingFailedError`, et ajoute la cause dans le log d'erreur.

la bonne facon de logguer les erreurs est donc : `logger.error(new CustomError(error))` ou `logger.error(new Error("custom mesage", { cause: error})` pour des erreurs non réutilisable
