### PR TITLE
🎨 Nouvel affichage pour raccordement sur la page projet 

### DIFF
--- a/packages/applications/legacy/src/views/pages/projectDetailsPage/sections/InfoGenerales/index.tsx
+++ b/packages/applications/legacy/src/views/pages/projectDetailsPage/sections/InfoGenerales/index.tsx
@@ -83,27 +83,38 @@ export const InfoGenerales = ({
           </Link>
         </div>
       )}
-      {Option.isSome(raccordement) && (
-        <div className="print:hidden">
-          <Heading3 className="m-0">Raccordement au réseau</Heading3>
-          <Link href={Routes.Raccordement.détail(formattedIdentifiantProjet)}>
-            Consulter{' '}
-            {role.aLaPermission('raccordement.gestionnaire.modifier') ? 'ou modifier ' : ''}
-            les données de raccordement
-          </Link>
-        </div>
-      )}
-      {isClasse &&
-        !isAbandoned &&
-        Option.isNone(raccordement) &&
-        role.aLaPermission('raccordement.gestionnaire.modifier') && (
-          <div className="print:hidden">
-            <Heading3 className="m-0">Raccordement au réseau</Heading3>
+      <div className="print:hidden">
+        <Heading3 className="m-0">Raccordement au réseau</Heading3>
+        {match({
+          raccordement: Option.isSome(raccordement),
+          isClasse,
+          isAbandoned,
+          modifierPermission: role.aLaPermission('raccordement.gestionnaire.modifier'),
+        })
+          .with({ raccordement: true }, ({ modifierPermission }) => (
             <Link href={Routes.Raccordement.détail(formattedIdentifiantProjet)}>
-              Renseigner les données de raccordement
+              {modifierPermission
+                ? 'Consulter ou modifier les documents'
+                : 'Consulter les documents'}
             </Link>
-          </div>
-        )}
+          ))
+          .with(
+            {
+              raccordement: false,
+              isClasse: true,
+              isAbandoned: false,
+              modifierPermission: true,
+            },
+            () => (
+              <Link href={Routes.Raccordement.détail(formattedIdentifiantProjet)}>
+                Renseigner les données de raccordement
+              </Link>
+            ),
+          )
+          .otherwise(() => (
+            <div>Aucun raccordement pour ce projet</div>
+          ))}
+      </div>
       <div>
         <Heading3 className="m-0">Performances</Heading3>
         <p className="m-0">
@@ -238,13 +249,13 @@ const GarantiesFinancièresProjet = ({
         {match({ peutModifier, peutLever })
           .with(
             { peutModifier: true, peutLever: true },
-            () => 'Consulter, modifier ou lever les garanties financières du projet',
+            () => 'Consulter, modifier ou lever les documents',
           )
           .with(
             { peutModifier: true, peutLever: false },
-            () => 'Consulter ou modifier les garanties financières du projet',
+            () => 'Consulter ou modifier les documents',
           )
-          .otherwise(() => 'Consulter les garanties financières du projet')}
+          .otherwise(() => 'Consulter les documents')}
       </Link>
     </div>
   );


### PR DESCRIPTION
# Description

=> https://linear.app/startup-potentiel/issue/POT-1064/informations-sur-le-raccordement-dun-projet

## Type de changement

Veuillez supprimer les options qui ne sont pas pertinentes.

- [x] Harmonisation front

# Comment cela a-t-il été testé?

CRE
<img width="1291" alt="Capture d’écran 2025-02-25 à 13 03 17" src="https://github.com/user-attachments/assets/4b7adfc1-b285-4476-a2a4-146d63e87fbe" />

ADMIN
<img width="1285" alt="Capture d’écran 2025-02-25 à 13 08 19" src="https://github.com/user-attachments/assets/a61d3dd4-7cc5-4cd5-a041-a62e3a57ad83" />



