### PR TITLE
🚑️ Consulter la demande de changement de représentant légal uniquement si l'utilisateur a la permission

### DIFF
--- a/packages/applications/legacy/src/controllers/project/getProjectPage/_utils/getReprésentantLégal.ts
+++ b/packages/applications/legacy/src/controllers/project/getProjectPage/_utils/getReprésentantLégal.ts
@@ -40,7 +40,9 @@ export const getReprésentantLégal: GetReprésentantLégal = async (identifiant
       });
 
     if (Option.isSome(représentantLégal)) {
-      const demandeChangementExistante = await getChangementReprésentantLégal(identifiantProjet);
+      const demandeChangementExistante =
+        utilisateur.aLaPermission('représentantLégal.consulterChangement') &&
+        (await getChangementReprésentantLégal(identifiantProjet));
 
       const statutAbandon = await getAbandonStatut(identifiantProjet);
       const abandonAccordé = statutAbandon?.statut === 'accordé';
@@ -54,10 +56,7 @@ export const getReprésentantLégal: GetReprésentantLégal = async (identifiant
         rôle,
       ));
 
-      const peutConsulterLaDemandeExistante =
-        utilisateur.aLaPermission('représentantLégal.consulter') &&
-        demandeChangementExistante &&
-        !abandonAccordé;
+      const peutConsulterLaDemandeExistante = demandeChangementExistante && !abandonAccordé;
 
       const peutFaireUneDemande =
         utilisateur.aLaPermission('représentantLégal.demanderChangement') &&


### PR DESCRIPTION
# Description

[Sentry](https://sentry.incubateur.net/organizations/betagouv/issues/142463/?alert_rule_id=125&alert_timestamp=1736777485373&alert_type=email&environment=production&notification_uuid=ea26d40a-18a1-468c-b5fd-6268dc7b95fa&project=155&referrer=alert_email) a remonté une erreur apparue pour un utilisateur n'ayant pas l'autorisation de consutler la demande de changement de représentant légal.

Cette PR empeche d'exécuter la query si l'utilisateur n'a pas la permission