### PR TITLE
✨ Ajout info investissement sur badge candidature

### DIFF
--- a/packages/applications/ssr/src/components/molecules/projet/ProjectListItemHeading.tsx
+++ b/packages/applications/ssr/src/components/molecules/projet/ProjectListItemHeading.tsx
@@ -3,6 +3,7 @@ import { FC } from 'react';
 import { IdentifiantProjet, StatutProjet } from '@potentiel-domain/common';
 import { Iso8601DateTime } from '@potentiel-libraries/iso8601-datetime';
 import { PlainType } from '@potentiel-domain/core';
+import { Candidature } from '@potentiel-domain/candidature';
 
 import { FormattedDate } from '../../atoms/FormattedDate';
 import { NotificationBadge } from '../candidature/NotificationBadge';
@@ -16,6 +17,7 @@ export type ProjectListItemHeadingProps = {
   prefix: string;
   misÀJourLe?: Iso8601DateTime;
   estNotifié?: boolean;
+  actionnariat?: Candidature.TypeActionnariat.RawType;
 };
 
 export const ProjectListItemHeading: FC<ProjectListItemHeadingProps> = ({
@@ -25,6 +27,7 @@ export const ProjectListItemHeading: FC<ProjectListItemHeadingProps> = ({
   misÀJourLe,
   statut,
   estNotifié,
+  actionnariat,
 }) => (
   <div className="flex flex-col gap-2">
     <div className="flex flex-row justify-between gap-2 w-full">
@@ -40,7 +43,7 @@ export const ProjectListItemHeading: FC<ProjectListItemHeadingProps> = ({
 
     <div className="flex gap-1 md:items-center md:flex-row flex-col">
       <div className="flex gap-1">
-        {statut && <StatutProjetBadge statut={statut} />}
+        {statut && <StatutProjetBadge statut={statut} actionnariat={actionnariat} />}
         {estNotifié !== undefined && <NotificationBadge estNotifié={estNotifié} />}
       </div>
 

--- a/packages/applications/ssr/src/components/molecules/projet/StatutProjetBadge.tsx
+++ b/packages/applications/ssr/src/components/molecules/projet/StatutProjetBadge.tsx
@@ -2,22 +2,35 @@ import { AlertProps } from '@codegouvfr/react-dsfr/Alert';
 import Badge from '@codegouvfr/react-dsfr/Badge';
 import { FC } from 'react';
 
-export type StatutProjet = 'non-notifié' | 'abandonné' | 'classé' | 'éliminé';
+import { Candidature } from '@potentiel-domain/candidature';
+import { StatutProjet } from '@potentiel-domain/common';
 
-const convertStatutProjetToBadgeSeverity: Record<StatutProjet, AlertProps.Severity> = {
+const convertStatutProjetToBadgeSeverity: Record<StatutProjet.RawType, AlertProps.Severity> = {
   classé: 'success',
   abandonné: 'warning',
   'non-notifié': 'info',
   éliminé: 'error',
 };
 
-const getStatutProjetBadgeLabel = (statut: StatutProjet): string => {
+const getStatutProjetBadgeLabel = (statut: StatutProjet.RawType): string => {
   if (statut === 'non-notifié') return 'à notifier';
   return statut;
 };
 
-export const StatutProjetBadge: FC<{ statut: StatutProjet }> = ({ statut }) => (
+const getFinancementType = (actionnariat?: Candidature.TypeActionnariat.RawType) =>
+  actionnariat
+    ? actionnariat
+        .split('-')
+        .map((word) => word[0].toUpperCase())
+        .join('')
+    : undefined;
+
+export const StatutProjetBadge: FC<{
+  statut: StatutProjet.RawType;
+  actionnariat?: Candidature.TypeActionnariat.RawType;
+}> = ({ statut, actionnariat }) => (
   <Badge small noIcon severity={convertStatutProjetToBadgeSeverity[statut]}>
     {getStatutProjetBadgeLabel(statut)}
+    {getFinancementType(actionnariat) && ` (${getFinancementType(actionnariat)})`}
   </Badge>
 );

--- a/packages/applications/ssr/src/components/molecules/projet/StatutProjetBadge.tsx
+++ b/packages/applications/ssr/src/components/molecules/projet/StatutProjetBadge.tsx
@@ -17,7 +17,7 @@ const getStatutProjetBadgeLabel = (statut: StatutProjet.RawType): string => {
   return statut;
 };
 
-const getFinancementType = (actionnariat?: Candidature.TypeActionnariat.RawType) =>
+const getTypeActionnariat = (actionnariat?: Candidature.TypeActionnariat.RawType) =>
   actionnariat
     ? actionnariat
         .split('-')
@@ -31,6 +31,6 @@ export const StatutProjetBadge: FC<{
 }> = ({ statut, actionnariat }) => (
   <Badge small noIcon severity={convertStatutProjetToBadgeSeverity[statut]}>
     {getStatutProjetBadgeLabel(statut)}
-    {getFinancementType(actionnariat) && ` (${getFinancementType(actionnariat)})`}
+    {getTypeActionnariat(actionnariat) && ` (${getTypeActionnariat(actionnariat)})`}
   </Badge>
 );

--- a/packages/applications/ssr/src/components/pages/candidature/lister/CandidatureListItem.tsx
+++ b/packages/applications/ssr/src/components/pages/candidature/lister/CandidatureListItem.tsx
@@ -25,6 +25,7 @@ export type CandidatureListItemProps = {
   puissanceProductionAnnuelle: Candidature.ConsulterCandidatureReadModel['puissanceProductionAnnuelle'];
   prixReference: Candidature.ConsulterCandidatureReadModel['prixReference'];
   evaluationCarboneSimplifiée: Candidature.ConsulterCandidatureReadModel['evaluationCarboneSimplifiée'];
+  actionnariat?: PlainType<Candidature.TypeActionnariat.ValueType>;
   localité: {
     commune: Candidature.ConsulterCandidatureReadModel['localité']['commune'];
     département: Candidature.ConsulterCandidatureReadModel['localité']['département'];
@@ -44,6 +45,7 @@ export const CandidatureListItem: FC<CandidatureListItemProps> = ({
   nomReprésentantLégal,
   emailContact,
   puissanceProductionAnnuelle,
+  actionnariat,
   prixReference,
   unitePuissance,
   evaluationCarboneSimplifiée,
@@ -57,6 +59,7 @@ export const CandidatureListItem: FC<CandidatureListItemProps> = ({
         prefix="Candidature du projet"
         statut={statut.statut}
         estNotifié={estNotifiée}
+        actionnariat={actionnariat?.type}
       />
       <div className="max-md:hidden">
         <CandidatureListItemActions

--- a/packages/domain/candidature/src/lister/listerCandidatures.query.ts
+++ b/packages/domain/candidature/src/lister/listerCandidatures.query.ts
@@ -6,7 +6,11 @@ import { DocumentProjet } from '@potentiel-domain/document';
 
 import * as StatutCandidature from '../statutCandidature.valueType';
 import { CandidatureEntity } from '../candidature.entity';
-import { ConsulterCandidatureReadModel, TypeGarantiesFinancières } from '../candidature';
+import {
+  ConsulterCandidatureReadModel,
+  TypeActionnariat,
+  TypeGarantiesFinancières,
+} from '../candidature';
 
 export type CandidaturesListItemReadModel = {
   identifiantProjet: IdentifiantProjet.ValueType;
@@ -18,6 +22,7 @@ export type CandidaturesListItemReadModel = {
   puissanceProductionAnnuelle: number;
   prixReference: ConsulterCandidatureReadModel['prixReference'];
   evaluationCarboneSimplifiée: ConsulterCandidatureReadModel['evaluationCarboneSimplifiée'];
+  actionnariat: ConsulterCandidatureReadModel['actionnariat'];
   typeGarantiesFinancières?: TypeGarantiesFinancières.ValueType;
   localité: {
     commune: ConsulterCandidatureReadModel['localité']['commune'];
@@ -108,6 +113,7 @@ export const mapToReadModel = ({
   notification,
   typeGarantiesFinancières,
   sociétéMère,
+  actionnariat,
 }: CandidatureEntity): CandidaturesListItemReadModel => ({
   identifiantProjet: IdentifiantProjet.convertirEnValueType(identifiantProjet),
   statut: StatutCandidature.convertirEnValueType(statut),
@@ -121,6 +127,7 @@ export const mapToReadModel = ({
   typeGarantiesFinancières: typeGarantiesFinancières
     ? TypeGarantiesFinancières.convertirEnValueType(typeGarantiesFinancières)
     : undefined,
+  actionnariat: actionnariat ? TypeActionnariat.convertirEnValueType(actionnariat) : undefined,
   localité: {
     commune,
     département,


### PR DESCRIPTION
# Description

[Ticket](https://linear.app/startup-potentiel/issue/POT-944/afficher-fc-et-gp-a-cote-de-classe-dans-la-liste-des-candidatures) 
Uniquement sur le badge liste, peut être ajouté à d'autres endroits si besoin

## Type de changement

Veuillez supprimer les options qui ne sont pas pertinentes.

- [ ] Correction de bug
- [ ] Nouvelle fonctionnalité
- [ ] Refacto de code
- [ ] Breaking changes (correction ou fonctionnalité qui ferait en sorte que la fonctionnalité existante ne fonctionne pas comme prévu)
- [ ] Ce changement nécessite une mise à jour de la documentation

# Comment cela a-t-il été testé?

<img width="1128" alt="Capture d’écran 2024-12-23 à 15 57 44" src="https://github.com/user-attachments/assets/5bf3b640-0109-4ca2-8d66-ffdf164dde3d" />

