### PR TITLE
✨ Reprendre l'instruction pour un recours ou un abandon ETQ Admin

### DIFF
--- a/packages/applications/legacy/src/controllers/project/getProjectPage/_utils/getAbandon.ts
+++ b/packages/applications/legacy/src/controllers/project/getProjectPage/_utils/getAbandon.ts
@@ -24,17 +24,11 @@ export const getAbandonStatut: GetAbandonStatut = async (
 
     const { statut } = abandon;
 
-    switch (statut.statut) {
-      case 'demandé':
-      case 'confirmé':
-      case 'accordé':
-      case 'rejeté':
-        return { statut: statut.statut };
-      case 'confirmation-demandée':
-        return { statut: 'à confirmer' };
-      default:
-        return undefined;
+    if (statut.estEnCours() || statut.estRejeté() || statut.estAccordé()) {
+      return { statut: statut.statut };
     }
+
+    return undefined;
   } catch (error) {
     getLogger('Legacy|getProjectPage|getAbandonStatut').error(`Impossible de consulter l'abandon`, {
       identifiantProjet: identifiantProjet.formatter(),

--- a/packages/applications/legacy/src/controllers/project/getProjectPage/index.ts
+++ b/packages/applications/legacy/src/controllers/project/getProjectPage/index.ts
@@ -139,6 +139,7 @@ v1Router.get(
       }
 
       const abandon = await getAbandonStatut(identifiantProjetValueType);
+
       const raccordement = await getRaccordement({
         role,
         identifiantProjet: identifiantProjetValueType,

--- a/packages/applications/legacy/src/views/pages/projectDetailsPage/ProjectDetails.tsx
+++ b/packages/applications/legacy/src/views/pages/projectDetailsPage/ProjectDetails.tsx
@@ -14,6 +14,7 @@ import {
   Heading2,
   InfoBox,
 } from '../../components';
+import { AbandonInfoBox } from './sections/AbandonInfoBox';
 import { afficherDate, hydrateOnClient } from '../../helpers';
 import {
   EtapesProjet,
@@ -30,7 +31,7 @@ import { ProjectHeader } from './components';
 import { Routes } from '@potentiel-applications/routes';
 import { formatProjectDataToIdentifiantProjetValueType } from '../../../helpers/dataToValueTypes';
 import { Role } from '@potentiel-domain/utilisateur';
-import { Raccordement } from '@potentiel-domain/laureat';
+import { Abandon, Raccordement } from '@potentiel-domain/laureat';
 import { Option } from '@potentiel-libraries/monads';
 
 export type AlerteRaccordement =
@@ -43,9 +44,7 @@ type ProjectDetailsProps = {
   raccordement: Option.Type<Raccordement.ConsulterRaccordementReadModel>;
   projectEventList?: ProjectEventListDTO;
   alertesRaccordement: AlerteRaccordement[];
-  abandon?: {
-    statut: string;
-  };
+  abandon?: { statut: string };
   demandeRecours: ProjectDataForProjectPage['demandeRecours'];
   garantiesFinancières?: GarantiesFinancièresProjetProps['garantiesFinancières'];
   représentantLégal?: ContactProps['représentantLégal'];
@@ -78,7 +77,10 @@ export const ProjectDetails = ({
     numeroCRE: project.numeroCRE,
   }).formatter();
 
-  const abandonEnCours = !!abandon && abandon.statut !== 'rejeté';
+  const abandonEnCoursOuAccordé =
+    !!abandon &&
+    (Abandon.StatutAbandon.convertirEnValueType(abandon.statut).estEnCours() ||
+      Abandon.StatutAbandon.convertirEnValueType(abandon.statut).estAccordé());
 
   return (
     <LegacyPageTemplate user={request.user} currentPage="list-projects">
@@ -90,7 +92,7 @@ export const ProjectDetails = ({
       <ProjectHeader
         user={user}
         project={project}
-        abandonEnCours={abandonEnCours}
+        abandonEnCoursOuAccordé={abandonEnCoursOuAccordé}
         modificationsNonPermisesParLeCDCActuel={modificationsNonPermisesParLeCDCActuel}
         hasAttestationConformité={hasAttestationConformité}
         demandeRecours={demandeRecours}
@@ -105,11 +107,7 @@ export const ProjectDetails = ({
       </div>
       <div className="flex flex-col gap-3 mt-5">
         <div className="print:hidden flex flex-col gap-3">
-          {abandon && (
-            <AlertBox title={`Abandon ${abandon.statut}`}>
-              <a href={Routes.Abandon.détail(identifiantProjet)}>Voir les détails de l'abandon</a>
-            </AlertBox>
-          )}
+          {abandon && <AbandonInfoBox abandon={abandon} identifiantProjet={identifiantProjet} />}
           {user.role === Role.porteur.nom && modificationsNonPermisesParLeCDCActuel && (
             <InfoBox>
               Votre cahier des charges actuel ne vous permet pas d'accéder aux fonctionnalités

--- a/packages/applications/legacy/src/views/pages/projectDetailsPage/ProjectDetails.tsx
+++ b/packages/applications/legacy/src/views/pages/projectDetailsPage/ProjectDetails.tsx
@@ -14,7 +14,6 @@ import {
   Heading2,
   InfoBox,
 } from '../../components';
-import { AbandonInfoBox } from './sections/AbandonInfoBox';
 import { afficherDate, hydrateOnClient } from '../../helpers';
 import {
   EtapesProjet,
@@ -31,8 +30,9 @@ import { ProjectHeader } from './components';
 import { Routes } from '@potentiel-applications/routes';
 import { formatProjectDataToIdentifiantProjetValueType } from '../../../helpers/dataToValueTypes';
 import { Role } from '@potentiel-domain/utilisateur';
-import { Abandon, Raccordement } from '@potentiel-domain/laureat';
+import { Raccordement } from '@potentiel-domain/laureat';
 import { Option } from '@potentiel-libraries/monads';
+import { AbandonInfoBox } from './sections/AbandonInfoBox';
 
 export type AlerteRaccordement =
   | 'référenceDossierManquantePourDélaiCDC2022'
@@ -77,10 +77,7 @@ export const ProjectDetails = ({
     numeroCRE: project.numeroCRE,
   }).formatter();
 
-  const abandonEnCoursOuAccordé =
-    !!abandon &&
-    (Abandon.StatutAbandon.convertirEnValueType(abandon.statut).estEnCours() ||
-      Abandon.StatutAbandon.convertirEnValueType(abandon.statut).estAccordé());
+  const abandonEnCoursOuAccordé = !!abandon && abandon.statut !== 'rejeté';
 
   return (
     <LegacyPageTemplate user={request.user} currentPage="list-projects">

--- a/packages/applications/legacy/src/views/pages/projectDetailsPage/components/ProjectActions.tsx
+++ b/packages/applications/legacy/src/views/pages/projectDetailsPage/components/ProjectActions.tsx
@@ -33,7 +33,7 @@ const EnregistrerUneModification = ({ projectId }: EnregistrerUneModificationPro
 
 type PorteurProjetActionsProps = {
   project: ProjectDataForProjectPage;
-  abandonEnCours: boolean;
+  abandonEnCoursOuAccordé: boolean;
   demandeRecours: ProjectDataForProjectPage['demandeRecours'];
   modificationsNonPermisesParLeCDCActuel: boolean;
   hasAttestationConformité: boolean;
@@ -46,7 +46,7 @@ type PorteurProjetActionsProps = {
 
 const PorteurProjetActions = ({
   project,
-  abandonEnCours,
+  abandonEnCoursOuAccordé,
   demandeRecours,
   modificationsNonPermisesParLeCDCActuel,
   hasAttestationConformité,
@@ -59,7 +59,7 @@ const PorteurProjetActions = ({
     familleId: project.familleId,
     numeroCRE: project.numeroCRE,
   }).formatter();
-  const peutDemanderAbandon = !abandonEnCours && !hasAttestationConformité;
+  const peutDemanderAbandon = !abandonEnCoursOuAccordé && !hasAttestationConformité;
 
   return (
     <div className="flex flex-col gap-3">
@@ -220,7 +220,7 @@ const DrealActions = ({ project }: DrealActionsProps) => {
 type ProjectActionsProps = {
   project: ProjectDataForProjectPage;
   user: User;
-  abandonEnCours: boolean;
+  abandonEnCoursOuAccordé: boolean;
   demandeRecours: ProjectDataForProjectPage['demandeRecours'];
   modificationsNonPermisesParLeCDCActuel: boolean;
   hasAttestationConformité: boolean;
@@ -235,7 +235,7 @@ type ProjectActionsProps = {
 export const ProjectActions = ({
   project,
   user,
-  abandonEnCours,
+  abandonEnCoursOuAccordé,
   demandeRecours,
   modificationsNonPermisesParLeCDCActuel,
   hasAttestationConformité,
@@ -247,7 +247,7 @@ export const ProjectActions = ({
     {userIs(['porteur-projet'])(user) && (
       <PorteurProjetActions
         project={project}
-        abandonEnCours={abandonEnCours}
+        abandonEnCoursOuAccordé={abandonEnCoursOuAccordé}
         demandeRecours={demandeRecours}
         modificationsNonPermisesParLeCDCActuel={modificationsNonPermisesParLeCDCActuel}
         hasAttestationConformité={hasAttestationConformité}

--- a/packages/applications/legacy/src/views/pages/projectDetailsPage/components/ProjectHeader.tsx
+++ b/packages/applications/legacy/src/views/pages/projectDetailsPage/components/ProjectHeader.tsx
@@ -8,7 +8,7 @@ import { ProjectHeaderBadge } from './ProjectHeaderBadge';
 type ProjectHeaderProps = {
   project: ProjectDataForProjectPage;
   user: User;
-  abandonEnCours: boolean;
+  abandonEnCoursOuAccordé: boolean;
   demandeRecours: ProjectDataForProjectPage['demandeRecours'];
   modificationsNonPermisesParLeCDCActuel: boolean;
   hasAttestationConformité: boolean;
@@ -22,7 +22,7 @@ type ProjectHeaderProps = {
 export const ProjectHeader = ({
   project,
   user,
-  abandonEnCours,
+  abandonEnCoursOuAccordé,
   demandeRecours,
   modificationsNonPermisesParLeCDCActuel,
   hasAttestationConformité,
@@ -55,7 +55,7 @@ export const ProjectHeader = ({
       <ProjectActions
         project={project}
         user={user}
-        abandonEnCours={abandonEnCours}
+        abandonEnCoursOuAccordé={abandonEnCoursOuAccordé}
         demandeRecours={demandeRecours}
         modificationsNonPermisesParLeCDCActuel={modificationsNonPermisesParLeCDCActuel}
         hasAttestationConformité={hasAttestationConformité}

--- a/packages/applications/legacy/src/views/pages/projectDetailsPage/sections/AbandonInfoBox.tsx
+++ b/packages/applications/legacy/src/views/pages/projectDetailsPage/sections/AbandonInfoBox.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Abandon } from '@potentiel-domain/laureat';
+import { InfoBox } from '../../../components';
+import { Routes } from '@potentiel-applications/routes';
+
+// c'est un duplicata du mapping côté SSR, à supprimer après migration de la page projet
+const convertStatutAbandonToStatutLabel: Record<Abandon.StatutAbandon.RawType, string> = {
+  demandé: 'demandé',
+  confirmé: 'confirmé',
+  accordé: 'accordé',
+  rejeté: 'rejeté',
+  annulé: 'annulé',
+  'confirmation-demandée': 'à confirmer',
+  'en-instruction': 'en instruction',
+  inconnu: 'inconnu',
+};
+
+type AbandonInfoBoxProps = {
+  abandon: { statut: string };
+  identifiantProjet: string;
+};
+
+export const AbandonInfoBox = ({ abandon, identifiantProjet }: AbandonInfoBoxProps) => {
+  const { statut } = Abandon.StatutAbandon.convertirEnValueType(abandon.statut);
+  return (
+    <InfoBox title={`Abandon ${convertStatutAbandonToStatutLabel[statut]}`}>
+      <a href={Routes.Abandon.détail(identifiantProjet)}>Voir les détails de l'abandon</a>
+    </InfoBox>
+  );
+};

--- a/packages/applications/legacy/src/views/pages/projectDetailsPage/sections/AbandonInfoBox.tsx
+++ b/packages/applications/legacy/src/views/pages/projectDetailsPage/sections/AbandonInfoBox.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
-import { Abandon } from '@potentiel-domain/laureat';
 import { InfoBox } from '../../../components';
 import { Routes } from '@potentiel-applications/routes';
 
 // c'est un duplicata du mapping côté SSR, à supprimer après migration de la page projet
-const convertStatutAbandonToStatutLabel: Record<Abandon.StatutAbandon.RawType, string> = {
+const convertStatutAbandonToStatutLabel: Record<string, string> = {
   demandé: 'demandé',
   confirmé: 'confirmé',
   accordé: 'accordé',
@@ -21,9 +20,8 @@ type AbandonInfoBoxProps = {
 };
 
 export const AbandonInfoBox = ({ abandon, identifiantProjet }: AbandonInfoBoxProps) => {
-  const { statut } = Abandon.StatutAbandon.convertirEnValueType(abandon.statut);
   return (
-    <InfoBox title={`Abandon ${convertStatutAbandonToStatutLabel[statut]}`}>
+    <InfoBox title={`Abandon ${convertStatutAbandonToStatutLabel[abandon.statut]}`}>
       <a href={Routes.Abandon.détail(identifiantProjet)}>Voir les détails de l'abandon</a>
     </InfoBox>
   );

--- a/packages/applications/legacy/src/views/pages/projectDetailsPage/sections/Contact.tsx
+++ b/packages/applications/legacy/src/views/pages/projectDetailsPage/sections/Contact.tsx
@@ -96,13 +96,14 @@ const ListComptesAvecAcces = ({ user, project }: ListComptesAvecAccesProps) => (
     <Heading3 className="mt-4 mb-1">Comptes ayant accès à ce projet</Heading3>
     <ul className="my-1">
       {project.users.map(({ id, fullName, email }) => (
-        <>
-          <li key={'project_user_' + id}>
+        <div key={'project_user_' + id}>
+          <li>
             {fullName && `${fullName} - `}
             {email}
           </li>
           {id !== user.id && (
             <Link
+              key={'project_user_' + id}
               href={ROUTES.REVOKE_USER_RIGHTS_TO_PROJECT_ACTION({
                 projectId: project.id,
                 userId: id,
@@ -116,7 +117,7 @@ const ListComptesAvecAcces = ({ user, project }: ListComptesAvecAccesProps) => (
               retirer les droits de {fullName || email}
             </Link>
           )}
-        </>
+        </div>
       ))}
       {!project.users.length && <li>Aucun utilisateur n'a accès à ce projet pour le moment.</li>}
     </ul>

--- a/packages/applications/ssr/src/app/elimine/[identifiant]/recours/page.tsx
+++ b/packages/applications/ssr/src/app/elimine/[identifiant]/recours/page.tsx
@@ -79,7 +79,7 @@ type MapToActionsProps = {
   statut: Recours.StatutRecours.RawType;
 };
 
-const mapToActions = (props: MapToActionsProps): AvailableRecoursAction[] =>
+const mapToActions = (props: MapToActionsProps) =>
   match(props)
     .returnType<ReadonlyArray<AvailableRecoursAction>>()
     .with(

--- a/packages/applications/ssr/src/app/elimine/[identifiant]/recours/page.tsx
+++ b/packages/applications/ssr/src/app/elimine/[identifiant]/recours/page.tsx
@@ -79,7 +79,7 @@ type MapToActionsProps = {
   statut: Recours.StatutRecours.RawType;
 };
 
-const mapToActions = (props: MapToActionsProps) =>
+const mapToActions = (props: MapToActionsProps): AvailableRecoursAction[] =>
   match(props)
     .returnType<ReadonlyArray<AvailableRecoursAction>>()
     .with(
@@ -90,14 +90,6 @@ const mapToActions = (props: MapToActionsProps) =>
       {
         role: 'dgec-validateur',
         statut: 'demandé',
-      },
-      {
-        role: 'admin',
-        statut: 'en-instruction',
-      },
-      {
-        role: 'dgec-validateur',
-        statut: 'en-instruction',
       },
       () => ['accorder', 'rejeter', 'passer-en-instruction'],
     )

--- a/packages/applications/ssr/src/app/elimine/[identifiant]/recours/page.tsx
+++ b/packages/applications/ssr/src/app/elimine/[identifiant]/recours/page.tsx
@@ -91,6 +91,14 @@ const mapToActions = (props: MapToActionsProps) =>
         role: 'dgec-validateur',
         statut: 'demandé',
       },
+      {
+        role: 'admin',
+        statut: 'en-instruction',
+      },
+      {
+        role: 'dgec-validateur',
+        statut: 'en-instruction',
+      },
       () => ['accorder', 'rejeter', 'passer-en-instruction'],
     )
     .with(
@@ -102,7 +110,7 @@ const mapToActions = (props: MapToActionsProps) =>
         role: 'dgec-validateur',
         statut: 'en-instruction',
       },
-      () => ['accorder', 'rejeter'],
+      () => ['accorder', 'rejeter', 'reprendre-instruction'],
     )
     .with(
       {

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/abandon/page.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/abandon/page.tsx
@@ -144,11 +144,11 @@ const mapToActions = ({
       if (statut.estEnCours() && !recandidature) {
         actions.push('accorder-sans-recandidature');
         actions.push('rejeter');
-        actions.push('passer-en-instruction');
-      }
-      if (statut.estEnInstruction() && !recandidature) {
-        actions.push('accorder-sans-recandidature');
-        actions.push('rejeter');
+        if (statut.estEnInstruction()) {
+          actions.push('reprendre-instruction');
+        } else {
+          actions.push('passer-en-instruction');
+        }
       }
       break;
 
@@ -159,8 +159,11 @@ const mapToActions = ({
       if (statut.estEnCours()) {
         actions.push(recandidature ? 'accorder-avec-recandidature' : 'accorder-sans-recandidature');
         actions.push('rejeter');
-        // TODO: on pourra reprendre l'instruction donc ça fait sens
-        actions.push('passer-en-instruction');
+        if (statut.estEnInstruction()) {
+          actions.push('reprendre-instruction');
+        } else {
+          actions.push('passer-en-instruction');
+        }
       }
       break;
 

--- a/packages/applications/ssr/src/components/pages/abandon/détails/DétailsAbandon.page.tsx
+++ b/packages/applications/ssr/src/components/pages/abandon/détails/DétailsAbandon.page.tsx
@@ -36,6 +36,7 @@ type AvailableActions = Array<
   | 'rejeter'
   | 'transmettre-preuve-recandidature'
   | 'passer-en-instruction'
+  | 'reprendre-instruction'
 >;
 
 type AvailableInformation = 'demande-de-mainlevée' | 'demande-abandon-pour-recandidature';
@@ -145,8 +146,11 @@ const mapToActionComponents = ({
       {actions.includes('rejeter') && <RejeterAbandon identifiantProjet={identifiantProjet} />}
       {actions.includes('confirmer') && <ConfirmerAbandon identifiantProjet={identifiantProjet} />}
       {actions.includes('annuler') && <AnnulerAbandon identifiantProjet={identifiantProjet} />}
-      {actions.includes('passer-en-instruction') && (
-        <PasserAbandonEnInstruction identifiantProjet={identifiantProjet} />
+      {(actions.includes('passer-en-instruction') || actions.includes('reprendre-instruction')) && (
+        <PasserAbandonEnInstruction
+          identifiantProjet={identifiantProjet}
+          estUneReprise={actions.includes('reprendre-instruction')}
+        />
       )}
       {actions.includes('transmettre-preuve-recandidature') && (
         <TransmettrePreuveRecandidature

--- a/packages/applications/ssr/src/components/pages/abandon/détails/passerEnInstruction/PasserAbandonEnInstruction.form.tsx
+++ b/packages/applications/ssr/src/components/pages/abandon/détails/passerEnInstruction/PasserAbandonEnInstruction.form.tsx
@@ -9,12 +9,17 @@ import { passerAbandonEnInstructionAction } from './passerAbandonEnInstruction.a
 
 type PasserAbandonEnInstructionFormProps = {
   identifiantProjet: string;
+  estUneReprise: boolean;
 };
 
 export const PasserAbandonEnInstruction = ({
   identifiantProjet,
+  estUneReprise,
 }: PasserAbandonEnInstructionFormProps) => {
   const [isOpen, setIsOpen] = useState(false);
+  const label = estUneReprise
+    ? "Êtes-vous sûr de vouloir reprendre l'instruction de l'abandon ?"
+    : 'Êtes-vous sûr de vouloir passer cet abandon en instruction ?';
 
   return (
     <>
@@ -39,7 +44,7 @@ export const PasserAbandonEnInstruction = ({
           omitMandatoryFieldsLegend: true,
           children: (
             <>
-              <p className="mt-3">Êtes-vous sûr de vouloir passer cet abandon en instruction ?</p>
+              <p className="mt-3">{label}</p>
               <input type={'hidden'} value={identifiantProjet} name="identifiantProjet" />
             </>
           ),

--- a/packages/applications/ssr/src/components/pages/abandon/détails/passerEnInstruction/PasserAbandonEnInstruction.form.tsx
+++ b/packages/applications/ssr/src/components/pages/abandon/détails/passerEnInstruction/PasserAbandonEnInstruction.form.tsx
@@ -20,6 +20,7 @@ export const PasserAbandonEnInstruction = ({
   const label = estUneReprise
     ? "Êtes-vous sûr de vouloir reprendre l'instruction de l'abandon ?"
     : 'Êtes-vous sûr de vouloir passer cet abandon en instruction ?';
+  const acceptButtonLabel = estUneReprise ? "Reprendre l'instruction" : 'Instruire';
 
   return (
     <>
@@ -28,7 +29,7 @@ export const PasserAbandonEnInstruction = ({
         onClick={() => setIsOpen(true)}
         className="block w-1/2 text-center"
       >
-        Instruire
+        {acceptButtonLabel}
       </Button>
 
       <ModalWithForm

--- a/packages/applications/ssr/src/components/pages/recours/détails/DétailsRecours.page.tsx
+++ b/packages/applications/ssr/src/components/pages/recours/détails/DétailsRecours.page.tsx
@@ -18,7 +18,12 @@ import { RejeterRecours } from './rejeter/RejeterRecours.form';
 import { AnnulerRecours } from './annuler/AnnulerRecours.form';
 import { PasserRecoursEnInstruction } from './passerEnInstruction/PasserRecoursEnInstruction.form';
 
-export type AvailableRecoursAction = 'accorder' | 'rejeter' | 'annuler' | 'passer-en-instruction';
+export type AvailableRecoursAction =
+  | 'accorder'
+  | 'rejeter'
+  | 'annuler'
+  | 'passer-en-instruction'
+  | 'reprendre-instruction';
 
 export type DétailsRecoursPageProps = {
   identifiantProjet: string;
@@ -94,8 +99,11 @@ const mapToActionComponents = ({ actions, identifiantProjet }: MapToActionsCompo
       {actions.includes('accorder') && <AccorderRecours identifiantProjet={identifiantProjet} />}
       {actions.includes('rejeter') && <RejeterRecours identifiantProjet={identifiantProjet} />}
       {actions.includes('annuler') && <AnnulerRecours identifiantProjet={identifiantProjet} />}
-      {actions.includes('passer-en-instruction') && (
-        <PasserRecoursEnInstruction identifiantProjet={identifiantProjet} />
+      {(actions.includes('passer-en-instruction') || actions.includes('reprendre-instruction')) && (
+        <PasserRecoursEnInstruction
+          identifiantProjet={identifiantProjet}
+          estUneReprise={actions.includes('reprendre-instruction')}
+        />
       )}
     </div>
   ) : null;

--- a/packages/applications/ssr/src/components/pages/recours/détails/passerEnInstruction/PasserRecoursEnInstruction.form.tsx
+++ b/packages/applications/ssr/src/components/pages/recours/détails/passerEnInstruction/PasserRecoursEnInstruction.form.tsx
@@ -20,6 +20,7 @@ export const PasserRecoursEnInstruction = ({
   const label = estUneReprise
     ? "Êtes-vous sûr de vouloir reprendre l'instruction du recours ?"
     : 'Êtes-vous sûr de vouloir passer ce recours en instruction ?';
+  const acceptButtonLabel = estUneReprise ? "Reprendre l'instruction" : 'Instruire';
 
   return (
     <>
@@ -28,7 +29,7 @@ export const PasserRecoursEnInstruction = ({
         onClick={() => setIsOpen(true)}
         className="block w-1/2 text-center"
       >
-        Instruire
+        {acceptButtonLabel}
       </Button>
 
       <ModalWithForm

--- a/packages/applications/ssr/src/components/pages/recours/détails/passerEnInstruction/PasserRecoursEnInstruction.form.tsx
+++ b/packages/applications/ssr/src/components/pages/recours/détails/passerEnInstruction/PasserRecoursEnInstruction.form.tsx
@@ -9,12 +9,17 @@ import { passerRecoursEnInstructionAction } from './passerRecoursEnInstruction.a
 
 type PasserRecoursEnInstructionFormProps = {
   identifiantProjet: string;
+  estUneReprise: boolean;
 };
 
 export const PasserRecoursEnInstruction = ({
   identifiantProjet,
+  estUneReprise,
 }: PasserRecoursEnInstructionFormProps) => {
   const [isOpen, setIsOpen] = useState(false);
+  const label = estUneReprise
+    ? "Êtes-vous sûr de vouloir reprendre l'instruction du recours ?"
+    : 'Êtes-vous sûr de vouloir passer ce recours en instruction ?';
 
   return (
     <>
@@ -39,7 +44,7 @@ export const PasserRecoursEnInstruction = ({
           omitMandatoryFieldsLegend: true,
           children: (
             <>
-              <p className="mt-3">Êtes-vous sûr de vouloir passer ce recours en instruction ?</p>
+              <p className="mt-3">{label}</p>
               <input type={'hidden'} value={identifiantProjet} name="identifiantProjet" />
             </>
           ),

--- a/packages/domain/lauréat/src/abandon/abandon.aggregate.ts
+++ b/packages/domain/lauréat/src/abandon/abandon.aggregate.ts
@@ -4,7 +4,7 @@ import {
   GetDefaultAggregateState,
   LoadAggregate,
 } from '@potentiel-domain/core';
-import { DateTime, IdentifiantProjet } from '@potentiel-domain/common';
+import { DateTime, Email, IdentifiantProjet } from '@potentiel-domain/common';
 import { IdentifiantUtilisateur } from '@potentiel-domain/utilisateur';
 import { DocumentProjet } from '@potentiel-domain/document';
 
@@ -72,6 +72,10 @@ export type AbandonAggregate = Aggregate<AbandonEvent> & {
     preuveRecandidatureTransmisePar?: IdentifiantUtilisateur.ValueType;
     demandéLe: DateTime.ValueType;
     demandéPar: IdentifiantUtilisateur.ValueType;
+    instruction?: {
+      démarréLe: DateTime.ValueType;
+      par: Email.ValueType;
+    };
     confirmation?: {
       réponseSignée: {
         format: string;
@@ -116,6 +120,7 @@ export const getDefaultAbandonAggregate: GetDefaultAggregateState<
     demandéPar: IdentifiantUtilisateur.unknownUser,
     recandidature: false,
     demandéLe: DateTime.convertirEnValueType(new Date()),
+    passéEnInstructionPar: IdentifiantUtilisateur.unknownUser,
   },
   accorder,
   annuler,
@@ -150,7 +155,7 @@ function apply(this: AbandonAggregate, event: AbandonEvent) {
       applyAbandonRejeté.bind(this)(event);
       break;
     case 'AbandonPasséEnInstruction-V1':
-      applyAbandonPasséEnInstruction.bind(this)();
+      applyAbandonPasséEnInstruction.bind(this)(event);
       break;
     case 'ConfirmationAbandonDemandée-V1':
       applyConfirmationAbandonDemandée.bind(this)(event);

--- a/packages/domain/lauréat/src/abandon/abandon.aggregate.ts
+++ b/packages/domain/lauréat/src/abandon/abandon.aggregate.ts
@@ -74,7 +74,7 @@ export type AbandonAggregate = Aggregate<AbandonEvent> & {
     demandéPar: IdentifiantUtilisateur.ValueType;
     instruction?: {
       démarréLe: DateTime.ValueType;
-      par: Email.ValueType;
+      instruitPar: Email.ValueType;
     };
     confirmation?: {
       réponseSignée: {

--- a/packages/domain/lauréat/src/abandon/instruire/passerAbandonEnInstruction.behavior.ts
+++ b/packages/domain/lauréat/src/abandon/instruire/passerAbandonEnInstruction.behavior.ts
@@ -25,7 +25,7 @@ export async function passerEnInstruction(
 ) {
   this.statut.vérifierQueLeChangementDeStatutEstPossibleEn(StatutAbandon.enInstruction);
 
-  if (this.demande.instruction?.par.estÉgaleÀ(identifiantUtilisateur)) {
+  if (this.demande.instruction?.instruitPar.estÉgaleÀ(identifiantUtilisateur)) {
     throw new AbandonDéjàEnInstructionAvecLeMêmeAdministrateurError();
   }
 
@@ -49,7 +49,7 @@ export function applyAbandonPasséEnInstruction(
   this.demande.instruction = {
     démarréLe:
       this.demande.instruction?.démarréLe ?? DateTime.convertirEnValueType(passéEnInstructionLe),
-    par: Email.convertirEnValueType(passéEnInstructionPar),
+    instruitPar: Email.convertirEnValueType(passéEnInstructionPar),
   };
 }
 

--- a/packages/domain/lauréat/src/abandon/instruire/passerAbandonEnInstruction.behavior.ts
+++ b/packages/domain/lauréat/src/abandon/instruire/passerAbandonEnInstruction.behavior.ts
@@ -1,5 +1,5 @@
 import { DateTime, Email, IdentifiantProjet } from '@potentiel-domain/common';
-import { DomainEvent } from '@potentiel-domain/core';
+import { DomainEvent, InvalidOperationError } from '@potentiel-domain/core';
 
 import { AbandonAggregate } from '../abandon.aggregate';
 import * as StatutAbandon from '../statutAbandon.valueType';
@@ -25,6 +25,10 @@ export async function passerEnInstruction(
 ) {
   this.statut.vérifierQueLeChangementDeStatutEstPossibleEn(StatutAbandon.enInstruction);
 
+  if (this.demande.instruction?.par.estÉgaleÀ(identifiantUtilisateur)) {
+    throw new AbandonDéjàEnInstructionAvecLeMêmeAdministrateurError();
+  }
+
   const event: AbandonPasséEnInstructionEvent = {
     type: 'AbandonPasséEnInstruction-V1',
     payload: {
@@ -37,6 +41,20 @@ export async function passerEnInstruction(
   await this.publish(event);
 }
 
-export function applyAbandonPasséEnInstruction(this: AbandonAggregate) {
+export function applyAbandonPasséEnInstruction(
+  this: AbandonAggregate,
+  { payload: { passéEnInstructionLe, passéEnInstructionPar } }: AbandonPasséEnInstructionEvent,
+) {
   this.statut = StatutAbandon.enInstruction;
+  this.demande.instruction = {
+    démarréLe:
+      this.demande.instruction?.démarréLe ?? DateTime.convertirEnValueType(passéEnInstructionLe),
+    par: Email.convertirEnValueType(passéEnInstructionPar),
+  };
+}
+
+class AbandonDéjàEnInstructionAvecLeMêmeAdministrateurError extends InvalidOperationError {
+  constructor() {
+    super("L'abandon est déjà en instruction avec le même administrateur");
+  }
 }

--- a/packages/domain/éliminé/src/recours/instruire/passerRecoursEnInstruction.behavior.ts
+++ b/packages/domain/éliminé/src/recours/instruire/passerRecoursEnInstruction.behavior.ts
@@ -1,5 +1,5 @@
 import { DateTime, Email, IdentifiantProjet } from '@potentiel-domain/common';
-import { DomainEvent } from '@potentiel-domain/core';
+import { DomainEvent, InvalidOperationError } from '@potentiel-domain/core';
 
 import * as StatutRecours from '../statutRecours.valueType';
 import { RecoursAggregate } from '../recours.aggregate';
@@ -25,6 +25,10 @@ export async function passerEnInstruction(
 ) {
   this.statut.vérifierQueLeChangementDeStatutEstPossibleEn(StatutRecours.enInstruction);
 
+  if (this.demande.instruction?.par.estÉgaleÀ(identifiantUtilisateur)) {
+    throw new RecoursDéjàEnInstructionAvecLeMêmeAdministrateurError();
+  }
+
   const event: RecoursPasséEnInstructionEvent = {
     type: 'RecoursPasséEnInstruction-V1',
     payload: {
@@ -37,6 +41,20 @@ export async function passerEnInstruction(
   await this.publish(event);
 }
 
-export function applyRecoursPasséEnInstruction(this: RecoursAggregate) {
+export function applyRecoursPasséEnInstruction(
+  this: RecoursAggregate,
+  { payload: { passéEnInstructionLe, passéEnInstructionPar } }: RecoursPasséEnInstructionEvent,
+) {
   this.statut = StatutRecours.enInstruction;
+  this.demande.instruction = {
+    démarréLe:
+      this.demande.instruction?.démarréLe ?? DateTime.convertirEnValueType(passéEnInstructionLe),
+    par: Email.convertirEnValueType(passéEnInstructionPar),
+  };
+}
+
+class RecoursDéjàEnInstructionAvecLeMêmeAdministrateurError extends InvalidOperationError {
+  constructor() {
+    super('Le recours est déjà en instruction avec le même administrateur');
+  }
 }

--- a/packages/domain/éliminé/src/recours/instruire/passerRecoursEnInstruction.behavior.ts
+++ b/packages/domain/éliminé/src/recours/instruire/passerRecoursEnInstruction.behavior.ts
@@ -25,7 +25,7 @@ export async function passerEnInstruction(
 ) {
   this.statut.vérifierQueLeChangementDeStatutEstPossibleEn(StatutRecours.enInstruction);
 
-  if (this.demande.instruction?.par.estÉgaleÀ(identifiantUtilisateur)) {
+  if (this.demande.instruction?.instruitPar.estÉgaleÀ(identifiantUtilisateur)) {
     throw new RecoursDéjàEnInstructionAvecLeMêmeAdministrateurError();
   }
 
@@ -49,7 +49,7 @@ export function applyRecoursPasséEnInstruction(
   this.demande.instruction = {
     démarréLe:
       this.demande.instruction?.démarréLe ?? DateTime.convertirEnValueType(passéEnInstructionLe),
-    par: Email.convertirEnValueType(passéEnInstructionPar),
+    instruitPar: Email.convertirEnValueType(passéEnInstructionPar),
   };
 }
 

--- a/packages/domain/éliminé/src/recours/recours.aggregate.ts
+++ b/packages/domain/éliminé/src/recours/recours.aggregate.ts
@@ -44,7 +44,7 @@ export type RecoursAggregate = Aggregate<RecoursEvent> & {
     demandéPar: IdentifiantUtilisateur.ValueType;
     instruction?: {
       démarréLe: DateTime.ValueType;
-      par: Email.ValueType;
+      instruitPar: Email.ValueType;
     };
   };
   rejet?: {

--- a/packages/domain/éliminé/src/recours/recours.aggregate.ts
+++ b/packages/domain/éliminé/src/recours/recours.aggregate.ts
@@ -7,6 +7,7 @@ import {
 import { DateTime, IdentifiantProjet } from '@potentiel-domain/common';
 import { IdentifiantUtilisateur } from '@potentiel-domain/utilisateur';
 import { DocumentProjet } from '@potentiel-domain/document';
+import { Email } from '@potentiel-domain/common';
 
 import * as StatutRecours from './statutRecours.valueType';
 import {
@@ -41,6 +42,10 @@ export type RecoursAggregate = Aggregate<RecoursEvent> & {
     pièceJustificative?: DocumentProjet.ValueType;
     demandéLe: DateTime.ValueType;
     demandéPar: IdentifiantUtilisateur.ValueType;
+    instruction?: {
+      démarréLe: DateTime.ValueType;
+      par: Email.ValueType;
+    };
   };
   rejet?: {
     rejetéLe: DateTime.ValueType;
@@ -71,7 +76,6 @@ export const getDefaultRecoursAggregate: GetDefaultAggregateState<
   demande: {
     raison: '',
     demandéPar: IdentifiantUtilisateur.unknownUser,
-    recandidature: false,
     demandéLe: DateTime.convertirEnValueType(new Date()),
   },
   accorder,
@@ -96,7 +100,7 @@ function apply(this: RecoursAggregate, event: RecoursEvent) {
       applyRecoursRejeté.bind(this)(event);
       break;
     case 'RecoursPasséEnInstruction-V1':
-      applyRecoursPasséEnInstruction.bind(this)();
+      applyRecoursPasséEnInstruction.bind(this)(event);
       break;
   }
 }

--- a/packages/specifications/src/projet/lauréat/abandon/passerAbandonEnInstruction.feature
+++ b/packages/specifications/src/projet/lauréat/abandon/passerAbandonEnInstruction.feature
@@ -10,6 +10,11 @@ Fonctionnalité: Passer un abandon d'un projet lauréat en instruction
         Quand l'administrateur passe en instruction l'abandon pour le projet lauréat
         Alors la demande d'abandon du projet lauréat devrait être en instruction
 
+    Scénario: Un administrateur reprend l'instruction de l'abandon du projet lauréat
+        Etant donné une demande d'abandon en instruction pour le projet lauréat
+        Quand un nouvel administrateur passe en instruction l'abandon pour le projet lauréat
+        Alors la demande d'abandon du projet lauréat devrait être en instruction
+
     Scénario: Impossible de passer l'abandon d'un projet lauréat en instruction si l'abandon a déjà été accordé
         Etant donné un abandon accordé pour le projet lauréat
         Quand l'administrateur passe en instruction l'abandon pour le projet lauréat
@@ -23,3 +28,8 @@ Fonctionnalité: Passer un abandon d'un projet lauréat en instruction
     Scénario: Impossible de passer l'abandon d'un projet lauréat en instruction si aucun abandon n'a été demandé
         Quand l'administrateur passe en instruction l'abandon pour le projet lauréat
         Alors le DGEC validateur devrait être informé que "Aucun abandon n'est en cours"
+
+    Scénario: Impossible de reprendre l'abandon d'un projet lauréat en instruction si on instruit déjà l'abandon
+        Etant donné une demande d'abandon en instruction pour le projet lauréat
+        Quand le même administrateur passe en instruction l'abandon pour le projet lauréat
+        Alors le DGEC validateur devrait être informé que "L'abandon est déjà en instruction avec le même administrateur"

--- a/packages/specifications/src/projet/lauréat/abandon/stepDefinitions/abandon.given.ts
+++ b/packages/specifications/src/projet/lauréat/abandon/stepDefinitions/abandon.given.ts
@@ -186,7 +186,9 @@ async function créerConfirmationAbandon(this: PotentielWorld) {
 async function passerDemandeAbandonEnInstruction(this: PotentielWorld) {
   const identifiantProjet = this.lauréatWorld.identifiantProjet.formatter();
   const { passéEnInstructionLe, passéEnInstructionPar } =
-    this.lauréatWorld.abandonWorld.passerEnInstructionAbandonFixture.créer();
+    this.lauréatWorld.abandonWorld.passerEnInstructionAbandonFixture.créer({
+      passéEnInstructionPar: this.utilisateurWorld.adminFixture.email,
+    });
 
   await mediator.send<Abandon.AbandonUseCase>({
     type: 'Lauréat.Abandon.UseCase.PasserAbandonEnInstruction',

--- a/packages/specifications/src/projet/lauréat/abandon/stepDefinitions/abandon.when.ts
+++ b/packages/specifications/src/projet/lauréat/abandon/stepDefinitions/abandon.when.ts
@@ -161,10 +161,15 @@ Quand(
 );
 
 Quand(
-  `l'administrateur passe en instruction l'abandon pour le projet lauréat`,
-  async function (this: PotentielWorld) {
+  /(.*)administrateur passe en instruction l'abandon pour le projet lauréat/,
+  async function (this: PotentielWorld, estLeMêmeOuNouvelAdmin: string) {
     try {
       const identifiantProjet = this.lauréatWorld.identifiantProjet.formatter();
+
+      const estUnNouvelAdmin = estLeMêmeOuNouvelAdmin?.includes('un nouvel');
+      if (estUnNouvelAdmin) {
+        this.utilisateurWorld.adminFixture.créer();
+      }
 
       const { passéEnInstructionLe, passéEnInstructionPar } =
         this.lauréatWorld.abandonWorld.passerEnInstructionAbandonFixture.créer({

--- a/packages/specifications/src/projet/éliminé/recours/passerRecoursEnInstruction.feature
+++ b/packages/specifications/src/projet/éliminé/recours/passerRecoursEnInstruction.feature
@@ -10,6 +10,11 @@ Fonctionnalité: Passer le recours d'un projet éliminé en instruction
         Quand l'administrateur passe en instruction le recours pour le projet éliminé
         Alors la demande de recours du projet éliminé devrait être en instruction
 
+    Scénario: Un administrateur reprend l'instruction du recours du projet éliminé
+        Etant donné une demande de recours en instruction pour le projet éliminé
+        Quand un nouvel administrateur passe en instruction le recours pour le projet éliminé
+        Alors la demande de recours du projet éliminé devrait être en instruction
+
     Scénario: Impossible de passer le recours d'un projet éliminé en instruction si le recours a déjà été accordé
         Etant donné un recours accordé pour le projet éliminé
         Quand l'administrateur passe en instruction le recours pour le projet éliminé
@@ -23,3 +28,8 @@ Fonctionnalité: Passer le recours d'un projet éliminé en instruction
     Scénario: Impossible de passer le recours d'un projet éliminé en instruction si aucun recours n'a été demandé
         Quand l'administrateur passe en instruction le recours pour le projet éliminé
         Alors le DGEC validateur devrait être informé que "Aucun recours n'est en cours"
+
+    Scénario: Impossible de reprendre le recours d'un projet éliminé en instruction si on instruit déjà le recours
+        Etant donné une demande de recours en instruction pour le projet éliminé
+        Quand le même administrateur passe en instruction le recours pour le projet éliminé
+        Alors le DGEC validateur devrait être informé que "Le recours est déjà en instruction avec le même administrateur"

--- a/packages/specifications/src/projet/éliminé/recours/stepDefinitions/recours.when.ts
+++ b/packages/specifications/src/projet/éliminé/recours/stepDefinitions/recours.when.ts
@@ -127,10 +127,15 @@ Quand(
 );
 
 Quand(
-  `l'administrateur passe en instruction le recours pour le projet éliminé`,
-  async function (this: PotentielWorld) {
+  /(.*)administrateur passe en instruction le recours pour le projet éliminé/,
+  async function (this: PotentielWorld, estLeMêmeOuNouvelAdmin: string) {
     try {
       const identifiantProjet = this.eliminéWorld.identifiantProjet.formatter();
+
+      const estUnNouvelAdmin = estLeMêmeOuNouvelAdmin?.includes('un nouvel');
+      if (estUnNouvelAdmin) {
+        this.utilisateurWorld.adminFixture.créer();
+      }
 
       const { passéEnInstructionLe, passéEnInstructionPar } =
         this.eliminéWorld.recoursWorld.passerRecoursEnInstructionFixture.créer({

--- a/packages/specifications/src/utilisateur/fixtures/admin.fixture.ts
+++ b/packages/specifications/src/utilisateur/fixtures/admin.fixture.ts
@@ -26,6 +26,8 @@ export class AdminFixture extends AbstractUtilisateur implements Admin, Fixture<
     };
 
     this.#aÉtéCréé = true;
+    this.email = utilisateur.email;
+
     return admin;
   }
 }


### PR DESCRIPTION
# Description

- Reprendre l'instruction pour un admin
- Domain
- front
- Mini changement pour l'affichage de l'abandon sur la page projet

## Type de changement

- [x] Nouvelle fonctionnalité

# Comment cela a-t-il été testé?
<img width="601" alt="Capture d’écran 2025-03-10 à 15 02 00" src="https://github.com/user-attachments/assets/93dff63c-2b30-4764-86f6-f3b751381a33" />
<img width="980" alt="Capture d’écran 2025-03-10 à 15 02 41" src="https://github.com/user-attachments/assets/10549739-524e-4e06-8f61-f7e801e22bff" />
<img width="983" alt="Capture d’écran 2025-03-10 à 15 01 52" src="https://github.com/user-attachments/assets/b4a1bc9d-7008-4b62-86dd-b403b4a28c2f" />

