### PR TITLE
🐛 Attendre que la session soit chargée avant de logout

### DIFF
--- a/packages/applications/ssr/src/components/molecules/SignOutRedirect.tsx
+++ b/packages/applications/ssr/src/components/molecules/SignOutRedirect.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { signOut } from 'next-auth/react';
+import { signOut, useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 
@@ -8,10 +8,16 @@ type SignOutRedirectProps = {
 };
 export const SignOutRedirect = ({ callbackUrl }: SignOutRedirectProps) => {
   const router = useRouter();
+  const { status } = useSession();
+
   useEffect(() => {
-    const timeout = setTimeout(() => signOut({}).then(() => router.push(callbackUrl ?? '/')), 500);
-    return () => clearTimeout(timeout);
-  }, []);
+    if (status === 'unauthenticated') {
+      return router.push('/');
+    }
+    if (status === 'authenticated') {
+      signOut().then(() => router.push(callbackUrl ?? '/'));
+    }
+  }, [status]);
 
   return null;
 };

--- a/packages/applications/ssr/src/components/molecules/SignOutRedirect.tsx
+++ b/packages/applications/ssr/src/components/molecules/SignOutRedirect.tsx
@@ -9,7 +9,8 @@ type SignOutRedirectProps = {
 export const SignOutRedirect = ({ callbackUrl }: SignOutRedirectProps) => {
   const router = useRouter();
   useEffect(() => {
-    signOut({}).then(() => router.push(callbackUrl ?? '/'));
+    const timeout = setTimeout(() => signOut({}).then(() => router.push(callbackUrl ?? '/')), 500);
+    return () => clearTimeout(timeout);
   }, []);
 
   return null;


### PR DESCRIPTION
Si le logout se fait dès le chargement de la page, la session est chargée en parallèle (via un appel HTTP à /auth/session) et le cookie est recréé aussitôt après avoir été supprimé

Cette PR permet d'attendre que la session soit chargée, et donc que l'appel HTTP soit terminé, donc plus de conflit possible. 

Explication ici: https://github.com/nextauthjs/next-auth/issues/4612#issuecomment-2035552856