### PR TITLE
✅ Wait event finish for sagas / notifs / projections in setup

### DIFF
--- a/packages/specifications/src/helpers/waitForSagasNotificationsAndProjectionsToFinish.ts
+++ b/packages/specifications/src/helpers/waitForSagasNotificationsAndProjectionsToFinish.ts
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 
 import { executeSelect } from '@potentiel-libraries/pg-helpers';
 
-export async function waitForEvents() {
+export async function waitForSagasNotificationsAndProjectionsToFinish() {
   await new Promise((r) => setTimeout(r, 50));
   // wait for sagas, notifications and projections to finish
   await waitForExpect(async () => {

--- a/packages/specifications/src/projet/lauréat/garantiesFinancières/en-attente/stepDefinitions/garantiesFinancièresEnAttente.given.ts
+++ b/packages/specifications/src/projet/lauréat/garantiesFinancières/en-attente/stepDefinitions/garantiesFinancièresEnAttente.given.ts
@@ -4,7 +4,6 @@ import { mediator } from 'mediateur';
 import { GarantiesFinancières } from '@potentiel-domain/laureat';
 
 import { PotentielWorld } from '../../../../../potentiel.world';
-import { waitForEvents } from '../../../../../helpers/waitForEvents';
 
 EtantDonné(
   `des garanties financières en attente pour le projet {string} avec :`,
@@ -25,6 +24,5 @@ EtantDonné(
         motifValue: motif,
       },
     });
-    await waitForEvents();
   },
 );

--- a/packages/specifications/src/projet/lauréat/garantiesFinancières/mainlevée/stepDefinitions/mainlevéeGarantiesFinancières.given.ts
+++ b/packages/specifications/src/projet/lauréat/garantiesFinancières/mainlevée/stepDefinitions/mainlevéeGarantiesFinancières.given.ts
@@ -4,7 +4,6 @@ import { mediator } from 'mediateur';
 import { GarantiesFinancières } from '@potentiel-domain/laureat';
 
 import { PotentielWorld } from '../../../../../potentiel.world';
-import { waitForEvents } from '../../../../../helpers/waitForEvents';
 
 import {
   setAccordMainlevéeData,
@@ -39,7 +38,6 @@ EtantDonné(
       type: 'Lauréat.GarantiesFinancières.Mainlevée.UseCase.Demander',
       data: setDemandeMainlevéeData({ identifiantProjet }),
     });
-    await waitForEvents();
 
     await mediator.send<GarantiesFinancières.DémarrerInstructionDemandeMainlevéeGarantiesFinancièresUseCase>(
       {

--- a/packages/specifications/src/projet/lauréat/stepDefinitions/lauréat.given.ts
+++ b/packages/specifications/src/projet/lauréat/stepDefinitions/lauréat.given.ts
@@ -9,7 +9,6 @@ import { Lauréat } from '@potentiel-domain/laureat';
 
 import { PotentielWorld } from '../../../potentiel.world';
 import { importerCandidature } from '../../../candidature/stepDefinitions/candidature.given';
-import { waitForEvents } from '../../../helpers/waitForEvents';
 
 EtantDonné('le projet lauréat {string}', async function (this: PotentielWorld, nomProjet: string) {
   await importerCandidature.call(this, nomProjet, 'classé');
@@ -84,7 +83,6 @@ EtantDonné(
 );
 
 export async function notifierLauréat(this: PotentielWorld, dateDésignation: string) {
-  await waitForEvents();
   const candidature = this.candidatureWorld.importerCandidature;
   const identifiantProjetValue = IdentifiantProjet.convertirEnValueType(
     candidature.identifiantProjet,

--- a/packages/specifications/src/raccordement/stepDefinitions/raccordement.given.ts
+++ b/packages/specifications/src/raccordement/stepDefinitions/raccordement.given.ts
@@ -10,12 +10,10 @@ import { ListerTâchesQuery } from '@potentiel-domain/tache';
 import { convertStringToReadableStream } from '../../helpers/convertStringToReadable';
 import { PotentielWorld } from '../../potentiel.world';
 import { RechercherTypeTâche } from '../../tâche/tâche.world';
-import { waitForEvents } from '../../helpers/waitForEvents';
 
 EtantDonné(
   'le gestionnaire de réseau {string} attribué au raccordement du projet lauréat',
   async function (this: PotentielWorld, raisonSocialeGestionnaireRéseau: string) {
-    await waitForEvents();
     const { codeEIC } = this.gestionnaireRéseauWorld.rechercherGestionnaireRéseauFixture(
       raisonSocialeGestionnaireRéseau,
     );
@@ -33,8 +31,6 @@ EtantDonné(
 EtantDonné(
   'le gestionnaire de réseau inconnu attribué au raccordement du projet lauréat',
   async function (this: PotentielWorld) {
-    await waitForEvents();
-
     await mediator.send<Raccordement.ModifierGestionnaireRéseauRaccordementUseCase>({
       type: 'Réseau.Raccordement.UseCase.ModifierGestionnaireRéseauRaccordement',
       data: {
@@ -70,9 +66,6 @@ EtantDonné(
       format,
       content,
     };
-
-    // le raccordement est créé par une saga
-    await waitForEvents();
 
     await mediator.send<Raccordement.RaccordementUseCase>({
       type: 'Réseau.Raccordement.UseCase.TransmettreDemandeComplèteRaccordement',
@@ -155,7 +148,6 @@ EtantDonné(
     const actualTypeTâche = this.tâcheWorld.rechercherTypeTâche(tâche);
     const { identifiantProjet } = this.lauréatWorld;
 
-    await waitForEvents();
     await mediator.send<Raccordement.RaccordementUseCase>({
       type: 'Réseau.Raccordement.UseCase.ModifierGestionnaireRéseauRaccordement',
       data: {

--- a/packages/specifications/src/raccordement/stepDefinitions/raccordement.then.ts
+++ b/packages/specifications/src/raccordement/stepDefinitions/raccordement.then.ts
@@ -10,7 +10,6 @@ import { DateTime, IdentifiantProjet } from '@potentiel-domain/common';
 
 import { convertReadableStreamToString } from '../../helpers/convertReadableToString';
 import { PotentielWorld } from '../../potentiel.world';
-import { waitForEvents } from '../../helpers/waitForEvents';
 
 Alors(
   `le dossier est consultable dans la liste des dossiers de raccordement du projet lauréat`,
@@ -172,7 +171,6 @@ Alors(
     référenceDossierRaccordement: string,
   ) {
     const { identifiantProjet } = this.lauréatWorld;
-    await waitForEvents();
     await waitForExpect(async () => {
       const actual = await mediator.send<Raccordement.ConsulterDossierRaccordementQuery>({
         type: 'Réseau.Raccordement.Query.ConsulterDossierRaccordement',

--- a/packages/specifications/src/raccordement/stepDefinitions/raccordement.when.ts
+++ b/packages/specifications/src/raccordement/stepDefinitions/raccordement.when.ts
@@ -7,7 +7,6 @@ import { Role } from '@potentiel-domain/utilisateur';
 
 import { convertStringToReadableStream } from '../../helpers/convertStringToReadable';
 import { PotentielWorld } from '../../potentiel.world';
-import { waitForEvents } from '../../helpers/waitForEvents';
 
 Quand(
   `le porteur transmet une demande complète de raccordement pour le projet {lauréat-éliminé} auprès du gestionnaire de réseau avec :`,
@@ -213,7 +212,6 @@ Quand(
 Quand(
   `un porteur modifie le gestionnaire de réseau du projet avec un gestionnaire non référencé`,
   async function (this: PotentielWorld) {
-    await waitForEvents();
     const { identifiantProjet } = this.lauréatWorld;
 
     try {
@@ -234,7 +232,6 @@ Quand(
 Quand(
   `le système modifie le gestionnaire de réseau du projet avec un gestionnaire inconnu`,
   async function (this: PotentielWorld) {
-    await waitForEvents();
     const { identifiantProjet } = this.lauréatWorld;
 
     try {
@@ -255,7 +252,6 @@ Quand(
 Quand(
   `un porteur modifie le gestionnaire de réseau du projet avec le gestionnaire {string}`,
   async function (this: PotentielWorld, raisonSocialGestionnaireRéseau: string) {
-    await waitForEvents();
     const { identifiantProjet } = this.lauréatWorld;
     const { codeEIC } = this.gestionnaireRéseauWorld.rechercherGestionnaireRéseauFixture(
       raisonSocialGestionnaireRéseau,

--- a/packages/specifications/src/tâche/stepDefinitions/tâche.then.ts
+++ b/packages/specifications/src/tâche/stepDefinitions/tâche.then.ts
@@ -7,14 +7,12 @@ import { ListerTâchesQuery } from '@potentiel-domain/tache';
 
 import { PotentielWorld } from '../../potentiel.world';
 import { RechercherTypeTâche } from '../tâche.world';
-import { waitForEvents } from '../../helpers/waitForEvents';
 
 Alors(
   `une tâche indiquant de {string} est consultable dans la liste des tâches du porteur pour le projet`,
   async function (this: PotentielWorld, typeTâche: RechercherTypeTâche) {
     const actualTypeTâche = this.tâcheWorld.rechercherTypeTâche(typeTâche);
 
-    await waitForEvents();
     await waitForExpect(async () => {
       const tâches = await mediator.send<ListerTâchesQuery>({
         type: 'Tâche.Query.ListerTâches',


### PR DESCRIPTION
# Description

Dans cette PR je reprends la fonction helpers qui s'appelait waitForEvents() et je lui applique deux changements : 
- renommage en waitForSagasNotificationsAndProjectionsToFinish() pour plus de clareté
- application de ce helper dans le setup  (dans l'After Step) en ciblant les .given et .when uniquement (il n'y aura que eux qui vont avoir besoin d'attendre que l'event émis soit traité)

## Type de changement

- [x] Refacto de code
