### PR TITLE
🔧 Ajouter un application_name aux connections Postgres

### DIFF
--- a/packages/applications/legacy/src/sequelize.config.ts
+++ b/packages/applications/legacy/src/sequelize.config.ts
@@ -19,6 +19,9 @@ const getOptionsFromUrl = (url): Options => {
     password,
     database: database ?? undefined,
     port: port ? +port : undefined,
+    dialectOptions: {
+      application_name: 'potentiel_legacy',
+    },
   };
 };
 

--- a/packages/applications/request-context/src/authOptions.ts
+++ b/packages/applications/request-context/src/authOptions.ts
@@ -25,6 +25,7 @@ const pool = new Pool({
   max: 5,
   idleTimeoutMillis: 30000,
   connectionTimeoutMillis: 2000,
+  application_name: 'potentiel_auth',
   options: '-c search_path=auth',
 });
 

--- a/packages/infrastructure/pg-event-sourcing/src/subscribe/subscribe.ts
+++ b/packages/infrastructure/pg-event-sourcing/src/subscribe/subscribe.ts
@@ -58,8 +58,10 @@ export const executeSubscribersRetry = async () => {
 };
 
 const connect = async () => {
-  const client = new Client(getConnectionString());
-
+  const client = new Client({
+    connectionString: getConnectionString(),
+    application_name: 'potentiel_subscribers',
+  });
   await client.connect();
   client.on('error', handleClientError);
 

--- a/packages/libraries/pg-helpers/src/usePoolClient.ts
+++ b/packages/libraries/pg-helpers/src/usePoolClient.ts
@@ -13,6 +13,7 @@ export const usePoolClient = async <TResult extends Record<string, unknown>>(
       connectionString: getConnectionString(),
       min: 0,
       idleTimeoutMillis: FIVE_MINUTES,
+      application_name: 'potentiel',
     });
   }
 


### PR DESCRIPTION
permet une meilleure analyse des connections ouvertes

exemple avec cette query

```
SELECT *
FROM pg_stat_activity
where datname = 'potentiel'
```