### PR TITLE
✨ Ajout de try/catch sur la page legacy projet pour éviter les erreurs de droit sur les queries

### DIFF
--- a/packages/applications/legacy/src/controllers/project/getProjectPage/_utils/getAbandon.ts
+++ b/packages/applications/legacy/src/controllers/project/getProjectPage/_utils/getAbandon.ts
@@ -36,11 +36,8 @@ export const getAbandonStatut: GetAbandonStatut = async (
         return undefined;
     }
   } catch (error) {
-    getLogger().error(`Impossible de consulter l'abandon`, {
+    getLogger('Legacy|getProjectPage|getAbandonStatut').error(`Impossible de consulter l'abandon`, {
       identifiantProjet: identifiantProjet.formatter(),
-      context: 'legacy',
-      controller: 'getProjectPage',
-      method: 'getAbandonStatut',
     });
     return undefined;
   }

--- a/packages/applications/legacy/src/controllers/project/getProjectPage/_utils/getAbandon.ts
+++ b/packages/applications/legacy/src/controllers/project/getProjectPage/_utils/getAbandon.ts
@@ -3,6 +3,7 @@ import { IdentifiantProjet } from '@potentiel-domain/common';
 import { Abandon } from '@potentiel-domain/laureat';
 
 import { Option } from '@potentiel-libraries/monads';
+import { getLogger } from '@potentiel-libraries/monitoring';
 
 export type GetAbandonStatut = (
   identifiantProjet: IdentifiantProjet.ValueType,
@@ -32,9 +33,15 @@ export const getAbandonStatut: GetAbandonStatut = async (
       case 'confirmation-demandée':
         return { statut: 'à confirmer' };
       default:
-        return;
+        return undefined;
     }
   } catch (error) {
-    return;
+    getLogger().error(`Impossible de consulter l'abandon`, {
+      identifiantProjet: identifiantProjet.formatter(),
+      context: 'legacy',
+      controller: 'getProjectPage',
+      method: 'getAbandonStatut',
+    });
+    return undefined;
   }
 };

--- a/packages/applications/legacy/src/controllers/project/getProjectPage/_utils/getAlertesRaccordement.ts
+++ b/packages/applications/legacy/src/controllers/project/getProjectPage/_utils/getAlertesRaccordement.ts
@@ -55,12 +55,12 @@ export const getAlertesRaccordement = async ({
 
     return alertes.length > 0 ? alertes : undefined;
   } catch (error) {
-    getLogger().error(`Impossible de consulter le raccordement`, {
-      identifiantProjet: identifiantProjet.formatter(),
-      context: 'legacy',
-      controller: 'getProjectPage',
-      method: 'getAlertesRaccordement',
-    });
+    getLogger('Legacy|getProjectPage|getAlertesRaccordement').error(
+      `Impossible de consulter le raccordement`,
+      {
+        identifiantProjet: identifiantProjet.formatter(),
+      },
+    );
     return undefined;
   }
 };

--- a/packages/applications/legacy/src/controllers/project/getProjectPage/_utils/getAlertesRaccordement.ts
+++ b/packages/applications/legacy/src/controllers/project/getProjectPage/_utils/getAlertesRaccordement.ts
@@ -6,6 +6,7 @@ import { Option } from '@potentiel-libraries/monads';
 
 import { UtilisateurReadModel } from '../../../../modules/utilisateur/récupérer/UtilisateurReadModel';
 import { AlerteRaccordement } from '../../../../views/pages';
+import { getLogger } from '@potentiel-libraries/monitoring';
 
 export const getAlertesRaccordement = async ({
   userRole,
@@ -21,35 +22,45 @@ export const getAlertesRaccordement = async ({
     isAbandonned: boolean;
   };
 }) => {
-  if (userRole !== 'porteur-projet' || !projet.isClasse || projet.isAbandonned) {
-    return;
-  }
-
-  const alertes: Array<AlerteRaccordement> = [];
-  const dossiersRaccordement = await mediator.send<Raccordement.ConsulterRaccordementQuery>({
-    type: 'Réseau.Raccordement.Query.ConsulterRaccordement',
-    data: { identifiantProjetValue: identifiantProjet.formatter() },
-  });
-
-  if (Option.isSome(dossiersRaccordement) && !!dossiersRaccordement.dossiers[0]) {
-    if (
-      CDC2022Choisi &&
-      dossiersRaccordement.dossiers[0].référence.estÉgaleÀ(
-        Raccordement.RéférenceDossierRaccordement.référenceNonTransmise,
-      )
-    ) {
-      alertes.push('référenceDossierManquantePourDélaiCDC2022');
+  try {
+    if (userRole !== 'porteur-projet' || !projet.isClasse || projet.isAbandonned) {
+      return undefined;
     }
 
-    if (!dossiersRaccordement.dossiers[0].demandeComplèteRaccordement.accuséRéception) {
+    const alertes: Array<AlerteRaccordement> = [];
+    const dossiersRaccordement = await mediator.send<Raccordement.ConsulterRaccordementQuery>({
+      type: 'Réseau.Raccordement.Query.ConsulterRaccordement',
+      data: { identifiantProjetValue: identifiantProjet.formatter() },
+    });
+
+    if (Option.isSome(dossiersRaccordement) && !!dossiersRaccordement.dossiers[0]) {
+      if (
+        CDC2022Choisi &&
+        dossiersRaccordement.dossiers[0].référence.estÉgaleÀ(
+          Raccordement.RéférenceDossierRaccordement.référenceNonTransmise,
+        )
+      ) {
+        alertes.push('référenceDossierManquantePourDélaiCDC2022');
+      }
+
+      if (!dossiersRaccordement.dossiers[0].demandeComplèteRaccordement.accuséRéception) {
+        alertes.push('demandeComplèteRaccordementManquante');
+      }
+    } else {
       alertes.push('demandeComplèteRaccordementManquante');
+      if (CDC2022Choisi) {
+        alertes.push('référenceDossierManquantePourDélaiCDC2022');
+      }
     }
-  } else {
-    alertes.push('demandeComplèteRaccordementManquante');
-    if (CDC2022Choisi) {
-      alertes.push('référenceDossierManquantePourDélaiCDC2022');
-    }
-  }
 
-  return alertes.length > 0 ? alertes : undefined;
+    return alertes.length > 0 ? alertes : undefined;
+  } catch (error) {
+    getLogger().error(`Impossible de consulter le raccordement`, {
+      identifiantProjet: identifiantProjet.formatter(),
+      context: 'legacy',
+      controller: 'getProjectPage',
+      method: 'getAlertesRaccordement',
+    });
+    return undefined;
+  }
 };

--- a/packages/applications/legacy/src/controllers/project/getProjectPage/_utils/getAttestationDeConformité.ts
+++ b/packages/applications/legacy/src/controllers/project/getProjectPage/_utils/getAttestationDeConformité.ts
@@ -5,27 +5,37 @@ import { Achèvement } from '@potentiel-domain/laureat';
 import { Option } from '@potentiel-libraries/monads';
 import { AchèvementRéelDTO } from '../../../../modules/frise';
 import { User } from '../../../../entities';
+import { getLogger } from '@potentiel-libraries/monitoring';
 
 export const getAttestationDeConformité = async (
   identifiantProjet: IdentifiantProjet.ValueType,
   user: User,
 ): Promise<AchèvementRéelDTO | undefined> => {
-  const attestationConformité = await mediator.send<Achèvement.ConsulterAttestationConformitéQuery>(
-    {
-      type: 'Lauréat.Achèvement.AttestationConformité.Query.ConsulterAttestationConformité',
-      data: { identifiantProjetValue: identifiantProjet.formatter() },
-    },
-  );
+  try {
+    const attestationConformité =
+      await mediator.send<Achèvement.ConsulterAttestationConformitéQuery>({
+        type: 'Lauréat.Achèvement.AttestationConformité.Query.ConsulterAttestationConformité',
+        data: { identifiantProjetValue: identifiantProjet.formatter() },
+      });
 
-  return Option.isSome(attestationConformité)
-    ? {
-        type: 'achevement-reel',
-        date: attestationConformité.dateTransmissionAuCocontractant.date.getTime(),
-        attestation: attestationConformité.attestation.formatter(),
-        preuveTransmissionAuCocontractant:
-          attestationConformité.preuveTransmissionAuCocontractant.formatter(),
-        identifiantProjet: identifiantProjet.formatter(),
-        permissionModifier: ['admin', 'dreal', 'dgec-validateur'].includes(user.role),
-      }
-    : undefined;
+    return Option.isSome(attestationConformité)
+      ? {
+          type: 'achevement-reel',
+          date: attestationConformité.dateTransmissionAuCocontractant.date.getTime(),
+          attestation: attestationConformité.attestation.formatter(),
+          preuveTransmissionAuCocontractant:
+            attestationConformité.preuveTransmissionAuCocontractant.formatter(),
+          identifiantProjet: identifiantProjet.formatter(),
+          permissionModifier: ['admin', 'dreal', 'dgec-validateur'].includes(user.role),
+        }
+      : undefined;
+  } catch (error) {
+    getLogger().error(`Impossible de consulter l'attestation de conformité`, {
+      identifiantProjet: identifiantProjet.formatter(),
+      context: 'legacy',
+      controller: 'getProjectPage',
+      method: 'getAttestationDeConformité',
+    });
+    return undefined;
+  }
 };

--- a/packages/applications/legacy/src/controllers/project/getProjectPage/_utils/getAttestationDeConformité.ts
+++ b/packages/applications/legacy/src/controllers/project/getProjectPage/_utils/getAttestationDeConformité.ts
@@ -30,12 +30,12 @@ export const getAttestationDeConformité = async (
         }
       : undefined;
   } catch (error) {
-    getLogger().error(`Impossible de consulter l'attestation de conformité`, {
-      identifiantProjet: identifiantProjet.formatter(),
-      context: 'legacy',
-      controller: 'getProjectPage',
-      method: 'getAttestationDeConformité',
-    });
+    getLogger('Legacy|getProjectPage|getAttestationDeConformité').error(
+      `Impossible de consulter l'attestation de conformité`,
+      {
+        identifiantProjet: identifiantProjet.formatter(),
+      },
+    );
     return undefined;
   }
 };

--- a/packages/applications/legacy/src/controllers/project/getProjectPage/_utils/getGarantiesFinancières.ts
+++ b/packages/applications/legacy/src/controllers/project/getProjectPage/_utils/getGarantiesFinancières.ts
@@ -85,12 +85,12 @@ export const getGarantiesFinancières = async (
       motifGfEnAttente,
     };
   } catch (error) {
-    getLogger().error(`Impossible de consulter les garanties financières`, {
-      identifiantProjet: identifiantProjet.formatter(),
-      context: 'legacy',
-      controller: 'getProjectPage',
-      method: 'getGarantiesFinancières',
-    });
+    getLogger('Legacy|getProjectPage|getGarantiesFinancières').error(
+      `Impossible de consulter les garanties financières`,
+      {
+        identifiantProjet: identifiantProjet.formatter(),
+      },
+    );
     return undefined;
   }
 };

--- a/packages/applications/legacy/src/controllers/project/getProjectPage/_utils/getGarantiesFinancières.ts
+++ b/packages/applications/legacy/src/controllers/project/getProjectPage/_utils/getGarantiesFinancières.ts
@@ -4,64 +4,75 @@ import { GarantiesFinancières } from '@potentiel-domain/laureat';
 
 import { Option } from '@potentiel-libraries/monads';
 import { ProjectDataForProjectPage } from '../../../../modules/project';
+import { getLogger } from '@potentiel-libraries/monitoring';
 
 export const getGarantiesFinancières = async (
   identifiantProjet: IdentifiantProjet.ValueType,
   isSoumisAuxGF: boolean,
 ): Promise<ProjectDataForProjectPage['garantiesFinancières'] | undefined> => {
-  if (!isSoumisAuxGF) {
+  try {
+    if (!isSoumisAuxGF) {
+      return undefined;
+    }
+
+    const garantiesFinancièresActuelles =
+      await mediator.send<GarantiesFinancières.ConsulterGarantiesFinancièresQuery>({
+        type: 'Lauréat.GarantiesFinancières.Query.ConsulterGarantiesFinancières',
+        data: { identifiantProjetValue: identifiantProjet.formatter() },
+      });
+
+    const dépôtEnCoursGarantiesFinancières =
+      await mediator.send<GarantiesFinancières.ConsulterDépôtEnCoursGarantiesFinancièresQuery>({
+        type: 'Lauréat.GarantiesFinancières.Query.ConsulterDépôtEnCoursGarantiesFinancières',
+        data: { identifiantProjetValue: identifiantProjet.formatter() },
+      });
+
+    const projetAvecGarantiesFinancièresEnAttente =
+      await mediator.send<GarantiesFinancières.ConsulterProjetAvecGarantiesFinancièresEnAttenteQuery>(
+        {
+          type: 'Lauréat.GarantiesFinancières.Query.ConsulterProjetAvecGarantiesFinancièresEnAttente',
+          data: { identifiantProjetValue: identifiantProjet.formatter() },
+        },
+      );
+
+    const actuelles = Option.isSome(garantiesFinancièresActuelles)
+      ? {
+          type: garantiesFinancièresActuelles.garantiesFinancières.type.type,
+          dateÉchéance:
+            garantiesFinancièresActuelles.garantiesFinancières.dateÉchéance &&
+            garantiesFinancièresActuelles.garantiesFinancières.dateÉchéance.formatter(),
+          dateConstitution:
+            garantiesFinancièresActuelles.garantiesFinancières.dateConstitution &&
+            garantiesFinancièresActuelles.garantiesFinancières.dateConstitution.formatter(),
+        }
+      : undefined;
+
+    const dépôtÀTraiter = Option.isSome(dépôtEnCoursGarantiesFinancières)
+      ? {
+          type: dépôtEnCoursGarantiesFinancières.dépôt.type.type,
+          dateÉchéance:
+            dépôtEnCoursGarantiesFinancières.dépôt.dateÉchéance &&
+            dépôtEnCoursGarantiesFinancières.dépôt.dateÉchéance.formatter(),
+          dateConstitution: dépôtEnCoursGarantiesFinancières.dépôt.dateConstitution.formatter(),
+        }
+      : undefined;
+
+    const garantiesFinancièresEnAttente = Option.isSome(projetAvecGarantiesFinancièresEnAttente)
+      ? { motif: projetAvecGarantiesFinancièresEnAttente.motif.motif }
+      : undefined;
+
+    return {
+      actuelles,
+      dépôtÀTraiter,
+      garantiesFinancièresEnAttente,
+    };
+  } catch (error) {
+    getLogger().error(`Impossible de consulter les garanties financières`, {
+      identifiantProjet: identifiantProjet.formatter(),
+      context: 'legacy',
+      controller: 'getProjectPage',
+      method: 'getGarantiesFinancières',
+    });
     return undefined;
   }
-
-  const garantiesFinancièresActuelles =
-    await mediator.send<GarantiesFinancières.ConsulterGarantiesFinancièresQuery>({
-      type: 'Lauréat.GarantiesFinancières.Query.ConsulterGarantiesFinancières',
-      data: { identifiantProjetValue: identifiantProjet.formatter() },
-    });
-
-  const dépôtEnCoursGarantiesFinancières =
-    await mediator.send<GarantiesFinancières.ConsulterDépôtEnCoursGarantiesFinancièresQuery>({
-      type: 'Lauréat.GarantiesFinancières.Query.ConsulterDépôtEnCoursGarantiesFinancières',
-      data: { identifiantProjetValue: identifiantProjet.formatter() },
-    });
-
-  const projetAvecGarantiesFinancièresEnAttente =
-    await mediator.send<GarantiesFinancières.ConsulterProjetAvecGarantiesFinancièresEnAttenteQuery>(
-      {
-        type: 'Lauréat.GarantiesFinancières.Query.ConsulterProjetAvecGarantiesFinancièresEnAttente',
-        data: { identifiantProjetValue: identifiantProjet.formatter() },
-      },
-    );
-
-  const actuelles = Option.isSome(garantiesFinancièresActuelles)
-    ? {
-        type: garantiesFinancièresActuelles.garantiesFinancières.type.type,
-        dateÉchéance:
-          garantiesFinancièresActuelles.garantiesFinancières.dateÉchéance &&
-          garantiesFinancièresActuelles.garantiesFinancières.dateÉchéance.formatter(),
-        dateConstitution:
-          garantiesFinancièresActuelles.garantiesFinancières.dateConstitution &&
-          garantiesFinancièresActuelles.garantiesFinancières.dateConstitution.formatter(),
-      }
-    : undefined;
-
-  const dépôtÀTraiter = Option.isSome(dépôtEnCoursGarantiesFinancières)
-    ? {
-        type: dépôtEnCoursGarantiesFinancières.dépôt.type.type,
-        dateÉchéance:
-          dépôtEnCoursGarantiesFinancières.dépôt.dateÉchéance &&
-          dépôtEnCoursGarantiesFinancières.dépôt.dateÉchéance.formatter(),
-        dateConstitution: dépôtEnCoursGarantiesFinancières.dépôt.dateConstitution.formatter(),
-      }
-    : undefined;
-
-  const garantiesFinancièresEnAttente = Option.isSome(projetAvecGarantiesFinancièresEnAttente)
-    ? { motif: projetAvecGarantiesFinancièresEnAttente.motif.motif }
-    : undefined;
-
-  return {
-    actuelles,
-    dépôtÀTraiter,
-    garantiesFinancièresEnAttente,
-  };
 };

--- a/packages/applications/legacy/src/controllers/project/getProjectPage/_utils/getRecours.ts
+++ b/packages/applications/legacy/src/controllers/project/getProjectPage/_utils/getRecours.ts
@@ -17,11 +17,8 @@ export const getRecours = async (
 
     return Option.isSome(recours) ? { statut: recours.statut.value } : undefined;
   } catch (error) {
-    getLogger().error(`Impossible de consulter le recours`, {
+    getLogger('Legacy|getProjectPage|getRecours').error(`Impossible de consulter le recours`, {
       identifiantProjet: identifiantProjet.formatter(),
-      context: 'legacy',
-      controller: 'getProjectPage',
-      method: 'getRecours',
     });
     return undefined;
   }

--- a/packages/applications/legacy/src/controllers/project/getProjectPage/_utils/getRecours.ts
+++ b/packages/applications/legacy/src/controllers/project/getProjectPage/_utils/getRecours.ts
@@ -4,14 +4,25 @@ import { Recours } from '@potentiel-domain/elimine';
 
 import { Option } from '@potentiel-libraries/monads';
 import { ProjectDataForProjectPage } from '../../../../modules/project';
+import { getLogger } from '@potentiel-libraries/monitoring';
 
 export const getRecours = async (
   identifiantProjet: IdentifiantProjet.ValueType,
 ): Promise<ProjectDataForProjectPage['demandeRecours']> => {
-  const recours = await mediator.send<Recours.ConsulterRecoursQuery>({
-    type: 'Éliminé.Recours.Query.ConsulterRecours',
-    data: { identifiantProjetValue: identifiantProjet.formatter() },
-  });
+  try {
+    const recours = await mediator.send<Recours.ConsulterRecoursQuery>({
+      type: 'Éliminé.Recours.Query.ConsulterRecours',
+      data: { identifiantProjetValue: identifiantProjet.formatter() },
+    });
 
-  return Option.isSome(recours) ? { statut: recours.statut.value } : undefined;
+    return Option.isSome(recours) ? { statut: recours.statut.value } : undefined;
+  } catch (error) {
+    getLogger().error(`Impossible de consulter le recours`, {
+      identifiantProjet: identifiantProjet.formatter(),
+      context: 'legacy',
+      controller: 'getProjectPage',
+      method: 'getRecours',
+    });
+    return undefined;
+  }
 };

--- a/packages/applications/legacy/src/controllers/project/getProjectPage/_utils/getReprésentantLégal.ts
+++ b/packages/applications/legacy/src/controllers/project/getProjectPage/_utils/getReprésentantLégal.ts
@@ -65,12 +65,12 @@ export const getReprésentantLégal: GetReprésentantLégal = async (identifiant
 
     return undefined;
   } catch (error) {
-    getLogger().error(`Impossible de consulter le représentant légal`, {
-      identifiantProjet: identifiantProjet.formatter(),
-      context: 'legacy',
-      controller: 'getProjectPage',
-      method: 'getReprésentantLégal',
-    });
+    getLogger('Legacy|getProjectPage|getReprésentantLégal').error(
+      `Impossible de consulter le représentant légal`,
+      {
+        identifiantProjet: identifiantProjet.formatter(),
+      },
+    );
     return undefined;
   }
 };

--- a/packages/applications/legacy/src/controllers/project/getProjectPage/_utils/getReprésentantLégal.ts
+++ b/packages/applications/legacy/src/controllers/project/getProjectPage/_utils/getReprésentantLégal.ts
@@ -65,9 +65,11 @@ export const getReprésentantLégal: GetReprésentantLégal = async (identifiant
 
     return undefined;
   } catch (error) {
-    getLogger().error(new Error('Erreur lors de la récupération du représentant légal'), {
-      error,
+    getLogger().error(`Impossible de consulter le représentant légal`, {
       identifiantProjet: identifiantProjet.formatter(),
+      context: 'legacy',
+      controller: 'getProjectPage',
+      method: 'getReprésentantLégal',
     });
     return undefined;
   }

--- a/packages/applications/legacy/src/controllers/project/getProjectPage/index.ts
+++ b/packages/applications/legacy/src/controllers/project/getProjectPage/index.ts
@@ -137,28 +137,20 @@ v1Router.get(
 
       const abandon = await getAbandonStatut(identifiantProjetValueType);
 
-      let alertesRaccordement: AlerteRaccordement[] | undefined = undefined;
-      try {
-        alertesRaccordement =
-          !abandon || abandon.statut === 'rejeté'
-            ? await getAlertesRaccordement({
-                userRole: user.role,
-                identifiantProjet: identifiantProjetValueType,
-                CDC2022Choisi:
-                  projet.cahierDesChargesActuel.type === 'modifié' &&
-                  projet.cahierDesChargesActuel.paruLe === '30/08/2022',
-                projet: {
-                  isClasse: projet.isClasse,
-                  isAbandonned: projet.isAbandoned,
-                },
-              })
-            : undefined;
-      } catch (error) {
-        getLogger().warn(`An error occurred when getting raccordements alerts`, {
-          error,
-          identifiantProjetValueType,
-        });
-      }
+      const alertesRaccordement: AlerteRaccordement[] | undefined =
+        !abandon || abandon.statut === 'rejeté'
+          ? await getAlertesRaccordement({
+              userRole: user.role,
+              identifiantProjet: identifiantProjetValueType,
+              CDC2022Choisi:
+                projet.cahierDesChargesActuel.type === 'modifié' &&
+                projet.cahierDesChargesActuel.paruLe === '30/08/2022',
+              projet: {
+                isClasse: projet.isClasse,
+                isAbandonned: projet.isAbandoned,
+              },
+            })
+          : undefined;
 
       const attestationConformité = await getAttestationDeConformité(
         identifiantProjetValueType,

--- a/packages/applications/legacy/src/modules/project/queries/GetProjectDataForProjectPage.ts
+++ b/packages/applications/legacy/src/modules/project/queries/GetProjectDataForProjectPage.ts
@@ -76,8 +76,6 @@ export type ProjectDataForProjectPage = {
   demandeRecours?: {
     statut: Recours.StatutRecours.RawType;
   };
-
-  garantiesFinancières?: GarantiesFinancièresForProjectPage;
 } & (IsNotified | IsNotNotified) &
   (IsClasse | IsElimine | IsAbandoned);
 
@@ -122,20 +120,4 @@ type NotesInnovation = {
   qualitéTechnique: string;
   adéquationAmbitionsIndustrielles: string;
   aspectsEnvironnementauxEtSociaux: string;
-};
-
-export type GarantiesFinancièresForProjectPage = {
-  garantiesFinancièresEnAttente?: {
-    motif: GarantiesFinancières.MotifDemandeGarantiesFinancières.RawType;
-  };
-  actuelles?: {
-    type?: Candidature.TypeGarantiesFinancières.RawType;
-    dateConstitution?: string;
-    dateÉchéance?: string;
-  };
-  dépôtÀTraiter?: {
-    type?: Candidature.TypeGarantiesFinancières.RawType;
-    dateConstitution: string;
-    dateÉchéance?: string;
-  };
 };

--- a/packages/applications/legacy/src/views/pages/projectDetailsPage/ProjectDetails.tsx
+++ b/packages/applications/legacy/src/views/pages/projectDetailsPage/ProjectDetails.tsx
@@ -23,6 +23,8 @@ import {
   MaterielsEtTechnologies,
   ResultatsAppelOffreInnovation,
   ContactProps,
+  InfoGeneralesProps,
+  GarantiesFinancièresProjetProps,
 } from './sections';
 import { ProjectHeader } from './components';
 import { Routes } from '@potentiel-applications/routes';
@@ -41,6 +43,7 @@ type ProjectDetailsProps = {
     statut: string;
   };
   demandeRecours: ProjectDataForProjectPage['demandeRecours'];
+  garantiesFinancières?: GarantiesFinancièresProjetProps['garantiesFinancières'];
   hasAttestationConformité: boolean;
   représentantLégal?: ContactProps['représentantLégal'];
 };
@@ -54,6 +57,7 @@ export const ProjectDetails = ({
   demandeRecours,
   hasAttestationConformité,
   représentantLégal,
+  garantiesFinancières,
 }: ProjectDetailsProps) => {
   const { user } = request;
   const { error, success } = (request.query as any) || {};
@@ -121,7 +125,12 @@ export const ProjectDetails = ({
             <EtapesProjet {...{ project, user, projectEventList }} />
           )}
           <div className={`flex flex-col flex-grow gap-3 break-before-page`}>
-            <InfoGenerales project={project} role={user.role} demandeRecours={demandeRecours} />
+            <InfoGenerales
+              project={project}
+              role={user.role}
+              demandeRecours={demandeRecours}
+              garantiesFinancières={garantiesFinancières}
+            />
             <Contact project={project} user={user} représentantLégal={représentantLégal} />
             <MaterielsEtTechnologies
               fournisseur={project.fournisseur}

--- a/packages/applications/legacy/src/views/pages/projectDetailsPage/sections/InfoGenerales.tsx
+++ b/packages/applications/legacy/src/views/pages/projectDetailsPage/sections/InfoGenerales.tsx
@@ -1,8 +1,5 @@
 import React, { ComponentProps } from 'react';
-import {
-  ProjectDataForProjectPage,
-  GarantiesFinancièresForProjectPage,
-} from '../../../../modules/project';
+import { ProjectDataForProjectPage } from '../../../../modules/project';
 import { BuildingIcon, Heading3, Link, Section, WarningIcon } from '../../../components';
 import { UserRole } from '../../../../modules/users';
 import { formatProjectDataToIdentifiantProjetValueType } from '../../../../helpers/dataToValueTypes';
@@ -11,13 +8,13 @@ import { Routes } from '@potentiel-applications/routes';
 
 import { GarantiesFinancières } from '@potentiel-domain/laureat';
 import { Candidature } from '@potentiel-domain/candidature';
-import { Recours } from '@potentiel-domain/elimine';
 import { Role } from '@potentiel-domain/utilisateur';
 
-type InfoGeneralesProps = {
+export type InfoGeneralesProps = {
   project: ProjectDataForProjectPage;
   role: UserRole;
   demandeRecours: ProjectDataForProjectPage['demandeRecours'];
+  garantiesFinancières?: GarantiesFinancièresProjetProps['garantiesFinancières'];
 };
 
 export const InfoGenerales = ({
@@ -30,7 +27,6 @@ export const InfoGenerales = ({
     puissance,
     isClasse,
     isAbandoned,
-    garantiesFinancières,
     désignationCatégorie,
     codePostalProjet,
     communeProjet,
@@ -39,6 +35,7 @@ export const InfoGenerales = ({
     adresseProjet,
   },
   role,
+  garantiesFinancières,
   demandeRecours,
 }: InfoGeneralesProps) => {
   const puissanceInférieurePuissanceMaxVolRéservé =
@@ -142,8 +139,20 @@ export const InfoGenerales = ({
   );
 };
 
-type GarantiesFinancièresProjetProps = {
-  garantiesFinancières: GarantiesFinancièresForProjectPage;
+export type GarantiesFinancièresProjetProps = {
+  garantiesFinancières: {
+    motifGfEnAttente?: GarantiesFinancières.MotifDemandeGarantiesFinancières.RawType;
+    actuelles?: {
+      type?: Candidature.TypeGarantiesFinancières.RawType;
+      dateConstitution?: string;
+      dateÉchéance?: string;
+    };
+    dépôtÀTraiter?: {
+      type?: Candidature.TypeGarantiesFinancières.RawType;
+      dateConstitution: string;
+      dateÉchéance?: string;
+    };
+  };
   project: {
     appelOffreId: string;
     periodeId: string;
@@ -151,18 +160,19 @@ type GarantiesFinancièresProjetProps = {
     numeroCRE: string;
   };
 };
+
 const GarantiesFinancièresProjet = ({
   garantiesFinancières,
   project: { appelOffreId, periodeId, familleId, numeroCRE },
 }: GarantiesFinancièresProjetProps) => {
   const motifDemandeGarantiesFinancières =
-    garantiesFinancières.garantiesFinancièresEnAttente &&
-    getMotifGFEnAttente(garantiesFinancières.garantiesFinancièresEnAttente.motif);
+    garantiesFinancières.motifGfEnAttente &&
+    getMotifGFEnAttente(garantiesFinancières.motifGfEnAttente);
 
   return (
     <div>
       <Heading3 className="m-0">Garanties financières</Heading3>
-      {garantiesFinancières.garantiesFinancièresEnAttente && (
+      {garantiesFinancières.motifGfEnAttente && (
         <AlertMessage>
           Des garanties financières sont en attente pour ce projet
           {motifDemandeGarantiesFinancières ? <> ({motifDemandeGarantiesFinancières})</> : ''}.

--- a/packages/domain/utilisateur/src/role.valueType.ts
+++ b/packages/domain/utilisateur/src/role.valueType.ts
@@ -867,7 +867,6 @@ const pageProjetPolicies: Policy[] = [
   // Garanties Financières
   'garantiesFinancières.actuelles.consulter',
   'garantiesFinancières.dépôt.consulter',
-  'garantiesFinancières.enAttente.consulter',
 
   // Achèvement
   'achèvement.consulter',
@@ -914,9 +913,7 @@ const adminPolicies: ReadonlyArray<Policy> = [
   'réseau.raccordement.listerDossierRaccordement',
 
   // Garanties financières
-  'garantiesFinancières.actuelles.consulter',
   'garantiesFinancières.archives.consulter',
-  'garantiesFinancières.dépôt.consulter',
   'garantiesFinancières.dépôt.lister',
   'garantiesFinancières.dépôt.demander',
   'garantiesFinancières.dépôt.valider',
@@ -926,6 +923,7 @@ const adminPolicies: ReadonlyArray<Policy> = [
   'garantiesFinancières.actuelles.enregistrerAttestation',
   'garantiesFinancières.actuelles.enregistrer',
   'garantiesFinancières.effacerHistorique',
+  'garantiesFinancières.enAttente.consulter',
   'garantiesFinancières.enAttente.lister',
   'garantiesFinancières.enAttente.générerModèleMiseEnDemeure',
   'garantiesFinancières.mainlevée.lister',
@@ -1064,6 +1062,7 @@ const porteurProjetPolicies: ReadonlyArray<Policy> = [
   'garantiesFinancières.mainlevée.annuler',
   'garantiesFinancières.mainlevée.lister',
   'garantiesFinancières.enAttente.lister',
+  'garantiesFinancières.enAttente.consulter',
 
   // Achèvement
   'achèvement.consulter',
@@ -1095,7 +1094,11 @@ const caisseDesDépôtsPolicies: ReadonlyArray<Policy> = [
 
 const grdPolicies: ReadonlyArray<Policy> = [
   ...commonPolicies,
+
+  // Gestionnaire réseau
   'réseau.gestionnaire.consulter',
+
+  // Raccordement
   'réseau.raccordement.consulter',
   'réseau.raccordement.listerDossierRaccordement',
   'réseau.raccordement.date-mise-en-service.transmettre',

--- a/packages/libraries/monitoring/src/logger.ts
+++ b/packages/libraries/monitoring/src/logger.ts
@@ -11,7 +11,7 @@ export type Logger = {
   debug(message: string, meta?: Record<string, unknown>): void;
   info(message: string, meta?: Record<string, unknown>): void;
   warn(message: string, meta?: Record<string, unknown>): void;
-  error(error: Error, meta?: Record<string, unknown>): void;
+  error(error: Error | string, meta?: Record<string, unknown>): void;
 };
 
 type GetLogger = (serviceName?: string) => Logger;
@@ -75,6 +75,13 @@ export const getLogger: GetLogger = (serviceName?: string): Logger => {
         getCapture()?.warn(message, meta);
       },
       error: (error, meta = {}) => {
+        if (typeof error === 'string') {
+          const e = new Error(error);
+          winstonLogger.error(e.message, { meta, error: e });
+          getCapture()?.error(e, meta);
+          return;
+        }
+
         winstonLogger.error(error.message, { meta, error });
         getCapture()?.error(error, meta);
       },


### PR DESCRIPTION
# Description
On a eu pas mal de soucis ces derniers temps pour les queries qui vont récupérer des infos des projections du domain. En effet si le role n'est pas autorisé à accéder à la ressource, la page projet est ko et impossible d'afficher quoi que ce soit.


J'ai ajouté des try/catch partout + modifié les props de la page pour dissocier la props `project` (legacy) des props provenant du domain (via les _utils)

## Type de changement

- [x] Refacto de code

# Comment cela a-t-il été testé?

Visuellement en switchant les roles