### PR TITLE
🐛 Permettre la déconnexion de proconnect si l'utilisateur n'est pas autorisé

### DIFF
--- a/packages/applications/legacy/.env.template
+++ b/packages/applications/legacy/.env.template
@@ -68,4 +68,4 @@ NEXT_PUBLIC_FLAGS_PROCONNECT_ACTIVATED=true
 PROCONNECT_ISSUER=https://fca.integ01.dev-agentconnect.fr/api/v2
 PROCONNECT_CLIENT_ID=
 PROCONNECT_CLIENT_SECRET=
-PROCONNECT_ACCOUNT=https://test.proconnect.gouv.fr/
+PROCONNECT_ACCOUNT=https://identite-sandbox.proconnect.gouv.fr/

--- a/packages/applications/request-context/src/authOptions.ts
+++ b/packages/applications/request-context/src/authOptions.ts
@@ -54,18 +54,28 @@ export const authOptions: AuthOptions = {
   },
   callbacks: {
     signIn({ account, user }) {
+      const logger = getLogger('Auth');
       if (
         user?.identifiantUtilisateur &&
         IdentifiantUtilisateur.bind(user.identifiantUtilisateur).estInconnu()
       ) {
-        return false;
+        logger.info(`User try to connect with ProConnect but is not registered yet`, {
+          user,
+        });
+        return Routes.Auth.signOut({
+          proConnectNotAvailableForUser: true,
+          idToken: account?.id_token,
+        });
       }
       if (account?.provider === 'proconnect' && !canConnectWithProConnect(user.role)) {
-        getLogger('Auth').info(`User try to connect with ProConnect but is not authorized yet`, {
+        logger.info(`User try to connect with ProConnect but is not authorized yet`, {
           user,
         });
 
-        return Routes.Auth.signIn({ proConnectNotAvailableForUser: true });
+        return Routes.Auth.signOut({
+          proConnectNotAvailableForUser: true,
+          idToken: account?.id_token,
+        });
       }
 
       return true;
@@ -75,7 +85,11 @@ export const authOptions: AuthOptions = {
         user?.identifiantUtilisateur &&
         IdentifiantUtilisateur.bind(user.identifiantUtilisateur).estInconnu()
       ) {
-        return {};
+        return {
+          ...token,
+          provider: account?.provider,
+          idToken: account?.id_token,
+        };
       }
       if (trigger === 'signIn' && account && user) {
         const { sub, expires_at = 0, provider } = account;

--- a/packages/applications/request-context/src/authOptions.ts
+++ b/packages/applications/request-context/src/authOptions.ts
@@ -59,7 +59,7 @@ export const authOptions: AuthOptions = {
         user?.identifiantUtilisateur &&
         IdentifiantUtilisateur.bind(user.identifiantUtilisateur).estInconnu()
       ) {
-        logger.info(`User try to connect with ProConnect but is not registered yet`, {
+        logger.info(`User tries to connect with ProConnect but is not registered yet`, {
           user,
         });
         return Routes.Auth.signOut({
@@ -68,7 +68,7 @@ export const authOptions: AuthOptions = {
         });
       }
       if (account?.provider === 'proconnect' && !canConnectWithProConnect(user.role)) {
-        logger.info(`User try to connect with ProConnect but is not authorized yet`, {
+        logger.info(`User tries to connect with ProConnect but is not authorized yet`, {
           user,
         });
 
@@ -85,11 +85,7 @@ export const authOptions: AuthOptions = {
         user?.identifiantUtilisateur &&
         IdentifiantUtilisateur.bind(user.identifiantUtilisateur).estInconnu()
       ) {
-        return {
-          ...token,
-          provider: account?.provider,
-          idToken: account?.id_token,
-        };
+        return {};
       }
       if (trigger === 'signIn' && account && user) {
         const { sub, expires_at = 0, provider } = account;

--- a/packages/applications/request-context/src/getLogoutUrl.ts
+++ b/packages/applications/request-context/src/getLogoutUrl.ts
@@ -2,7 +2,7 @@ import { EndSessionParameters } from 'openid-client';
 
 import { getOpenIdClient } from './openid';
 
-export const getLogoutUrl = async (params: EndSessionParameters) => {
-  const client = await getOpenIdClient();
+export const getLogoutUrl = async (params: EndSessionParameters, provider?: string) => {
+  const client = await getOpenIdClient(provider);
   return client.endSessionUrl(params);
 };

--- a/packages/applications/routes/src/auth/auth.routes.ts
+++ b/packages/applications/routes/src/auth/auth.routes.ts
@@ -1,8 +1,4 @@
-export const signIn = (options?: {
-  callbackUrl?: string;
-  showProConnect?: boolean;
-  proConnectNotAvailableForUser?: boolean;
-}) => {
+export const signIn = (options?: { callbackUrl?: string; showProConnect?: boolean }) => {
   const route = `/auth/signIn`;
 
   if (!options) {
@@ -10,14 +6,10 @@ export const signIn = (options?: {
   }
 
   const params = new URLSearchParams();
-  const { callbackUrl, proConnectNotAvailableForUser, showProConnect } = options;
+  const { callbackUrl, showProConnect } = options;
 
   if (callbackUrl) {
     params.set('callbackUrl', callbackUrl);
-  }
-
-  if (proConnectNotAvailableForUser) {
-    params.set('proConnectNotAvailableForUser', 'true');
   }
 
   if (showProConnect) {
@@ -28,11 +20,18 @@ export const signIn = (options?: {
 };
 
 // The signout page, where the user is redirected after federeated logout
-export const signOut = (callbackUrl?: string) => {
+export const signOut = (options?: {
+  callbackUrl?: string;
+  idToken?: string;
+  proConnectNotAvailableForUser?: boolean;
+}) => {
   const route = `/auth/signOut`;
-  if (!callbackUrl) return route;
-  const params = new URLSearchParams({ callbackUrl });
-  return `${route}?${params}`;
+  const { proConnectNotAvailableForUser, ...stringOptions } = options ?? {};
+  const params = new URLSearchParams(stringOptions);
+  if (proConnectNotAvailableForUser) {
+    params.set('proConnectNotAvailableForUser', 'true');
+  }
+  return params.size > 0 ? `${route}?${params}` : route;
 };
 
 export const redirectToDashboard = () => `/go-to-user-dashboard`;

--- a/packages/applications/ssr/.env.template
+++ b/packages/applications/ssr/.env.template
@@ -76,4 +76,4 @@ NEXT_PUBLIC_FLAGS_PROCONNECT_ACTIVATED=true
 PROCONNECT_ISSUER=https://fca.integ01.dev-agentconnect.fr/api/v2
 PROCONNECT_CLIENT_ID=
 PROCONNECT_CLIENT_SECRET=
-PROCONNECT_ACCOUNT=https://test.proconnect.gouv.fr/
+PROCONNECT_ACCOUNT=https://identite-sandbox.proconnect.gouv.fr/

--- a/packages/applications/ssr/src/app/auth/signIn/page.tsx
+++ b/packages/applications/ssr/src/app/auth/signIn/page.tsx
@@ -20,22 +20,20 @@ export default function SignIn() {
     params.get('showProConnect') ??
     process.env.NEXT_PUBLIC_FLAGS_PROCONNECT_ACTIVATED?.toLowerCase() === 'true';
 
-  const proConnectNotAvailableForUser = params.get('proConnectNotAvailableForUser') ?? false;
-
   useEffect(() => {
     switch (status) {
       case 'authenticated':
         // This checks that the session is up to date with the necessary requirements
         // it's useful when changing what's inside the cookie for instance
         if (!data.utilisateur) {
-          redirect(Routes.Auth.signOut(callbackUrl));
+          redirect(Routes.Auth.signOut({ callbackUrl }));
           break;
         }
         redirect(callbackUrl);
         break;
 
       case 'unauthenticated':
-        if (!showProConnect || proConnectNotAvailableForUser) {
+        if (!showProConnect) {
           setTimeout(() => signIn('keycloak', { callbackUrl }), 2000);
         }
 
@@ -45,12 +43,7 @@ export default function SignIn() {
 
   return (
     <PageTemplate>
-      {proConnectNotAvailableForUser ? (
-        <div className="font-bold text-2xl">
-          Vous n'êtes pas autorisé à utiliser ce mode d'authentification. Nous vous redirigeons vers
-          le mode de connexion classique. Veuillez patienter ...
-        </div>
-      ) : showProConnect ? (
+      {showProConnect ? (
         <>
           <Heading1>Identifiez-vous</Heading1>
           <div className="flex flex-col items-center gap-6 mt-12 md:mt-20">

--- a/packages/applications/ssr/src/app/auth/signOut/page.tsx
+++ b/packages/applications/ssr/src/app/auth/signOut/page.tsx
@@ -1,14 +1,31 @@
 import { getServerSession } from 'next-auth';
+import { z } from 'zod';
 import { redirect } from 'next/navigation';
 
 import { getLogoutUrl } from '@potentiel-applications/request-context';
 
 import { PageTemplate } from '@/components/templates/Page.template';
 import { SignOutRedirect } from '@/components/molecules/SignOutRedirect';
+import { SignOutProConnect } from '@/components/molecules/SignOutProConnect';
 
-export default async function SignOut() {
+type PageProps = {
+  searchParams: {
+    proConnectNotAvailableForUser?: string;
+    idToken?: string;
+  };
+};
+
+const searchParamsSchema = z.object({
+  proConnectNotAvailableForUser: z
+    .literal('true')
+    .optional()
+    .transform((s) => s === 'true'),
+  idToken: z.string().optional(),
+});
+
+export default async function SignOut({ searchParams }: PageProps) {
   const { BASE_URL = '' } = process.env;
-
+  const { proConnectNotAvailableForUser, idToken } = searchParamsSchema.parse(searchParams);
   const session = await getServerSession({
     callbacks: {
       session({ session, token }) {
@@ -17,24 +34,37 @@ export default async function SignOut() {
       },
     },
   });
-
-  if (!session) {
-    return redirect(BASE_URL);
-  }
-
-  const callbackUrl =
-    session.idToken &&
-    (await getLogoutUrl({
+  if (session) {
+    const callbackUrl = await getLogoutUrl({
       id_token_hint: session.idToken,
       post_logout_redirect_uri: BASE_URL,
-    }));
+    });
+    return (
+      <PageTemplate>
+        <div className="flex m-auto">
+          <SignOutRedirect callbackUrl={callbackUrl} />
+          <div className="font-bold text-2xl">Déconnexion en cours, merci de patienter ...</div>
+        </div>
+      </PageTemplate>
+    );
+  }
 
-  return (
-    <PageTemplate>
-      <div className="flex m-auto">
-        <SignOutRedirect callbackUrl={callbackUrl} />
-        <div className="font-bold text-2xl">Déconnexion en cours, merci de patienter ...</div>
-      </div>
-    </PageTemplate>
-  );
+  if (proConnectNotAvailableForUser) {
+    const callbackUrl = idToken
+      ? await getLogoutUrl(
+          {
+            id_token_hint: idToken,
+            post_logout_redirect_uri: BASE_URL,
+          },
+          'proconnect',
+        )
+      : BASE_URL;
+    return (
+      <PageTemplate>
+        <SignOutProConnect callbackUrl={callbackUrl} />
+      </PageTemplate>
+    );
+  }
+
+  redirect('/');
 }

--- a/packages/applications/ssr/src/components/molecules/SignOutProConnect.tsx
+++ b/packages/applications/ssr/src/components/molecules/SignOutProConnect.tsx
@@ -17,7 +17,7 @@ export const SignOutProConnect = ({ callbackUrl }: SignOutProConnectProps) => {
       <Heading1>Vous n'êtes pas autorisé à utiliser ProConnect.</Heading1>
       <p className={fr.cx('fr-text--sm', 'fr-mb-3w')}>
         ProConnect est en phase d'expérimentation actuellement. <br />
-        Vous allez être déconnecté, veuillez choisir l'authentification par mot de passe.
+        Veuillez vous déconnecter et choisir l'authentification par mot de passe.
       </p>
       <ul className={fr.cx('fr-btns-group', 'fr-btns-group--inline-md')}>
         <li>

--- a/packages/applications/ssr/src/components/molecules/SignOutProConnect.tsx
+++ b/packages/applications/ssr/src/components/molecules/SignOutProConnect.tsx
@@ -1,0 +1,31 @@
+'use client';
+import { fr } from '@codegouvfr/react-dsfr';
+import Button from '@codegouvfr/react-dsfr/Button';
+import { signOut } from 'next-auth/react';
+import { useRouter } from 'next/navigation';
+
+import { Heading1 } from '../atoms/headings';
+
+type SignOutProConnectProps = {
+  callbackUrl: string | undefined;
+};
+
+export const SignOutProConnect = ({ callbackUrl }: SignOutProConnectProps) => {
+  const router = useRouter();
+  return (
+    <div className={fr.cx('fr-container')}>
+      <Heading1>Vous n'êtes pas autorisé à utiliser ProConnect.</Heading1>
+      <p className={fr.cx('fr-text--sm', 'fr-mb-3w')}>
+        ProConnect est en phase d'expérimentation actuellement. <br />
+        Vous allez être déconnecté, veuillez choisir l'authentification par mot de passe.
+      </p>
+      <ul className={fr.cx('fr-btns-group', 'fr-btns-group--inline-md')}>
+        <li>
+          <Button onClick={() => signOut().then(() => router.push(callbackUrl ?? '/'))}>
+            Me déconnecter
+          </Button>
+        </li>
+      </ul>
+    </div>
+  );
+};


### PR DESCRIPTION
Si l'utilisateur n'est pas autorisé sur Potentiel, il risque de ne pas pouvoir se déconnecter de proconnect. Ceci impacte surtout les envs de test car on utilise plusieurs comptes, mais pourrait arriver en prod si quelqu'un a plusieurs comptes proconnect. 