### PR TITLE
✨ Remplacement des documents sensisbles après accord ou rejet de changement de représentant légal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27489,7 +27489,8 @@
         "@potentiel-libraries/flat": "*",
         "@potentiel-libraries/pg-helpers": "*",
         "flat": "^6.0.1",
-        "mediateur": "^0.3.0"
+        "mediateur": "^0.3.0",
+        "pdf-lib": "^1.17.1"
       },
       "devDependencies": {
         "@potentiel-config/tsconfig": "*"

--- a/packages/applications/projectors/package.json
+++ b/packages/applications/projectors/package.json
@@ -23,7 +23,8 @@
     "@potentiel-libraries/pg-helpers": "*",
     "@potentiel-libraries/flat": "*",
     "flat": "^6.0.1",
-    "mediateur": "^0.3.0"
+    "mediateur": "^0.3.0",
+    "pdf-lib": "^1.17.1"
   },
   "devDependencies": {
     "@potentiel-config/tsconfig": "*"

--- a/packages/applications/projectors/src/subscribers/lauréat/représentant-légal/getSensibleDocReplacement.ts
+++ b/packages/applications/projectors/src/subscribers/lauréat/représentant-légal/getSensibleDocReplacement.ts
@@ -1,0 +1,24 @@
+import { PDFDocument, StandardFonts } from 'pdf-lib';
+
+export const getSensibleDocReplacement = async () => {
+  const pdfDoc = await PDFDocument.create();
+  const page = pdfDoc.addPage();
+
+  const text = 'Document sensible supprimé automatiquement';
+  const textSize = 24;
+
+  const helveticaFont = await pdfDoc.embedFont(StandardFonts.Helvetica);
+  const textWidth = helveticaFont.widthOfTextAtSize(text, textSize);
+  const textHeight = helveticaFont.heightAtSize(textSize);
+
+  page.drawText(text, {
+    x: page.getWidth() / 2 - textWidth / 2,
+    y: page.getHeight() / 2 - textHeight / 2,
+    size: textSize,
+    font: helveticaFont,
+  });
+
+  const pdfBytes = await pdfDoc.save();
+
+  return new Blob([pdfBytes], { type: 'application/pdf' }).stream();
+};

--- a/packages/applications/projectors/src/subscribers/lauréat/représentant-légal/getSensibleDocReplacement.ts
+++ b/packages/applications/projectors/src/subscribers/lauréat/représentant-légal/getSensibleDocReplacement.ts
@@ -1,10 +1,9 @@
 import { PDFDocument, StandardFonts } from 'pdf-lib';
 
-export const getSensibleDocReplacement = async () => {
+export const getSensibleDocReplacement = async (text: string) => {
   const pdfDoc = await PDFDocument.create();
   const page = pdfDoc.addPage();
 
-  const text = 'Document sensible supprimé automatiquement';
   const textSize = 24;
 
   const helveticaFont = await pdfDoc.embedFont(StandardFonts.Helvetica);

--- a/packages/applications/projectors/src/subscribers/lauréat/représentant-légal/handleChangementReprésentantLégalAccordé.ts
+++ b/packages/applications/projectors/src/subscribers/lauréat/représentant-légal/handleChangementReprésentantLégalAccordé.ts
@@ -2,8 +2,12 @@ import { ReprésentantLégal } from '@potentiel-domain/laureat';
 import { findProjection } from '@potentiel-infrastructure/pg-projections';
 import { Option } from '@potentiel-libraries/monads';
 import { getLogger } from '@potentiel-libraries/monitoring';
+import { fileExists, upload } from '@potentiel-libraries/file-storage';
+import { DocumentProjet } from '@potentiel-domain/document';
 
 import { updateOneProjection, upsertProjection } from '../../../infrastructure';
+
+import { getSensibleDocReplacement } from './getSensibleDocReplacement';
 
 export const handleChangementReprésentantLégalAccordé = async (
   event: ReprésentantLégal.ChangementReprésentantLégalAccordéEvent,
@@ -54,4 +58,15 @@ export const handleChangementReprésentantLégalAccordé = async (
       typeReprésentantLégal,
     },
   );
+
+  const pièceJustificative = DocumentProjet.convertirEnValueType(
+    identifiantProjet,
+    ReprésentantLégal.TypeDocumentChangementReprésentantLégal.pièceJustificative.formatter(),
+    changementReprésentantLégal.demande.demandéLe,
+    changementReprésentantLégal.demande.pièceJustificative.format,
+  );
+
+  if (await fileExists(pièceJustificative.formatter())) {
+    await upload(pièceJustificative.formatter(), await getSensibleDocReplacement());
+  }
 };

--- a/packages/applications/projectors/src/subscribers/lauréat/représentant-légal/handleChangementReprésentantLégalAccordé.ts
+++ b/packages/applications/projectors/src/subscribers/lauréat/représentant-légal/handleChangementReprésentantLégalAccordé.ts
@@ -67,6 +67,9 @@ export const handleChangementReprésentantLégalAccordé = async (
   );
 
   if (await fileExists(pièceJustificative.formatter())) {
-    await upload(pièceJustificative.formatter(), await getSensibleDocReplacement());
+    await upload(
+      pièceJustificative.formatter(),
+      await getSensibleDocReplacement('Document sensible supprimé automatiquement après accord'),
+    );
   }
 };

--- a/packages/applications/projectors/src/subscribers/lauréat/représentant-légal/handleChangementReprésentantLégalRejeté.ts
+++ b/packages/applications/projectors/src/subscribers/lauréat/représentant-légal/handleChangementReprésentantLégalRejeté.ts
@@ -51,6 +51,9 @@ export const handleChangementReprésentantLégalRejeté = async (
   );
 
   if (await fileExists(pièceJustificative.formatter())) {
-    await upload(pièceJustificative.formatter(), await getSensibleDocReplacement());
+    await upload(
+      pièceJustificative.formatter(),
+      await getSensibleDocReplacement('Document sensible supprimé automatiquement après rejet'),
+    );
   }
 };


### PR DESCRIPTION
Pourquoi un remplacement et pas une suppression ? Et bien tout simplement afin d'avoir toujours un document existant et ainsi préserver l'historique du stream d'event.