### PR TITLE
✨ Commune Picker dans le formulaire de correction de candidature

### DIFF
--- a/packages/applications/legacy/.env.template
+++ b/packages/applications/legacy/.env.template
@@ -64,3 +64,5 @@ NEXT_PUBLIC_SENTRY_DSN=
 
 # ORE API
 ORE_ENDPOINT=https://opendata.agenceore.fr
+
+NEXT_PUBLIC_GEO_API_URL=https://geo.api.gouv.fr

--- a/packages/applications/ssr/.env.template
+++ b/packages/applications/ssr/.env.template
@@ -71,3 +71,5 @@ FILIGRANE_FACILE_ENDPOINT=https://api.filigrane.beta.gouv.fr
 NEXTAUTH_URL=http://localhost:3000
 NEXTAUTH_SECRET=fake-secret
 NEXT_AUTH_SESSION_TOKEN_COOKIE_NAME=next-auth.session-token
+
+NEXT_PUBLIC_GEO_API_URL=https://geo.api.gouv.fr

--- a/packages/applications/ssr/src/app/candidatures/[identifiant]/corriger/page.tsx
+++ b/packages/applications/ssr/src/app/candidatures/[identifiant]/corriger/page.tsx
@@ -65,6 +65,8 @@ const mapToProps: MapToProps = (candidature) => ({
     adresse2: candidature.localité.adresse2,
     codePostal: candidature.localité.codePostal,
     commune: candidature.localité.commune,
+    departement: candidature.localité.département,
+    region: candidature.localité.région,
     technologie: candidature.technologie.formatter(),
     typeGarantiesFinancieres: candidature.typeGarantiesFinancières?.type,
     dateEcheanceGf: candidature.dateÉchéanceGf?.date,

--- a/packages/applications/ssr/src/components/molecules/CommunePicker.tsx
+++ b/packages/applications/ssr/src/components/molecules/CommunePicker.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import Autocomplete from '@mui/material/Autocomplete';
+import Input, { InputProps } from '@codegouvfr/react-dsfr/Input';
+import { debounce } from '@mui/material/utils';
+
+type GeoApiCommuneItem = {
+  nom: string;
+  codesPostaux: string[];
+  departement: {
+    code: string;
+    nom: string;
+  };
+  region: {
+    code: string;
+    nom: string;
+  };
+};
+
+type Commune = {
+  commune: string;
+  codePostal: string;
+  departement: string;
+  region: string;
+};
+
+const fetchCommunes = async (search: string, signal?: AbortSignal): Promise<Commune[]> => {
+  const params = new URLSearchParams({
+    nom: search,
+    fields: 'departement,region,codesPostaux',
+    boost: 'population',
+    limit: '10',
+  });
+
+  const response = await fetch(`https://geo.api.gouv.fr/communes?${params}`, { signal });
+  const data: GeoApiCommuneItem[] = await response.json();
+  return data.map(({ nom, region, departement, codesPostaux }) => ({
+    commune: nom,
+    region: region.nom,
+    departement: departement.nom,
+    codePostal: codesPostaux[0],
+  }));
+};
+
+export type CommunePickerProps = {
+  onSelected?: (commune: Commune | null) => void;
+  defaultValue?: Commune;
+} & Pick<InputProps, 'className' | 'label' | 'nativeInputProps'>;
+
+export const CommunePicker: React.FC<CommunePickerProps> = ({
+  label,
+  nativeInputProps,
+  defaultValue,
+  className,
+  onSelected,
+}) => {
+  const [communes, setCommunes] = useState<Commune[]>([]);
+  const [selectedCommune, setSelectedCommune] = useState<Commune | null>(defaultValue ?? null);
+  const [search, setSearch] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!search) {
+      setCommunes([]);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    const controller = new AbortController();
+    fetchCommunes(search, controller.signal)
+      .then((data) => {
+        setCommunes(data);
+        setLoading(false);
+      })
+      .catch((error) => console.error('Error fetching communes:', error));
+    return () => {
+      controller.abort();
+    };
+  }, [search]);
+
+  const searchDelayed = debounce(setSearch, 400);
+
+  return (
+    <Autocomplete
+      options={communes}
+      loading={loading}
+      loadingText="Chargement..."
+      noOptionsText="Aucun résultat"
+      className={className}
+      getOptionLabel={({ commune, departement, region }) => `${commune}, ${departement}, ${region}`}
+      getOptionKey={({ commune, codePostal }) => commune + codePostal}
+      isOptionEqualToValue={(commune, value) =>
+        commune.commune === value.commune && commune.codePostal === value.codePostal
+      }
+      filterOptions={(x) => x}
+      autoHighlight
+      autoComplete
+      value={selectedCommune}
+      onChange={(_, value) => {
+        setSelectedCommune(value);
+        onSelected?.(value);
+      }}
+      onInputChange={(_, newInputValue) => searchDelayed(newInputValue)}
+      renderInput={({ inputProps, InputProps }) => {
+        return (
+          <div ref={InputProps.ref}>
+            <Input
+              id={inputProps.id}
+              label={label}
+              nativeInputProps={{
+                type: 'text',
+                ...inputProps,
+                ...nativeInputProps,
+              }}
+            />
+          </div>
+        );
+      }}
+    />
+  );
+};

--- a/packages/applications/ssr/src/components/molecules/CommunePicker.tsx
+++ b/packages/applications/ssr/src/components/molecules/CommunePicker.tsx
@@ -33,7 +33,9 @@ const fetchCommunes = async (search: string, signal?: AbortSignal): Promise<Comm
     limit: '10',
   });
 
-  const response = await fetch(`https://geo.api.gouv.fr/communes?${params}`, { signal });
+  const apiUrl = process.env.NEXT_PUBLIC_GEO_API_URL || '';
+
+  const response = await fetch(`${apiUrl}/communes?${params}`, { signal });
   const data: GeoApiCommuneItem[] = await response.json();
   return data.map(({ nom, region, departement, codesPostaux }) => ({
     commune: nom,

--- a/packages/applications/ssr/src/components/pages/candidature/corriger/CorrigerCandidature.form.tsx
+++ b/packages/applications/ssr/src/components/pages/candidature/corriger/CorrigerCandidature.form.tsx
@@ -15,6 +15,7 @@ import { Form } from '@/components/atoms/form/Form';
 import { SubmitButton } from '@/components/atoms/form/SubmitButton';
 import { ValidationErrors } from '@/utils/formAction';
 import { InputDate } from '@/components/atoms/form/InputDate';
+import { CommunePicker } from '@/components/molecules/CommunePicker';
 
 import { getGarantiesFinancièresTypeLabel } from '../../garanties-financières/getGarantiesFinancièresTypeLabel';
 import { getTechnologieTypeLabel } from '../helpers';
@@ -44,6 +45,13 @@ export const CorrigerCandidatureForm: React.FC<CorrigerCandidatureFormProps> = (
   const [showDateGf, setShowDateGf] = useState(
     candidature.typeGarantiesFinancieres === 'avec-date-échéance',
   );
+
+  const [commune, setCommune] = useState({
+    commune: candidature.commune,
+    codePostal: candidature.codePostal,
+    departement: candidature.departement,
+    region: candidature.region,
+  });
 
   const typesActionnariat = IdentifiantProjet.convertirEnValueType(
     candidature.identifiantProjet,
@@ -199,28 +207,37 @@ export const CorrigerCandidatureForm: React.FC<CorrigerCandidatureFormProps> = (
           defaultValue: candidature.adresse2,
         }}
       />
-      <Input
-        state={validationErrors['codePostal'] ? 'error' : 'default'}
-        stateRelatedMessage={validationErrors['codePostal']}
-        label="Code Postal"
-        nativeInputProps={{
-          name: 'codePostal',
-          defaultValue: candidature.codePostal,
-          required: true,
-          'aria-required': true,
-        }}
-      />
-      <Input
-        state={validationErrors['commune'] ? 'error' : 'default'}
-        stateRelatedMessage={validationErrors['commune']}
-        label="Commune"
-        nativeInputProps={{
-          name: 'commune',
-          defaultValue: candidature.commune,
-          required: true,
-          'aria-required': true,
-        }}
-      />
+      <div className="flex flex-row gap-2 justify-between">
+        <CommunePicker
+          defaultValue={commune}
+          label="Commune"
+          nativeInputProps={{
+            required: true,
+            'aria-required': true,
+          }}
+          onSelected={(commune) => commune && setCommune(commune)}
+          className="mb-6 flex-1"
+        />
+        <input type="hidden" value={commune.commune} name="commune" />
+        {validationErrors['commune']}
+        <input type="hidden" value={commune.departement} name="departement" />
+        {validationErrors['departement']}
+        <input type="hidden" value={commune.region} name="region" />
+        {validationErrors['region']}
+        <Input
+          state={validationErrors['codePostal'] ? 'error' : 'default'}
+          stateRelatedMessage={validationErrors['codePostal']}
+          label="Code Postal"
+          nativeInputProps={{
+            name: 'codePostal',
+            defaultValue: commune.codePostal,
+            required: true,
+            'aria-required': true,
+            minLength: 5,
+            maxLength: 5,
+          }}
+        />
+      </div>
       <Select
         state={validationErrors['technologie'] ? 'error' : 'default'}
         stateRelatedMessage={validationErrors['technologie']}
@@ -345,7 +362,6 @@ export const CorrigerCandidatureForm: React.FC<CorrigerCandidatureFormProps> = (
           />
         </>
       )}
-
       <RadioButtons
         state={validationErrors['doitRegenererAttestation'] ? 'error' : 'default'}
         stateRelatedMessage={validationErrors['doitRegenererAttestation']}

--- a/packages/applications/ssr/src/components/pages/candidature/corriger/corrigerCandidature.action.ts
+++ b/packages/applications/ssr/src/components/pages/candidature/corriger/corrigerCandidature.action.ts
@@ -12,8 +12,6 @@ import { withUtilisateur } from '@/utils/withUtilisateur';
 import { getCandidature } from '@/app/candidatures/_helpers/getCandidature';
 import { candidatureSchema } from '@/utils/zod/candidature';
 
-import { getLocalité } from '../helpers';
-
 export type CorrigerCandidaturesState = FormState;
 
 const schema = candidatureSchema;
@@ -63,12 +61,14 @@ const mapBodyToUseCaseData = (
     noteTotaleValue: data.noteTotale,
     nomReprésentantLégalValue: data.nomRepresentantLegal,
     emailContactValue: data.emailContact,
-    localitéValue: getLocalité({
-      codePostaux: data.codePostal.split('/').map((x) => x.trim()),
-      commune: data.commune,
+    localitéValue: {
+      codePostal: data.codePostal,
       adresse1: data.adresse1,
       adresse2: data.adresse2,
-    }),
+      commune: data.commune,
+      département: data.departement,
+      région: data.region,
+    },
     motifÉliminationValue: data.motifElimination,
     puissanceALaPointeValue: data.puissanceALaPointe,
     evaluationCarboneSimplifiéeValue: data.evaluationCarboneSimplifiee,

--- a/packages/applications/ssr/src/utils/zod/candidature/candidature.schema.ts
+++ b/packages/applications/ssr/src/utils/zod/candidature/candidature.schema.ts
@@ -23,6 +23,8 @@ import {
   technologieSchema,
   typeGarantiesFinancieresSchema,
   communeSchema,
+  départementSchema,
+  régionSchema,
 } from './candidatureFields.schema';
 
 /** Schema simplifié pour utilisation sans données Csv */
@@ -41,6 +43,8 @@ export const candidatureSchema = z
     adresse2: adresse2Schema,
     codePostal: codePostalSchema,
     commune: communeSchema,
+    departement: départementSchema,
+    region: régionSchema,
     statut: statutSchema,
     puissanceALaPointe: puissanceALaPointeSchema,
     evaluationCarboneSimplifiee: évaluationCarboneSimplifiéeSchema,

--- a/packages/applications/ssr/src/utils/zod/candidature/candidatureFields.schema.ts
+++ b/packages/applications/ssr/src/utils/zod/candidature/candidatureFields.schema.ts
@@ -39,6 +39,8 @@ export const codePostalSchema = requiredStringSchema
   .transform((val) => val.join(' / '));
 
 export const communeSchema = requiredStringSchema;
+export const départementSchema = requiredStringSchema;
+export const régionSchema = requiredStringSchema;
 export const doitRegenererAttestationSchema = booleanSchema.optional();
 export const motifEliminationSchema = optionalStringSchema.transform((val) => val || undefined);
 export const typeGarantiesFinancieresSchema = optionalEnum(

--- a/packages/specifications/src/candidature/importerCandidature.feature
+++ b/packages/specifications/src/candidature/importerCandidature.feature
@@ -72,10 +72,3 @@ Fonctionnalité: Importer une candidature
             | période       | 1                           |
             | famille       |                             |
         Alors l'administrateur devrait être informé que "Cette période est obsolète et ne peut être importée"
-
-    @NotImplemented
-    Scénario: Impossible d'importer une candidature si la région ou le département n'existe pas
-        Quand le DGEC validateur importe la candidature "Du boulodrome de Marseille" avec :
-            | statut      | classé  |
-            | code postal | inconnu |
-        Alors l'administrateur devrait être informé que "Le code postal renseigné ne correspond à aucun département ou région connu"


### PR DESCRIPTION
Changements : 
- un picker pour la commune, qui préremplit le codePostal (mais reste éditable dans un premier temps) et la région/département, basé sur l'[API Géo](https://geo.api.gouv.fr/)
- la région / département provient donc de l'API et plus du référentiel hard-codé. Le référentiel hard-codé reste pour l'import via CSV pour le moment

![image](https://github.com/user-attachments/assets/376df856-6240-46c7-8025-ae20722a9388)
