### PR TITLE
🥅 Ajout d'un mécanisme de reconnection des subscribers en cas de déconnection

### DIFF
--- a/packages/infrastructure/pg-event-sourcing/src/subscribe/eventStreamEmitter.ts
+++ b/packages/infrastructure/pg-event-sourcing/src/subscribe/eventStreamEmitter.ts
@@ -70,6 +70,18 @@ export class EventStreamEmitter extends EventEmitter {
     );
   }
 
+  async updateClient(client: Client) {
+    this.#client = client;
+
+    this.removeAllListeners('domain-event' satisfies ChannelName);
+    this.removeAllListeners('unknown-event' satisfies ChannelName);
+    this.removeAllListeners('rebuild' satisfies ChannelName);
+
+    this.#setupListener();
+
+    await this.listen();
+  }
+
   #getChannelName(eventType: string): ChannelName {
     if (eventType === 'RebuildTriggered') {
       return 'rebuild';

--- a/packages/infrastructure/pg-event-sourcing/src/subscribe/eventStreamEmitter.ts
+++ b/packages/infrastructure/pg-event-sourcing/src/subscribe/eventStreamEmitter.ts
@@ -32,6 +32,10 @@ export class EventStreamEmitter extends EventEmitter {
     this.#setupListener();
   }
 
+  public get subscriber(): Subscriber {
+    return this.#subscriber;
+  }
+
   async unlisten() {
     await this.#client.query(
       format(`unlisten "${this.#subscriber.streamCategory}|${this.#subscriber.name}"`),

--- a/packages/infrastructure/pg-event-sourcing/src/subscribe/eventStreamEmitter.ts
+++ b/packages/infrastructure/pg-event-sourcing/src/subscribe/eventStreamEmitter.ts
@@ -77,12 +77,8 @@ export class EventStreamEmitter extends EventEmitter {
   async updateClient(client: Client) {
     this.#client = client;
 
-    this.removeAllListeners('domain-event' satisfies ChannelName);
-    this.removeAllListeners('unknown-event' satisfies ChannelName);
-    this.removeAllListeners('rebuild' satisfies ChannelName);
-
+    await this.unlisten();
     this.#setupListener();
-
     await this.listen();
   }
 

--- a/packages/infrastructure/pg-event-sourcing/src/subscribe/subscribe.test.ts
+++ b/packages/infrastructure/pg-event-sourcing/src/subscribe/subscribe.test.ts
@@ -502,7 +502,7 @@ describe(`subscribe`, () => {
 
   it(`
     Étant donné un event handler en attente du traitement d'un type d'événement
-    Lorsque la connexion au client est interronmpue
+    Lorsque la connexion au client est interrompue
     Et qu'on émet un événement correspondant au type
     Alors l'event handler est exécuté
     Et il reçoit l'événement en paramétre

--- a/packages/infrastructure/pg-event-sourcing/src/subscribe/subscribe.test.ts
+++ b/packages/infrastructure/pg-event-sourcing/src/subscribe/subscribe.test.ts
@@ -499,4 +499,73 @@ describe(`subscribe`, () => {
       actual1.payload.should.be.deep.equal(event.payload);
     });
   });
+
+  it(`
+    Étant donné un event handler en attente du traitement d'un type d'événement
+    Lorsque la connexion au client est interronmpue
+    Et qu'on émet un événement correspondant au type
+    Alors l'event handler est exécuté
+    Et il reçoit l'événement en paramétre
+    Et il n'y a pas d'acknowledgement en attente pour cet événement après son traitement
+  `, async () => {
+    // Arrange
+    const eventType = 'event-1';
+    const payload = {
+      propriété: 'propriété',
+    };
+
+    let eventHandler1HasBeenCalled = false;
+    let eventHandler2HasBeenCalled = false;
+    const eventHandler1 = async () => {
+      eventHandler1HasBeenCalled = true;
+      return Promise.resolve();
+    };
+    const eventHandler2 = async () => {
+      eventHandler2HasBeenCalled = true;
+      return Promise.resolve();
+    };
+
+    const unsubscribe1 = await subscribe({
+      name: subscriberName1,
+      eventType: eventType,
+      eventHandler: eventHandler1,
+      streamCategory,
+    });
+    unsubscribes.push(unsubscribe1);
+
+    const unsubscribe2 = await subscribe({
+      name: subscriberName2,
+      eventType: eventType,
+      eventHandler: eventHandler2,
+      streamCategory,
+    });
+    unsubscribes.push(unsubscribe2);
+
+    const event1 = {
+      type: eventType,
+      payload,
+    };
+
+    // Act
+    await executeQuery(`
+      SELECT pg_terminate_backend(pid) 
+      FROM pg_stat_activity 
+      WHERE usename = 'potentiel'
+      AND   query LIKE 'listen%'`);
+
+    await publish(`${streamCategory}|${id}`, event1);
+
+    await waitForExpect(async () => {
+      // Assert
+      eventHandler1HasBeenCalled.should.be.true;
+      eventHandler2HasBeenCalled.should.be.true;
+
+      const actuals = [
+        ...(await getPendingAcknowledgements(streamCategory, subscriberName1)),
+        ...(await getPendingAcknowledgements(streamCategory, subscriberName2)),
+      ];
+
+      actuals.length.should.be.equal(0);
+    });
+  });
 });

--- a/packages/infrastructure/pg-event-sourcing/src/subscribe/subscribe.test.ts
+++ b/packages/infrastructure/pg-event-sourcing/src/subscribe/subscribe.test.ts
@@ -547,12 +547,7 @@ describe(`subscribe`, () => {
     };
 
     // Act
-    await executeQuery(`
-      SELECT pg_terminate_backend(pid) 
-      FROM pg_stat_activity 
-      WHERE usename = 'potentiel'
-      AND   query LIKE 'listen%'`);
-
+    await disconnectAllSubscriberClients();
     await publish(`${streamCategory}|${id}`, event1);
 
     await waitForExpect(async () => {
@@ -569,3 +564,10 @@ describe(`subscribe`, () => {
     });
   });
 });
+
+const disconnectAllSubscriberClients = () =>
+  executeQuery(`
+  SELECT pg_terminate_backend(pid) 
+  FROM pg_stat_activity 
+  WHERE usename = 'potentiel'
+  AND   query LIKE 'listen%'`);

--- a/packages/infrastructure/pg-event-sourcing/src/subscribe/subscribe.test.ts
+++ b/packages/infrastructure/pg-event-sourcing/src/subscribe/subscribe.test.ts
@@ -75,12 +75,12 @@ describe(`subscribe`, () => {
 
     let eventHandler1HasBeenCalled = false;
     let eventHandler2HasBeenCalled = false;
-    const eventHandler1 = async () => {
-      eventHandler1HasBeenCalled = true;
+    const eventHandler1 = async (event: { type: string }) => {
+      eventHandler1HasBeenCalled = event.type === eventType;
       return Promise.resolve();
     };
-    const eventHandler2 = async () => {
-      eventHandler2HasBeenCalled = true;
+    const eventHandler2 = async (event: { type: string }) => {
+      eventHandler2HasBeenCalled = event.type === eventType;
       return Promise.resolve();
     };
 
@@ -186,8 +186,8 @@ describe(`subscribe`, () => {
     };
 
     let eventHandlerHasBeenCalled = false;
-    const eventHandler = async () => {
-      eventHandlerHasBeenCalled = true;
+    const eventHandler = async (event: { type: string }) => {
+      eventHandlerHasBeenCalled = event.type === eventType;
       return Promise.resolve();
     };
 
@@ -516,12 +516,12 @@ describe(`subscribe`, () => {
 
     let eventHandler1HasBeenCalled = false;
     let eventHandler2HasBeenCalled = false;
-    const eventHandler1 = async () => {
-      eventHandler1HasBeenCalled = true;
+    const eventHandler1 = async (event: { type: string }) => {
+      eventHandler1HasBeenCalled = event.type === eventType;
       return Promise.resolve();
     };
-    const eventHandler2 = async () => {
-      eventHandler2HasBeenCalled = true;
+    const eventHandler2 = async (event: { type: string }) => {
+      eventHandler2HasBeenCalled = event.type === eventType;
       return Promise.resolve();
     };
 

--- a/packages/infrastructure/pg-event-sourcing/src/subscribe/subscribe.ts
+++ b/packages/infrastructure/pg-event-sourcing/src/subscribe/subscribe.ts
@@ -43,7 +43,7 @@ export const subscribe = async <TEvent extends Event = Event>(
     await eventStreamEmitter.unlisten();
 
     eventStreamEmitters.delete(eventStreamEmitterId);
-    client?.setMaxListeners(eventStreamEmitters.size);
+    client?.setMaxListeners(eventStreamEmitters.size + 1);
 
     if (eventStreamEmitters.size === 0) {
       await disconnect();

--- a/packages/infrastructure/pg-event-sourcing/src/subscribe/subscribe.ts
+++ b/packages/infrastructure/pg-event-sourcing/src/subscribe/subscribe.ts
@@ -72,11 +72,10 @@ const disconnect = async () => {
 };
 
 const handleClientError = async (error: Error) => {
-  const logger = getLogger('EventSourcing Subscribe');
-
-  logger.warn(`An error occurred from subscribe Postgresql client`, { error });
-
   if (!isReconnecting) {
+    const logger = getLogger('EventSourcing Subscribe');
+
+    logger.warn(`An error occurred from subscribe Postgresql client`, { error });
     logger.info(`Trying to reconnect subscribe Postgresql client...`);
 
     isReconnecting = true;

--- a/packages/infrastructure/pg-event-sourcing/src/subscribe/subscribe.ts
+++ b/packages/infrastructure/pg-event-sourcing/src/subscribe/subscribe.ts
@@ -91,6 +91,8 @@ const handleClientError = async (error: Error) => {
 
     await retryPolicy.execute(async () => {
       client = await connect();
+      client.setMaxListeners(eventStreamEmitters.size + 1);
+
       logger.info(`Subscribe Postgresql client reconnection succeeds !`);
     });
 


### PR DESCRIPTION
Ces changements permettent de gérer les déconnexions du client postgresql des subscribers permettant d'alimenter les projections, de notifier par email ou encore d'exécuter les comportements métier de l'application legacy.

Lors d'une erreur on tente de se reconnecter 10 fois (grâce à une policy avec un ExponentialBackoff).

Après une reconnection il faut bien entendu réessayer le traitement des pending acknowledgments qui ont pu avoir lieu entre temps.