### PR TITLE
🎨 Autoriser les fichiers jusqu'à 25 mo

### DIFF
--- a/packages/applications/legacy/src/controllers/upload.ts
+++ b/packages/applications/legacy/src/controllers/upload.ts
@@ -2,7 +2,7 @@ import multer from 'multer';
 import { promises as fs } from 'fs';
 import { logger } from '../core/utils';
 
-export const FILE_SIZE_LIMIT_IN_MB = 50;
+export const FILE_SIZE_LIMIT_IN_MB = 25;
 
 const uploadWithMulter = multer({
   dest: 'temp',

--- a/packages/applications/ssr/src/utils/zod/blob/cannotExceedSize.ts
+++ b/packages/applications/ssr/src/utils/zod/blob/cannotExceedSize.ts
@@ -1,4 +1,4 @@
-export const fileSizeLimitInMegaBytes = 5;
+export const fileSizeLimitInMegaBytes = 25;
 const fromMegaBytesToBytes = (sizeInMegaBytes: number): number => sizeInMegaBytes * 1024 * 1024;
 
 const refine = ({ size }: Blob) => size <= fromMegaBytesToBytes(fileSizeLimitInMegaBytes);


### PR DESCRIPTION
# Description

Autoriser l'upload de fichiers jusqu'à 25 mo

## Type de changement

Veuillez supprimer les options qui ne sont pas pertinentes.

- [x] Nouvelle fonctionnalité

# Comment cela a-t-il été testé?

Interface
