### PR TITLE
✨ Impossible de notifier une période sans nom ou fonction

### DIFF
--- a/packages/domain/candidature/src/notifier/notifierCandidature.behavior.ts
+++ b/packages/domain/candidature/src/notifier/notifierCandidature.behavior.ts
@@ -55,6 +55,13 @@ export async function notifier(
     throw new CandidatureDéjàNotifiéeError(identifiantProjet);
   }
 
+  if (!validateur.fonction) {
+    throw new FonctionManquanteError();
+  }
+  if (!validateur.nomComplet) {
+    throw new NomManquantError();
+  }
+
   const event: CandidatureNotifiéeEvent = {
     type: 'CandidatureNotifiée-V2',
     payload: {
@@ -81,5 +88,17 @@ export function applyCandidatureNotifiée(
 class CandidatureDéjàNotifiéeError extends InvalidOperationError {
   constructor(identifiantProjet: IdentifiantProjet.ValueType) {
     super(`La candidature est déjà notifiée`, { identifiantProjet });
+  }
+}
+
+class FonctionManquanteError extends InvalidOperationError {
+  constructor() {
+    super(`La fonction de l'utilisateur doit être précisée pour cette opération`);
+  }
+}
+
+class NomManquantError extends InvalidOperationError {
+  constructor() {
+    super(`Le nom de l'utilisateur doit être précisé pour cette opération`);
   }
 }

--- a/packages/domain/période/src/notifier/notifierPériode.command.ts
+++ b/packages/domain/période/src/notifier/notifierPériode.command.ts
@@ -36,6 +36,7 @@ export const registerNotifierPériodeCommand = (loadAggregate: LoadAggregate) =>
     const identifiantLauréats: Array<IdentifiantProjet.ValueType> = [];
     const identifiantÉliminés: Array<IdentifiantProjet.ValueType> = [];
 
+    let nbError = 0;
     for (const identifiantCandidature of identifiantCandidatures) {
       const candidature = await loadCandidature(identifiantCandidature);
 
@@ -77,6 +78,10 @@ export const registerNotifierPériodeCommand = (loadAggregate: LoadAggregate) =>
         }
       } catch (error) {
         getLogger().error(error as Error, { identifiantCandidature });
+        nbError++;
+        if (nbError === identifiantCandidatures.length) {
+          throw error;
+        }
       }
     }
 

--- a/packages/specifications/src/période/notifierPériode.feature
+++ b/packages/specifications/src/période/notifierPériode.feature
@@ -18,3 +18,15 @@ Fonctionnalité: Notifier une période d'un appel d'offres
         Et les candidatures de la période notifiée devraient être notifiées
         Et les attestations de désignation des candidatures de la période notifiée devraient être consultables
         Et les lauréats et éliminés devraient être consultables
+
+    Scénario: Impossible de notifier une période sans fonction pour le validateur
+        Etant donné le DGEC Validateur sans fonction "Faustine Morel"
+        Et une période avec des candidats importés
+        Quand le DGEC validateur notifie la période d'un appel d'offres
+        Alors le DGEC validateur devrait être informé que "La fonction de l'utilisateur doit être précisée pour cette opération"
+
+    Scénario: Impossible de notifier une période sans nom pour le validateur
+        Etant donné le DGEC Validateur sans nom
+        Et une période avec des candidats importés
+        Quand le DGEC validateur notifie la période d'un appel d'offres
+        Alors le DGEC validateur devrait être informé que "Le nom de l'utilisateur doit être précisé pour cette opération"

--- a/packages/specifications/src/période/stepDefinitions/période.when.ts
+++ b/packages/specifications/src/période/stepDefinitions/période.when.ts
@@ -7,7 +7,7 @@ import { Période } from '@potentiel-domain/periode';
 import { PotentielWorld } from '../../potentiel.world';
 
 Quand(
-  `un DGEC validateur notifie la période d'un appel d'offres`,
+  /.* DGEC validateur notifie la période d'un appel d'offres/,
   async function (this: PotentielWorld) {
     await notifierPériode.call(this);
   },

--- a/packages/specifications/src/utilisateur/fixtures/validateur.fixture.ts
+++ b/packages/specifications/src/utilisateur/fixtures/validateur.fixture.ts
@@ -3,7 +3,7 @@ import { Fixture } from '../../fixture';
 import { Utilisateur, AbstractUtilisateur } from './utilisateur';
 
 const validateurRole = 'dgec-validateur';
-const validateurFonction = 'fonction du DGEC validateur';
+const validateurFonction: string = 'fonction du DGEC validateur';
 
 interface Validateur extends Utilisateur {
   readonly role: typeof validateurRole;
@@ -24,8 +24,9 @@ export class ValidateurFixture
     return validateurRole;
   }
 
-  get fonction(): typeof validateurFonction {
-    return validateurFonction;
+  #fonction!: string;
+  get fonction(): string {
+    return this.#fonction;
   }
 
   créer(partialFixture?: Partial<Readonly<Omit<Validateur, 'role>'>>>): Readonly<Validateur> {
@@ -34,8 +35,10 @@ export class ValidateurFixture
     const porteur: Validateur = {
       role: validateurRole,
       fonction: validateurFonction,
+      ...partialFixture,
       ...utilisateur,
     };
+    this.#fonction = porteur.fonction;
 
     this.#aÉtéCréé = true;
     return porteur;

--- a/packages/specifications/src/utilisateur/stepDefinitions/utilisateur.given.ts
+++ b/packages/specifications/src/utilisateur/stepDefinitions/utilisateur.given.ts
@@ -48,6 +48,26 @@ EtantDonné(
   },
 );
 
+EtantDonné(
+  'le DGEC Validateur sans fonction {string}',
+  async function (this: PotentielWorld, nom: string) {
+    const validateur = this.utilisateurWorld.validateurFixture.créer({
+      nom,
+      fonction: undefined,
+    });
+
+    await insérerUtilisateur(validateur);
+  },
+);
+
+EtantDonné('le DGEC Validateur sans nom', async function (this: PotentielWorld) {
+  const validateur = this.utilisateurWorld.validateurFixture.créer({
+    nom: '',
+  });
+
+  await insérerUtilisateur(validateur);
+});
+
 async function récupérerProjets(identifiantProjet: IdentifiantProjet.ValueType) {
   return executeSelect<{
     id: string;


### PR DESCRIPTION
Sans ces informations, la notification serait incomplète et le rattrapage compliqué, mieux vaut planter directement. 

J'ai également ajouté que si toutes les notifications de candidat sont en erreur, alors le use case notifier période est également en erreur. Ce comportement n'est pas idéal, peut-être vaudrait-il mieux planter à la première erreur... J'ai pris ce parti pour limiter les changements dans cette PR qui n'a pas pour objectif de changer le comportement des erreurs
