### PR TITLE
🐛 Corriger le type de `updateOneProjection` pour permettre de modifier un sous-objet

### DIFF
--- a/packages/applications/projectors/src/infrastructure/updateManyProjections.ts
+++ b/packages/applications/projectors/src/infrastructure/updateManyProjections.ts
@@ -2,13 +2,13 @@ import { getWhereClause } from '@potentiel-infrastructure/pg-projections';
 import { Entity, WhereOptions } from '@potentiel-domain/entity';
 import { executeQuery } from '@potentiel-libraries/pg-helpers';
 
-import { getUpdateClause, AtLeastOne } from './updateOneProjection';
+import { getUpdateClause, DeepPartial } from './updateOneProjection';
 
 /** */
 export const updateManyProjections = async <TEntity extends Entity>(
   category: TEntity['type'],
   where: WhereOptions<Omit<TEntity, 'type'>>,
-  update: AtLeastOne<Omit<TEntity, 'type'>>,
+  update: DeepPartial<Omit<TEntity, 'type'>>,
 ): Promise<void> => {
   const [updateQuery, values] = getUpdateProjectionQuery(category, where, update);
   await executeQuery(updateQuery, ...values);
@@ -17,7 +17,7 @@ export const updateManyProjections = async <TEntity extends Entity>(
 const getUpdateProjectionQuery = <TEntity extends Entity>(
   category: TEntity['type'],
   where: WhereOptions<Omit<TEntity, 'type'>>,
-  update: AtLeastOne<Omit<TEntity, 'type'>>,
+  update: DeepPartial<Omit<TEntity, 'type'>>,
 ): [string, Array<unknown>] => {
   const [whereClause, whereValues] = getWhereClause({
     where,

--- a/packages/applications/projectors/src/infrastructure/updateManyProjections.ts
+++ b/packages/applications/projectors/src/infrastructure/updateManyProjections.ts
@@ -2,9 +2,7 @@ import { getWhereClause } from '@potentiel-infrastructure/pg-projections';
 import { Entity, WhereOptions } from '@potentiel-domain/entity';
 import { executeQuery } from '@potentiel-libraries/pg-helpers';
 
-import { getUpdateClause } from './updateOneProjection';
-
-type AtLeastOne<T, U = { [K in keyof T]: Pick<T, K> }> = Partial<T> & U[keyof U];
+import { getUpdateClause, AtLeastOne } from './updateOneProjection';
 
 /** */
 export const updateManyProjections = async <TEntity extends Entity>(

--- a/packages/applications/projectors/src/infrastructure/updateOneProjection.ts
+++ b/packages/applications/projectors/src/infrastructure/updateOneProjection.ts
@@ -6,7 +6,8 @@ import { executeQuery } from '@potentiel-libraries/pg-helpers';
 import { getLogger } from '@potentiel-libraries/monitoring';
 import { getWhereClause } from '@potentiel-infrastructure/pg-projections';
 
-type AtLeastOne<T, U = { [K in keyof T]: Pick<T, K> }> = Partial<T> & U[keyof U];
+type DeepPartial<T> = T extends object ? { [P in keyof T]?: DeepPartial<T[P]> } : T;
+export type AtLeastOne<T, U = { [K in keyof T]: Pick<T, K> }> = DeepPartial<T> & U[keyof U];
 
 /** */
 export const updateOneProjection = async <TProjection extends Entity>(

--- a/packages/applications/projectors/src/infrastructure/updateOneProjection.ts
+++ b/packages/applications/projectors/src/infrastructure/updateOneProjection.ts
@@ -6,13 +6,11 @@ import { executeQuery } from '@potentiel-libraries/pg-helpers';
 import { getLogger } from '@potentiel-libraries/monitoring';
 import { getWhereClause } from '@potentiel-infrastructure/pg-projections';
 
-type DeepPartial<T> = T extends object ? { [P in keyof T]?: DeepPartial<T[P]> } : T;
-export type AtLeastOne<T, U = { [K in keyof T]: Pick<T, K> }> = DeepPartial<T> & U[keyof U];
+export type DeepPartial<T> = T extends object ? { [P in keyof T]?: DeepPartial<T[P]> } : T;
 
-/** */
 export const updateOneProjection = async <TProjection extends Entity>(
   id: `${TProjection['type']}|${string}`,
-  readModel: AtLeastOne<Omit<TProjection, 'type'>>,
+  readModel: DeepPartial<Omit<TProjection, 'type'>>,
 ): Promise<void> => {
   const [updateClause, updateValues] = getUpdateClause(readModel, 1);
   const [whereClause, whereValues] = getWhereClause({ key: { operator: 'equal', value: id } });
@@ -37,7 +35,7 @@ export const updateOneProjection = async <TProjection extends Entity>(
  * startIndex allows to shift the variable ($1,...)
  */
 export const getUpdateClause = <TProjection extends Entity>(
-  readModel: AtLeastOne<Omit<TProjection, 'type'>>,
+  readModel: DeepPartial<Omit<TProjection, 'type'>>,
   startIndex: number,
 ): [string, Array<unknown>] => {
   const flatReadModel = flatten(readModel) as Record<string, unknown>;

--- a/packages/applications/projectors/src/subscribers/lauréat/abandon/abandonAccordé.projector.ts
+++ b/packages/applications/projectors/src/subscribers/lauréat/abandon/abandonAccordé.projector.ts
@@ -1,26 +1,12 @@
 import { Abandon } from '@potentiel-domain/laureat';
-import { getLogger } from '@potentiel-libraries/monitoring';
 
 import { updateOneProjection } from '../../../infrastructure';
-
-import { getInfosAbandon } from './utils/getInfosAbandon';
 
 export const abandonAccordéProjector = async ({
   payload: { identifiantProjet, accordéLe, accordéPar, réponseSignée },
 }: Abandon.AbandonAccordéEvent) => {
-  const abandonToUpsert = await getInfosAbandon(identifiantProjet);
-
-  if (!abandonToUpsert) {
-    getLogger().error(`Abandon non trouvé`, {
-      identifiantProjet,
-      fonction: 'abandonAccordéProjector',
-    });
-    return;
-  }
-
   await updateOneProjection<Abandon.AbandonEntity>(`abandon|${identifiantProjet}`, {
     demande: {
-      ...abandonToUpsert.demande,
       accord: {
         accordéLe: accordéLe,
         accordéPar: accordéPar,

--- a/packages/applications/projectors/src/subscribers/lauréat/abandon/abandonConfirmé.projector.ts
+++ b/packages/applications/projectors/src/subscribers/lauréat/abandon/abandonConfirmé.projector.ts
@@ -1,28 +1,13 @@
 import { Abandon } from '@potentiel-domain/laureat';
-import { getLogger } from '@potentiel-libraries/monitoring';
 
 import { updateOneProjection } from '../../../infrastructure';
-
-import { getInfosAbandon } from './utils/getInfosAbandon';
 
 export const abandonConfirméProjector = async ({
   payload: { identifiantProjet, confirméLe, confirméPar },
 }: Abandon.AbandonConfirméEvent) => {
-  const abandonToUpsert = await getInfosAbandon(identifiantProjet);
-
-  if (!abandonToUpsert) {
-    getLogger().error(`Abandon non trouvé`, {
-      identifiantProjet,
-      fonction: 'abandonConfirméProjector',
-    });
-    return;
-  }
-
   await updateOneProjection<Abandon.AbandonEntity>(`abandon|${identifiantProjet}`, {
     demande: {
-      ...abandonToUpsert.demande,
       confirmation: {
-        ...abandonToUpsert.demande.confirmation!,
         confirméLe: confirméLe,
         confirméPar: confirméPar,
       },

--- a/packages/applications/projectors/src/subscribers/lauréat/abandon/abandonPasséEnInstruction.projector.ts
+++ b/packages/applications/projectors/src/subscribers/lauréat/abandon/abandonPasséEnInstruction.projector.ts
@@ -1,26 +1,12 @@
 import { Abandon } from '@potentiel-domain/laureat';
-import { getLogger } from '@potentiel-libraries/monitoring';
 
 import { updateOneProjection } from '../../../infrastructure';
-
-import { getInfosAbandon } from './utils/getInfosAbandon';
 
 export const abandonPasséEnInstructionProjector = async ({
   payload: { identifiantProjet, passéEnInstructionLe, passéEnInstructionPar },
 }: Abandon.AbandonPasséEnInstructionEvent) => {
-  const abandonToUpsert = await getInfosAbandon(identifiantProjet);
-
-  if (!abandonToUpsert) {
-    getLogger().error(`Abandon non trouvé`, {
-      identifiantProjet,
-      fonction: 'abandonPasséEnInstructionProjector',
-    });
-    return;
-  }
-
   await updateOneProjection<Abandon.AbandonEntity>(`abandon|${identifiantProjet}`, {
     demande: {
-      ...abandonToUpsert.demande,
       instruction: {
         passéEnInstructionLe: passéEnInstructionLe,
         passéEnInstructionPar: passéEnInstructionPar,

--- a/packages/applications/projectors/src/subscribers/lauréat/abandon/abandonRejeté.projector.ts
+++ b/packages/applications/projectors/src/subscribers/lauréat/abandon/abandonRejeté.projector.ts
@@ -1,26 +1,12 @@
 import { Abandon } from '@potentiel-domain/laureat';
-import { getLogger } from '@potentiel-libraries/monitoring';
 
 import { updateOneProjection } from '../../../infrastructure';
-
-import { getInfosAbandon } from './utils/getInfosAbandon';
 
 export const abandonRejetéProjector = async ({
   payload: { identifiantProjet, rejetéLe, rejetéPar, réponseSignée },
 }: Abandon.AbandonRejetéEvent) => {
-  const abandonToUpsert = await getInfosAbandon(identifiantProjet);
-
-  if (!abandonToUpsert) {
-    getLogger().error(`Abandon non trouvé`, {
-      identifiantProjet,
-      fonction: 'abandonRejetéProjector',
-    });
-    return;
-  }
-
   await updateOneProjection<Abandon.AbandonEntity>(`abandon|${identifiantProjet}`, {
     demande: {
-      ...abandonToUpsert.demande,
       rejet: {
         rejetéLe: rejetéLe,
         rejetéPar: rejetéPar,

--- a/packages/applications/projectors/src/subscribers/lauréat/abandon/confirmationAbandonDemandée.projector.ts
+++ b/packages/applications/projectors/src/subscribers/lauréat/abandon/confirmationAbandonDemandée.projector.ts
@@ -1,26 +1,12 @@
 import { Abandon } from '@potentiel-domain/laureat';
-import { getLogger } from '@potentiel-libraries/monitoring';
 
 import { updateOneProjection } from '../../../infrastructure';
-
-import { getInfosAbandon } from './utils/getInfosAbandon';
 
 export const confirmationAbandonDemandéeProjector = async ({
   payload: { identifiantProjet, confirmationDemandéeLe, confirmationDemandéePar, réponseSignée },
 }: Abandon.ConfirmationAbandonDemandéeEvent) => {
-  const abandonToUpsert = await getInfosAbandon(identifiantProjet);
-
-  if (!abandonToUpsert) {
-    getLogger().error(`Abandon non trouvé`, {
-      identifiantProjet,
-      fonction: 'confirmationAbandonDemandéeProjector',
-    });
-    return;
-  }
-
   await updateOneProjection<Abandon.AbandonEntity>(`abandon|${identifiantProjet}`, {
     demande: {
-      ...abandonToUpsert.demande,
       confirmation: {
         demandéeLe: confirmationDemandéeLe,
         demandéePar: confirmationDemandéePar,


### PR DESCRIPTION
Avant ce changement, le Partial n'était appliqué qu'aux propriétés à la racine: cette PR permet de modifier un sous objet.

Malheureusement je n'ai pas réussi à faire fonctionner `DeepPartial` avec `AtLeastOne` mais il me semble que AtLeastOne est moins important, car il est peu probable d'oublier de spécifier un champs à mettre à jour (ou si c'est le cas, les tests le montreront), alors que l'absence de DeepPartial cause un problème d'utilisation actuellement.


