### PR TITLE
✨ Afficher les infos représentant légal dans la projection lauréat

### DIFF
--- a/packages/applications/legacy/src/controllers/project/getProjectPage/_utils/getReprésentantLégal.ts
+++ b/packages/applications/legacy/src/controllers/project/getProjectPage/_utils/getReprésentantLégal.ts
@@ -27,11 +27,10 @@ export const getReprésentantLégal: GetReprésentantLégal = async (identifiant
   try {
     const utilisateur = Role.convertirEnValueType(rôle);
 
-    const représentantLégal =
-      await mediator.send<ReprésentantLégal.ConsulterReprésentantLégalQuery>({
-        type: 'Lauréat.ReprésentantLégal.Query.ConsulterReprésentantLégal',
-        data: { identifiantProjet: identifiantProjet.formatter() },
-      });
+    const représentantLégal = await mediator.send<ReprésentantLégal.ReprésentantLégalQuery>({
+      type: 'Lauréat.ReprésentantLégal.Query.ConsulterReprésentantLégal',
+      data: { identifiantProjet: identifiantProjet.formatter() },
+    });
 
     if (Option.isSome(représentantLégal)) {
       return {

--- a/packages/applications/projectors/src/subscribers/lauréat/lauréat.projector.ts
+++ b/packages/applications/projectors/src/subscribers/lauréat/lauréat.projector.ts
@@ -25,6 +25,7 @@ export const register = () => {
             identifiantProjet,
             notifiéLe,
             notifiéPar,
+            représentantLégal: undefined,
           });
           break;
       }

--- a/packages/applications/ssr/src/components/pages/représentant-légal/modifier/ModifierReprésentantLégal.page.tsx
+++ b/packages/applications/ssr/src/components/pages/représentant-légal/modifier/ModifierReprésentantLégal.page.tsx
@@ -12,7 +12,6 @@ import { ModifierReprésentantLégalForm } from './ModifierReprésentantLégal.f
 
 export type ModifierReprésentantLégalPageProps =
   PlainType<ReprésentantLégal.ConsulterReprésentantLégalReadModel>;
-
 export const ModifierReprésentantLégalPage: FC<ModifierReprésentantLégalPageProps> = ({
   identifiantProjet,
   nomReprésentantLégal,

--- a/packages/domain/lauréat/src/lauréat.entity.ts
+++ b/packages/domain/lauréat/src/lauréat.entity.ts
@@ -1,11 +1,17 @@
 import { DateTime, Email, IdentifiantProjet } from '@potentiel-domain/common';
 import { Entity } from '@potentiel-domain/entity';
 
+import { ReprésentantLégal } from '.';
+
 export type LauréatEntity = Entity<
   'lauréat',
   {
     identifiantProjet: IdentifiantProjet.RawType;
     notifiéLe: DateTime.RawType;
     notifiéPar: Email.RawType;
+    représentantLégal?: {
+      nom: string;
+      type: ReprésentantLégal.TypeReprésentantLégal.RawType;
+    };
   }
 >;


### PR DESCRIPTION
# Description

Utilisation de la projection lauréat pour obtenir les infos de représentant légal. Pour l'instant j'ai conservé la query "ConsulterReprésentantLégal" tant qu'on est pas capable de séléctionner des attributs en particulier.

## Type de changement
- [x] Refacto de code

# Comment cela a-t-il été testé?

TDD + test visuel