### PR TITLE
🔊 Utilisation de sentry pour monitorer la tâche cron du backup 3-2-1

### DIFF
--- a/packages/applications/scheduled-tasks/backup-3-2-1.sh
+++ b/packages/applications/scheduled-tasks/backup-3-2-1.sh
@@ -1,5 +1,5 @@
 #! /bin/bash -l
-CHECK_IN_ID="$(uuidgen)"
+CHECK_IN_ID="$(($(date +%s%N)/1000000))"
 curl "$SENTRY_CRONS?check_in_id=${CHECK_IN_ID}&status=in_progress&environment=$APPLICATION_STAGE"
 
 handle_error() {

--- a/packages/applications/scheduled-tasks/backup-3-2-1.sh
+++ b/packages/applications/scheduled-tasks/backup-3-2-1.sh
@@ -1,4 +1,27 @@
 #! /bin/bash -l
+
+handle_error() {
+  local message="Error on backup 3-2-1 script line $1"
+  echo $message
+
+  local timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+  local hostname=$(hostname)
+
+  curl -X POST "$SENTRY_DSN" \
+    -H 'Content-Type: application/json' \
+    -d '{
+      "level": "error",
+      "timestamp": "'"$timestamp"'",
+      "platform": "shell",
+      "message": "'"$message"'"
+      "environment": "'"$APPLICATION_STAGE"'"
+    }'
+
+  exit 1
+}
+
+trap 'handle_error $LINENO' ERR
+
 echo "Installing PG utils..."
 dbclient-fetcher pgsql
 
@@ -37,3 +60,8 @@ echo "Uploading backups to bucket..."
 ./aws s3 cp ../../${COMPRESSED_BACKUP_FILE_NAME} s3://${S3_BUCKET}/db_backups/${COMPRESSED_BACKUP_FILE_NAME}
 ./aws s3 cp ../../${PLAIN_BACKUP_FILE_NAME} s3://${S3_BUCKET}/db_backups/${PLAIN_BACKUP_FILE_NAME}
 ./aws s3 cp ../../${GZ_BACKUP_FILE_NAME} s3://${S3_BUCKET}/db_backups/${GZ_BACKUP_FILE_NAME}
+
+## TODO: Check-in for crons in sentry
+
+echo "Backup 3-2-1 successfully executed !"
+exit 0

--- a/packages/applications/scheduled-tasks/backup-3-2-1.sh
+++ b/packages/applications/scheduled-tasks/backup-3-2-1.sh
@@ -55,8 +55,6 @@ echo "Uploading backups to bucket..."
 ./aws s3 cp ../../${PLAIN_BACKUP_FILE_NAME} s3://${S3_BUCKET}/db_backups/${PLAIN_BACKUP_FILE_NAME}
 ./aws s3 cp ../../${GZ_BACKUP_FILE_NAME} s3://${S3_BUCKET}/db_backups/${GZ_BACKUP_FILE_NAME}
 
-## TODO: Check-in for crons in sentry
-
 echo "Backup 3-2-1 successfully executed !"
 
 curl "$SENTRY_CRONS?check_in_id=${CHECK_IN_ID}&status=ok&environment=$APPLICATION_STAGE"

--- a/packages/applications/scheduled-tasks/backup-3-2-1.sh
+++ b/packages/applications/scheduled-tasks/backup-3-2-1.sh
@@ -1,4 +1,6 @@
 #! /bin/bash -l
+CHECK_IN_ID="$(uuidgen)"
+curl "$SENTRY_CRONS?check_in_id=${CHECK_IN_ID}&status=in_progress&environment=$APPLICATION_STAGE"
 
 handle_error() {
   local message="Error on backup 3-2-1 script line $1"
@@ -7,15 +9,7 @@ handle_error() {
   local timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
   local hostname=$(hostname)
 
-  curl -X POST "$SENTRY_DSN" \
-    -H 'Content-Type: application/json' \
-    -d '{
-      "level": "error",
-      "timestamp": "'"$timestamp"'",
-      "platform": "shell",
-      "message": "'"$message"'"
-      "environment": "'"$APPLICATION_STAGE"'"
-    }'
+  curl "$SENTRY_CRONS?check_in_id=${CHECK_IN_ID}&status=error&environment=$APPLICATION_STAGE"
 
   exit 1
 }
@@ -64,4 +58,7 @@ echo "Uploading backups to bucket..."
 ## TODO: Check-in for crons in sentry
 
 echo "Backup 3-2-1 successfully executed !"
+
+curl "$SENTRY_CRONS?check_in_id=${CHECK_IN_ID}&status=ok&environment=$APPLICATION_STAGE"
+
 exit 0


### PR DESCRIPTION
Nous utilisons comme CHECK_IN_ID la date car sur les container scalingo la fonction uuidgen n'est pas présente ou inaccessible avec notre utilisateur