### PR TITLE
✨ Rejeter une demande de changement de puissance - Domain

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23870,7 +23870,6 @@
         "@potentiel-infrastructure/pg-event-sourcing": "*",
         "@potentiel-infrastructure/pg-projection-read": "*",
         "@potentiel-libraries/file-storage": "*",
-        "@potentiel-libraries/keycloak-cjs": "*",
         "@potentiel-libraries/monads": "*",
         "@potentiel-libraries/monitoring": "*",
         "@potentiel-statistiques/statistiques-publiques": "*",

--- a/packages/applications/bootstrap/src/setupLauréat.ts
+++ b/packages/applications/bootstrap/src/setupLauréat.ts
@@ -467,6 +467,7 @@ export const setupLauréat = async ({
       'ChangementPuissanceSupprimé-V1',
       'ChangementPuissanceEnregistré-V1',
       'ChangementPuissanceAccordé-V1',
+      'ChangementPuissanceRejeté-V1',
     ],
     eventHandler: async (event) => {
       await mediator.send<PuissanceProjector.Execute>({
@@ -487,6 +488,8 @@ export const setupLauréat = async ({
         'ChangementPuissanceAnnulé-V1',
         'ChangementPuissanceSupprimé-V1',
         'ChangementPuissanceAccordé-V1',
+        'ChangementPuissanceRejeté-V1',
+        'ChangementPuissanceEnregistré-V1',
       ],
       eventHandler: async (event) => {
         await mediator.publish<PuissanceNotification.Execute>({

--- a/packages/applications/notifications/src/subscribers/lauréat/puissance/changementPuissanceRejeté.notification.ts
+++ b/packages/applications/notifications/src/subscribers/lauréat/puissance/changementPuissanceRejeté.notification.ts
@@ -1,0 +1,48 @@
+import { récupérerPorteursParIdentifiantProjetAdapter } from '@potentiel-infrastructure/domain-adapters';
+import { getLogger } from '@potentiel-libraries/monitoring';
+import { Routes } from '@potentiel-applications/routes';
+import { Puissance } from '@potentiel-domain/laureat';
+import { IdentifiantProjet } from '@potentiel-domain/projet';
+
+import { RegisterPuissanceNotificationDependencies } from '.';
+
+type ChangementPuissanceRejetéNotificationProps = {
+  sendEmail: RegisterPuissanceNotificationDependencies['sendEmail'];
+  event: Puissance.ChangementPuissanceRejetéEvent;
+  projet: {
+    nom: string;
+    département: string;
+  };
+  baseUrl: string;
+};
+
+export const changementPuissanceRejetéNotification = async ({
+  sendEmail,
+  event,
+  projet,
+  baseUrl,
+}: ChangementPuissanceRejetéNotificationProps) => {
+  const identifiantProjet = IdentifiantProjet.convertirEnValueType(event.payload.identifiantProjet);
+  const porteurs = await récupérerPorteursParIdentifiantProjetAdapter(identifiantProjet);
+
+  if (porteurs.length === 0) {
+    getLogger().error('Aucun porteur trouvé', {
+      identifiantProjet: identifiantProjet.formatter(),
+      application: 'notifications',
+      fonction: 'changementPuissanceRejetéNotification',
+    });
+    return;
+  }
+
+  return sendEmail({
+    templateId: 6873755,
+    messageSubject: `Potentiel - La demande de changement de puissance pour le projet ${projet.nom} dans le département ${projet.département} a été rejetée`,
+    recipients: porteurs,
+    variables: {
+      type: 'rejet',
+      nom_projet: projet.nom,
+      departement_projet: projet.département,
+      url: `${baseUrl}${Routes.Projet.details(identifiantProjet.formatter())}`,
+    },
+  });
+};

--- a/packages/applications/notifications/src/subscribers/lauréat/puissance/index.ts
+++ b/packages/applications/notifications/src/subscribers/lauréat/puissance/index.ts
@@ -11,6 +11,7 @@ import { IdentifiantProjet } from '@potentiel-domain/projet';
 import { SendEmail } from '../../../sendEmail';
 
 import { changementPuissanceAccordéNotification } from './changementPuissanceAccordé.notification';
+import { changementPuissanceRejetéNotification } from './changementPuissanceRejeté.notification';
 
 export type SubscriptionEvent = Puissance.PuissanceEvent & Event;
 
@@ -55,6 +56,14 @@ export const register = ({ sendEmail }: RegisterPuissanceNotificationDependencie
     return match(event)
       .with({ type: 'ChangementPuissanceAccordé-V1' }, async (event) =>
         changementPuissanceAccordéNotification({
+          sendEmail,
+          event,
+          projet,
+          baseUrl,
+        }),
+      )
+      .with({ type: 'ChangementPuissanceRejeté-V1' }, async (event) =>
+        changementPuissanceRejetéNotification({
           sendEmail,
           event,
           projet,

--- a/packages/applications/projectors/src/subscribers/lauréat/puissance/changementPuissanceRejeté.projector.ts
+++ b/packages/applications/projectors/src/subscribers/lauréat/puissance/changementPuissanceRejeté.projector.ts
@@ -1,0 +1,77 @@
+import { Puissance } from '@potentiel-domain/laureat';
+import { findProjection } from '@potentiel-infrastructure/pg-projection-read';
+import { upsertProjection } from '@potentiel-infrastructure/pg-projection-write';
+import { getLogger } from '@potentiel-libraries/monitoring';
+import { Option } from '@potentiel-libraries/monads';
+
+export const changementPuissanceRejetéProjector = async ({
+  payload: { identifiantProjet, rejetéLe, rejetéPar, réponseSignée },
+}: Puissance.ChangementPuissanceRejetéEvent) => {
+  const projectionPuissance = await findProjection<Puissance.PuissanceEntity>(
+    `puissance|${identifiantProjet}`,
+  );
+
+  if (Option.isNone(projectionPuissance)) {
+    getLogger().error('Puissance non trouvée', {
+      identifiantProjet,
+      fonction: 'changementPuissanceRejetéProjector',
+    });
+    return;
+  }
+
+  if (!projectionPuissance.dateDemandeEnCours) {
+    getLogger().error('Demande de changement de puissance non trouvée', {
+      identifiantProjet,
+      fonction: 'changementPuissanceRejetéProjector',
+    });
+    return;
+  }
+
+  const projectionDemandeChangementPuissance =
+    await findProjection<Puissance.ChangementPuissanceEntity>(
+      `changement-puissance|${identifiantProjet}#${projectionPuissance.dateDemandeEnCours}`,
+    );
+
+  if (Option.isNone(projectionDemandeChangementPuissance)) {
+    getLogger().error('Demande de changement de puissance non trouvée', {
+      identifiantProjet,
+      fonction: 'changementPuissanceRejetéProjector',
+    });
+    return;
+  }
+
+  if (projectionDemandeChangementPuissance.demande.statut === 'information-enregistrée') {
+    getLogger().error(
+      `Demande non instruite car l'information a déjà été enregistrée automatiquement`,
+      {
+        identifiantProjet,
+        fonction: 'changementPuissanceRejetéProjector',
+      },
+    );
+    return;
+  }
+
+  await upsertProjection<Puissance.ChangementPuissanceEntity>(
+    `changement-puissance|${identifiantProjet}#${projectionPuissance.dateDemandeEnCours}`,
+    {
+      identifiantProjet,
+      demande: {
+        ...projectionDemandeChangementPuissance.demande,
+        statut: Puissance.StatutChangementPuissance.accordé.statut,
+        rejet: {
+          rejetéeLe: rejetéLe,
+          rejetéePar: rejetéPar,
+          réponseSignée: {
+            format: réponseSignée.format,
+          },
+        },
+      },
+    },
+  );
+
+  await upsertProjection<Puissance.PuissanceEntity>(`puissance|${identifiantProjet}`, {
+    ...projectionPuissance,
+    miseÀJourLe: rejetéLe,
+    dateDemandeEnCours: undefined,
+  });
+};

--- a/packages/applications/projectors/src/subscribers/lauréat/puissance/changementPuissanceRejeté.projector.ts
+++ b/packages/applications/projectors/src/subscribers/lauréat/puissance/changementPuissanceRejeté.projector.ts
@@ -57,7 +57,7 @@ export const changementPuissanceRejetéProjector = async ({
       identifiantProjet,
       demande: {
         ...projectionDemandeChangementPuissance.demande,
-        statut: Puissance.StatutChangementPuissance.accordé.statut,
+        statut: Puissance.StatutChangementPuissance.rejeté.statut,
         rejet: {
           rejetéeLe: rejetéLe,
           rejetéePar: rejetéPar,

--- a/packages/applications/projectors/src/subscribers/lauréat/puissance/index.ts
+++ b/packages/applications/projectors/src/subscribers/lauréat/puissance/index.ts
@@ -12,6 +12,7 @@ import { changementPuissanceAnnuléProjector } from './changementPuissanceAnnul�
 import { changementPuissanceSuppriméProjector } from './changementPuissanceSupprimé.projector';
 import { changementPuissanceAccordéProjector } from './changementPuissanceAccordé.projector';
 import { changementPuissanceEnregistréProjector } from './changementPuissanceEnregistré.projector';
+import { changementPuissanceRejetéProjector } from './changementPuissanceRejeté.projector';
 
 export type SubscriptionEvent = (Puissance.PuissanceEvent & Event) | RebuildTriggered;
 
@@ -26,8 +27,9 @@ export const register = () => {
       .with({ type: 'ChangementPuissanceDemandé-V1' }, changementPuissanceDemandéProjector)
       .with({ type: 'ChangementPuissanceAnnulé-V1' }, changementPuissanceAnnuléProjector)
       .with({ type: 'ChangementPuissanceSupprimé-V1' }, changementPuissanceSuppriméProjector)
-      .with({ type: 'ChangementPuissanceAccordé-V1' }, changementPuissanceAccordéProjector)
       .with({ type: 'ChangementPuissanceEnregistré-V1' }, changementPuissanceEnregistréProjector)
+      .with({ type: 'ChangementPuissanceAccordé-V1' }, changementPuissanceAccordéProjector)
+      .with({ type: 'ChangementPuissanceRejeté-V1' }, changementPuissanceRejetéProjector)
       .exhaustive();
 
   mediator.register('System.Projector.Lauréat.Puissance', handler);

--- a/packages/domain/lauréat/src/puissance/changement/accorder/accorderChangementPuissance.behavior.ts
+++ b/packages/domain/lauréat/src/puissance/changement/accorder/accorderChangementPuissance.behavior.ts
@@ -9,7 +9,6 @@ import { PuissanceAggregate } from '../../puissance.aggregate';
 import {
   DemandeDeChangementInexistanteError,
   DemandeDoitÊtreInstruiteParDGECError,
-  DemandeDoitÊtreInstruiteParDREALError,
 } from '../errors';
 
 export type ChangementPuissanceAccordéEvent = DomainEvent<
@@ -47,13 +46,6 @@ export async function accorderDemandeChangement(
 
   if (this.demande.autoritéCompétente === 'dgec' && rôleUtilisateur.nom === 'dreal') {
     throw new DemandeDoitÊtreInstruiteParDGECError();
-  }
-
-  if (
-    this.demande.autoritéCompétente === 'dreal' &&
-    (rôleUtilisateur.nom === 'admin' || rôleUtilisateur.nom === 'dgec-validateur')
-  ) {
-    throw new DemandeDoitÊtreInstruiteParDREALError();
   }
 
   const event: ChangementPuissanceAccordéEvent = {

--- a/packages/domain/lauréat/src/puissance/changement/errors.ts
+++ b/packages/domain/lauréat/src/puissance/changement/errors.ts
@@ -31,8 +31,3 @@ export class DemandeDoitÊtreInstruiteParDGECError extends DomainError {
     super('Une demande de changement de puissance à la hausse doit être instruite par la DGEC');
   }
 }
-export class DemandeDoitÊtreInstruiteParDREALError extends DomainError {
-  constructor() {
-    super('Une demande de changement de puissance à la baisse doit être instruite par la DREAL');
-  }
-}

--- a/packages/domain/lauréat/src/puissance/changement/rejeter/rejeterChangementPuissance.behavior.ts
+++ b/packages/domain/lauréat/src/puissance/changement/rejeter/rejeterChangementPuissance.behavior.ts
@@ -1,0 +1,78 @@
+import { DateTime, Email } from '@potentiel-domain/common';
+import { DomainEvent } from '@potentiel-domain/core';
+import { DocumentProjet } from '@potentiel-domain/document';
+import { IdentifiantProjet } from '@potentiel-domain/projet';
+import { Role } from '@potentiel-domain/utilisateur';
+
+import { StatutChangementPuissance } from '../..';
+import { PuissanceAggregate } from '../../puissance.aggregate';
+import {
+  DemandeDeChangementInexistanteError,
+  DemandeDoitÊtreInstruiteParDGECError,
+  DemandeDoitÊtreInstruiteParDREALError,
+} from '../errors';
+
+export type ChangementPuissanceRejetéEvent = DomainEvent<
+  'ChangementPuissanceRejeté-V1',
+  {
+    identifiantProjet: IdentifiantProjet.RawType;
+    rejetéLe: DateTime.RawType;
+    rejetéPar: Email.RawType;
+    réponseSignée: {
+      format: string;
+    };
+  }
+>;
+
+type Options = {
+  identifiantProjet: IdentifiantProjet.ValueType;
+  rejetéLe: DateTime.ValueType;
+  rejetéPar: Email.ValueType;
+  réponseSignée: DocumentProjet.ValueType;
+  rôleUtilisateur: Role.ValueType;
+};
+
+export async function rejeterDemandeChangement(
+  this: PuissanceAggregate,
+  { identifiantProjet, rejetéLe, rejetéPar, réponseSignée, rôleUtilisateur }: Options,
+) {
+  if (!this.demande) {
+    throw new DemandeDeChangementInexistanteError();
+  }
+
+  this.demande.statut.vérifierQueLeChangementDeStatutEstPossibleEn(
+    StatutChangementPuissance.rejeté,
+  );
+
+  if (this.demande.autoritéCompétente === 'dgec' && rôleUtilisateur.nom === 'dreal') {
+    throw new DemandeDoitÊtreInstruiteParDGECError();
+  }
+
+  if (
+    this.demande.autoritéCompétente === 'dreal' &&
+    (rôleUtilisateur.nom === 'admin' || rôleUtilisateur.nom === 'dgec-validateur')
+  ) {
+    throw new DemandeDoitÊtreInstruiteParDREALError();
+  }
+
+  const event: ChangementPuissanceRejetéEvent = {
+    type: 'ChangementPuissanceRejeté-V1',
+    payload: {
+      identifiantProjet: identifiantProjet.formatter(),
+      rejetéLe: rejetéLe.formatter(),
+      rejetéPar: rejetéPar.formatter(),
+      réponseSignée: {
+        format: réponseSignée.format,
+      },
+    },
+  };
+
+  await this.publish(event);
+}
+
+export function applyChangementPuissanceRejeté(
+  this: PuissanceAggregate,
+  _: ChangementPuissanceRejetéEvent,
+) {
+  this.demande = undefined;
+}

--- a/packages/domain/lauréat/src/puissance/changement/rejeter/rejeterChangementPuissance.behavior.ts
+++ b/packages/domain/lauréat/src/puissance/changement/rejeter/rejeterChangementPuissance.behavior.ts
@@ -9,7 +9,6 @@ import { PuissanceAggregate } from '../../puissance.aggregate';
 import {
   DemandeDeChangementInexistanteError,
   DemandeDoitÊtreInstruiteParDGECError,
-  DemandeDoitÊtreInstruiteParDREALError,
 } from '../errors';
 
 export type ChangementPuissanceRejetéEvent = DomainEvent<
@@ -51,10 +50,6 @@ export async function rejeterDemandeChangement(
     !rôlesAutorisésPourDGEC.includes(rôleUtilisateur.nom)
   ) {
     throw new DemandeDoitÊtreInstruiteParDGECError();
-  }
-
-  if (this.demande.autoritéCompétente === 'dreal' && rôleUtilisateur.nom !== 'dreal') {
-    throw new DemandeDoitÊtreInstruiteParDREALError();
   }
 
   const event: ChangementPuissanceRejetéEvent = {

--- a/packages/domain/lauréat/src/puissance/changement/rejeter/rejeterChangementPuissance.behavior.ts
+++ b/packages/domain/lauréat/src/puissance/changement/rejeter/rejeterChangementPuissance.behavior.ts
@@ -44,14 +44,16 @@ export async function rejeterDemandeChangement(
     StatutChangementPuissance.rejeté,
   );
 
-  if (this.demande.autoritéCompétente === 'dgec' && rôleUtilisateur.nom === 'dreal') {
+  const rôlesAutorisésPourDGEC: Array<Role.RawType> = ['admin', 'dgec-validateur'];
+
+  if (
+    this.demande.autoritéCompétente === 'dgec' &&
+    !rôlesAutorisésPourDGEC.includes(rôleUtilisateur.nom)
+  ) {
     throw new DemandeDoitÊtreInstruiteParDGECError();
   }
 
-  if (
-    this.demande.autoritéCompétente === 'dreal' &&
-    (rôleUtilisateur.nom === 'admin' || rôleUtilisateur.nom === 'dgec-validateur')
-  ) {
+  if (this.demande.autoritéCompétente === 'dreal' && rôleUtilisateur.nom !== 'dreal') {
     throw new DemandeDoitÊtreInstruiteParDREALError();
   }
 

--- a/packages/domain/lauréat/src/puissance/changement/rejeter/rejeterChangementPuissance.command.ts
+++ b/packages/domain/lauréat/src/puissance/changement/rejeter/rejeterChangementPuissance.command.ts
@@ -1,0 +1,42 @@
+import { Message, MessageHandler, mediator } from 'mediateur';
+
+import { DateTime, Email, IdentifiantProjet } from '@potentiel-domain/common';
+import { LoadAggregate } from '@potentiel-domain/core';
+import { DocumentProjet } from '@potentiel-domain/document';
+import { Role } from '@potentiel-domain/utilisateur';
+
+import { loadPuissanceFactory } from '../../puissance.aggregate';
+
+export type RejeterChangementPuissanceCommand = Message<
+  'Lauréat.Puissance.Command.RejeterChangement',
+  {
+    identifiantProjet: IdentifiantProjet.ValueType;
+    rejetéLe: DateTime.ValueType;
+    rejetéPar: Email.ValueType;
+    réponseSignée: DocumentProjet.ValueType;
+    rôleUtilisateur: Role.ValueType;
+  }
+>;
+
+export const registerRejeterChangementPuissanceCommand = (loadAggregate: LoadAggregate) => {
+  const loadPuissance = loadPuissanceFactory(loadAggregate);
+
+  const handler: MessageHandler<RejeterChangementPuissanceCommand> = async ({
+    identifiantProjet,
+    rejetéLe,
+    rejetéPar,
+    réponseSignée,
+    rôleUtilisateur,
+  }) => {
+    const puissance = await loadPuissance(identifiantProjet);
+
+    await puissance.rejeterDemandeChangement({
+      identifiantProjet,
+      rejetéLe,
+      rejetéPar,
+      réponseSignée,
+      rôleUtilisateur,
+    });
+  };
+  mediator.register('Lauréat.Puissance.Command.RejeterChangement', handler);
+};

--- a/packages/domain/lauréat/src/puissance/changement/rejeter/rejeterChangementPuissance.usecase.ts
+++ b/packages/domain/lauréat/src/puissance/changement/rejeter/rejeterChangementPuissance.usecase.ts
@@ -1,0 +1,65 @@
+import { Message, MessageHandler, mediator } from 'mediateur';
+
+import { DateTime, Email } from '@potentiel-domain/common';
+import { DocumentProjet, EnregistrerDocumentProjetCommand } from '@potentiel-domain/document';
+import { IdentifiantProjet } from '@potentiel-domain/projet';
+import { Role } from '@potentiel-domain/utilisateur';
+
+import { TypeDocumentPuissance } from '../..';
+
+import { RejeterChangementPuissanceCommand } from './rejeterChangementPuissance.command';
+
+export type RejeterChangementPuissanceUseCase = Message<
+  'Lauréat.Puissance.UseCase.RejeterDemandeChangement',
+  {
+    identifiantProjetValue: string;
+    rejetéLeValue: string;
+    rejetéParValue: string;
+    réponseSignéeValue: {
+      content: ReadableStream;
+      format: string;
+    };
+    rôleUtilisateurValue: string;
+  }
+>;
+
+export const registerRejeterChangementPuissanceUseCase = () => {
+  const runner: MessageHandler<RejeterChangementPuissanceUseCase> = async ({
+    identifiantProjetValue,
+    rejetéLeValue,
+    rejetéParValue,
+    réponseSignéeValue: { format, content },
+    rôleUtilisateurValue,
+  }) => {
+    const identifiantProjet = IdentifiantProjet.convertirEnValueType(identifiantProjetValue);
+    const rejetéLe = DateTime.convertirEnValueType(rejetéLeValue);
+    const rejetéPar = Email.convertirEnValueType(rejetéParValue);
+    const réponseSignée = DocumentProjet.convertirEnValueType(
+      identifiantProjetValue,
+      TypeDocumentPuissance.changementRejeté.formatter(),
+      rejetéLe.formatter(),
+      format,
+    );
+    const rôleUtilisateur = Role.convertirEnValueType(rôleUtilisateurValue);
+
+    await mediator.send<RejeterChangementPuissanceCommand>({
+      type: 'Lauréat.Puissance.Command.RejeterChangement',
+      data: {
+        rejetéLe,
+        rejetéPar,
+        identifiantProjet,
+        réponseSignée,
+        rôleUtilisateur,
+      },
+    });
+
+    await mediator.send<EnregistrerDocumentProjetCommand>({
+      type: 'Document.Command.EnregistrerDocumentProjet',
+      data: {
+        content,
+        documentProjet: réponseSignée,
+      },
+    });
+  };
+  mediator.register('Lauréat.Puissance.UseCase.RejeterDemandeChangement', runner);
+};

--- a/packages/domain/lauréat/src/puissance/index.ts
+++ b/packages/domain/lauréat/src/puissance/index.ts
@@ -17,6 +17,8 @@ import { AnnulerChangementPuissanceCommand } from './changement/annuler/annulerC
 import { AccorderChangementPuissanceCommand } from './changement/accorder/accorderChangementPuissance.command';
 import { EnregistrerChangementPuissanceCommand } from './changement/enregistrerChangement/enregistrerChangementPuissance.command';
 import { EnregistrerChangementPuissanceUseCase } from './changement/enregistrerChangement/enregistrerChangementPuissance.usecase';
+import { RejeterChangementPuissanceUseCase } from './changement/rejeter/rejeterChangementPuissance.usecase';
+import { RejeterChangementPuissanceCommand } from './changement/rejeter/rejeterChangementPuissance.command';
 
 // Query
 export type PuissanceQuery = ConsulterPuissanceQuery | ConsulterChangementPuissanceQuery;
@@ -30,8 +32,9 @@ export type PuissanceUseCase =
   | ModifierPuissanceUseCase
   | DemanderChangementUseCase
   | AnnulerChangementPuissanceUseCase
+  | EnregistrerChangementPuissanceUseCase
   | AccorderChangementPuissanceUseCase
-  | EnregistrerChangementPuissanceUseCase;
+  | RejeterChangementPuissanceUseCase;
 
 export type {
   ModifierPuissanceUseCase,
@@ -39,6 +42,7 @@ export type {
   AnnulerChangementPuissanceUseCase,
   AccorderChangementPuissanceUseCase,
   EnregistrerChangementPuissanceUseCase,
+  RejeterChangementPuissanceUseCase,
 };
 
 // Command
@@ -48,7 +52,8 @@ export type PuissanceCommand =
   | DemanderChangementCommand
   | AnnulerChangementPuissanceCommand
   | AccorderChangementPuissanceCommand
-  | EnregistrerChangementPuissanceCommand;
+  | EnregistrerChangementPuissanceCommand
+  | RejeterChangementPuissanceCommand;
 
 export type {
   ImporterPuissanceCommand,
@@ -57,6 +62,7 @@ export type {
   AnnulerChangementPuissanceCommand,
   AccorderChangementPuissanceCommand,
   EnregistrerChangementPuissanceCommand,
+  RejeterChangementPuissanceCommand,
 };
 
 // Event
@@ -66,8 +72,9 @@ export type { PuissanceModifiéeEvent } from './modifier/modifierPuissance.behav
 export type { ChangementPuissanceDemandéEvent } from './changement/demander/demanderChangementPuissance.behavior';
 export type { ChangementPuissanceAnnuléEvent } from './changement/annuler/annulerChangementPuissance.behavior';
 export type { ChangementPuissanceSuppriméEvent } from './changement/supprimer/supprimerChangementPuissance.behavior';
-export type { ChangementPuissanceAccordéEvent } from './changement/accorder/accorderChangementPuissance.behavior';
 export type { ChangementPuissanceEnregistréEvent } from './changement/enregistrerChangement/enregistrerChangementPuissance.behavior';
+export type { ChangementPuissanceAccordéEvent } from './changement/accorder/accorderChangementPuissance.behavior';
+export type { ChangementPuissanceRejetéEvent } from './changement/rejeter/rejeterChangementPuissance.behavior';
 
 // Entities
 export * from './puissance.entity';

--- a/packages/domain/lauréat/src/puissance/puissance.aggregate.ts
+++ b/packages/domain/lauréat/src/puissance/puissance.aggregate.ts
@@ -38,6 +38,11 @@ import {
   enregistrerChangement,
 } from './changement/enregistrerChangement/enregistrerChangementPuissance.behavior';
 import { PuissanceIntrouvableError } from './errors';
+import {
+  applyChangementPuissanceRejeté,
+  ChangementPuissanceRejetéEvent,
+  rejeterDemandeChangement,
+} from './changement/rejeter/rejeterChangementPuissance.behavior';
 
 export type PuissanceEvent =
   | PuissanceImportéeEvent
@@ -45,8 +50,9 @@ export type PuissanceEvent =
   | ChangementPuissanceDemandéEvent
   | ChangementPuissanceAnnuléEvent
   | ChangementPuissanceSuppriméEvent
+  | ChangementPuissanceEnregistréEvent
   | ChangementPuissanceAccordéEvent
-  | ChangementPuissanceEnregistréEvent;
+  | ChangementPuissanceRejetéEvent;
 
 export type PuissanceAggregate = Aggregate<PuissanceEvent> & {
   identifiantProjet: IdentifiantProjet.ValueType;
@@ -63,6 +69,7 @@ export type PuissanceAggregate = Aggregate<PuissanceEvent> & {
   readonly annulerDemandeChangement: typeof annulerDemandeChangement;
   readonly supprimerDemandeChangement: typeof supprimerDemandeChangement;
   readonly accorderDemandeChangement: typeof accorderDemandeChangement;
+  readonly rejeterDemandeChangement: typeof rejeterDemandeChangement;
   readonly enregistrerChangement: typeof enregistrerChangement;
 };
 
@@ -80,6 +87,7 @@ export const getDefaultPuissanceAggregate: GetDefaultAggregateState<
   supprimerDemandeChangement,
   accorderDemandeChangement,
   enregistrerChangement,
+  rejeterDemandeChangement,
 });
 
 function apply(this: PuissanceAggregate, event: PuissanceEvent) {
@@ -89,11 +97,12 @@ function apply(this: PuissanceAggregate, event: PuissanceEvent) {
     .with({ type: 'ChangementPuissanceDemandé-V1' }, applyChangementPuissanceDemandé.bind(this))
     .with({ type: 'ChangementPuissanceAnnulé-V1' }, applyChangementPuissanceAnnulé.bind(this))
     .with({ type: 'ChangementPuissanceSupprimé-V1' }, applyChangementPuissanceSupprimé.bind(this))
-    .with({ type: 'ChangementPuissanceAccordé-V1' }, applyChangementPuissanceAccordé.bind(this))
     .with(
       { type: 'ChangementPuissanceEnregistré-V1' },
       applyChangementPuissanceEnregistré.bind(this),
     )
+    .with({ type: 'ChangementPuissanceAccordé-V1' }, applyChangementPuissanceAccordé.bind(this))
+    .with({ type: 'ChangementPuissanceRejeté-V1' }, applyChangementPuissanceRejeté.bind(this))
     .exhaustive();
 }
 

--- a/packages/domain/lauréat/src/puissance/puissance.register.ts
+++ b/packages/domain/lauréat/src/puissance/puissance.register.ts
@@ -17,6 +17,8 @@ import { registerAccorderChangementPuissanceUseCase } from './changement/accorde
 import { registerAccorderChangementPuissanceCommand } from './changement/accorder/accorderChangementPuissance.command';
 import { registerEnregistrerChangementPuissanceCommand } from './changement/enregistrerChangement/enregistrerChangementPuissance.command';
 import { registerEnregistrerChangementPuissanceUseCase } from './changement/enregistrerChangement/enregistrerChangementPuissance.usecase';
+import { registerRejeterChangementPuissanceUseCase } from './changement/rejeter/rejeterChangementPuissance.usecase';
+import { registerRejeterChangementPuissanceCommand } from './changement/rejeter/rejeterChangementPuissance.command';
 
 export type PuissanceQueryDependencies = ConsulterPuissanceDependencies;
 
@@ -28,16 +30,18 @@ export const registerPuissanceUseCases = ({ loadAggregate }: PuissanceCommandDep
   registerModifierPuissanceUseCase();
   registerDemanderChangementPuissanceUseCase();
   registerAnnulerChangementPuissanceUseCase();
-  registerAccorderChangementPuissanceUseCase();
   registerEnregistrerChangementPuissanceUseCase();
+  registerAccorderChangementPuissanceUseCase();
+  registerRejeterChangementPuissanceUseCase();
 
   registerImporterPuissanceCommand(loadAggregate);
   registerModifierPuissanceCommand(loadAggregate);
   registerDemanderChangementPuissanceCommand(loadAggregate);
   registerAnnulerChangementPuissanceCommand(loadAggregate);
   registerSupprimerChangementPuissanceCommand(loadAggregate);
-  registerAccorderChangementPuissanceCommand(loadAggregate);
   registerEnregistrerChangementPuissanceCommand(loadAggregate);
+  registerAccorderChangementPuissanceCommand(loadAggregate);
+  registerRejeterChangementPuissanceCommand(loadAggregate);
 };
 
 export const registerPuissanceQueries = (dependencies: PuissanceQueryDependencies) => {

--- a/packages/specifications/src/projet/lauréat/puissance/changement/accorderChangementPuissance.feature
+++ b/packages/specifications/src/projet/lauréat/puissance/changement/accorderChangementPuissance.feature
@@ -52,7 +52,6 @@ Fonctionnalité: Accorder le changement de puissance d'un projet lauréat
         Quand la DREAL associée au projet accorde le changement de puissance à la baisse pour le projet lauréat
         Alors l'utilisateur DREAL devrait être informé que "Aucune demande de changement de puissance n'est en cours"
 
-    @NotImplemented
     Scénario: Impossible d'accorder le changement de puissance d'un projet lauréat si la demande a déjà été rejetée
         Etant donné une demande de changement de puissance à la baisse rejetée pour le projet lauréat
         Quand la DREAL associée au projet accorde le changement de puissance à la baisse pour le projet lauréat

--- a/packages/specifications/src/projet/lauréat/puissance/changement/accorderChangementPuissance.feature
+++ b/packages/specifications/src/projet/lauréat/puissance/changement/accorderChangementPuissance.feature
@@ -8,7 +8,7 @@ Fonctionnalité: Accorder le changement de puissance d'un projet lauréat
 
     Scénario: la DREAL associée au projet accorde une demande de changement de puissance à la baisse d'un projet lauréat
         Etant donné une demande de changement de puissance à la baisse pour le projet lauréat
-        Quand la DREAL associée au projet accorde le changement de puissance à la baisse pour le projet lauréat
+        Quand la DREAL associée au projet accorde le changement de puissance pour le projet lauréat
         Alors la demande de changement de la puissance devrait être accordée
         Et la puissance du projet lauréat devrait être mise à jour
         Et un email a été envoyé au porteur avec :
@@ -19,7 +19,7 @@ Fonctionnalité: Accorder le changement de puissance d'un projet lauréat
 
     Scénario: le DGEC validateur accorde une demande de changement de puissance à la hausse d'un projet lauréat
         Etant donné une demande de changement de puissance à la hausse pour le projet lauréat
-        Quand le DGEC validateur accorde le changement de puissance à la hausse pour le projet lauréat
+        Quand le DGEC validateur accorde le changement de puissance pour le projet lauréat
         Alors la demande de changement de la puissance devrait être accordée
         Et la puissance du projet lauréat devrait être mise à jour
         Et un email a été envoyé au porteur avec :
@@ -30,24 +30,24 @@ Fonctionnalité: Accorder le changement de puissance d'un projet lauréat
 
     Scénario: Impossible d'accorder une demande de changement de puissance à la hausse d'un projet lauréat pour un utilisateur DREAL
         Etant donné une demande de changement de puissance à la hausse pour le projet lauréat
-        Quand la DREAL associée au projet accorde le changement de puissance à la baisse pour le projet lauréat
+        Quand la DREAL associée au projet accorde le changement de puissance pour le projet lauréat
         Alors l'utilisateur DREAL devrait être informé que "Une demande de changement de puissance à la hausse doit être instruite par la DGEC"
 
     Scénario: Impossible d'accorder le changement de puissance d'un projet lauréat si aucune demande n'est en cours
-        Quand la DREAL associée au projet accorde le changement de puissance à la baisse pour le projet lauréat
+        Quand la DREAL associée au projet accorde le changement de puissance pour le projet lauréat
         Alors l'utilisateur DREAL devrait être informé que "Aucune demande de changement de puissance n'est en cours"
 
     Scénario: Impossible d'accorder le changement de puissance d'un projet lauréat si la demande a déjà été accordée
         Etant donné une demande de changement de puissance à la baisse accordée pour le projet lauréat
-        Quand la DREAL associée au projet accorde le changement de puissance à la baisse pour le projet lauréat
+        Quand la DREAL associée au projet accorde le changement de puissance pour le projet lauréat
         Alors l'utilisateur DREAL devrait être informé que "Aucune demande de changement de puissance n'est en cours"
 
     Scénario: Impossible d'accorder le changement de puissance d'un projet lauréat si la demande a déjà été annulée
         Etant donné une demande de changement de puissance à la baisse annulée pour le projet lauréat
-        Quand la DREAL associée au projet accorde le changement de puissance à la baisse pour le projet lauréat
+        Quand la DREAL associée au projet accorde le changement de puissance pour le projet lauréat
         Alors l'utilisateur DREAL devrait être informé que "Aucune demande de changement de puissance n'est en cours"
 
     Scénario: Impossible d'accorder le changement de puissance d'un projet lauréat si la demande a déjà été rejetée
         Etant donné une demande de changement de puissance à la baisse rejetée pour le projet lauréat
-        Quand la DREAL associée au projet accorde le changement de puissance à la baisse pour le projet lauréat
+        Quand la DREAL associée au projet accorde le changement de puissance pour le projet lauréat
         Alors l'utilisateur DREAL devrait être informé que "Aucune demande de changement de puissance n'est en cours"

--- a/packages/specifications/src/projet/lauréat/puissance/changement/accorderChangementPuissance.feature
+++ b/packages/specifications/src/projet/lauréat/puissance/changement/accorderChangementPuissance.feature
@@ -33,11 +33,6 @@ Fonctionnalité: Accorder le changement de puissance d'un projet lauréat
         Quand la DREAL associée au projet accorde le changement de puissance à la baisse pour le projet lauréat
         Alors l'utilisateur DREAL devrait être informé que "Une demande de changement de puissance à la hausse doit être instruite par la DGEC"
 
-    Scénario: Impossible d'accorder une demande de changement de puissance à la baisse d'un projet lauréat pour un utilisateur DGEC
-        Etant donné une demande de changement de puissance à la baisse pour le projet lauréat
-        Quand le DGEC validateur accorde le changement de puissance à la baisse pour le projet lauréat
-        Alors l'utilisateur DGEC devrait être informé que "Une demande de changement de puissance à la baisse doit être instruite par la DREAL"
-
     Scénario: Impossible d'accorder le changement de puissance d'un projet lauréat si aucune demande n'est en cours
         Quand la DREAL associée au projet accorde le changement de puissance à la baisse pour le projet lauréat
         Alors l'utilisateur DREAL devrait être informé que "Aucune demande de changement de puissance n'est en cours"

--- a/packages/specifications/src/projet/lauréat/puissance/changement/annulerChangementPuissance.feature
+++ b/packages/specifications/src/projet/lauréat/puissance/changement/annulerChangementPuissance.feature
@@ -21,8 +21,7 @@ Fonctionnalité: Annuler la demande changement de puissance d'un projet lauréat
         Quand le porteur annule la demande de changement de puissance pour le projet lauréat
         Alors l'utilisateur devrait être informé que "Aucune demande de changement de puissance n'est en cours"
 
-    @NotImplemented
     Scénario: Impossible d'annuler la demande de changement de puissance si la demande est rejetée
-        Etant donné une demande de changement de puissance rejetée pour le projet lauréat
+        Etant donné une demande de changement de puissance à la baisse rejetée pour le projet lauréat
         Quand le porteur annule la demande de changement de puissance pour le projet lauréat
         Alors l'utilisateur devrait être informé que "Aucune demande de changement de puissance n'est en cours"

--- a/packages/specifications/src/projet/lauréat/puissance/changement/changementPuissance.world.ts
+++ b/packages/specifications/src/projet/lauréat/puissance/changement/changementPuissance.world.ts
@@ -114,7 +114,25 @@ export class ChangementPuissanceWorld {
                   ),
                 }
               : undefined,
-            rejet: undefined,
+            rejet: this.#rejeterChangementPuissanceFixture.aÉtéCréé
+              ? {
+                  rejetéeLe: DateTime.convertirEnValueType(
+                    this.#rejeterChangementPuissanceFixture.rejetéeLe,
+                  ),
+                  rejetéePar: Email.convertirEnValueType(
+                    this.#rejeterChangementPuissanceFixture.rejetéePar,
+                  ),
+
+                  réponseSignée: DocumentProjet.convertirEnValueType(
+                    identifiantProjet.formatter(),
+                    Puissance.TypeDocumentPuissance.changementRejeté.formatter(),
+                    DateTime.convertirEnValueType(
+                      this.#rejeterChangementPuissanceFixture.rejetéeLe,
+                    ).formatter(),
+                    this.#rejeterChangementPuissanceFixture.réponseSignée.format,
+                  ),
+                }
+              : undefined,
           },
     };
   }

--- a/packages/specifications/src/projet/lauréat/puissance/changement/changementPuissance.world.ts
+++ b/packages/specifications/src/projet/lauréat/puissance/changement/changementPuissance.world.ts
@@ -7,6 +7,7 @@ import { DemanderChangementPuissanceFixture } from './fixture/demanderChangement
 import { AnnulerChangementPuissanceFixture } from './fixture/annulerChangementPuissance.fixture';
 import { AccorderChangementPuissanceFixture } from './fixture/accorderChangementPuissance.fixture';
 import { EnregistrerChangementPuissanceFixture } from './fixture/enregistrerChangementPuissance.fixture';
+import { RejeterChangementPuissanceFixture } from './fixture/rejeterChangementPuissance.fixture';
 
 type MapToDemandeExpectedProps = {
   identifiantProjet: IdentifiantProjet.ValueType;
@@ -25,21 +26,27 @@ export class ChangementPuissanceWorld {
     return this.#annulerChangementPuissanceFixture;
   }
 
-  #accorderChangementPuissanceFixture: AccorderChangementPuissanceFixture;
-  get accorderChangementPuissanceFixture() {
-    return this.#accorderChangementPuissanceFixture;
-  }
-
   #enregistrerChangementPuissanceFixture: EnregistrerChangementPuissanceFixture;
   get enregistrerChangementPuissanceFixture() {
     return this.#enregistrerChangementPuissanceFixture;
   }
 
+  #accorderChangementPuissanceFixture: AccorderChangementPuissanceFixture;
+  get accorderChangementPuissanceFixture() {
+    return this.#accorderChangementPuissanceFixture;
+  }
+
+  #rejeterChangementPuissanceFixture: RejeterChangementPuissanceFixture;
+  get rejeterChangementPuissanceFixture() {
+    return this.#rejeterChangementPuissanceFixture;
+  }
+
   constructor() {
     this.#demanderChangementPuissanceFixture = new DemanderChangementPuissanceFixture();
     this.#annulerChangementPuissanceFixture = new AnnulerChangementPuissanceFixture();
-    this.#accorderChangementPuissanceFixture = new AccorderChangementPuissanceFixture();
     this.#enregistrerChangementPuissanceFixture = new EnregistrerChangementPuissanceFixture();
+    this.#accorderChangementPuissanceFixture = new AccorderChangementPuissanceFixture();
+    this.#rejeterChangementPuissanceFixture = new RejeterChangementPuissanceFixture();
   }
 
   mapToExpected({

--- a/packages/specifications/src/projet/lauréat/puissance/changement/fixture/rejeterChangementPuissance.fixture.ts
+++ b/packages/specifications/src/projet/lauréat/puissance/changement/fixture/rejeterChangementPuissance.fixture.ts
@@ -1,0 +1,55 @@
+import { faker } from '@faker-js/faker';
+
+import { AbstractFixture } from '../../../../../fixture';
+import { convertStringToReadableStream } from '../../../../../helpers/convertStringToReadable';
+
+interface RejeterChangementPuissance {
+  readonly réponseSignée: { format: string; content: ReadableStream };
+  readonly rejetetéeLe: string;
+  readonly rejetetéePar: string;
+}
+
+export class RejeterChangementPuissanceFixture
+  extends AbstractFixture<RejeterChangementPuissance>
+  implements RejeterChangementPuissance
+{
+  #format!: string;
+  #content!: string;
+
+  get réponseSignée(): RejeterChangementPuissance['réponseSignée'] {
+    return {
+      format: this.#format,
+      content: convertStringToReadableStream(this.#content),
+    };
+  }
+
+  #rejetetéeLe!: string;
+  get rejetetéeLe(): string {
+    return this.#rejetetéeLe;
+  }
+
+  #rejetetéePar!: string;
+  get rejetetéePar(): string {
+    return this.#rejetetéePar;
+  }
+
+  créer(partialData?: Partial<RejeterChangementPuissance>): Readonly<RejeterChangementPuissance> {
+    const content = faker.word.words();
+
+    const fixture = {
+      réponseSignée: {
+        format: faker.potentiel.fileFormat(),
+        content: convertStringToReadableStream(content),
+      },
+      rejetetéeLe: faker.date.recent().toISOString(),
+      rejetetéePar: faker.internet.email(),
+      ...partialData,
+    };
+
+    this.#rejetetéeLe = fixture.rejetetéeLe;
+    this.#rejetetéePar = fixture.rejetetéePar;
+
+    this.aÉtéCréé = true;
+    return fixture;
+  }
+}

--- a/packages/specifications/src/projet/lauréat/puissance/changement/fixture/rejeterChangementPuissance.fixture.ts
+++ b/packages/specifications/src/projet/lauréat/puissance/changement/fixture/rejeterChangementPuissance.fixture.ts
@@ -5,8 +5,8 @@ import { convertStringToReadableStream } from '../../../../../helpers/convertStr
 
 interface RejeterChangementPuissance {
   readonly réponseSignée: { format: string; content: ReadableStream };
-  readonly rejetetéeLe: string;
-  readonly rejetetéePar: string;
+  readonly rejetéeLe: string;
+  readonly rejetéePar: string;
 }
 
 export class RejeterChangementPuissanceFixture
@@ -23,14 +23,14 @@ export class RejeterChangementPuissanceFixture
     };
   }
 
-  #rejetetéeLe!: string;
-  get rejetetéeLe(): string {
-    return this.#rejetetéeLe;
+  #rejetéeLe!: string;
+  get rejetéeLe(): string {
+    return this.#rejetéeLe;
   }
 
-  #rejetetéePar!: string;
-  get rejetetéePar(): string {
-    return this.#rejetetéePar;
+  #rejetéePar!: string;
+  get rejetéePar(): string {
+    return this.#rejetéePar;
   }
 
   créer(partialData?: Partial<RejeterChangementPuissance>): Readonly<RejeterChangementPuissance> {
@@ -41,13 +41,15 @@ export class RejeterChangementPuissanceFixture
         format: faker.potentiel.fileFormat(),
         content: convertStringToReadableStream(content),
       },
-      rejetetéeLe: faker.date.recent().toISOString(),
-      rejetetéePar: faker.internet.email(),
+      rejetéeLe: faker.date.recent().toISOString(),
+      rejetéePar: faker.internet.email(),
       ...partialData,
     };
 
-    this.#rejetetéeLe = fixture.rejetetéeLe;
-    this.#rejetetéePar = fixture.rejetetéePar;
+    this.#rejetéeLe = fixture.rejetéeLe;
+    this.#rejetéePar = fixture.rejetéePar;
+    this.#format = fixture.réponseSignée.format;
+    this.#content = content;
 
     this.aÉtéCréé = true;
     return fixture;

--- a/packages/specifications/src/projet/lauréat/puissance/changement/rejeterChangementPuissance.feature
+++ b/packages/specifications/src/projet/lauréat/puissance/changement/rejeterChangementPuissance.feature
@@ -38,7 +38,6 @@ Fonctionnalité: Rejeter la demande de changement de puissance d'un projet laur�
         Quand le DGEC validateur accorde le changement de puissance à la baisse pour le projet lauréat
         Alors l'utilisateur DGEC devrait être informé que "Une demande de changement de puissance à la baisse doit être instruite par la DREAL"
 
-    @NotImplemented
     Scénario: Impossible de rejeter le changement de puissance d'un projet lauréat si aucune demande n'est en cours
         Quand la DREAL associée au projet rejette le changement de puissance à la baisse pour le projet lauréat
         Alors l'utilisateur DREAL devrait être informé que "Aucune demande de changement de puissance n'est en cours"

--- a/packages/specifications/src/projet/lauréat/puissance/changement/rejeterChangementPuissance.feature
+++ b/packages/specifications/src/projet/lauréat/puissance/changement/rejeterChangementPuissance.feature
@@ -8,7 +8,7 @@ Fonctionnalité: Rejeter la demande de changement de puissance d'un projet laur�
 
     Scénario: la DREAL associée au projet rejette le changement de puissance d'un projet lauréat
         Etant donné une demande de changement de puissance à la baisse pour le projet lauréat
-        Quand la DREAL associée au projet rejette le changement de puissance à la baisse pour le projet lauréat
+        Quand la DREAL associée au projet rejette le changement de puissance pour le projet lauréat
         Alors la demande de changement de la puissance devrait être rejetée
         Et la puissance du projet lauréat ne devrait pas être mise à jour
         Et un email a été envoyé au porteur avec :
@@ -19,7 +19,7 @@ Fonctionnalité: Rejeter la demande de changement de puissance d'un projet laur�
 
     Scénario: le DGEC validateur rejette le changement de puissance d'un projet lauréat
         Etant donné une demande de changement de puissance à la hausse pour le projet lauréat
-        Quand le DGEC validateur rejette le changement de puissance à la hausse pour le projet lauréat
+        Quand le DGEC validateur rejette le changement de puissance pour le projet lauréat
         Alors la demande de changement de la puissance devrait être rejetée
         Et la puissance du projet lauréat ne devrait pas être mise à jour
         Et un email a été envoyé au porteur avec :
@@ -30,24 +30,24 @@ Fonctionnalité: Rejeter la demande de changement de puissance d'un projet laur�
 
     Scénario: Impossible de rejeter une demande de changement de puissance à la hausse d'un projet lauréat pour un utilisateur DREAL
         Etant donné une demande de changement de puissance à la hausse pour le projet lauréat
-        Quand la DREAL associée au projet accorde le changement de puissance à la hausse pour le projet lauréat
+        Quand la DREAL associée au projet accorde le changement de puissance pour le projet lauréat
         Alors l'utilisateur DREAL devrait être informé que "Une demande de changement de puissance à la hausse doit être instruite par la DGEC"
 
     Scénario: Impossible de rejeter le changement de puissance d'un projet lauréat si aucune demande n'est en cours
-        Quand la DREAL associée au projet rejette le changement de puissance à la baisse pour le projet lauréat
+        Quand la DREAL associée au projet rejette le changement de puissance pour le projet lauréat
         Alors l'utilisateur DREAL devrait être informé que "Aucune demande de changement de puissance n'est en cours"
 
     Scénario: Impossible de rejeter le changement de puissance d'un projet lauréat si la demande a déjà été accordée
         Etant donné une demande de changement de puissance à la baisse accordée pour le projet lauréat
-        Quand la DREAL associée au projet rejette le changement de puissance à la baisse pour le projet lauréat
+        Quand la DREAL associée au projet rejette le changement de puissance pour le projet lauréat
         Alors l'utilisateur DREAL devrait être informé que "Aucune demande de changement de puissance n'est en cours"
 
     Scénario: Impossible de rejeter le changement de puissance d'un projet lauréat si la demande a déjà été annulée
         Etant donné une demande de changement de puissance à la baisse annulée pour le projet lauréat
-        Quand la DREAL associée au projet rejette le changement de puissance à la baisse pour le projet lauréat
+        Quand la DREAL associée au projet rejette le changement de puissance pour le projet lauréat
         Alors l'utilisateur DREAL devrait être informé que "Aucune demande de changement de puissance n'est en cours"
 
     Scénario: Impossible de rejeter le changement de puissance d'un projet lauréat si la demande a déjà été rejetée
         Etant donné une demande de changement de puissance à la baisse rejetée pour le projet lauréat
-        Quand la DREAL associée au projet rejette le changement de puissance à la baisse pour le projet lauréat
+        Quand la DREAL associée au projet rejette le changement de puissance pour le projet lauréat
         Alors l'utilisateur DREAL devrait être informé que "Aucune demande de changement de puissance n'est en cours"

--- a/packages/specifications/src/projet/lauréat/puissance/changement/rejeterChangementPuissance.feature
+++ b/packages/specifications/src/projet/lauréat/puissance/changement/rejeterChangementPuissance.feature
@@ -28,14 +28,13 @@ Fonctionnalité: Rejeter la demande de changement de puissance d'un projet laur�
             | url        | https://potentiel.beta.gouv.fr/projet/.*/details.html                                                                             |
             | type       | rejet                                                                                                                             |
 
-    @NotImplemented
-    Scénario: Impossible d'accorder une demande de changement de puissance à la hausse d'un projet lauréat pour un utilisateur DREAL
+    Scénario: Impossible de rejeter une demande de changement de puissance à la hausse d'un projet lauréat pour un utilisateur DREAL
         Etant donné une demande de changement de puissance à la hausse pour le projet lauréat
         Quand la DREAL associée au projet accorde le changement de puissance à la baisse pour le projet lauréat
         Alors l'utilisateur DREAL devrait être informé que "Une demande de changement de puissance à la hausse doit être instruite par la DGEC"
 
     @NotImplemented
-    Scénario: Impossible d'accorder une demande de changement de puissance à la baisse d'un projet lauréat pour un utilisateur DGEC
+    Scénario: Impossible de rejeter une demande de changement de puissance à la baisse d'un projet lauréat pour un utilisateur DGEC
         Etant donné une demande de changement de puissance à la baisse pour le projet lauréat
         Quand le DGEC validateur accorde le changement de puissance à la baisse pour le projet lauréat
         Alors l'utilisateur DGEC devrait être informé que "Une demande de changement de puissance à la baisse doit être instruite par la DREAL"

--- a/packages/specifications/src/projet/lauréat/puissance/changement/rejeterChangementPuissance.feature
+++ b/packages/specifications/src/projet/lauréat/puissance/changement/rejeterChangementPuissance.feature
@@ -33,7 +33,6 @@ Fonctionnalité: Rejeter la demande de changement de puissance d'un projet laur�
         Quand la DREAL associée au projet accorde le changement de puissance à la baisse pour le projet lauréat
         Alors l'utilisateur DREAL devrait être informé que "Une demande de changement de puissance à la hausse doit être instruite par la DGEC"
 
-    @NotImplemented
     Scénario: Impossible de rejeter une demande de changement de puissance à la baisse d'un projet lauréat pour un utilisateur DGEC
         Etant donné une demande de changement de puissance à la baisse pour le projet lauréat
         Quand le DGEC validateur accorde le changement de puissance à la baisse pour le projet lauréat

--- a/packages/specifications/src/projet/lauréat/puissance/changement/rejeterChangementPuissance.feature
+++ b/packages/specifications/src/projet/lauréat/puissance/changement/rejeterChangementPuissance.feature
@@ -47,7 +47,6 @@ Fonctionnalité: Rejeter la demande de changement de puissance d'un projet laur�
         Quand la DREAL associée au projet rejette le changement de puissance à la baisse pour le projet lauréat
         Alors l'utilisateur DREAL devrait être informé que "Aucune demande de changement de puissance n'est en cours"
 
-    @NotImplemented
     Scénario: Impossible de rejeter le changement de puissance d'un projet lauréat si la demande a déjà été annulée
         Etant donné une demande de changement de puissance à la baisse annulée pour le projet lauréat
         Quand la DREAL associée au projet rejette le changement de puissance à la baisse pour le projet lauréat

--- a/packages/specifications/src/projet/lauréat/puissance/changement/rejeterChangementPuissance.feature
+++ b/packages/specifications/src/projet/lauréat/puissance/changement/rejeterChangementPuissance.feature
@@ -17,9 +17,8 @@ Fonctionnalité: Rejeter la demande de changement de puissance d'un projet laur�
             | url        | https://potentiel.beta.gouv.fr/projet/.*/details.html                                                                             |
             | type       | rejet                                                                                                                             |
 
-    @NotImplemented
     Scénario: le DGEC validateur rejette le changement de puissance d'un projet lauréat
-        Etant donné une demande de changement de puissance à la baisse pour le projet lauréat
+        Etant donné une demande de changement de puissance à la hausse pour le projet lauréat
         Quand le DGEC validateur rejette le changement de puissance à la hausse pour le projet lauréat
         Alors la demande de changement de la puissance devrait être rejetée
         Et la puissance du projet lauréat ne devrait pas être mise à jour

--- a/packages/specifications/src/projet/lauréat/puissance/changement/rejeterChangementPuissance.feature
+++ b/packages/specifications/src/projet/lauréat/puissance/changement/rejeterChangementPuissance.feature
@@ -52,7 +52,6 @@ Fonctionnalité: Rejeter la demande de changement de puissance d'un projet laur�
         Quand la DREAL associée au projet rejette le changement de puissance à la baisse pour le projet lauréat
         Alors l'utilisateur DREAL devrait être informé que "Aucune demande de changement de puissance n'est en cours"
 
-    @NotImplemented
     Scénario: Impossible de rejeter le changement de puissance d'un projet lauréat si la demande a déjà été rejetée
         Etant donné une demande de changement de puissance à la baisse rejetée pour le projet lauréat
         Quand la DREAL associée au projet rejette le changement de puissance à la baisse pour le projet lauréat

--- a/packages/specifications/src/projet/lauréat/puissance/changement/rejeterChangementPuissance.feature
+++ b/packages/specifications/src/projet/lauréat/puissance/changement/rejeterChangementPuissance.feature
@@ -30,7 +30,7 @@ Fonctionnalité: Rejeter la demande de changement de puissance d'un projet laur�
 
     Scénario: Impossible de rejeter une demande de changement de puissance à la hausse d'un projet lauréat pour un utilisateur DREAL
         Etant donné une demande de changement de puissance à la hausse pour le projet lauréat
-        Quand la DREAL associée au projet accorde le changement de puissance à la baisse pour le projet lauréat
+        Quand la DREAL associée au projet accorde le changement de puissance à la hausse pour le projet lauréat
         Alors l'utilisateur DREAL devrait être informé que "Une demande de changement de puissance à la hausse doit être instruite par la DGEC"
 
     Scénario: Impossible de rejeter le changement de puissance d'un projet lauréat si aucune demande n'est en cours

--- a/packages/specifications/src/projet/lauréat/puissance/changement/rejeterChangementPuissance.feature
+++ b/packages/specifications/src/projet/lauréat/puissance/changement/rejeterChangementPuissance.feature
@@ -33,11 +33,6 @@ Fonctionnalité: Rejeter la demande de changement de puissance d'un projet laur�
         Quand la DREAL associée au projet accorde le changement de puissance à la baisse pour le projet lauréat
         Alors l'utilisateur DREAL devrait être informé que "Une demande de changement de puissance à la hausse doit être instruite par la DGEC"
 
-    Scénario: Impossible de rejeter une demande de changement de puissance à la baisse d'un projet lauréat pour un utilisateur DGEC
-        Etant donné une demande de changement de puissance à la baisse pour le projet lauréat
-        Quand le DGEC validateur accorde le changement de puissance à la baisse pour le projet lauréat
-        Alors l'utilisateur DGEC devrait être informé que "Une demande de changement de puissance à la baisse doit être instruite par la DREAL"
-
     Scénario: Impossible de rejeter le changement de puissance d'un projet lauréat si aucune demande n'est en cours
         Quand la DREAL associée au projet rejette le changement de puissance à la baisse pour le projet lauréat
         Alors l'utilisateur DREAL devrait être informé que "Aucune demande de changement de puissance n'est en cours"

--- a/packages/specifications/src/projet/lauréat/puissance/changement/rejeterChangementPuissance.feature
+++ b/packages/specifications/src/projet/lauréat/puissance/changement/rejeterChangementPuissance.feature
@@ -1,5 +1,4 @@
 # language: fr
-@NotImplemented
 Fonctionnalité: Rejeter la demande de changement de puissance d'un projet lauréat
 
     Contexte:
@@ -8,41 +7,58 @@ Fonctionnalité: Rejeter la demande de changement de puissance d'un projet laur�
         Et la dreal "Dreal du sud" associée à la région du projet
 
     Scénario: la DREAL associée au projet rejette le changement de puissance d'un projet lauréat
-        Etant donné une demande de changement de puissance à la baisse en cours pour le projet lauréat
+        Etant donné une demande de changement de puissance à la baisse pour le projet lauréat
         Quand la DREAL associée au projet rejette le changement de puissance à la baisse pour le projet lauréat
-        Alors la demande de changement de puissance devrait être rejetée
-        Et la puissance du projet lauréat ne devrait pas être mis à jour
+        Alors la demande de changement de la puissance devrait être rejetée
+        Et la puissance du projet lauréat ne devrait pas être mise à jour
         Et un email a été envoyé au porteur avec :
             | sujet      | Potentiel - La demande de changement de puissance pour le projet Du boulodrome de Marseille dans le département(.*) a été rejetée |
             | nom_projet | Du boulodrome de Marseille                                                                                                        |
             | url        | https://potentiel.beta.gouv.fr/projet/.*/details.html                                                                             |
             | type       | rejet                                                                                                                             |
 
+    @NotImplemented
     Scénario: le DGEC validateur rejette le changement de puissance d'un projet lauréat
-        Etant donné une demande de changement de puissance à la hausse en cours pour le projet lauréat
+        Etant donné une demande de changement de puissance à la baisse pour le projet lauréat
         Quand le DGEC validateur rejette le changement de puissance à la hausse pour le projet lauréat
-        Alors la demande de changement de puissance devrait être rejetée
-        Et la puissance du projet lauréat ne devrait pas être mis à jour
+        Alors la demande de changement de la puissance devrait être rejetée
+        Et la puissance du projet lauréat ne devrait pas être mise à jour
         Et un email a été envoyé au porteur avec :
             | sujet      | Potentiel - La demande de changement de puissance pour le projet Du boulodrome de Marseille dans le département(.*) a été rejetée |
             | nom_projet | Du boulodrome de Marseille                                                                                                        |
             | url        | https://potentiel.beta.gouv.fr/projet/.*/details.html                                                                             |
             | type       | rejet                                                                                                                             |
 
+    @NotImplemented
+    Scénario: Impossible d'accorder une demande de changement de puissance à la hausse d'un projet lauréat pour un utilisateur DREAL
+        Etant donné une demande de changement de puissance à la hausse pour le projet lauréat
+        Quand la DREAL associée au projet accorde le changement de puissance à la baisse pour le projet lauréat
+        Alors l'utilisateur DREAL devrait être informé que "Une demande de changement de puissance à la hausse doit être instruite par la DGEC"
+
+    @NotImplemented
+    Scénario: Impossible d'accorder une demande de changement de puissance à la baisse d'un projet lauréat pour un utilisateur DGEC
+        Etant donné une demande de changement de puissance à la baisse pour le projet lauréat
+        Quand le DGEC validateur accorde le changement de puissance à la baisse pour le projet lauréat
+        Alors l'utilisateur DGEC devrait être informé que "Une demande de changement de puissance à la baisse doit être instruite par la DREAL"
+
+    @NotImplemented
     Scénario: Impossible de rejeter le changement de puissance d'un projet lauréat si aucune demande n'est en cours
         Quand la DREAL associée au projet rejette le changement de puissance à la baisse pour le projet lauréat
         Alors l'utilisateur DREAL devrait être informé que "Aucune demande de changement de puissance n'est en cours"
 
+    @NotImplemented
     Scénario: Impossible de rejeter le changement de puissance d'un projet lauréat si la demande a déjà été accordée
         Etant donné une demande de changement de puissance à la baisse accordée pour le projet lauréat
         Quand la DREAL associée au projet rejette le changement de puissance à la baisse pour le projet lauréat
         Alors l'utilisateur DREAL devrait être informé que "La demande de changement de puissance a déjà été accordée"
 
+    @NotImplemented
     Scénario: Impossible de rejeter le changement de puissance d'un projet lauréat si la demande a déjà été annulée
         Etant donné une demande de changement de puissance à la baisse annulée pour le projet lauréat
         Quand la DREAL associée au projet rejette le changement de puissance à la baisse pour le projet lauréat
         Alors l'utilisateur DREAL devrait être informé que "Aucune demande de changement de puissance n'est en cours"
 
+    @NotImplemented
     Scénario: Impossible de rejeter le changement de puissance d'un projet lauréat si la demande a déjà été rejetée
         Etant donné une demande de changement de puissance à la baisse rejetée pour le projet lauréat
         Quand la DREAL associée au projet rejette le changement de puissance à la baisse pour le projet lauréat

--- a/packages/specifications/src/projet/lauréat/puissance/changement/rejeterChangementPuissance.feature
+++ b/packages/specifications/src/projet/lauréat/puissance/changement/rejeterChangementPuissance.feature
@@ -42,11 +42,10 @@ Fonctionnalité: Rejeter la demande de changement de puissance d'un projet laur�
         Quand la DREAL associée au projet rejette le changement de puissance à la baisse pour le projet lauréat
         Alors l'utilisateur DREAL devrait être informé que "Aucune demande de changement de puissance n'est en cours"
 
-    @NotImplemented
     Scénario: Impossible de rejeter le changement de puissance d'un projet lauréat si la demande a déjà été accordée
         Etant donné une demande de changement de puissance à la baisse accordée pour le projet lauréat
         Quand la DREAL associée au projet rejette le changement de puissance à la baisse pour le projet lauréat
-        Alors l'utilisateur DREAL devrait être informé que "La demande de changement de puissance a déjà été accordée"
+        Alors l'utilisateur DREAL devrait être informé que "Aucune demande de changement de puissance n'est en cours"
 
     @NotImplemented
     Scénario: Impossible de rejeter le changement de puissance d'un projet lauréat si la demande a déjà été annulée

--- a/packages/specifications/src/projet/lauréat/puissance/changement/stepDefinitions/changementPuissance.given.ts
+++ b/packages/specifications/src/projet/lauréat/puissance/changement/stepDefinitions/changementPuissance.given.ts
@@ -6,6 +6,7 @@ import {
   demanderChangementPuissance,
   accorderChangementPuissance,
   annulerChangementPuissance,
+  rejeterChangementPuissance,
 } from './changementPuissance.when';
 
 EtantDonné(
@@ -25,6 +26,17 @@ EtantDonné(
     try {
       await demanderChangementPuissance.call(this, 'lauréat');
       await accorderChangementPuissance.call(this, this.utilisateurWorld.drealFixture.role);
+    } catch (error) {
+      this.error = error as Error;
+    }
+  },
+);
+EtantDonné(
+  'une demande de changement de puissance à la baisse rejetée pour le projet lauréat',
+  async function (this: PotentielWorld) {
+    try {
+      await demanderChangementPuissance.call(this, 'lauréat');
+      await rejeterChangementPuissance.call(this, this.utilisateurWorld.drealFixture.role);
     } catch (error) {
       this.error = error as Error;
     }

--- a/packages/specifications/src/projet/lauréat/puissance/changement/stepDefinitions/changementPuissance.then.ts
+++ b/packages/specifications/src/projet/lauréat/puissance/changement/stepDefinitions/changementPuissance.then.ts
@@ -58,7 +58,7 @@ Alors(
 Alors(
   `la demande de changement de la puissance devrait être rejetée`,
   async function (this: PotentielWorld) {
-    await vérifierChangementPuissance.bind(
+    await vérifierChangementPuissance.call(
       this,
       this.candidatureWorld.importerCandidature.identifiantProjet,
       Puissance.StatutChangementPuissance.rejeté,

--- a/packages/specifications/src/projet/lauréat/puissance/changement/stepDefinitions/changementPuissance.then.ts
+++ b/packages/specifications/src/projet/lauréat/puissance/changement/stepDefinitions/changementPuissance.then.ts
@@ -56,6 +56,17 @@ Alors(
 );
 
 Alors(
+  `la demande de changement de la puissance devrait être rejetée`,
+  async function (this: PotentielWorld) {
+    await vérifierChangementPuissance.bind(
+      this,
+      this.candidatureWorld.importerCandidature.identifiantProjet,
+      Puissance.StatutChangementPuissance.rejeté,
+    );
+  },
+);
+
+Alors(
   'le changement enregistré de puissance devrait être consultable',
   async function (this: PotentielWorld) {
     await vérifierChangementPuissance.call(
@@ -130,6 +141,30 @@ async function vérifierChangementPuissance(
     const actualContent = await convertReadableStreamToString(result.content);
     const expectedContent = await convertReadableStreamToString(
       this.lauréatWorld.puissanceWorld.changementPuissanceWorld.accorderChangementPuissanceFixture
+        .réponseSignée?.content ?? new ReadableStream(),
+    );
+    expect(actualContent).to.be.equal(expectedContent);
+  }
+
+  if (
+    this.lauréatWorld.puissanceWorld.changementPuissanceWorld.rejeterChangementPuissanceFixture
+      .aÉtéCréé &&
+    !demandeEnCours.demande.isInformationEnregistrée
+  ) {
+    const result = await mediator.send<ConsulterDocumentProjetQuery>({
+      type: 'Document.Query.ConsulterDocumentProjet',
+      data: {
+        documentKey: demandeEnCours.demande.rejet
+          ? demandeEnCours.demande.rejet.réponseSignée.formatter()
+          : '',
+      },
+    });
+
+    assert(Option.isSome(result), `Réponse signée non trouvée !`);
+
+    const actualContent = await convertReadableStreamToString(result.content);
+    const expectedContent = await convertReadableStreamToString(
+      this.lauréatWorld.puissanceWorld.changementPuissanceWorld.rejeterChangementPuissanceFixture
         .réponseSignée?.content ?? new ReadableStream(),
     );
     expect(actualContent).to.be.equal(expectedContent);

--- a/packages/specifications/src/projet/lauréat/puissance/changement/stepDefinitions/changementPuissance.when.ts
+++ b/packages/specifications/src/projet/lauréat/puissance/changement/stepDefinitions/changementPuissance.when.ts
@@ -124,6 +124,28 @@ Quand(
   },
 );
 
+Quand(
+  /la DREAL associée au projet rejette le changement de puissance (.*) pour le projet lauréat/,
+  async function (this: PotentielWorld, _: 'à la hausse' | 'à la baisse') {
+    try {
+      await rejeterChangementPuissance.call(this, this.utilisateurWorld.drealFixture.role);
+    } catch (error) {
+      this.error = error as Error;
+    }
+  },
+);
+
+Quand(
+  /le DGEC validateur rejette le changement de puissance (.*) pour le projet lauréat/,
+  async function (this: PotentielWorld, _: 'à la hausse' | 'à la baisse') {
+    try {
+      await rejeterChangementPuissance.call(this, this.utilisateurWorld.adminFixture.role);
+    } catch (error) {
+      this.error = error as Error;
+    }
+  },
+);
+
 export async function demanderChangementPuissance(
   this: PotentielWorld,
   statutProjet: 'lauréat' | 'éliminé',
@@ -234,6 +256,37 @@ export async function accorderChangementPuissance(
       identifiantProjetValue: identifiantProjet,
       accordéLeValue: accordéeLe,
       accordéParValue: accordéePar,
+      réponseSignéeValue: {
+        content: réponseSignée.content,
+        format: réponseSignée.format,
+      },
+      rôleUtilisateurValue,
+    },
+  });
+}
+
+export async function rejeterChangementPuissance(
+  this: PotentielWorld,
+  rôleUtilisateurValue: 'dreal' | 'admin',
+) {
+  const identifiantProjet = this.lauréatWorld.identifiantProjet.formatter();
+
+  const { rejetetéeLe, rejetetéePar, réponseSignée } =
+    this.lauréatWorld.puissanceWorld.changementPuissanceWorld.rejeterChangementPuissanceFixture.créer(
+      {
+        rejetetéePar:
+          rôleUtilisateurValue === 'dreal'
+            ? this.utilisateurWorld.drealFixture.email
+            : this.utilisateurWorld.adminFixture.email,
+      },
+    );
+
+  await mediator.send<Puissance.PuissanceUseCase>({
+    type: 'Lauréat.Puissance.UseCase.RejeterDemandeChangement',
+    data: {
+      identifiantProjetValue: identifiantProjet,
+      rejetéLeValue: rejetetéeLe,
+      rejetéParValue: rejetetéePar,
       réponseSignéeValue: {
         content: réponseSignée.content,
         format: réponseSignée.format,

--- a/packages/specifications/src/projet/lauréat/puissance/changement/stepDefinitions/changementPuissance.when.ts
+++ b/packages/specifications/src/projet/lauréat/puissance/changement/stepDefinitions/changementPuissance.when.ts
@@ -104,10 +104,18 @@ Quand(
 );
 
 Quand(
-  /la DREAL associée au projet accorde le changement de puissance (.*) pour le projet lauréat/,
-  async function (this: PotentielWorld, _: 'à la hausse' | 'à la baisse') {
+  /(.*) accorde le changement de puissance pour le projet lauréat/,
+  async function (
+    this: PotentielWorld,
+    rôle: 'la DREAL associée au projet' | 'le DGEC validateur',
+  ) {
     try {
-      await accorderChangementPuissance.call(this, this.utilisateurWorld.drealFixture.role);
+      await accorderChangementPuissance.call(
+        this,
+        rôle === 'la DREAL associée au projet'
+          ? this.utilisateurWorld.drealFixture.role
+          : this.utilisateurWorld.adminFixture.role,
+      );
     } catch (error) {
       this.error = error as Error;
     }
@@ -115,32 +123,18 @@ Quand(
 );
 
 Quand(
-  /le DGEC validateur accorde le changement de puissance (.*) pour le projet lauréat/,
-  async function (this: PotentielWorld, _: 'à la hausse' | 'à la baisse') {
+  /(.*) rejette le changement de puissance pour le projet lauréat/,
+  async function (
+    this: PotentielWorld,
+    rôle: 'la DREAL associée au projet' | 'le DGEC validateur',
+  ) {
     try {
-      await accorderChangementPuissance.call(this, this.utilisateurWorld.adminFixture.role);
-    } catch (error) {
-      this.error = error as Error;
-    }
-  },
-);
-
-Quand(
-  /la DREAL associée au projet rejette le changement de puissance (.*) pour le projet lauréat/,
-  async function (this: PotentielWorld, _: 'à la hausse' | 'à la baisse') {
-    try {
-      await rejeterChangementPuissance.call(this, this.utilisateurWorld.drealFixture.role);
-    } catch (error) {
-      this.error = error as Error;
-    }
-  },
-);
-
-Quand(
-  /le DGEC validateur rejette le changement de puissance (.*) pour le projet lauréat/,
-  async function (this: PotentielWorld, _: 'à la hausse' | 'à la baisse') {
-    try {
-      await rejeterChangementPuissance.call(this, this.utilisateurWorld.adminFixture.role);
+      await rejeterChangementPuissance.call(
+        this,
+        rôle === 'la DREAL associée au projet'
+          ? this.utilisateurWorld.drealFixture.role
+          : this.utilisateurWorld.adminFixture.role,
+      );
     } catch (error) {
       this.error = error as Error;
     }

--- a/packages/specifications/src/projet/lauréat/puissance/changement/stepDefinitions/changementPuissance.when.ts
+++ b/packages/specifications/src/projet/lauréat/puissance/changement/stepDefinitions/changementPuissance.when.ts
@@ -4,6 +4,7 @@ import { mediator } from 'mediateur';
 import { Puissance } from '@potentiel-domain/laureat';
 
 import { PotentielWorld } from '../../../../../potentiel.world';
+import { UtilisateurWorld } from '../../../../../utilisateur/utilisateur.world';
 
 Quand(
   'le porteur demande le changement de puissance avec la même valeur pour le projet lauréat',
@@ -236,7 +237,9 @@ export async function annulerChangementPuissance(this: PotentielWorld) {
 
 export async function accorderChangementPuissance(
   this: PotentielWorld,
-  rôleUtilisateurValue: 'dreal' | 'admin',
+  rôleUtilisateurValue:
+    | UtilisateurWorld['drealFixture']['role']
+    | UtilisateurWorld['adminFixture']['role'],
 ) {
   const identifiantProjet = this.lauréatWorld.identifiantProjet.formatter();
 
@@ -267,7 +270,9 @@ export async function accorderChangementPuissance(
 
 export async function rejeterChangementPuissance(
   this: PotentielWorld,
-  rôleUtilisateurValue: 'dreal' | 'admin',
+  rôleUtilisateurValue:
+    | UtilisateurWorld['drealFixture']['role']
+    | UtilisateurWorld['adminFixture']['role'],
 ) {
   const identifiantProjet = this.lauréatWorld.identifiantProjet.formatter();
 

--- a/packages/specifications/src/projet/lauréat/puissance/changement/stepDefinitions/changementPuissance.when.ts
+++ b/packages/specifications/src/projet/lauréat/puissance/changement/stepDefinitions/changementPuissance.when.ts
@@ -276,10 +276,10 @@ export async function rejeterChangementPuissance(
 ) {
   const identifiantProjet = this.lauréatWorld.identifiantProjet.formatter();
 
-  const { rejetetéeLe, rejetetéePar, réponseSignée } =
+  const { rejetéeLe, rejetéePar, réponseSignée } =
     this.lauréatWorld.puissanceWorld.changementPuissanceWorld.rejeterChangementPuissanceFixture.créer(
       {
-        rejetetéePar:
+        rejetéePar:
           rôleUtilisateurValue === 'dreal'
             ? this.utilisateurWorld.drealFixture.email
             : this.utilisateurWorld.adminFixture.email,
@@ -290,8 +290,8 @@ export async function rejeterChangementPuissance(
     type: 'Lauréat.Puissance.UseCase.RejeterDemandeChangement',
     data: {
       identifiantProjetValue: identifiantProjet,
-      rejetéLeValue: rejetetéeLe,
-      rejetéParValue: rejetetéePar,
+      rejetéLeValue: rejetéeLe,
+      rejetéParValue: rejetéePar,
       réponseSignéeValue: {
         content: réponseSignée.content,
         format: réponseSignée.format,

--- a/packages/specifications/src/projet/lauréat/puissance/puissance.world.ts
+++ b/packages/specifications/src/projet/lauréat/puissance/puissance.world.ts
@@ -56,6 +56,10 @@ export class PuissanceWorld {
         }).demande.nouvellePuissance;
         expected.dateDemandeEnCours = undefined;
       }
+
+      if (this.#changementPuissanceWorld.rejeterChangementPuissanceFixture.aÉtéCréé) {
+        expected.dateDemandeEnCours = undefined;
+      }
     }
 
     return expected;

--- a/packages/specifications/src/projet/lauréat/puissance/stepDefinitions/puissance.then.ts
+++ b/packages/specifications/src/projet/lauréat/puissance/stepDefinitions/puissance.then.ts
@@ -34,32 +34,7 @@ Alors(
 );
 
 Alors(
-  'la puissance du projet lauréat devrait être mise à jour',
-  async function (this: PotentielWorld) {
-    return waitForExpect(async () => {
-      const identifiantProjet = IdentifiantProjet.convertirEnValueType(
-        this.candidatureWorld.importerCandidature.identifiantProjet,
-      );
-
-      const puissance = await mediator.send<Puissance.PuissanceQuery>({
-        type: 'Lauréat.Puissance.Query.ConsulterPuissance',
-        data: {
-          identifiantProjet: identifiantProjet.formatter(),
-        },
-      });
-
-      const actual = mapToPlainObject(puissance);
-      const expected = mapToPlainObject(
-        this.lauréatWorld.puissanceWorld.mapToExpected(identifiantProjet),
-      );
-
-      actual.should.be.deep.equal(expected);
-    });
-  },
-);
-
-Alors(
-  'la puissance du projet lauréat ne devrait pas être mise à jour',
+  'la puissance du projet lauréat( ne) devrait( pas) être mise à jour',
   async function (this: PotentielWorld) {
     return waitForExpect(async () => {
       const identifiantProjet = IdentifiantProjet.convertirEnValueType(

--- a/packages/specifications/src/projet/lauréat/puissance/stepDefinitions/puissance.then.ts
+++ b/packages/specifications/src/projet/lauréat/puissance/stepDefinitions/puissance.then.ts
@@ -4,7 +4,7 @@ import waitForExpect from 'wait-for-expect';
 
 import { mapToPlainObject } from '@potentiel-domain/core';
 import { Puissance } from '@potentiel-domain/laureat';
-import { IdentifiantProjet } from '@potentiel-domain/common';
+import { IdentifiantProjet } from '@potentiel-domain/projet';
 
 import { PotentielWorld } from '../../../../potentiel.world';
 
@@ -35,6 +35,31 @@ Alors(
 
 Alors(
   'la puissance du projet lauréat devrait être mise à jour',
+  async function (this: PotentielWorld) {
+    return waitForExpect(async () => {
+      const identifiantProjet = IdentifiantProjet.convertirEnValueType(
+        this.candidatureWorld.importerCandidature.identifiantProjet,
+      );
+
+      const puissance = await mediator.send<Puissance.PuissanceQuery>({
+        type: 'Lauréat.Puissance.Query.ConsulterPuissance',
+        data: {
+          identifiantProjet: identifiantProjet.formatter(),
+        },
+      });
+
+      const actual = mapToPlainObject(puissance);
+      const expected = mapToPlainObject(
+        this.lauréatWorld.puissanceWorld.mapToExpected(identifiantProjet),
+      );
+
+      actual.should.be.deep.equal(expected);
+    });
+  },
+);
+
+Alors(
+  'la puissance du projet lauréat ne devrait pas être mise à jour',
   async function (this: PotentielWorld) {
     return waitForExpect(async () => {
       const identifiantProjet = IdentifiantProjet.convertirEnValueType(


### PR DESCRIPTION
- **✅ La DREAL associée au projet rejette le changement de puissance d'un projet lauréat**
- **✅ Le DGEC validateur rejette le changement de puissance d'un projet lauréat**
- **✅ Impossible de rejeter une demande de changement de puissance à la hausse d'un projet lauréat pour un utilisateur DREAL**
- **✅ Impossible de rejeter une demande de changement de puissance à la baisse d'un projet lauréat pour un utilisateur DGEC**
- **✅ Impossible de rejeter le changement de puissance d'un projet lauréat si aucune demande n'est en cours**
- **✅ Impossible de rejeter le changement de puissance d'un projet lauréat si la demande a déjà été accordée**
- **✅ Impossible de rejeter le changement de puissance d'un projet lauréat si la demande a déjà été annulée**
- **✅ Impossible de rejeter le changement de puissance d'un projet lauréat si la demande a déjà été rejetée**
- **✅ Impossible d'accorder le changement de puissance d'un projet lauréat si la demande a déjà été rejetée**
