### PR TITLE
🐛 Gérer les caractères spéciaux dans `updateOneProjection`

### DIFF
--- a/packages/applications/projectors/package.json
+++ b/packages/applications/projectors/package.json
@@ -6,7 +6,8 @@
   "types": "dist/index.d.ts",
   "private": true,
   "scripts": {
-    "build": "tsc"
+    "build": "tsc",
+    "test": "tsx --test src/**/*.test.ts"
   },
   "dependencies": {
     "@potentiel-domain/entity": "*",

--- a/packages/applications/projectors/src/infrastructure/updateOneProjection.test.ts
+++ b/packages/applications/projectors/src/infrastructure/updateOneProjection.test.ts
@@ -48,4 +48,12 @@ describe('updateOneProjection', () => {
     );
     expect(values).to.deep.eq(['""', -1, false]);
   });
+
+  test(`escaping characters`, () => {
+    const [, values] = getUpdateClause<TestEntity>(
+      { foo: `hello "you" with  'quotes' and \n \t \r` },
+      1,
+    );
+    expect(values).to.deep.eq([`"hello \\"you\\" with  ''quotes'' and \\n \\t \\r"`]);
+  });
 });

--- a/packages/applications/projectors/src/infrastructure/updateOneProjection.ts
+++ b/packages/applications/projectors/src/infrastructure/updateOneProjection.ts
@@ -13,9 +13,6 @@ export const updateOneProjection = async <TProjection extends Entity>(
   readModel: AtLeastOne<Omit<TProjection, 'type'>>,
 ): Promise<void> => {
   const [updateQuery, values] = getUpdateClause(readModel, 1);
-
-  console.log({ updateQuery, values });
-
   const result = await executeQuery(`${updateQuery} where key = $1`, id, ...values);
   if (result.rowCount === 0) {
     getLogger('Projectors.infrastructure.updateOneProjection').warn(


### PR DESCRIPTION
Dans des cas où une string contient des caractères du type ", ' ou \n... , l'update avec `updateOneProjection` ne fonctionne pas