### PR TITLE
🐛 Empecher de créer un utilisateur de type porteur avec un email déjà utilisé par un compte utilisateur Potentiel (désactivé ou non)

### DIFF
--- a/packages/applications/legacy/src/controllers/userAccount/postSignup.ts
+++ b/packages/applications/legacy/src/controllers/userAccount/postSignup.ts
@@ -54,7 +54,7 @@ v1Router.post(
         .some(() =>
           response.redirect(
             addQueryParams(routes.SIGNUP, {
-              error: `Un compte existe déjà avec cette adresse email. Si vous avez oublié votre mot de passe, vous pouvez le réinitialiser.`,
+              error: `Une erreur est survenue lors de la création du compte. N'hésitez pas à nous contacter si le problème persiste.`,
             }),
           ),
         )

--- a/packages/applications/legacy/src/controllers/userAccount/postSignup.ts
+++ b/packages/applications/legacy/src/controllers/userAccount/postSignup.ts
@@ -1,5 +1,8 @@
 import { sanitize } from 'isomorphic-dompurify';
 
+import { récupérerUtilisateurAdapter } from '@potentiel-infrastructure/domain-adapters';
+import { Option } from '@potentiel-libraries/monads';
+
 import routes from '../../routes';
 import { v1Router } from '../v1Router';
 import { createUser, créerProfilUtilisateur } from '../../config';
@@ -45,54 +48,66 @@ v1Router.post(
     async (request, response) => {
       const { firstname, lastname, email, utilisateurInvité } = request.body;
 
-      if (utilisateurInvité) {
-        return créerProfilUtilisateur({ email, nom: lastname, prénom: firstname }).match(
-          () =>
-            response.redirect(
-              addQueryParams(routes.SIGNUP, {
-                success: true,
-              }),
-            ),
-          (e) =>
-            response.redirect(
+      const existingUser = await récupérerUtilisateurAdapter(email);
+
+      return Option.match(existingUser)
+        .some(() =>
+          response.redirect(
+            addQueryParams(routes.SIGNUP, {
+              error: `Un compte existe déjà avec cette adresse email. Si vous avez oublié votre mot de passe, vous pouvez le réinitialiser.`,
+            }),
+          ),
+        )
+        .none(async () => {
+          if (utilisateurInvité) {
+            return créerProfilUtilisateur({ email, nom: lastname, prénom: firstname }).match(
+              () =>
+                response.redirect(
+                  addQueryParams(routes.SIGNUP, {
+                    success: true,
+                  }),
+                ),
+              (e) =>
+                response.redirect(
+                  addQueryParams(routes.SIGNUP, {
+                    error:
+                      e.message ||
+                      `Une erreur est survenue lors de la création du compte. N'hésitez pas à nous contacter si le problème persiste.`,
+                    ...request.body,
+                  }),
+                ),
+            );
+          }
+
+          const res = await createUser({
+            email,
+            fullName: `${firstname} ${lastname}`,
+            role: 'porteur-projet',
+          });
+
+          if (res.isErr()) {
+            if (!(res.error instanceof EmailAlreadyUsedError)) {
+              logger.error(res.error);
+            } else {
+              logger.info(res.error.message, email, res.error.userId);
+            }
+
+            return response.redirect(
               addQueryParams(routes.SIGNUP, {
                 error:
-                  e.message ||
+                  res.error.message ||
                   `Une erreur est survenue lors de la création du compte. N'hésitez pas à nous contacter si le problème persiste.`,
                 ...request.body,
               }),
-            ),
-        );
-      } else {
-        const res = await createUser({
-          email,
-          fullName: `${firstname} ${lastname}`,
-          role: 'porteur-projet',
-        });
-
-        if (res.isErr()) {
-          if (!(res.error instanceof EmailAlreadyUsedError)) {
-            logger.error(res.error);
-          } else {
-            logger.info(res.error.message, email, res.error.userId);
+            );
           }
 
           return response.redirect(
             addQueryParams(routes.SIGNUP, {
-              error:
-                res.error.message ||
-                `Une erreur est survenue lors de la création du compte. N'hésitez pas à nous contacter si le problème persiste.`,
-              ...request.body,
+              success: true,
             }),
           );
-        }
-
-        return response.redirect(
-          addQueryParams(routes.SIGNUP, {
-            success: true,
-          }),
-        );
-      }
+        });
     },
   ),
 );


### PR DESCRIPTION
# Description

⚠️  Cette PR est full legacy. J'ai fais le choix de faire la vérification en amont en utilisant l'adapter récupérerUtilisateur plutôt que modifier le legacy des useCase (difficile à maintenir). Ce code est temporaire puisqu'il sera prochainement ré-écrit en fonction des choix fait sur la partie migration du module utilisateur ⚠️ 