### PR TITLE
🐛 Correction de la projection raccordement en cas de modification du GRD

### DIFF
--- a/packages/applications/projectors/src/subscribers/réseau/raccordement.projector.ts
+++ b/packages/applications/projectors/src/subscribers/réseau/raccordement.projector.ts
@@ -33,13 +33,14 @@ export const register = () => {
       const raccordement = await getRaccordementToUpsert(identifiantProjet);
 
       if (
-        event.type === 'GestionnaireRéseauRaccordementModifié-V1' ||
-        event.type === 'GestionnaireRéseauInconnuAttribué-V1'
+        type === 'GestionnaireRéseauRaccordementModifié-V1' ||
+        type === 'GestionnaireRéseauInconnuAttribué-V1' ||
+        type === 'GestionnaireRéseauAttribué-V1'
       ) {
         const identifiantGestionnaireRéseau =
-          type === 'GestionnaireRéseauRaccordementModifié-V1'
-            ? payload.identifiantGestionnaireRéseau
-            : GestionnaireRéseau.IdentifiantGestionnaireRéseau.inconnu.formatter();
+          type === 'GestionnaireRéseauInconnuAttribué-V1'
+            ? GestionnaireRéseau.IdentifiantGestionnaireRéseau.inconnu.formatter()
+            : payload.identifiantGestionnaireRéseau;
         await upsertProjection<Raccordement.RaccordementEntity>(
           `raccordement|${event.payload.identifiantProjet}`,
           {
@@ -120,14 +121,6 @@ export const register = () => {
         await upsertProjection<Raccordement.DossierRaccordementEntity>(
           `dossier-raccordement|${event.payload.identifiantProjet}#${event.payload.référenceDossierRaccordement}`,
           dossier,
-        );
-      } else if (event.type === 'GestionnaireRéseauAttribué-V1') {
-        await upsertProjection<Raccordement.RaccordementEntity>(
-          `raccordement|${event.payload.identifiantProjet}`,
-          {
-            ...raccordement,
-            identifiantGestionnaireRéseau: event.payload.identifiantGestionnaireRéseau,
-          },
         );
       } else if (event.type === 'DossierDuRaccordementSupprimé-V1') {
         const { identifiantProjet, référenceDossier } = event.payload;

--- a/packages/specifications/src/raccordement/modifierGestionnaireRéseauRaccordement.feature
+++ b/packages/specifications/src/raccordement/modifierGestionnaireRéseauRaccordement.feature
@@ -9,6 +9,10 @@ Fonctionnalité: Modifier le gestionnaire de réseau d'un raccordement
         Et le porteur "Marcel Patoulatchi" ayant accés au projet lauréat "Du boulodrome de Marseille"
 
     Scénario: Un porteur de projet modifie le gestionnaire de réseau d'un raccordement
+        Quand un porteur modifie le gestionnaire de réseau du projet avec le gestionnaire "Arc Energies Maurienne"
+        Alors le projet devrait avoir un raccordement attribué au gestionnaire de réseau "Arc Energies Maurienne"
+
+    Scénario: Un porteur de projet modifie le gestionnaire de réseau d'un raccordement avec dossier
         Etant donné une demande complète de raccordement pour le projet lauréat transmise auprès du gestionnaire de réseau avec :
             | La date de qualification                | 2022-10-28                                                                                            |
             | La référence du dossier de raccordement | OUE-RP-2022-000033                                                                                    |
@@ -17,12 +21,21 @@ Fonctionnalité: Modifier le gestionnaire de réseau d'un raccordement
         Quand un porteur modifie le gestionnaire de réseau du projet avec le gestionnaire "Arc Energies Maurienne"
         Alors le projet devrait avoir un raccordement attribué au gestionnaire de réseau "Arc Energies Maurienne"
 
-    Scénario: Un porteur de projet modifie le gestionnaire de réseau d'un raccordement avec un gestionnaire non référencé
+    Scénario: Un porteur de projet modifie le gestionnaire de réseau d'un raccordement avec plusieurs dossiers
         Etant donné une demande complète de raccordement pour le projet lauréat transmise auprès du gestionnaire de réseau avec :
             | La date de qualification                | 2022-10-28                                                                                            |
             | La référence du dossier de raccordement | OUE-RP-2022-000033                                                                                    |
             | Le format de l'accusé de réception      | application/pdf                                                                                       |
             | Le contenu de l'accusé de réception     | Accusé de réception ayant pour référence OUE-RP-2022-000033 et la date de qualification au 2022-10-28 |
+        Etant donné une demande complète de raccordement pour le projet lauréat transmise auprès du gestionnaire de réseau avec :
+            | La date de qualification                | 2022-10-28                                                                                            |
+            | La référence du dossier de raccordement | OUE-RP-2022-000034                                                                                    |
+            | Le format de l'accusé de réception      | application/pdf                                                                                       |
+            | Le contenu de l'accusé de réception     | Accusé de réception ayant pour référence OUE-RP-2022-000034 et la date de qualification au 2022-10-28 |
+        Quand un porteur modifie le gestionnaire de réseau du projet avec le gestionnaire "Arc Energies Maurienne"
+        Alors le projet devrait avoir un raccordement attribué au gestionnaire de réseau "Arc Energies Maurienne"
+
+    Scénario: Un porteur de projet modifie le gestionnaire de réseau d'un raccordement avec un gestionnaire non référencé
         Quand un porteur modifie le gestionnaire de réseau du projet avec un gestionnaire non référencé
         Alors le porteur devrait être informé que "Le gestionnaire de réseau n'est pas référencé"
 

--- a/packages/specifications/src/raccordement/modifierGestionnaireRéseauRaccordement.feature
+++ b/packages/specifications/src/raccordement/modifierGestionnaireRéseauRaccordement.feature
@@ -27,7 +27,7 @@ Fonctionnalité: Modifier le gestionnaire de réseau d'un raccordement
             | La référence du dossier de raccordement | OUE-RP-2022-000033                                                                                    |
             | Le format de l'accusé de réception      | application/pdf                                                                                       |
             | Le contenu de l'accusé de réception     | Accusé de réception ayant pour référence OUE-RP-2022-000033 et la date de qualification au 2022-10-28 |
-        Etant donné une demande complète de raccordement pour le projet lauréat transmise auprès du gestionnaire de réseau avec :
+        Et une demande complète de raccordement pour le projet lauréat transmise auprès du gestionnaire de réseau avec :
             | La date de qualification                | 2022-10-28                                                                                            |
             | La référence du dossier de raccordement | OUE-RP-2022-000034                                                                                    |
             | Le format de l'accusé de réception      | application/pdf                                                                                       |

--- a/packages/specifications/src/raccordement/stepDefinitions/raccordement.when.ts
+++ b/packages/specifications/src/raccordement/stepDefinitions/raccordement.when.ts
@@ -7,6 +7,7 @@ import { Role } from '@potentiel-domain/utilisateur';
 
 import { convertStringToReadableStream } from '../../helpers/convertStringToReadable';
 import { PotentielWorld } from '../../potentiel.world';
+import { waitForEvents } from '../../helpers/waitForEvents';
 
 Quand(
   `le porteur transmet une demande complète de raccordement pour le projet {lauréat-éliminé} auprès du gestionnaire de réseau avec :`,
@@ -212,6 +213,7 @@ Quand(
 Quand(
   `un porteur modifie le gestionnaire de réseau du projet avec un gestionnaire non référencé`,
   async function (this: PotentielWorld) {
+    await waitForEvents();
     const { identifiantProjet } = this.lauréatWorld;
 
     try {
@@ -232,6 +234,7 @@ Quand(
 Quand(
   `le système modifie le gestionnaire de réseau du projet avec un gestionnaire inconnu`,
   async function (this: PotentielWorld) {
+    await waitForEvents();
     const { identifiantProjet } = this.lauréatWorld;
 
     try {
@@ -252,6 +255,7 @@ Quand(
 Quand(
   `un porteur modifie le gestionnaire de réseau du projet avec le gestionnaire {string}`,
   async function (this: PotentielWorld, raisonSocialGestionnaireRéseau: string) {
+    await waitForEvents();
     const { identifiantProjet } = this.lauréatWorld;
     const { codeEIC } = this.gestionnaireRéseauWorld.rechercherGestionnaireRéseauFixture(
       raisonSocialGestionnaireRéseau,


### PR DESCRIPTION
- ajout des types manquants
- merger les cas `GestionnaireRéseauAttribué`, `GestionnaireRéseauInconnuAttribué`,  `GestionnaireRéseauRaccordementModifié` 
- mettre à jour `raccordement.dossiers` et `dossier-raccordement`  en cas de `GestionnaireRéseauAttribué`, `GestionnaireRéseauInconnuAttribué`, `GestionnaireRéseauRaccordementModifié`

[Ticket](https://linear.app/startup-potentiel/issue/POT-961/investiguer-donnee-grd-inconsistante-dans-les-dossiers-de-raccordement)