### PR TITLE
✨ Personaliser l'icône du LinkAction + plusieurs filtres affectés

### DIFF
--- a/packages/applications/ssr/src/app/candidatures/page.tsx
+++ b/packages/applications/ssr/src/app/candidatures/page.tsx
@@ -72,7 +72,7 @@ export default async function Page({ searchParams }: PageProps) {
           label: appelOffre.id,
           value: appelOffre.id,
         })),
-        affects: 'periode',
+        affects: ['periode'],
       },
       {
         label: `Période`,

--- a/packages/applications/ssr/src/components/atoms/LinkAction.tsx
+++ b/packages/applications/ssr/src/components/atoms/LinkAction.tsx
@@ -13,10 +13,7 @@ export const LinkAction: FC<LinkActionProps> = ({
   href,
   iconId = 'fr-icon-arrow-right-line',
 }) => (
-  <Link
-    href={href}
-    className={`w-fit fr-link fr-icon-arrow-right-line fr-link--icon-right ${iconId}`}
-  >
+  <Link href={href} className={`w-fit fr-link fr-link--icon-right ${iconId}`}>
     {label}
   </Link>
 );

--- a/packages/applications/ssr/src/components/atoms/LinkAction.tsx
+++ b/packages/applications/ssr/src/components/atoms/LinkAction.tsx
@@ -1,23 +1,21 @@
+import { FrIconClassName, RiIconClassName } from '@codegouvfr/react-dsfr';
 import Link from 'next/link';
 import React, { FC } from 'react';
 
-type LinkActionProps = {
+export type LinkActionProps = {
   label: string;
   href: string;
-  key?: string;
-  className?: string;
+  iconId?: FrIconClassName | RiIconClassName;
 };
 
 export const LinkAction: FC<LinkActionProps> = ({
   label,
   href,
-  key = undefined,
-  className = undefined,
+  iconId = 'fr-icon-arrow-right-line',
 }) => (
   <Link
     href={href}
-    key={key ?? undefined}
-    className={`w-fit fr-link fr-icon-arrow-right-line fr-link--icon-right ${className}`}
+    className={`w-fit fr-link fr-icon-arrow-right-line fr-link--icon-right ${iconId}`}
   >
     {label}
   </Link>

--- a/packages/applications/ssr/src/components/molecules/ListFilters.tsx
+++ b/packages/applications/ssr/src/components/molecules/ListFilters.tsx
@@ -46,9 +46,7 @@ export const ListFilters: FC<ListFiltersProps> = ({ filters }) => {
               const newSearchParams = new URLSearchParams(searchParams);
               if (value === '') {
                 newSearchParams.delete(searchParamKey);
-                if (affects) {
-                  affects.forEach((affected) => newSearchParams.delete(affected));
-                }
+                affects?.forEach((affected) => newSearchParams.delete(affected));
               } else {
                 const option = options.find((option) => option.value === value);
                 if (option) {

--- a/packages/applications/ssr/src/components/molecules/ListFilters.tsx
+++ b/packages/applications/ssr/src/components/molecules/ListFilters.tsx
@@ -16,7 +16,7 @@ export type ListFilterItem<TSearchParamKey = string> = {
    *  - the affected filter will be disabled unless current has a value
    *  - the affected filter will be removed when current changes
    **/
-  affects?: TSearchParamKey;
+  affects?: TSearchParamKey[];
 };
 
 export type ListFiltersProps = {
@@ -32,7 +32,7 @@ export const ListFilters: FC<ListFiltersProps> = ({ filters }) => {
     <div className="flex flex-col gap">
       {filters.map(({ label, searchParamKey, options, affects }) => {
         const disabled = filters.some(
-          (f) => f.affects === searchParamKey && !searchParams.get(f.searchParamKey),
+          (f) => f.affects?.includes(searchParamKey) && !searchParams.get(f.searchParamKey),
         );
 
         return (
@@ -46,8 +46,8 @@ export const ListFilters: FC<ListFiltersProps> = ({ filters }) => {
               const newSearchParams = new URLSearchParams(searchParams);
               if (value === '') {
                 newSearchParams.delete(searchParamKey);
-                if (affects && searchParams.get(affects)) {
-                  newSearchParams.delete(affects);
+                if (affects) {
+                  affects.forEach((affected) => newSearchParams.delete(affected));
                 }
               } else {
                 const option = options.find((option) => option.value === value);

--- a/packages/applications/ssr/src/components/organisms/ListHeader.tsx
+++ b/packages/applications/ssr/src/components/organisms/ListHeader.tsx
@@ -10,7 +10,7 @@ export type ListHeaderProps = {
   totalCount: number;
 };
 
-type TagFilter = { label: string; searchParamKey: string; affects?: string };
+type TagFilter = { label: string; searchParamKey: string; affects?: string[] };
 
 export const ListHeader: FC<ListHeaderProps> = ({ filters, totalCount }) => {
   const searchParams = useSearchParams();
@@ -32,7 +32,7 @@ export const ListHeader: FC<ListHeaderProps> = ({ filters, totalCount }) => {
     ];
   }, [] as TagFilter[]);
 
-  const onClick = (tagName: string, affects?: string) => {
+  const onClick = (tagName: string, affects: string[]) => {
     const newSearchParams = tagFilters.reduce((urlSearchParams, { searchParamKey }) => {
       if (searchParams.has(searchParamKey)) {
         urlSearchParams.set(searchParamKey, searchParams.get(searchParamKey) ?? '');
@@ -40,9 +40,7 @@ export const ListHeader: FC<ListHeaderProps> = ({ filters, totalCount }) => {
       return urlSearchParams;
     }, new URLSearchParams());
     newSearchParams.delete(tagName);
-    if (affects) {
-      newSearchParams.delete(affects);
-    }
+    affects.forEach((affected) => newSearchParams.delete(affected));
     const url = `${pathname}${newSearchParams.size > 0 ? `?${newSearchParams.toString()}` : ''}`;
     router.push(url);
   };
@@ -56,7 +54,7 @@ export const ListHeader: FC<ListHeaderProps> = ({ filters, totalCount }) => {
               <Tag
                 dismissible
                 nativeButtonProps={{
-                  onClick: () => onClick(searchParamKey, affects),
+                  onClick: () => onClick(searchParamKey, affects ?? []),
                 }}
               >
                 {label}

--- a/packages/applications/ssr/src/components/pages/réseau/gestionnaire/lister/GestionnaireRéseauList.page.tsx
+++ b/packages/applications/ssr/src/components/pages/réseau/gestionnaire/lister/GestionnaireRéseauList.page.tsx
@@ -31,8 +31,8 @@ export const GestionnaireRéseauListPage: FC<GestionnaireRéseauListPageProps> =
       heading="Gestionnaires réseaux"
       actions={[
         {
-          name: 'Ajouter un gestionnaire',
-          link: Routes.Gestionnaire.ajouter,
+          label: 'Ajouter un gestionnaire',
+          href: Routes.Gestionnaire.ajouter,
         },
       ]}
       items={gestionnaireRéseaux.map((gestionnaireRéseaux) => ({

--- a/packages/applications/ssr/src/components/templates/ListPage.template.tsx
+++ b/packages/applications/ssr/src/components/templates/ListPage.template.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react';
 
-import { LinkAction } from '../atoms/LinkAction';
+import { LinkAction, LinkActionProps } from '../atoms/LinkAction';
 import { Heading1 } from '../atoms/headings';
 import { Search, SearchProps } from '../molecules/Search';
 import { List } from '../organisms/List';
@@ -13,10 +13,7 @@ import { PageTemplate } from './Page.template';
 export type ListPageTemplateProps<TItem> = {
   heading: string;
   filters: ListFiltersProps['filters'];
-  actions: Array<{
-    name: string;
-    link: string;
-  }>;
+  actions: Array<LinkActionProps>;
   currentPage: number;
   totalItems: number;
   itemsPerPage: number;
@@ -44,12 +41,7 @@ export const ListPageTemplate = <TItem,>({
         {actions.length ? (
           <>
             {actions.map((a) => (
-              <LinkAction
-                label={a.name}
-                href={a.link}
-                key={a.link}
-                className="w-fit fr-link fr-icon-arrow-right-line fr-link--icon-right"
-              />
+              <LinkAction key={a.href} label={a.label} href={a.href} iconId={a.iconId} />
             ))}
           </>
         ) : null}


### PR DESCRIPTION
LinkAction : voir page gestionnaire réseau. Jusque là l'icone est hard-codée, on peut désormais la personaliser au besoin

Filtres: un paramètre de filtre (ie AppelOffre) peut maintenant affecter plusieurs autres paramètres (ie les reset quand on change appelOffre par exemple)