### PR TITLE
✨ Accepter le mimeType pour le format du document à télécharger

### DIFF
--- a/packages/applications/ssr/src/components/atoms/form/document/DownloadDocument.tsx
+++ b/packages/applications/ssr/src/components/atoms/form/document/DownloadDocument.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react';
 import { Download } from '@codegouvfr/react-dsfr/Download';
-
+import { extension } from 'mime-types';
 export type DownloadDocumentProps = {
   className?: string;
   label: string;
@@ -17,7 +17,7 @@ export const DownloadDocument: FC<DownloadDocumentProps> = ({
   <Download
     className={className}
     label={label}
-    details={format.toUpperCase()}
+    details={(extension(format) || format).toUpperCase()}
     linkProps={{
       href: url,
       target: '_blank',


### PR DESCRIPTION
Pour afficher PDF et non "application/pdf" quand on passe le format du document en paramètre :
```ts
 <DownloadDocument
        label="Télécharger la pièce justificative"
        format={pièceJustificative.format} //ici la valeur est application/pdf
       {...} 
      />
```
![image](https://github.com/user-attachments/assets/6026ae8f-1130-4cc6-a234-5a8711d16cf2)
