### PR TITLE
🐛 AbandonDemandé-V2 doit être représenté dans l'historique abandon

### DIFF
--- a/packages/applications/ssr/src/components/molecules/historique/timeline/abandon/mapToAbandonDemandéTimelineItemProps.tsx
+++ b/packages/applications/ssr/src/components/molecules/historique/timeline/abandon/mapToAbandonDemandéTimelineItemProps.tsx
@@ -1,22 +1,39 @@
+import { match } from 'ts-pattern';
+
 import { Routes } from '@potentiel-applications/routes';
 import { DocumentProjet } from '@potentiel-domain/document';
 import { Historique } from '@potentiel-domain/historique';
 import { Abandon } from '@potentiel-domain/laureat';
+import { DateTime } from '@potentiel-domain/common';
 
 import { DownloadDocument } from '@/components/atoms/form/document/DownloadDocument';
 
 export const mapToAbandonDemandéTimelineItemProps = (
   abandonDemandé: Historique.ListerHistoriqueProjetReadModel['items'][number],
 ) => {
-  const { demandéLe, demandéPar, identifiantProjet, recandidature, pièceJustificative } =
-    abandonDemandé.payload as Abandon.AbandonDemandéEventV1['payload'];
+  const event = match(abandonDemandé)
+    .with(
+      { type: 'AbandonDemandé-V1' },
+      (event) => event as unknown as Abandon.AbandonDemandéEventV1,
+    )
+    .with({ type: 'AbandonDemandé-V2' }, (event) => event as unknown as Abandon.AbandonDemandéEvent)
+    .otherwise(() => undefined);
+
+  if (!event) {
+    return {
+      date: abandonDemandé.createdAt as DateTime.RawType,
+      title: 'Étape abandon demandé inconnue',
+    };
+  }
+
+  const { demandéLe, demandéPar, identifiantProjet, pièceJustificative } = event.payload;
 
   return {
     date: demandéLe,
     title: <div>Demande déposée par {<span className="font-semibold">{demandéPar}</span>}</div>,
     content: (
       <>
-        {recandidature && (
+        {event.type === 'AbandonDemandé-V1' && event.payload.recandidature && (
           <div className="mb-4">
             Le projet s'inscrit dans un{' '}
             <span className="font-semibold">contexte de recandidature</span>

--- a/packages/applications/ssr/src/components/molecules/historique/timeline/abandon/mapToAbandonTimelineItemProps.tsx
+++ b/packages/applications/ssr/src/components/molecules/historique/timeline/abandon/mapToAbandonTimelineItemProps.tsx
@@ -1,4 +1,4 @@
-import { match } from 'ts-pattern';
+import { match, P } from 'ts-pattern';
 
 import { HistoryRecord } from '@potentiel-domain/entity';
 import { DateTime } from '@potentiel-domain/common';
@@ -19,7 +19,7 @@ export const mapToAbandonTimelineItemProps = (record: HistoryRecord) => {
     .returnType<TimelineItemProps>()
     .with(
       {
-        type: 'AbandonDemandé-V1',
+        type: P.union('AbandonDemandé-V1', 'AbandonDemandé-V2'),
       },
       mapToAbandonDemandéTimelineItemProps,
     )

--- a/packages/domain/lauréat/src/abandon/index.ts
+++ b/packages/domain/lauréat/src/abandon/index.ts
@@ -54,7 +54,10 @@ export type {
 // Event
 export type { AbandonEvent } from './abandon.aggregate';
 export type { AbandonAnnuléEvent } from './annuler/annulerAbandon.behavior';
-export type { AbandonDemandéEventV1 } from './demander/demanderAbandon.behavior';
+export type {
+  AbandonDemandéEventV1,
+  AbandonDemandéEvent,
+} from './demander/demanderAbandon.behavior';
 export type { ConfirmationAbandonDemandéeEvent } from './demanderConfirmation/demanderConfirmationAbandon.behavior';
 export type { AbandonConfirméEvent } from './confirmer/confirmerAbandon.behavior';
 export type { AbandonRejetéEvent } from './rejeter/rejeterAbandon.behavior';


### PR DESCRIPTION
# Description
![Capture d’écran 2025-01-22 à 10 49 26](https://github.com/user-attachments/assets/96ca2b66-537c-41cc-8395-559eaa25abc5)

Suite à une V2 de l'event, l'historique affichait "étape inconnue" car l'event n'était pas trigger

J'ai fixé le cas, mais il faudrait typer HistoryRecord pour qu'il soit suffisament intelligent pour bloquer si on rajoute un event sans qu'il soit représenté ici
