### PR TITLE
✨ Ajout des règles de ratios dans le domain puissance

### DIFF
--- a/packages/applications/routes/src/lauréat/puissance.routes.ts
+++ b/packages/applications/routes/src/lauréat/puissance.routes.ts
@@ -4,7 +4,7 @@ import { encodeParameter } from '../encodeParameter';
 
 type ListerFilters = {
   statut?: Puissance.StatutChangementPuissance.RawType;
-  autoriteInstructrice?: Puissance.RatioChangementPuissance.AutoritéCompétente;
+  autoriteInstructrice?: Puissance.AutoritéCompétente.RawType;
 };
 
 export const modifier = (identifiantProjet: string) =>

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/puissance/changement/[date]/page.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/puissance/changement/[date]/page.tsx
@@ -99,7 +99,7 @@ export default async function Page({ params: { identifiant, date } }: PageProps)
 const mapToActions = (
   statut: Puissance.StatutChangementPuissance.ValueType,
   rôle: Role.ValueType,
-  autoritéCompétente?: Puissance.RatioChangementPuissance.AutoritéCompétente,
+  autoritéCompétente?: Puissance.AutoritéCompétente.RawType,
 ): Array<ChangementPuissanceActions> => {
   const actions: Array<ChangementPuissanceActions> = [];
 

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/puissance/changement/[date]/page.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/puissance/changement/[date]/page.tsx
@@ -85,7 +85,7 @@ export default async function Page({ params: { identifiant, date } }: PageProps)
           actions={mapToActions(
             changement.demande.statut,
             utilisateur.role,
-            changement.demande.autoritéCompétente,
+            changement.demande.autoritéCompétente?.autoritéCompétente,
           )}
           demandeEnCoursDate={
             puissance.dateDemandeEnCours ? puissance.dateDemandeEnCours.formatter() : undefined

--- a/packages/applications/ssr/src/app/laureats/changements/puissance/page.tsx
+++ b/packages/applications/ssr/src/app/laureats/changements/puissance/page.tsx
@@ -29,7 +29,7 @@ const paramsSchema = z.object({
   page: z.coerce.number().int().optional().default(1),
   nomProjet: z.string().optional(),
   appelOffre: z.string().optional(),
-  autoriteInstructrice: z.enum(Puissance.RatioChangementPuissance.autoritéCompétentes).optional(),
+  autoriteInstructrice: z.enum(Puissance.AutoritéCompétente.autoritéCompétentes).optional(),
   statut: z.enum(Puissance.StatutChangementPuissance.statuts).optional(),
 });
 
@@ -90,7 +90,7 @@ export default async function Page({ searchParams }: PageProps) {
         filters.push({
           label: 'Autorité instructrice',
           searchParamKey: 'autoriteInstructrice',
-          options: Puissance.RatioChangementPuissance.autoritéCompétentes.map((autorité) => ({
+          options: Puissance.AutoritéCompétente.autoritéCompétentes.map((autorité) => ({
             label: match(autorité)
               .with('dreal', () => 'DREAL')
               .with('dgec-admin', () => 'DGEC')

--- a/packages/applications/ssr/src/components/pages/puissance/changement/détails/DétailsChangementPuissance.tsx
+++ b/packages/applications/ssr/src/components/pages/puissance/changement/détails/DétailsChangementPuissance.tsx
@@ -68,7 +68,7 @@ export const DétailsChangementPuissance: FC<DétailsChangementPuissanceProps> =
           nouvellePuissance={demande.nouvellePuissance}
           raison={demande.raison}
           pièceJustificative={demande.pièceJustificative}
-          autoritéCompétente={demande.autoritéCompétente}
+          autoritéCompétente={demande.autoritéCompétente?.autoritéCompétente}
           unitéPuissance={unitéPuissance}
         />
       </>
@@ -80,7 +80,7 @@ type ChangementProps = {
   raison: DétailsChangementPuissanceProps['demande']['raison'];
   pièceJustificative: DétailsChangementPuissanceProps['demande']['pièceJustificative'];
   nouvellePuissance: DétailsChangementPuissanceProps['demande']['nouvellePuissance'];
-  unitePuissance: DétailsChangementPuissanceProps['unitePuissance'];
+  unitéPuissance: DétailsChangementPuissanceProps['unitéPuissance'];
   autoritéCompétente?: Puissance.AutoritéCompétente.RawType;
 };
 

--- a/packages/applications/ssr/src/components/pages/puissance/changement/détails/DétailsChangementPuissance.tsx
+++ b/packages/applications/ssr/src/components/pages/puissance/changement/détails/DétailsChangementPuissance.tsx
@@ -80,8 +80,8 @@ type ChangementProps = {
   raison: DétailsChangementPuissanceProps['demande']['raison'];
   pièceJustificative: DétailsChangementPuissanceProps['demande']['pièceJustificative'];
   nouvellePuissance: DétailsChangementPuissanceProps['demande']['nouvellePuissance'];
-  unitéPuissance: DétailsChangementPuissanceProps['unitéPuissance'];
-  autoritéCompétente?: Puissance.RatioChangementPuissance.AutoritéCompétente;
+  unitePuissance: DétailsChangementPuissanceProps['unitePuissance'];
+  autoritéCompétente?: Puissance.AutoritéCompétente.RawType;
 };
 
 const Changement: FC<ChangementProps> = ({

--- a/packages/domain/candidature/src/candidature.aggregate.ts
+++ b/packages/domain/candidature/src/candidature.aggregate.ts
@@ -28,7 +28,7 @@ import {
   notifier,
 } from './notifier/notifierCandidature.behavior';
 import { CandidatureNonTrouvéeError } from './candidatureNonTrouvée.error';
-import { TypeActionnariat } from './candidature';
+import { TypeActionnariat, TypeTechnologie } from './candidature';
 
 export type CandidatureEvent =
   | CandidatureImportéeEvent
@@ -70,6 +70,8 @@ export type CandidatureAggregate = Aggregate<CandidatureEvent> &
     };
     emailContact: Email.ValueType;
     prixRéférence: number;
+    technologie: TypeTechnologie.ValueType;
+    note: number;
     importer: typeof importer;
     corriger: typeof corriger;
     notifier: typeof notifier;
@@ -118,6 +120,8 @@ export const getDefaultCandidatureAggregate: GetDefaultAggregateState<
   nomReprésentantLégal: '',
   sociétéMère: '',
   estNotifiée: false,
+  note: 0,
+  technologie: TypeTechnologie.nonApplicable,
   apply,
   importer,
   corriger,

--- a/packages/domain/candidature/src/corriger/corrigerCandidature.behavior.ts
+++ b/packages/domain/candidature/src/corriger/corrigerCandidature.behavior.ts
@@ -20,7 +20,7 @@ import {
 import { AttestationNonGénéréeError } from '../attestationNonGénérée.error';
 import { CandidatureNonTrouvéeError } from '../candidatureNonTrouvée.error';
 import * as TypeGarantiesFinancières from '../typeGarantiesFinancières.valueType';
-import { TypeActionnariat } from '../candidature';
+import { TypeActionnariat, TypeTechnologie } from '../candidature';
 import {
   ChoixCoefficientKNonAttenduError,
   ChoixCoefficientKRequisError,
@@ -161,6 +161,8 @@ export function applyCandidatureCorrigée(
   this.sociétéMère = payload.sociétéMère;
   this.nomReprésentantLégal = payload.nomReprésentantLégal;
   this.puissance = payload.puissanceProductionAnnuelle;
+  this.note = payload.noteTotale;
+  this.technologie = TypeTechnologie.convertirEnValueType(payload.technologie);
 }
 
 class StatutNonModifiableAprèsNotificationError extends InvalidOperationError {

--- a/packages/domain/candidature/src/importer/importerCandidature.behavior.ts
+++ b/packages/domain/candidature/src/importer/importerCandidature.behavior.ts
@@ -197,6 +197,8 @@ export function applyCandidatureImportée(
     : undefined;
   this.emailContact = Email.convertirEnValueType(payload.emailContact);
   this.prixRéférence = payload.prixReference;
+  this.note = payload.noteTotale;
+  this.technologie = TypeTechnologie.convertirEnValueType(payload.technologie);
 }
 
 export const mapToEventPayload = (candidature: ImporterCandidatureBehaviorCommonOptions) => ({

--- a/packages/domain/lauréat/src/puissance/changement/changementPuissance.entity.ts
+++ b/packages/domain/lauréat/src/puissance/changement/changementPuissance.entity.ts
@@ -1,7 +1,7 @@
 import { DateTime } from '@potentiel-domain/common';
 import { Entity } from '@potentiel-domain/entity';
 
-import { RatioChangementPuissance, StatutChangementPuissance } from '..';
+import { AutoritéCompétente, StatutChangementPuissance } from '..';
 
 export type ChangementPuissanceEntity = Entity<
   'changement-puissance',
@@ -13,7 +13,7 @@ export type ChangementPuissanceEntity = Entity<
       demandéeLe: DateTime.RawType;
       nouvellePuissance: number;
       statut: StatutChangementPuissance.RawType;
-      autoritéCompétente?: RatioChangementPuissance.AutoritéCompétente;
+      autoritéCompétente?: AutoritéCompétente.RawType;
       raison?: string;
       pièceJustificative?: {
         format: string;

--- a/packages/domain/lauréat/src/puissance/changement/consulter/consulterChangementPuissance.query.ts
+++ b/packages/domain/lauréat/src/puissance/changement/consulter/consulterChangementPuissance.query.ts
@@ -7,8 +7,8 @@ import { DocumentProjet } from '@potentiel-domain/document';
 import { IdentifiantProjet } from '@potentiel-domain/projet';
 
 import {
+  AutoritéCompétente,
   ChangementPuissanceEntity,
-  RatioChangementPuissance,
   StatutChangementPuissance,
   TypeDocumentPuissance,
 } from '../..';
@@ -21,7 +21,7 @@ export type ConsulterChangementPuissanceReadModel = {
     demandéeLe: DateTime.ValueType;
     nouvellePuissance: number;
     statut: StatutChangementPuissance.ValueType;
-    autoritéCompétente?: RatioChangementPuissance.AutoritéCompétente;
+    autoritéCompétente?: AutoritéCompétente.ValueType;
     raison?: string;
     pièceJustificative?: DocumentProjet.ValueType;
     accord?: {

--- a/packages/domain/lauréat/src/puissance/changement/consulter/consulterChangementPuissance.query.ts
+++ b/packages/domain/lauréat/src/puissance/changement/consulter/consulterChangementPuissance.query.ts
@@ -83,7 +83,9 @@ export const mapToReadModel = (result: ChangementPuissanceEntity) => {
       nouvellePuissance: result.demande.nouvellePuissance,
       statut,
       raison: result.demande.raison,
-      autoritéCompétente: result.demande.autoritéCompétente,
+      autoritéCompétente: result.demande.autoritéCompétente
+        ? AutoritéCompétente.convertirEnValueType(result.demande.autoritéCompétente)
+        : undefined,
       pièceJustificative: result.demande.pièceJustificative
         ? DocumentProjet.convertirEnValueType(
             result.identifiantProjet,

--- a/packages/domain/lauréat/src/puissance/changement/demander/demanderChangementPuissance.behavior.ts
+++ b/packages/domain/lauréat/src/puissance/changement/demander/demanderChangementPuissance.behavior.ts
@@ -12,8 +12,6 @@ import {
   ProjetAbandonnéError,
   ProjetAvecDemandeAbandonEnCoursError,
   ProjetAchevéError,
-  PuissanceDépassePuissanceMaxFamille,
-  PuissanceDépasseVolumeRéservéAO,
   AppelOffreInexistantError,
   CahierDesChargesInexistantError,
   PériodeInexistanteError,
@@ -109,7 +107,7 @@ export async function demanderChangement(
   }
   const famille = période.familles.find((f) => f.id === identifiantProjet.famille);
 
-  const ratioValueType = RatioChangementPuissance.bind({
+  RatioChangementPuissance.bind({
     appelOffre,
     période,
     famille,
@@ -118,16 +116,7 @@ export async function demanderChangement(
     technologie: technologie.type,
     nouvellePuissance: puissance,
     note,
-  });
-
-  // ordre des erreurs suit celui du legacy
-  if (ratioValueType.dépassePuissanceMaxFamille()) {
-    throw new PuissanceDépassePuissanceMaxFamille();
-  }
-
-  if (ratioValueType.dépassePuissanceMaxDuVolumeRéservé()) {
-    throw new PuissanceDépasseVolumeRéservéAO();
-  }
+  }).vérifierQueLaDemandeEstPossible('demande');
 
   const event: ChangementPuissanceDemandéEvent = {
     type: 'ChangementPuissanceDemandé-V1',

--- a/packages/domain/lauréat/src/puissance/changement/demander/demanderChangementPuissance.behavior.ts
+++ b/packages/domain/lauréat/src/puissance/changement/demander/demanderChangementPuissance.behavior.ts
@@ -134,9 +134,8 @@ export async function demanderChangement(
     payload: {
       identifiantProjet: identifiantProjet.formatter(),
       puissance,
-      autoritéCompétente: AutoritéCompétente.bind({
-        ratio: puissance / this.puissance,
-      }).getAutoritéCompétente(),
+      autoritéCompétente: AutoritéCompétente.déterminer(puissance / this.puissance)
+        .autoritéCompétente,
       pièceJustificative: {
         format: pièceJustificative.format,
       },

--- a/packages/domain/lauréat/src/puissance/changement/demander/demanderChangementPuissance.command.ts
+++ b/packages/domain/lauréat/src/puissance/changement/demander/demanderChangementPuissance.command.ts
@@ -3,10 +3,13 @@ import { Message, MessageHandler, mediator } from 'mediateur';
 import { DateTime, Email, IdentifiantProjet } from '@potentiel-domain/common';
 import { DocumentProjet } from '@potentiel-domain/document';
 import { LoadAggregate } from '@potentiel-domain/core';
+import { AppelOffre } from '@potentiel-domain/appel-offre';
+import { Candidature } from '@potentiel-domain/candidature';
 
 import { loadAbandonFactory } from '../../../abandon';
 import { loadAchèvementFactory } from '../../../achèvement/achèvement.aggregate';
 import { loadPuissanceFactory } from '../../puissance.aggregate';
+import { CahierDesCharges } from '../../..';
 
 export type DemanderChangementCommand = Message<
   'Lauréat.Puissance.Command.DemanderChangement',
@@ -24,6 +27,7 @@ export const registerDemanderChangementPuissanceCommand = (loadAggregate: LoadAg
   const loadPuissance = loadPuissanceFactory(loadAggregate);
   const loadAbandon = loadAbandonFactory(loadAggregate);
   const loadAchèvement = loadAchèvementFactory(loadAggregate);
+  const loadCandidature = Candidature.Aggregate.loadCandidatureFactory(loadAggregate);
   const handler: MessageHandler<DemanderChangementCommand> = async ({
     identifiantProjet,
     pièceJustificative,
@@ -35,6 +39,24 @@ export const registerDemanderChangementPuissanceCommand = (loadAggregate: LoadAg
     const puissanceAggrégat = await loadPuissance(identifiantProjet);
     const abandon = await loadAbandon(identifiantProjet, false);
     const achèvement = await loadAchèvement(identifiantProjet, false);
+    const candidature = await loadCandidature(identifiantProjet);
+
+    // Après migration aggregate root, à remplacer
+    const appelOffre = await mediator.send<AppelOffre.ConsulterAppelOffreQuery>({
+      type: 'AppelOffre.Query.ConsulterAppelOffre',
+      data: {
+        identifiantAppelOffre: identifiantProjet.appelOffre,
+      },
+    });
+
+    // Après migration cahier des charges, à remplacer
+    const cahierDesChargesChoisi =
+      await mediator.send<CahierDesCharges.ConsulterCahierDesChargesChoisiQuery>({
+        type: 'Lauréat.CahierDesCharges.Query.ConsulterCahierDesChargesChoisi',
+        data: {
+          identifiantProjet: identifiantProjet.formatter(),
+        },
+      });
 
     await puissanceAggrégat.demanderChangement({
       identifiantProjet,
@@ -46,6 +68,10 @@ export const registerDemanderChangementPuissanceCommand = (loadAggregate: LoadAg
       estAbandonné: abandon.statut.estAccordé(),
       demandeAbandonEnCours: abandon.statut.estEnCours(),
       estAchevé: achèvement.estAchevé(),
+      appelOffre,
+      technologie: candidature.technologie,
+      cahierDesCharges: cahierDesChargesChoisi,
+      note: candidature.note,
     });
   };
   mediator.register('Lauréat.Puissance.Command.DemanderChangement', handler);

--- a/packages/domain/lauréat/src/puissance/changement/enregistrerChangement/enregistrerChangementPuissance.behavior.ts
+++ b/packages/domain/lauréat/src/puissance/changement/enregistrerChangement/enregistrerChangementPuissance.behavior.ts
@@ -1,15 +1,26 @@
 import { DomainEvent } from '@potentiel-domain/core';
 import { DateTime, Email, IdentifiantProjet } from '@potentiel-domain/common';
 import { DocumentProjet } from '@potentiel-domain/document';
+import { Candidature } from '@potentiel-domain/candidature';
+import { Option } from '@potentiel-libraries/monads';
+import { AppelOffre } from '@potentiel-domain/appel-offre';
 
 import { PuissanceAggregate } from '../../puissance.aggregate';
-import { StatutChangementPuissance } from '../..';
+import { RatioChangementPuissance, StatutChangementPuissance } from '../..';
 import {
   ProjetAbandonnéError,
   ProjetAvecDemandeAbandonEnCoursError,
   ProjetAchevéError,
+  PuissanceDépassePuissanceMaxAO,
+  PuissanceEnDeçaPuissanceMinAO,
+  PuissanceDépassePuissanceMaxFamille,
+  PuissanceDépasseVolumeRéservéAO,
+  AppelOffreInexistantError,
+  CahierDesChargesInexistantError,
+  PériodeInexistanteError,
 } from '../errors';
 import { PuissanceIdentiqueError } from '../../errors';
+import { ConsulterCahierDesChargesChoisiReadmodel } from '../../../cahierDesChargesChoisi';
 
 export type ChangementPuissanceEnregistréEvent = DomainEvent<
   'ChangementPuissanceEnregistré-V1',
@@ -35,6 +46,10 @@ export type EnregistrerChangementOptions = {
   estAbandonné: boolean;
   estAchevé: boolean;
   demandeAbandonEnCours: boolean;
+  appelOffre: Option.Type<AppelOffre.ConsulterAppelOffreReadModel>;
+  technologie: Candidature.TypeTechnologie.ValueType;
+  cahierDesCharges: Option.Type<ConsulterCahierDesChargesChoisiReadmodel>;
+  note: number;
 };
 
 export async function enregistrerChangement(
@@ -49,15 +64,15 @@ export async function enregistrerChangement(
     estAbandonné,
     estAchevé,
     demandeAbandonEnCours,
+    appelOffre,
+    technologie,
+    cahierDesCharges,
+    note,
   }: EnregistrerChangementOptions,
 ) {
   if (this.puissance === puissance) {
     throw new PuissanceIdentiqueError();
   }
-
-  // TODO: on ajoutera des vraies règles pour valider le ratios ici à l'aide du value type
-  // const ratio = puissance / this.puissance;
-  // vérifierQueLeChangementDePuissanceEstPossibleAvecEn(this.puissance)
 
   if (this.demande) {
     this.demande.statut.vérifierQueLeChangementDeStatutEstPossibleEn(
@@ -75,6 +90,48 @@ export async function enregistrerChangement(
 
   if (estAchevé) {
     throw new ProjetAchevéError();
+  }
+
+  if (Option.isNone(cahierDesCharges)) {
+    throw new CahierDesChargesInexistantError();
+  }
+
+  if (Option.isNone(appelOffre)) {
+    throw new AppelOffreInexistantError(identifiantProjet.appelOffre);
+  }
+
+  const période = appelOffre.periodes.find((p) => p.id === identifiantProjet.période);
+  if (!période) {
+    throw new PériodeInexistanteError(identifiantProjet.période);
+  }
+  const famille = période.familles.find((f) => f.id === identifiantProjet.famille);
+
+  const ratioValueType = RatioChangementPuissance.bind({
+    appelOffre,
+    période,
+    famille,
+    cahierDesCharges,
+    technologie: technologie.type,
+    ratio: puissance / this.puissance,
+    nouvellePuissance: puissance,
+    note,
+  });
+
+  // ordre des erreurs suit celui du legacy
+  if (ratioValueType.dépassePuissanceMaxFamille()) {
+    throw new PuissanceDépassePuissanceMaxFamille();
+  }
+
+  if (ratioValueType.dépassePuissanceMaxDuVolumeRéservé()) {
+    throw new PuissanceDépasseVolumeRéservéAO();
+  }
+
+  if (ratioValueType.dépasseRatiosChangementPuissance().dépasseMax) {
+    throw new PuissanceDépassePuissanceMaxAO();
+  }
+
+  if (ratioValueType.dépasseRatiosChangementPuissance().enDeçaDeMin) {
+    throw new PuissanceEnDeçaPuissanceMinAO();
   }
 
   const event: ChangementPuissanceEnregistréEvent = {

--- a/packages/domain/lauréat/src/puissance/changement/enregistrerChangement/enregistrerChangementPuissance.behavior.ts
+++ b/packages/domain/lauréat/src/puissance/changement/enregistrerChangement/enregistrerChangementPuissance.behavior.ts
@@ -11,10 +11,6 @@ import {
   ProjetAbandonnéError,
   ProjetAvecDemandeAbandonEnCoursError,
   ProjetAchevéError,
-  PuissanceDépassePuissanceMaxAO,
-  PuissanceEnDeçaPuissanceMinAO,
-  PuissanceDépassePuissanceMaxFamille,
-  PuissanceDépasseVolumeRéservéAO,
   AppelOffreInexistantError,
   CahierDesChargesInexistantError,
   PériodeInexistanteError,
@@ -106,7 +102,7 @@ export async function enregistrerChangement(
   }
   const famille = période.familles.find((f) => f.id === identifiantProjet.famille);
 
-  const ratioValueType = RatioChangementPuissance.bind({
+  RatioChangementPuissance.bind({
     appelOffre,
     période,
     famille,
@@ -115,24 +111,7 @@ export async function enregistrerChangement(
     ratio: puissance / this.puissance,
     nouvellePuissance: puissance,
     note,
-  });
-
-  // ordre des erreurs suit celui du legacy
-  if (ratioValueType.dépassePuissanceMaxFamille()) {
-    throw new PuissanceDépassePuissanceMaxFamille();
-  }
-
-  if (ratioValueType.dépassePuissanceMaxDuVolumeRéservé()) {
-    throw new PuissanceDépasseVolumeRéservéAO();
-  }
-
-  if (ratioValueType.dépasseRatiosChangementPuissance().dépasseMax) {
-    throw new PuissanceDépassePuissanceMaxAO();
-  }
-
-  if (ratioValueType.dépasseRatiosChangementPuissance().enDeçaDeMin) {
-    throw new PuissanceEnDeçaPuissanceMinAO();
-  }
+  }).vérifierQueLaDemandeEstPossible('information-enregistrée');
 
   const event: ChangementPuissanceEnregistréEvent = {
     type: 'ChangementPuissanceEnregistré-V1',

--- a/packages/domain/lauréat/src/puissance/changement/errors.ts
+++ b/packages/domain/lauréat/src/puissance/changement/errors.ts
@@ -1,4 +1,4 @@
-import { DomainError } from '@potentiel-domain/core';
+import { DomainError, InvalidOperationError } from '@potentiel-domain/core';
 
 export class ProjetAbandonnéError extends DomainError {
   constructor() {

--- a/packages/domain/lauréat/src/puissance/changement/errors.ts
+++ b/packages/domain/lauréat/src/puissance/changement/errors.ts
@@ -37,3 +37,21 @@ export class RéponseSignéeObligatoireSiAccordSansDécisionDeLEtatError extends
     super("La réponse signée est obligatoire si l'accord n'est pas une décision de l'État");
   }
 }
+
+export class AppelOffreInexistantError extends InvalidOperationError {
+  constructor(appelOffre: string) {
+    super(`L'appel d'offre spécifié n'existe pas`, { appelOffre });
+  }
+}
+
+export class PériodeInexistanteError extends InvalidOperationError {
+  constructor(période: string) {
+    super(`La période spécifiée n'existe pas`, { période });
+  }
+}
+
+export class CahierDesChargesInexistantError extends InvalidOperationError {
+  constructor() {
+    super(`Le cahier des charges spécifié n'existe pas`);
+  }
+}

--- a/packages/domain/lauréat/src/puissance/changement/lister/listerChangementPuissance.query.ts
+++ b/packages/domain/lauréat/src/puissance/changement/lister/listerChangementPuissance.query.ts
@@ -10,11 +10,7 @@ import {
   Utilisateur,
 } from '../../../_utils/getRoleBasedWhereCondition';
 import { Lauréat } from '../../..';
-import {
-  ChangementPuissanceEntity,
-  RatioChangementPuissance,
-  StatutChangementPuissance,
-} from '../..';
+import { AutoritéCompétente, ChangementPuissanceEntity, StatutChangementPuissance } from '../..';
 
 type ChangementPuissanceItemReadModel = {
   identifiantProjet: IdentifiantProjet.ValueType;
@@ -38,7 +34,7 @@ export type ListerChangementPuissanceQuery = Message<
     statut?: StatutChangementPuissance.RawType;
     appelOffre?: string;
     nomProjet?: string;
-    autoriteInstructrice?: RatioChangementPuissance.AutoritéCompétente;
+    autoriteInstructrice?: AutoritéCompétente.RawType;
     range: RangeOptions;
   },
   ListerChangementPuissanceReadModel

--- a/packages/domain/lauréat/src/puissance/index.ts
+++ b/packages/domain/lauréat/src/puissance/index.ts
@@ -99,6 +99,7 @@ export * from './changement/changementPuissance.entity';
 export * as StatutChangementPuissance from './valueType/statutChangementPuissance.valueType';
 export * as TypeDocumentPuissance from './valueType/typeDocumentPuissance.valueType';
 export * as RatioChangementPuissance from './valueType/ratioChangementPuissance.valueType';
+export * as AutoritéCompétente from './valueType/autoritéCompétente.valueType';
 
 // Saga
 export * as PuissanceSaga from './saga';

--- a/packages/domain/lauréat/src/puissance/puissance.aggregate.ts
+++ b/packages/domain/lauréat/src/puissance/puissance.aggregate.ts
@@ -3,7 +3,7 @@ import { match } from 'ts-pattern';
 import { IdentifiantProjet } from '@potentiel-domain/common';
 import { Aggregate, GetDefaultAggregateState, LoadAggregate } from '@potentiel-domain/core';
 
-import { RatioChangementPuissance, StatutChangementPuissance } from '.';
+import { AutoritéCompétente, StatutChangementPuissance } from '.';
 
 import { applyPuissanceImportée, importer } from './importer/importerPuissance.behavior';
 import { PuissanceImportéeEvent } from './importer/importerPuissance.behavior';
@@ -60,7 +60,7 @@ export type PuissanceAggregate = Aggregate<PuissanceEvent> & {
   demande?: {
     statut: StatutChangementPuissance.ValueType;
     nouvellePuissance: number;
-    autoritéCompétente?: RatioChangementPuissance.AutoritéCompétente;
+    autoritéCompétente?: AutoritéCompétente.RawType;
   };
 
   readonly importer: typeof importer;

--- a/packages/domain/lauréat/src/puissance/valueType/autoritéCompétente.valueType.ts
+++ b/packages/domain/lauréat/src/puissance/valueType/autoritéCompétente.valueType.ts
@@ -1,24 +1,44 @@
-import { PlainType, ReadonlyValueType } from '@potentiel-domain/core';
+import { InvalidOperationError, PlainType, ReadonlyValueType } from '@potentiel-domain/core';
 
 export const autoritéCompétentes = ['dreal', 'dgec-admin'] as const;
 
 export type RawType = (typeof autoritéCompétentes)[number];
 
 export type ValueType = ReadonlyValueType<{
-  ratio: number;
-  getAutoritéCompétente: () => RawType;
+  autoritéCompétente: RawType;
 }>;
 
-export const bind = ({ ratio }: PlainType<ValueType>): ValueType => {
+export const bind = ({ autoritéCompétente }: PlainType<ValueType>): ValueType => {
   return {
-    get ratio() {
-      return ratio;
-    },
-    getAutoritéCompétente(): RawType {
-      return ratio < 1 ? 'dreal' : 'dgec-admin';
+    get autoritéCompétente() {
+      return autoritéCompétente;
     },
     estÉgaleÀ(valueType) {
-      return this.ratio === valueType.ratio;
+      return this.autoritéCompétente === valueType.autoritéCompétente;
     },
   };
 };
+
+export const convertirEnValueType = (value: string): ValueType => {
+  estValide(value);
+  return bind({ autoritéCompétente: value });
+};
+
+function estValide(value: string): asserts value is RawType {
+  const isValid = autoritéCompétentes.includes(value as RawType);
+
+  if (!isValid) {
+    throw new AutoritéCompétenteInvalideError(value);
+  }
+}
+
+export const déterminer = (ratio: number): ValueType =>
+  ratio < 1 ? convertirEnValueType('dreal') : convertirEnValueType('dgec-admin');
+
+class AutoritéCompétenteInvalideError extends InvalidOperationError {
+  constructor(value: string) {
+    super(`L'autorité compétente ne correspond à aucune valeur connue`, {
+      value,
+    });
+  }
+}

--- a/packages/domain/lauréat/src/puissance/valueType/autoritéCompétente.valueType.ts
+++ b/packages/domain/lauréat/src/puissance/valueType/autoritéCompétente.valueType.ts
@@ -1,0 +1,24 @@
+import { PlainType, ReadonlyValueType } from '@potentiel-domain/core';
+
+export const autoritéCompétentes = ['dreal', 'dgec-admin'] as const;
+
+export type RawType = (typeof autoritéCompétentes)[number];
+
+export type ValueType = ReadonlyValueType<{
+  ratio: number;
+  getAutoritéCompétente: () => RawType;
+}>;
+
+export const bind = ({ ratio }: PlainType<ValueType>): ValueType => {
+  return {
+    get ratio() {
+      return ratio;
+    },
+    getAutoritéCompétente(): RawType {
+      return ratio < 1 ? 'dreal' : 'dgec-admin';
+    },
+    estÉgaleÀ(valueType) {
+      return this.ratio === valueType.ratio;
+    },
+  };
+};

--- a/packages/domain/lauréat/src/puissance/valueType/helpers/dépassePuissanceMaxDuVolumeRéservé.ts
+++ b/packages/domain/lauréat/src/puissance/valueType/helpers/dépassePuissanceMaxDuVolumeRéservé.ts
@@ -1,0 +1,33 @@
+import { AppelOffre } from '@potentiel-domain/appel-offre';
+import { PlainType } from '@potentiel-domain/core';
+
+export const dépassePuissanceMaxDuVolumeRéservé = ({
+  période,
+  nouvellePuissance,
+  puissanceActuelle,
+  note,
+}: {
+  note: number;
+  nouvellePuissance: number;
+  puissanceActuelle: number;
+  période: PlainType<AppelOffre.Periode>;
+}): boolean => {
+  if (période.noteThresholdBy !== 'category') return false;
+
+  const désignationCatégorie =
+    puissanceActuelle <= période.noteThreshold.volumeReserve.puissanceMax &&
+    note >= période.noteThreshold.volumeReserve.noteThreshold
+      ? 'volume-réservé'
+      : 'hors-volume-réservé';
+
+  const volumeReservé = période.noteThreshold.volumeReserve;
+
+  if (volumeReservé) {
+    const { puissanceMax } = volumeReservé;
+    if (désignationCatégorie == 'volume-réservé' && nouvellePuissance > puissanceMax) {
+      return true;
+    }
+  }
+
+  return false;
+};

--- a/packages/domain/lauréat/src/puissance/valueType/helpers/dépassePuissanceMaxFamille.ts
+++ b/packages/domain/lauréat/src/puissance/valueType/helpers/dépassePuissanceMaxFamille.ts
@@ -1,0 +1,17 @@
+import { AppelOffre } from '@potentiel-domain/appel-offre';
+
+export const dépassePuissanceMaxFamille = ({
+  famille,
+  nouvellePuissance,
+}: {
+  famille: Pick<AppelOffre.Famille, 'puissanceMax'> | undefined;
+  nouvellePuissance: number;
+}): boolean => {
+  const puissanceMaxFamille = famille?.puissanceMax;
+
+  if (!puissanceMaxFamille) {
+    return false;
+  }
+
+  return nouvellePuissance > puissanceMaxFamille;
+};

--- a/packages/domain/lauréat/src/puissance/valueType/helpers/dépasseRatiosChangementPuissance.ts
+++ b/packages/domain/lauréat/src/puissance/valueType/helpers/dépasseRatiosChangementPuissance.ts
@@ -1,0 +1,9 @@
+export const dépasseRatiosChangementPuissance = ({
+  minRatio,
+  maxRatio,
+  ratio,
+}: {
+  minRatio: number;
+  maxRatio: number;
+  ratio: number;
+}) => ({ enDeçaDeMin: ratio < minRatio, dépasseMax: ratio > maxRatio });

--- a/packages/domain/lauréat/src/puissance/valueType/helpers/getRatiosChangementPuissance.ts
+++ b/packages/domain/lauréat/src/puissance/valueType/helpers/getRatiosChangementPuissance.ts
@@ -1,0 +1,49 @@
+import { Candidature } from '@potentiel-domain/candidature';
+import { AppelOffre } from '@potentiel-domain/appel-offre';
+import { PlainType } from '@potentiel-domain/core';
+
+import { ConsulterCahierDesChargesChoisiReadmodel } from '../../../cahierDesChargesChoisi';
+
+const defaultRatios = { min: 0.9, max: 1.1 };
+
+export const getRatiosChangementPuissance = ({
+  appelOffre,
+  technologie,
+  cahierDesCharges,
+}: {
+  appelOffre: Pick<AppelOffre.ConsulterAppelOffreReadModel, 'changementPuissance'>;
+  technologie: Candidature.TypeTechnologie.RawType;
+  cahierDesCharges: PlainType<ConsulterCahierDesChargesChoisiReadmodel>;
+}): { min: number; max: number } => {
+  if (!appelOffre) {
+    return defaultRatios;
+  }
+
+  // prendre les ratios du CDC 2022 si existants
+  if (cahierDesCharges.type === 'modifié' && cahierDesCharges.paruLe === '30/08/2022') {
+    const seuilsCDC = cahierDesCharges?.seuilSupplémentaireChangementPuissance;
+
+    if (seuilsCDC?.changementByTechnologie) {
+      if (technologie === 'N/A') {
+        return defaultRatios;
+      }
+      return seuilsCDC.ratios[technologie];
+    } else if (seuilsCDC) {
+      return seuilsCDC.ratios;
+    }
+  }
+
+  // sinon prendre les ratio du CDC initial par technologie
+  const { changementPuissance } = appelOffre;
+
+  if (changementPuissance.changementByTechnologie) {
+    if (technologie === 'N/A') {
+      return defaultRatios;
+    }
+
+    return changementPuissance.ratios[technologie];
+  }
+
+  // sinon prendre les ratios du CDC initial
+  return changementPuissance.ratios;
+};

--- a/packages/domain/lauréat/src/puissance/valueType/helpers/index.ts
+++ b/packages/domain/lauréat/src/puissance/valueType/helpers/index.ts
@@ -1,0 +1,4 @@
+export * from './dépassePuissanceMaxDuVolumeRéservé';
+export * from './getRatiosChangementPuissance';
+export * from './dépasseRatiosChangementPuissance';
+export * from './dépassePuissanceMaxFamille';

--- a/packages/domain/lauréat/src/puissance/valueType/ratioChangementPuissance.valueType.ts
+++ b/packages/domain/lauréat/src/puissance/valueType/ratioChangementPuissance.valueType.ts
@@ -129,12 +129,12 @@ class PuissanceEnDeçaPuissanceMinAO extends DomainError {
 
 class PuissanceDépassePuissanceMaxFamille extends DomainError {
   constructor() {
-    super("La puissance dépasse la puissance maximale de la famille de votre appel d'offre");
+    super("La puissance dépasse la puissance maximale de la famille de l'appel d'offre");
   }
 }
 
 class PuissanceDépasseVolumeRéservéAO extends DomainError {
   constructor() {
-    super("La puissance dépasse le volume réservé de votre appel d'offre");
+    super("La puissance dépasse le volume réservé de l'appel d'offre");
   }
 }

--- a/packages/domain/lauréat/src/puissance/valueType/ratioChangementPuissance.valueType.ts
+++ b/packages/domain/lauréat/src/puissance/valueType/ratioChangementPuissance.valueType.ts
@@ -1,29 +1,95 @@
 import { PlainType, ReadonlyValueType } from '@potentiel-domain/core';
+import { AppelOffre } from '@potentiel-domain/appel-offre';
+import { Candidature } from '@potentiel-domain/candidature';
 
-// work in progress
-// ce value type sera utilisé pour vérifier les règles de ratios de puissance
-// ainsi que pour la règle liée à l'autorité compétente
-export const autoritéCompétentes = ['dreal', 'dgec-admin'] as const;
+import { ConsulterCahierDesChargesChoisiReadmodel } from '../../cahierDesChargesChoisi';
 
-export type AutoritéCompétente = (typeof autoritéCompétentes)[number];
+import {
+  dépassePuissanceMaxDuVolumeRéservé,
+  dépassePuissanceMaxFamille,
+  dépasseRatiosChangementPuissance,
+  getRatiosChangementPuissance,
+} from './helpers';
 
 export type RawType = number;
 
 export type ValueType = ReadonlyValueType<{
   ratio: number;
-  getAutoritéCompétente: () => AutoritéCompétente;
+  appelOffre: PlainType<AppelOffre.ConsulterAppelOffreReadModel>;
+  technologie: Candidature.TypeTechnologie.RawType;
+  cahierDesCharges: PlainType<ConsulterCahierDesChargesChoisiReadmodel>;
+  période: PlainType<AppelOffre.Periode>;
+  nouvellePuissance: number;
+  famille?: AppelOffre.Famille;
+  note: number;
+  dépasseRatiosChangementPuissance: () => { enDeçaDeMin: boolean; dépasseMax: boolean };
+  dépassePuissanceMaxDuVolumeRéservé: () => boolean;
+  dépassePuissanceMaxFamille: () => boolean;
 }>;
 
-export const bind = ({ ratio }: PlainType<ValueType>): ValueType => {
+export const bind = ({
+  ratio,
+  appelOffre,
+  note,
+  période,
+  nouvellePuissance,
+  famille,
+  technologie,
+  cahierDesCharges,
+}: PlainType<ValueType>): ValueType => {
   return {
     get ratio() {
       return ratio;
     },
+    get appelOffre() {
+      return appelOffre;
+    },
+    get technologie() {
+      return technologie;
+    },
+    get cahierDesCharges() {
+      return cahierDesCharges;
+    },
+    get période() {
+      return période;
+    },
+    get nouvellePuissance() {
+      return nouvellePuissance;
+    },
+    get famille() {
+      return famille;
+    },
+    get note() {
+      return note;
+    },
     estÉgaleÀ(valueType) {
       return this.ratio === valueType.ratio;
     },
-    getAutoritéCompétente(): AutoritéCompétente {
-      return ratio < 1 ? 'dreal' : 'dgec-admin';
+    dépasseRatiosChangementPuissance(): { enDeçaDeMin: boolean; dépasseMax: boolean } {
+      const { min, max } = getRatiosChangementPuissance({
+        appelOffre: this.appelOffre,
+        technologie,
+        cahierDesCharges: this.cahierDesCharges,
+      });
+      return dépasseRatiosChangementPuissance({
+        minRatio: min,
+        maxRatio: max,
+        ratio,
+      });
+    },
+    dépassePuissanceMaxFamille(): boolean {
+      return dépassePuissanceMaxFamille({
+        famille: this.famille,
+        nouvellePuissance,
+      });
+    },
+    dépassePuissanceMaxDuVolumeRéservé(): boolean {
+      return dépassePuissanceMaxDuVolumeRéservé({
+        note,
+        période,
+        nouvellePuissance,
+        puissanceActuelle: nouvellePuissance / this.ratio,
+      });
     },
   };
 };

--- a/packages/specifications/src/projet/lauréat/puissance/changement/accorderChangementPuissance.feature
+++ b/packages/specifications/src/projet/lauréat/puissance/changement/accorderChangementPuissance.feature
@@ -2,7 +2,10 @@
 Fonctionnalité: Accorder le changement de puissance d'un projet lauréat
 
     Contexte:
-        Etant donné le projet lauréat "Du boulodrome de Marseille"
+        # on est obligés de cibler un AO et une période spécifique pour simplifier les fixtures
+        Etant donné le projet lauréat "Du boulodrome de Marseille" avec :
+            | appel d'offre | PPE2 - Eolien |
+            | période       | 1             |
         Et le porteur "Marcel Patoulatchi" ayant accés au projet lauréat "Du boulodrome de Marseille"
         Et la dreal "Dreal du sud" associée à la région du projet
 

--- a/packages/specifications/src/projet/lauréat/puissance/changement/accorderChangementPuissance.feature
+++ b/packages/specifications/src/projet/lauréat/puissance/changement/accorderChangementPuissance.feature
@@ -2,7 +2,6 @@
 Fonctionnalité: Accorder le changement de puissance d'un projet lauréat
 
     Contexte:
-        # on est obligés de cibler un AO et une période spécifique pour simplifier les fixtures
         Etant donné le projet lauréat "Du boulodrome de Marseille" avec :
             | appel d'offre | PPE2 - Eolien |
             | période       | 1             |
@@ -10,7 +9,8 @@ Fonctionnalité: Accorder le changement de puissance d'un projet lauréat
         Et la dreal "Dreal du sud" associée à la région du projet
 
     Scénario: la DREAL associée au projet accorde une demande de changement de puissance à la baisse d'un projet lauréat
-        Etant donné une demande de changement de puissance à la baisse pour le projet lauréat
+        Etant donné une demande de changement de puissance pour le projet lauréat avec :
+            | ratio puissance | 0.75 |
         Quand la DREAL associée au projet accorde le changement de puissance pour le projet lauréat
         Alors la demande de changement de la puissance devrait être accordée
         Et la puissance du projet lauréat devrait être mise à jour
@@ -21,7 +21,8 @@ Fonctionnalité: Accorder le changement de puissance d'un projet lauréat
             | type       | accord                                                                                                                             |
 
     Scénario: le DGEC validateur accorde une demande de changement de puissance à la hausse d'un projet lauréat
-        Etant donné une demande de changement de puissance à la hausse pour le projet lauréat
+        Etant donné une demande de changement de puissance pour le projet lauréat avec :
+            | ratio puissance | 1.45 |
         Quand le DGEC validateur accorde le changement de puissance pour le projet lauréat
         Alors la demande de changement de la puissance devrait être accordée
         Et la puissance du projet lauréat devrait être mise à jour
@@ -32,7 +33,8 @@ Fonctionnalité: Accorder le changement de puissance d'un projet lauréat
             | type       | accord                                                                                                                             |
 
     Scénario: Impossible d'accorder une demande de changement de puissance à la hausse d'un projet lauréat pour un utilisateur DREAL
-        Etant donné une demande de changement de puissance à la hausse pour le projet lauréat
+        Etant donné une demande de changement de puissance pour le projet lauréat avec :
+            | ratio puissance | 1.45 |
         Quand la DREAL associée au projet accorde le changement de puissance pour le projet lauréat
         Alors l'utilisateur DREAL devrait être informé que "Une demande de changement de puissance à la hausse doit être instruite par la DGEC"
 
@@ -41,16 +43,17 @@ Fonctionnalité: Accorder le changement de puissance d'un projet lauréat
         Alors l'utilisateur DREAL devrait être informé que "Aucune demande de changement de puissance n'est en cours"
 
     Scénario: Impossible d'accorder le changement de puissance d'un projet lauréat si la demande a déjà été accordée
-        Etant donné une demande de changement de puissance à la baisse accordée pour le projet lauréat
         Quand la DREAL associée au projet accorde le changement de puissance pour le projet lauréat
         Alors l'utilisateur DREAL devrait être informé que "Aucune demande de changement de puissance n'est en cours"
 
     Scénario: Impossible d'accorder le changement de puissance d'un projet lauréat si la demande a déjà été annulée
-        Etant donné une demande de changement de puissance à la baisse annulée pour le projet lauréat
+        Etant donné une demande de changement de puissance annulée pour le projet lauréat
+            | ratio puissance | 0.75 |
         Quand la DREAL associée au projet accorde le changement de puissance pour le projet lauréat
         Alors l'utilisateur DREAL devrait être informé que "Aucune demande de changement de puissance n'est en cours"
 
     Scénario: Impossible d'accorder le changement de puissance d'un projet lauréat si la demande a déjà été rejetée
-        Etant donné une demande de changement de puissance à la baisse rejetée pour le projet lauréat
+        Etant donné une demande de changement de puissance rejetée pour le projet lauréat
+            | ratio puissance | 0.75 |
         Quand la DREAL associée au projet accorde le changement de puissance pour le projet lauréat
         Alors l'utilisateur DREAL devrait être informé que "Aucune demande de changement de puissance n'est en cours"

--- a/packages/specifications/src/projet/lauréat/puissance/changement/annulerChangementPuissance.feature
+++ b/packages/specifications/src/projet/lauréat/puissance/changement/annulerChangementPuissance.feature
@@ -2,15 +2,25 @@
 Fonctionnalité: Annuler la demande changement de puissance d'un projet lauréat
 
     Contexte:
-        # on est obligés de cibler un AO et une période spécifique pour simplifier les fixtures
         Etant donné le projet lauréat "Du boulodrome de Marseille" avec :
             | appel d'offre | PPE2 - Eolien |
             | période       | 1             |
         Et le porteur "Marcel Patoulatchi" ayant accés au projet lauréat "Du boulodrome de Marseille"
         Et la dreal "Dreal du sud" associée à la région du projet
 
-    Scénario: Annuler la demande de changement de puissance d'un projet lauréat
-        Etant donné une demande de changement de puissance à la baisse pour le projet lauréat
+    Scénario: Annuler la demande de changement de puissance à la baisse d'un projet lauréat
+        Etant donné une demande de changement de puissance pour le projet lauréat avec :
+            | ratio puissance | 0.75 |
+        Quand le porteur annule la demande de changement de puissance pour le projet lauréat
+        Alors la demande de changement de puissance ne devrait plus être consultable
+        Et un email a été envoyé à la dreal avec :
+            | sujet      | Potentiel - La demande de changement de puissance pour le projet Du boulodrome de Marseille dans le département(.*) a été annulée |
+            | nom_projet | Du boulodrome de Marseille                                                                                                        |
+            | url        | https://potentiel.beta.gouv.fr/projet/.*/details.html                                                                             |
+
+    Scénario: Annuler la demande de changement de puissance à la hause d'un projet lauréat
+        Etant donné une demande de changement de puissance pour le projet lauréat avec :
+            | ratio puissance | 1.41 |
         Quand le porteur annule la demande de changement de puissance pour le projet lauréat
         Alors la demande de changement de puissance ne devrait plus être consultable
         Et un email a été envoyé à la dreal avec :
@@ -23,11 +33,13 @@ Fonctionnalité: Annuler la demande changement de puissance d'un projet lauréat
         Alors l'utilisateur devrait être informé que "Aucune demande de changement de puissance n'est en cours"
 
     Scénario: Impossible d'annuler la demande de changement de puissance si la demande est acceptée
-        Etant donné une demande de changement de puissance à la baisse accordée pour le projet lauréat
+        Etant donné une demande de changement de puissance accordée pour le projet lauréat
+            | ratio puissance | 0.75 |
         Quand le porteur annule la demande de changement de puissance pour le projet lauréat
         Alors l'utilisateur devrait être informé que "Aucune demande de changement de puissance n'est en cours"
 
     Scénario: Impossible d'annuler la demande de changement de puissance si la demande est rejetée
-        Etant donné une demande de changement de puissance à la baisse rejetée pour le projet lauréat
+        Etant donné une demande de changement de puissance rejetée pour le projet lauréat
+            | ratio puissance | 0.75 |
         Quand le porteur annule la demande de changement de puissance pour le projet lauréat
         Alors l'utilisateur devrait être informé que "Aucune demande de changement de puissance n'est en cours"

--- a/packages/specifications/src/projet/lauréat/puissance/changement/annulerChangementPuissance.feature
+++ b/packages/specifications/src/projet/lauréat/puissance/changement/annulerChangementPuissance.feature
@@ -33,7 +33,7 @@ Fonctionnalité: Annuler la demande changement de puissance d'un projet lauréat
         Alors l'utilisateur devrait être informé que "Aucune demande de changement de puissance n'est en cours"
 
     Scénario: Impossible d'annuler la demande de changement de puissance si la demande est acceptée
-        Etant donné une demande de changement de puissance accordée pour le projet lauréat
+        Etant donné une demande de changement de puissance accordée pour le projet lauréat avec :
             | ratio puissance | 0.75 |
         Quand le porteur annule la demande de changement de puissance pour le projet lauréat
         Alors l'utilisateur devrait être informé que "Aucune demande de changement de puissance n'est en cours"

--- a/packages/specifications/src/projet/lauréat/puissance/changement/annulerChangementPuissance.feature
+++ b/packages/specifications/src/projet/lauréat/puissance/changement/annulerChangementPuissance.feature
@@ -2,7 +2,10 @@
 Fonctionnalité: Annuler la demande changement de puissance d'un projet lauréat
 
     Contexte:
-        Etant donné le projet lauréat "Du boulodrome de Marseille"
+        # on est obligés de cibler un AO et une période spécifique pour simplifier les fixtures
+        Etant donné le projet lauréat "Du boulodrome de Marseille" avec :
+            | appel d'offre | PPE2 - Eolien |
+            | période       | 1             |
         Et le porteur "Marcel Patoulatchi" ayant accés au projet lauréat "Du boulodrome de Marseille"
         Et la dreal "Dreal du sud" associée à la région du projet
 

--- a/packages/specifications/src/projet/lauréat/puissance/changement/changementPuissance.world.ts
+++ b/packages/specifications/src/projet/lauréat/puissance/changement/changementPuissance.world.ts
@@ -83,9 +83,7 @@ export class ChangementPuissanceWorld {
         statut,
         // viovio
         autoritéCompétente: this.demanderChangementPuissanceFixture.aÉtéCréé
-          ? Puissance.AutoritéCompétente.bind({
-              ratio: this.demanderChangementPuissanceFixture.ratio,
-            }).getAutoritéCompétente()
+          ? Puissance.AutoritéCompétente.déterminer(baseFixture.ratio)
           : undefined,
       },
     };

--- a/packages/specifications/src/projet/lauréat/puissance/changement/changementPuissance.world.ts
+++ b/packages/specifications/src/projet/lauréat/puissance/changement/changementPuissance.world.ts
@@ -81,8 +81,9 @@ export class ChangementPuissanceWorld {
         ),
         raison: baseFixture.raison,
         statut,
+        // viovio
         autoritéCompétente: this.demanderChangementPuissanceFixture.aÉtéCréé
-          ? Puissance.RatioChangementPuissance.bind({
+          ? Puissance.AutoritéCompétente.bind({
               ratio: this.demanderChangementPuissanceFixture.ratio,
             }).getAutoritéCompétente()
           : undefined,

--- a/packages/specifications/src/projet/lauréat/puissance/changement/changementPuissance.world.ts
+++ b/packages/specifications/src/projet/lauréat/puissance/changement/changementPuissance.world.ts
@@ -81,7 +81,6 @@ export class ChangementPuissanceWorld {
         ),
         raison: baseFixture.raison,
         statut,
-        // viovio
         autoritéCompétente: this.demanderChangementPuissanceFixture.aÉtéCréé
           ? Puissance.AutoritéCompétente.déterminer(baseFixture.ratio)
           : undefined,

--- a/packages/specifications/src/projet/lauréat/puissance/changement/demanderChangementPuissance.feature
+++ b/packages/specifications/src/projet/lauréat/puissance/changement/demanderChangementPuissance.feature
@@ -54,7 +54,7 @@ Fonctionnalité: Demander le changement de puissance d'un projet lauréat
             | famille       | 1                 |
         Quand le porteur demande le changement de puissance pour le projet lauréat avec :
             | nouvelle puissance | 3.1 |
-        Alors l'utilisateur devrait être informé que "La puissance dépasse la puissance maximale de la famille de votre appel d'offre"
+        Alors l'utilisateur devrait être informé que "La puissance dépasse la puissance maximale de la famille de l'appel d'offre"
 
     Scénario: Scénario: Impossible pour le porteur de demander un changement de puissance si elle dépasse le volume réservé de l'appel d'offre
         Etant donné le projet lauréat "Du bouchon lyonnais" avec :
@@ -63,7 +63,7 @@ Fonctionnalité: Demander le changement de puissance d'un projet lauréat
             | note totale   | 34         |
         Quand le porteur demande le changement de puissance pour le projet lauréat avec :
             | nouvelle puissance | 6 |
-        Alors l'utilisateur devrait être informé que "La puissance dépasse le volume réservé de votre appel d'offre"
+        Alors l'utilisateur devrait être informé que "La puissance dépasse le volume réservé de l'appel d'offre"
 
     Scénario: Impossible de demander le changement de puissance si une demande existe déjà
         Etant donné une demande de changement de puissance pour le projet lauréat avec :

--- a/packages/specifications/src/projet/lauréat/puissance/changement/demanderChangementPuissance.feature
+++ b/packages/specifications/src/projet/lauréat/puissance/changement/demanderChangementPuissance.feature
@@ -2,7 +2,10 @@
 Fonctionnalité: Demander le changement de puissance d'un projet lauréat
 
     Contexte:
-        Etant donné le projet lauréat "Du boulodrome de Marseille"
+        # on est obligés de cibler un AO et une période spécifique pour simplifier les fixtures
+        Etant donné le projet lauréat "Du boulodrome de Marseille" avec :
+            | appel d'offre | PPE2 - Eolien |
+            | période       | 1             |
         Et le porteur "Marcel Patoulatchi" ayant accés au projet lauréat "Du boulodrome de Marseille"
         Et la dreal "Dreal du sud" associée à la région du projet
 
@@ -41,21 +44,22 @@ Fonctionnalité: Demander le changement de puissance d'un projet lauréat
             | 0     |
             | -1    |
 
-    @NotImplemented
-    Scénario: Impossible de demander le changement de puissance si la nouvelle puissance dépasse la puissance max par famille
+    Scénario: Impossible pour le porteur d'enregistrer un changement de puissance si elle dépasse la puissance max par famille
+        Etant donné le projet lauréat "Du bouchon lyonnais" avec :
+            | appel d'offre | PPE2 - Innovation |
+            | période       | 1                 |
+            | famille       | 1                 |
         Quand le porteur demande le changement de puissance pour le projet lauréat avec :
-            | nouvelle puissance |  |
-            | appel d'offre      |  |
-            | période            |  |
-            | famille            |  |
-
+            | nouvelle puissance | 3.1 |
         Alors l'utilisateur devrait être informé que "La puissance dépasse la puissance maximale de la famille de votre appel d'offre"
 
-    @NotImplemented
-    Scénario: Impossible de demander le changement de puissance si la nouvelle puissance dépasse le volume réservé de l'appel d'offre
+    Scénario: Scénario: Impossible pour le porteur de demander un changement de puissance si elle dépasse le volume réservé de l'appel d'offre
+        Etant donné le projet lauréat "Du bouchon lyonnais" avec :
+            | appel d'offre | PPE2 - Sol |
+            | période       | 3          |
+            | note totale   | 34         |
         Quand le porteur demande le changement de puissance pour le projet lauréat avec :
-            | nouvelle puissance |  |
-            | appel d'offre      |  |
+            | nouvelle puissance | 6 |
         Alors l'utilisateur devrait être informé que "La puissance dépasse le volume réservé de votre appel d'offre"
 
     Scénario: Impossible de demander le changement de puissance si une demande existe déjà

--- a/packages/specifications/src/projet/lauréat/puissance/changement/demanderChangementPuissance.feature
+++ b/packages/specifications/src/projet/lauréat/puissance/changement/demanderChangementPuissance.feature
@@ -2,7 +2,6 @@
 Fonctionnalité: Demander le changement de puissance d'un projet lauréat
 
     Contexte:
-        # on est obligés de cibler un AO et une période spécifique pour simplifier les fixtures
         Etant donné le projet lauréat "Du boulodrome de Marseille" avec :
             | appel d'offre | PPE2 - Eolien |
             | période       | 1             |
@@ -10,7 +9,8 @@ Fonctionnalité: Demander le changement de puissance d'un projet lauréat
         Et la dreal "Dreal du sud" associée à la région du projet
 
     Scénario: Demander le changement de puissance d'un projet lauréat avec un ratio à la baisse
-        Quand le porteur demande le changement de puissance à la baisse pour le projet lauréat
+        Quand le porteur demande le changement de puissance pour le projet lauréat avec :
+            | ratio puissance | 0.75 |
         Alors la demande de changement de puissance devrait être consultable
         Et un email a été envoyé à la dreal avec :
             | sujet      | Potentiel - changement de puissance pour le projet Du boulodrome de Marseille dans le département(.*) demandé |
@@ -18,7 +18,8 @@ Fonctionnalité: Demander le changement de puissance d'un projet lauréat
             | url        | https://potentiel.beta.gouv.fr/laureats/.*/puissance/changement/.*                                            |
 
     Scénario: Demander le changement de puissance d'un projet lauréat avec un ratio à la hausse
-        Quand le porteur demande le changement de puissance à la hausse pour le projet lauréat
+        Quand le porteur demande le changement de puissance pour le projet lauréat avec :
+            | ratio puissance | 1.25 |
         Alors la demande de changement de puissance devrait être consultable
         Et un email a été envoyé à la dgec avec :
             | sujet      | Potentiel - changement de puissance pour le projet Du boulodrome de Marseille dans le département(.*) demandé |
@@ -27,11 +28,13 @@ Fonctionnalité: Demander le changement de puissance d'un projet lauréat
 
     Scénario: Impossible de demander le changement de puissance si la puissance est inexistante
         Etant donné le projet éliminé "Du boulodrome de Lyon"
-        Quand le porteur demande le changement de puissance à la baisse pour le projet éliminé
+        Quand le porteur demande le changement de puissance pour le projet éliminé avec :
+            | ratio puissance | 0.75 |
         Alors l'utilisateur devrait être informé que "La puissance n'existe pas"
 
     Scénario: Impossible de demander le changement de puissance d'un projet lauréat avec une valeur identique
-        Quand le porteur demande le changement de puissance avec la même valeur pour le projet lauréat
+        Quand le porteur demande le changement de puissance pour le projet lauréat avec :
+            | ratio puissance | 1 |
         Alors l'utilisateur devrait être informé que "La puissance doit avoir une valeur différente"
 
     Scénario: Impossible de demander le changement de puissance si la nouvelle valeur est nulle ou négative
@@ -63,21 +66,26 @@ Fonctionnalité: Demander le changement de puissance d'un projet lauréat
         Alors l'utilisateur devrait être informé que "La puissance dépasse le volume réservé de votre appel d'offre"
 
     Scénario: Impossible de demander le changement de puissance si une demande existe déjà
-        Etant donné une demande de changement de puissance à la baisse pour le projet lauréat
-        Quand le porteur demande le changement de puissance à la baisse pour le projet lauréat
+        Etant donné une demande de changement de puissance pour le projet lauréat avec :
+            | ratio puissance | 0.95 |
+        Quand le porteur demande le changement de puissance pour le projet lauréat avec :
+            | ratio puissance | 1.25 |
         Alors l'utilisateur devrait être informé que "Une demande de changement est déjà en cours"
 
     Scénario: Impossible de demander le changement de puissance d'un projet lauréat abandonné
         Etant donné un abandon accordé pour le projet lauréat
-        Quand le porteur demande le changement de puissance à la baisse pour le projet lauréat
+        Quand le porteur demande le changement de puissance pour le projet lauréat avec :
+            | ratio puissance | 1.25 |
         Alors le porteur devrait être informé que "Impossible de demander le changement de puissance pour un projet abandonné"
 
     Scénario: Impossible de demander le changement de puissance si une demande d'abandon est en cours
         Etant donné une demande d'abandon en cours pour le projet lauréat
-        Quand le porteur demande le changement de puissance à la baisse pour le projet lauréat
+        Quand le porteur demande le changement de puissance pour le projet lauréat avec :
+            | ratio puissance | 1.25 |
         Alors le porteur devrait être informé que "Impossible de demander le changement de puissance car une demande d'abandon est en cours pour le projet"
 
     Scénario: Impossible de demander le changement de puissance d'un projet achevé
         Etant donné une attestation de conformité transmise pour le projet lauréat
-        Quand le porteur demande le changement de puissance à la baisse pour le projet lauréat
+        Quand le porteur demande le changement de puissance pour le projet lauréat avec :
+            | ratio puissance | 1.25 |
         Alors le porteur devrait être informé que "Impossible de demander le changement de puissance pour un projet achevé"

--- a/packages/specifications/src/projet/lauréat/puissance/changement/enregistrerChangementPuissance.feature
+++ b/packages/specifications/src/projet/lauréat/puissance/changement/enregistrerChangementPuissance.feature
@@ -2,7 +2,10 @@
 Fonctionnalité: Enregistrer un changement de puissance d'un projet lauréat
 
     Contexte:
-        Etant donné le projet lauréat "Du boulodrome de Marseille"
+        # on est obligés de cibler un AO et une période spécifique pour simplifier les fixtures
+        Etant donné le projet lauréat "Du boulodrome de Marseille" avec :
+            | appel d'offre | PPE2 - Eolien |
+            | période       | 1             |
         Et le porteur "Marcel Patoulatchi" ayant accés au projet lauréat "Du boulodrome de Marseille"
         Et la dreal "Dreal du sud" associée à la région du projet
 
@@ -20,7 +23,7 @@ Fonctionnalité: Enregistrer un changement de puissance d'un projet lauréat
         Alors l'utilisateur devrait être informé que "La puissance doit avoir une valeur différente"
 
     Scénario: Impossible d'enregistrer un changement de puissance si la puissance est inexistant
-        Etant donné le projet éliminé "Du boulodrome de Lyon"
+        Etant donné le projet éliminé "Du boulodrome lyonnais"
         Quand le porteur enregistre un changement de puissance pour le projet éliminé
         Alors l'utilisateur devrait être informé que "La puissance n'existe pas"
 
@@ -44,47 +47,46 @@ Fonctionnalité: Enregistrer un changement de puissance d'un projet lauréat
         Quand le porteur enregistre un changement de puissance pour le projet lauréat
         Alors le porteur devrait être informé que "Impossible de demander le changement de puissance pour un projet achevé"
 
-    @NotImplemented
-    Scénario: Impossible pour le porteur d'enregistrer un changement de puissance si elle est inférieure au ratio min
-        Etant donné le projet lauréat "Du bouchon de Lyon le retour" avec :
-            | appel d'offre   | <Appel d'offre> |
-            | ratio puissance | <Ratio>         |
-        Quand le porteur enregistre un changement de puissance pour le projet lauréat
-        Alors le porteur devrait être informé que "La puissance dépasse la puissance maximale autorisée par l'appel d'offres"
-
-        Exemples:
-            | Appel d'offre     | Ratio |
-            | PPE2 - Eolien     | 0.75  |
-            | CRE4 - Bâtiment   | 0.85  |
-            | CRE4 - Innovation | 0.65  |
-
-    @NotImplemented
-    Scénario: Impossible pour le porteur d'enregistrer un changement de puissance si elle est supérieure au ratio max
-        Etant donné le projet lauréat "Du bouchon de Lyon" avec :
-            | appel d'offre   | <Appel d'offre> |
-            | ratio puissance | <Ratio>         |
-        Quand le porteur enregistre un changement de puissance pour le projet lauréat
+    Scénario: Impossible pour le porteur d'enregistrer un changement de puissance si elle est inférieure au ratio min autorisé par l'appel d'offres
+        Etant donné le projet lauréat "Du bouchon lyonnais" avec :
+            | appel d'offre | <Appel d'offre> |
+            | période       | <Période>       |
+        Quand le porteur enregistre un changement de puissance pour le projet lauréat avec :
+            | ratio puissance | <Ratio> |
         Alors le porteur devrait être informé que "La puissance est en deça de la puissance minimale autorisée par l'appel d'offres"
 
         Exemples:
-            | Appel d'offre     | Ratio |
-            | PPE2 - Eolien     | 1.25  |
-            | CRE4 - Bâtiment   | 1.55  |
-            | CRE4 - Innovation | 1.15  |
+            | Appel d'offre | Période | Ratio |
+            | PPE2 - Eolien | 1       | 0.75  |
+            | CRE4 - Sol    | 7       | 0.85  |
 
-    @NotImplemented
+    Scénario: Impossible pour le porteur d'enregistrer un changement de puissance si elle est supérieure au ratio max autorisé par l'appel d'offres
+        Etant donné le projet lauréat "Du bouchon lyonnais" avec :
+            | appel d'offre | <Appel d'offre> |
+            | période       | <Période>       |
+        Quand le porteur enregistre un changement de puissance pour le projet lauréat avec :
+            | ratio puissance | <Ratio> |
+        Alors le porteur devrait être informé que "La puissance dépasse la puissance maximale autorisée par l'appel d'offres"
+
+        Exemples:
+            | Appel d'offre | Période | Ratio |
+            | PPE2 - Eolien | 1       | 1.25  |
+            | CRE4 - Sol    | 7       | 1.15  |
+
     Scénario: Impossible pour le porteur d'enregistrer un changement de puissance si elle dépasse la puissance max par famille
-        Quand le porteur demande le changement de puissance pour le projet lauréat avec :
-            | nouvelle puissance |  |
-            | appel d'offre      |  |
-            | période            |  |
-            | famille            |  |
-
+        Etant donné le projet lauréat "Du bouchon lyonnais" avec :
+            | appel d'offre | PPE2 - Innovation |
+            | période       | 1                 |
+            | famille       | 1                 |
+        Quand le porteur enregistre un changement de puissance pour le projet lauréat avec :
+            | nouvelle puissance | 3.1 |
         Alors l'utilisateur devrait être informé que "La puissance dépasse la puissance maximale de la famille de votre appel d'offre"
 
-    @NotImplemented
     Scénario: Scénario: Impossible pour le porteur d'enregistrer un changement de puissance si elle dépasse le volume réservé de l'appel d'offre
-        Quand le porteur demande le changement de puissance pour le projet lauréat avec :
-            | nouvelle puissance |  |
-            | appel d'offre      |  |
+        Etant donné le projet lauréat "Du bouchon lyonnais" avec :
+            | appel d'offre | PPE2 - Sol |
+            | période       | 3          |
+            | note totale   | 34         |
+        Quand le porteur enregistre un changement de puissance pour le projet lauréat avec :
+            | nouvelle puissance | 6 |
         Alors l'utilisateur devrait être informé que "La puissance dépasse le volume réservé de votre appel d'offre"

--- a/packages/specifications/src/projet/lauréat/puissance/changement/enregistrerChangementPuissance.feature
+++ b/packages/specifications/src/projet/lauréat/puissance/changement/enregistrerChangementPuissance.feature
@@ -87,7 +87,7 @@ Fonctionnalité: Enregistrer un changement de puissance d'un projet lauréat
             | famille       | 1                 |
         Quand le porteur enregistre un changement de puissance pour le projet lauréat avec :
             | nouvelle puissance | 3.1 |
-        Alors l'utilisateur devrait être informé que "La puissance dépasse la puissance maximale de la famille de votre appel d'offre"
+        Alors l'utilisateur devrait être informé que "La puissance dépasse la puissance maximale de la famille de l'appel d'offre"
 
     Scénario: Scénario: Impossible pour le porteur d'enregistrer un changement de puissance si elle dépasse le volume réservé de l'appel d'offre
         Etant donné le projet lauréat "Du bouchon lyonnais" avec :
@@ -96,4 +96,4 @@ Fonctionnalité: Enregistrer un changement de puissance d'un projet lauréat
             | note totale   | 34         |
         Quand le porteur enregistre un changement de puissance pour le projet lauréat avec :
             | nouvelle puissance | 6 |
-        Alors l'utilisateur devrait être informé que "La puissance dépasse le volume réservé de votre appel d'offre"
+        Alors l'utilisateur devrait être informé que "La puissance dépasse le volume réservé de l'appel d'offre"

--- a/packages/specifications/src/projet/lauréat/puissance/changement/enregistrerChangementPuissance.feature
+++ b/packages/specifications/src/projet/lauréat/puissance/changement/enregistrerChangementPuissance.feature
@@ -2,7 +2,6 @@
 Fonctionnalité: Enregistrer un changement de puissance d'un projet lauréat
 
     Contexte:
-        # on est obligés de cibler un AO et une période spécifique pour simplifier les fixtures
         Etant donné le projet lauréat "Du boulodrome de Marseille" avec :
             | appel d'offre | PPE2 - Eolien |
             | période       | 1             |
@@ -10,7 +9,8 @@ Fonctionnalité: Enregistrer un changement de puissance d'un projet lauréat
         Et la dreal "Dreal du sud" associée à la région du projet
 
     Scénario: Enregistrer un changement de puissance d'un projet lauréat
-        Quand le porteur enregistre un changement de puissance pour le projet lauréat
+        Quand le porteur enregistre un changement de puissance pour le projet lauréat avec :
+            | ratio puissance | 0.95 |
         Alors la puissance du projet lauréat devrait être mise à jour
         Et le changement enregistré de puissance devrait être consultable
         Et un email a été envoyé à la dreal avec :
@@ -19,32 +19,39 @@ Fonctionnalité: Enregistrer un changement de puissance d'un projet lauréat
             | url        | https://potentiel.beta.gouv.fr/projet/.*/details.html                                                                     |
 
     Scénario: Impossible de demander le changement de puissance d'un projet lauréat avec une valeur identique
-        Quand le porteur enregistre un changement de puissance avec la même valeur pour le projet lauréat
+        Quand le porteur enregistre un changement de puissance pour le projet lauréat avec :
+            | ratio puissance | 1 |
         Alors l'utilisateur devrait être informé que "La puissance doit avoir une valeur différente"
 
     Scénario: Impossible d'enregistrer un changement de puissance si la puissance est inexistant
         Etant donné le projet éliminé "Du boulodrome lyonnais"
-        Quand le porteur enregistre un changement de puissance pour le projet éliminé
+        Quand le porteur enregistre un changement de puissance pour le projet éliminé avec :
+            | ratio puissance | 0.95 |
         Alors l'utilisateur devrait être informé que "La puissance n'existe pas"
 
     Scénario: Impossible d'enregistrer un changement de puissance alors qu'un changement de puissance est en cours
-        Etant donné une demande de changement de puissance à la baisse pour le projet lauréat
-        Quand le porteur enregistre un changement de puissance pour le projet lauréat
+        Etant donné une demande de changement de puissance pour le projet lauréat avec :
+            | ratio puissance | 0.75 |
+        Quand le porteur enregistre un changement de puissance pour le projet lauréat avec :
+            | ratio puissance | 0.95 |
         Alors l'utilisateur devrait être informé que "Une demande de changement est déjà en cours"
 
     Scénario: Impossible pour le porteur d'enregistrer un changement de puissance d'un projet lauréat abandonné
         Etant donné un abandon accordé pour le projet lauréat
-        Quand le porteur enregistre un changement de puissance pour le projet lauréat
+        Quand le porteur enregistre un changement de puissance pour le projet lauréat avec :
+            | ratio puissance | 0.95 |
         Alors le porteur devrait être informé que "Impossible de demander le changement de puissance pour un projet abandonné"
 
     Scénario: Impossible pour le porteur d'enregistrer un changement de puissance si une demande d'abandon est en cours
         Etant donné une demande d'abandon en cours pour le projet lauréat
-        Quand le porteur enregistre un changement de puissance pour le projet lauréat
+        Quand le porteur enregistre un changement de puissance pour le projet lauréat avec :
+            | ratio puissance | 0.95 |
         Alors le porteur devrait être informé que "Impossible de demander le changement de puissance car une demande d'abandon est en cours pour le projet"
 
     Scénario: Impossible pour le porteur d'enregistrer un changement de puissance d'un projet achevé
         Etant donné une attestation de conformité transmise pour le projet lauréat
-        Quand le porteur enregistre un changement de puissance pour le projet lauréat
+        Quand le porteur enregistre un changement de puissance pour le projet lauréat avec :
+            | ratio puissance | 0.95 |
         Alors le porteur devrait être informé que "Impossible de demander le changement de puissance pour un projet achevé"
 
     Scénario: Impossible pour le porteur d'enregistrer un changement de puissance si elle est inférieure au ratio min autorisé par l'appel d'offres

--- a/packages/specifications/src/projet/lauréat/puissance/changement/fixture/demanderChangementPuissance.fixture.ts
+++ b/packages/specifications/src/projet/lauréat/puissance/changement/fixture/demanderChangementPuissance.fixture.ts
@@ -60,7 +60,8 @@ export class DemanderChangementPuissanceFixture
         format: faker.potentiel.fileFormat(),
         content: convertStringToReadableStream(content),
       },
-      ratio: faker.number.float({ min: 0.5, max: 0.8, multipleOf: 0.01 }),
+      // ce ratio est inférieur à celui de l'AO PPE2 - Eolien, Période 1 (0.8)
+      ratio: faker.number.float({ min: 0.7, max: 0.79, multipleOf: 0.01 }),
       ...partialData,
     };
 

--- a/packages/specifications/src/projet/lauréat/puissance/changement/fixture/enregistrerChangementPuissance.fixture.ts
+++ b/packages/specifications/src/projet/lauréat/puissance/changement/fixture/enregistrerChangementPuissance.fixture.ts
@@ -62,7 +62,7 @@ export class EnregistrerChangementPuissanceFixture
         format: faker.potentiel.fileFormat(),
         content: convertStringToReadableStream(content),
       },
-      ratio: faker.number.float({ min: 0.5, max: 0.8, multipleOf: 0.01 }),
+      ratio: faker.number.float({ min: 0.9, max: 0.99, multipleOf: 0.01 }),
       ...partialData,
     };
 

--- a/packages/specifications/src/projet/lauréat/puissance/changement/rejeterChangementPuissance.feature
+++ b/packages/specifications/src/projet/lauréat/puissance/changement/rejeterChangementPuissance.feature
@@ -2,7 +2,6 @@
 Fonctionnalité: Rejeter la demande de changement de puissance d'un projet lauréat
 
     Contexte:
-        # on est obligés de cibler un AO et une période spécifique pour simplifier les fixtures
         Etant donné le projet lauréat "Du boulodrome de Marseille" avec :
             | appel d'offre | PPE2 - Eolien |
             | période       | 1             |
@@ -10,7 +9,8 @@ Fonctionnalité: Rejeter la demande de changement de puissance d'un projet laur�
         Et la dreal "Dreal du sud" associée à la région du projet
 
     Scénario: la DREAL associée au projet rejette le changement de puissance d'un projet lauréat
-        Etant donné une demande de changement de puissance à la baisse pour le projet lauréat
+        Etant donné une demande de changement de puissance pour le projet lauréat avec :
+            | ratio puissance | 0.75 |
         Quand la DREAL associée au projet rejette le changement de puissance pour le projet lauréat
         Alors la demande de changement de la puissance devrait être rejetée
         Et la puissance du projet lauréat ne devrait pas être mise à jour
@@ -21,7 +21,8 @@ Fonctionnalité: Rejeter la demande de changement de puissance d'un projet laur�
             | type       | rejet                                                                                                                             |
 
     Scénario: le DGEC validateur rejette le changement de puissance d'un projet lauréat
-        Etant donné une demande de changement de puissance à la hausse pour le projet lauréat
+        Etant donné une demande de changement de puissance pour le projet lauréat avec :
+            | ratio puissance | 1.45 |
         Quand le DGEC validateur rejette le changement de puissance pour le projet lauréat
         Alors la demande de changement de la puissance devrait être rejetée
         Et la puissance du projet lauréat ne devrait pas être mise à jour
@@ -32,7 +33,8 @@ Fonctionnalité: Rejeter la demande de changement de puissance d'un projet laur�
             | type       | rejet                                                                                                                             |
 
     Scénario: Impossible de rejeter une demande de changement de puissance à la hausse d'un projet lauréat pour un utilisateur DREAL
-        Etant donné une demande de changement de puissance à la hausse pour le projet lauréat
+        Etant donné une demande de changement de puissance pour le projet lauréat avec :
+            | ratio puissance | 1.45 |
         Quand la DREAL associée au projet accorde le changement de puissance pour le projet lauréat
         Alors l'utilisateur DREAL devrait être informé que "Une demande de changement de puissance à la hausse doit être instruite par la DGEC"
 
@@ -41,16 +43,19 @@ Fonctionnalité: Rejeter la demande de changement de puissance d'un projet laur�
         Alors l'utilisateur DREAL devrait être informé que "Aucune demande de changement de puissance n'est en cours"
 
     Scénario: Impossible de rejeter le changement de puissance d'un projet lauréat si la demande a déjà été accordée
-        Etant donné une demande de changement de puissance à la baisse accordée pour le projet lauréat
+        Etant donné une demande de changement de puissance accordée pour le projet lauréat avec :
+            | ratio puissance | 0.75 |
         Quand la DREAL associée au projet rejette le changement de puissance pour le projet lauréat
         Alors l'utilisateur DREAL devrait être informé que "Aucune demande de changement de puissance n'est en cours"
 
     Scénario: Impossible de rejeter le changement de puissance d'un projet lauréat si la demande a déjà été annulée
-        Etant donné une demande de changement de puissance à la baisse annulée pour le projet lauréat
+        Etant donné une demande de changement de puissance annulée pour le projet lauréat
+            | ratio puissance | 0.75 |
         Quand la DREAL associée au projet rejette le changement de puissance pour le projet lauréat
         Alors l'utilisateur DREAL devrait être informé que "Aucune demande de changement de puissance n'est en cours"
 
     Scénario: Impossible de rejeter le changement de puissance d'un projet lauréat si la demande a déjà été rejetée
-        Etant donné une demande de changement de puissance à la baisse rejetée pour le projet lauréat
+        Etant donné une demande de changement de puissance rejetée pour le projet lauréat
+            | ratio puissance | 0.75 |
         Quand la DREAL associée au projet rejette le changement de puissance pour le projet lauréat
         Alors l'utilisateur DREAL devrait être informé que "Aucune demande de changement de puissance n'est en cours"

--- a/packages/specifications/src/projet/lauréat/puissance/changement/rejeterChangementPuissance.feature
+++ b/packages/specifications/src/projet/lauréat/puissance/changement/rejeterChangementPuissance.feature
@@ -2,7 +2,10 @@
 Fonctionnalité: Rejeter la demande de changement de puissance d'un projet lauréat
 
     Contexte:
-        Etant donné le projet lauréat "Du boulodrome de Marseille"
+        # on est obligés de cibler un AO et une période spécifique pour simplifier les fixtures
+        Etant donné le projet lauréat "Du boulodrome de Marseille" avec :
+            | appel d'offre | PPE2 - Eolien |
+            | période       | 1             |
         Et le porteur "Marcel Patoulatchi" ayant accés au projet lauréat "Du boulodrome de Marseille"
         Et la dreal "Dreal du sud" associée à la région du projet
 

--- a/packages/specifications/src/projet/lauréat/puissance/changement/stepDefinitions/changementPuissance.given.ts
+++ b/packages/specifications/src/projet/lauréat/puissance/changement/stepDefinitions/changementPuissance.given.ts
@@ -21,6 +21,18 @@ EtantDonné(
 );
 
 EtantDonné(
+  'une demande de changement de puissance à la hausse pour le projet lauréat',
+  async function (this: PotentielWorld) {
+    try {
+      // ce ratio est supérieur à celui de l'AO PPE2 - Eolien, Période 1 (1.4)
+      await demanderChangementPuissance.call(this, 'lauréat', 1.41);
+    } catch (error) {
+      this.error = error as Error;
+    }
+  },
+);
+
+EtantDonné(
   'une demande de changement de puissance à la baisse accordée pour le projet lauréat',
   async function (this: PotentielWorld) {
     try {
@@ -49,17 +61,6 @@ EtantDonné(
     try {
       await demanderChangementPuissance.call(this, 'lauréat');
       await annulerChangementPuissance.call(this);
-    } catch (error) {
-      this.error = error as Error;
-    }
-  },
-);
-
-EtantDonné(
-  'une demande de changement de puissance à la hausse pour le projet lauréat',
-  async function (this: PotentielWorld) {
-    try {
-      await demanderChangementPuissance.call(this, 'lauréat', 1.2);
     } catch (error) {
       this.error = error as Error;
     }

--- a/packages/specifications/src/projet/lauréat/puissance/changement/stepDefinitions/changementPuissance.given.ts
+++ b/packages/specifications/src/projet/lauréat/puissance/changement/stepDefinitions/changementPuissance.given.ts
@@ -1,4 +1,4 @@
-import { Given as EtantDonné } from '@cucumber/cucumber';
+import { DataTable, Given as EtantDonné } from '@cucumber/cucumber';
 
 import { PotentielWorld } from '../../../../../potentiel.world';
 
@@ -10,10 +10,11 @@ import {
 } from './changementPuissance.when';
 
 EtantDonné(
-  'une demande de changement de puissance à la baisse pour le projet lauréat',
-  async function (this: PotentielWorld) {
+  'une demande de changement de puissance pour le projet lauréat avec :',
+  async function (this: PotentielWorld, dataTable: DataTable) {
+    const exemple = dataTable.rowsHash();
     try {
-      await demanderChangementPuissance.call(this, 'lauréat');
+      await demanderChangementPuissance.call(this, 'lauréat', Number(exemple['ratio puissance']));
     } catch (error) {
       this.error = error as Error;
     }
@@ -21,22 +22,11 @@ EtantDonné(
 );
 
 EtantDonné(
-  'une demande de changement de puissance à la hausse pour le projet lauréat',
-  async function (this: PotentielWorld) {
+  'une demande de changement de puissance accordée pour le projet lauréat avec :',
+  async function (this: PotentielWorld, dataTable: DataTable) {
+    const exemple = dataTable.rowsHash();
     try {
-      // ce ratio est supérieur à celui de l'AO PPE2 - Eolien, Période 1 (1.4)
-      await demanderChangementPuissance.call(this, 'lauréat', 1.41);
-    } catch (error) {
-      this.error = error as Error;
-    }
-  },
-);
-
-EtantDonné(
-  'une demande de changement de puissance à la baisse accordée pour le projet lauréat',
-  async function (this: PotentielWorld) {
-    try {
-      await demanderChangementPuissance.call(this, 'lauréat');
+      await demanderChangementPuissance.call(this, 'lauréat', Number(exemple['ratio puissance']));
       await accorderChangementPuissance.call(this, this.utilisateurWorld.drealFixture.role);
     } catch (error) {
       this.error = error as Error;
@@ -44,10 +34,11 @@ EtantDonné(
   },
 );
 EtantDonné(
-  'une demande de changement de puissance à la baisse rejetée pour le projet lauréat',
-  async function (this: PotentielWorld) {
+  'une demande de changement de puissance rejetée pour le projet lauréat',
+  async function (this: PotentielWorld, dataTable: DataTable) {
+    const exemple = dataTable.rowsHash();
     try {
-      await demanderChangementPuissance.call(this, 'lauréat');
+      await demanderChangementPuissance.call(this, 'lauréat', Number(exemple['ratio puissance']));
       await rejeterChangementPuissance.call(this, this.utilisateurWorld.drealFixture.role);
     } catch (error) {
       this.error = error as Error;
@@ -56,10 +47,11 @@ EtantDonné(
 );
 
 EtantDonné(
-  'une demande de changement de puissance à la baisse annulée pour le projet lauréat',
-  async function (this: PotentielWorld) {
+  'une demande de changement de puissance annulée pour le projet lauréat',
+  async function (this: PotentielWorld, dataTable: DataTable) {
+    const exemple = dataTable.rowsHash();
     try {
-      await demanderChangementPuissance.call(this, 'lauréat');
+      await demanderChangementPuissance.call(this, 'lauréat', Number(exemple['ratio puissance']));
       await annulerChangementPuissance.call(this);
     } catch (error) {
       this.error = error as Error;

--- a/packages/specifications/src/projet/lauréat/puissance/changement/stepDefinitions/changementPuissance.when.ts
+++ b/packages/specifications/src/projet/lauréat/puissance/changement/stepDefinitions/changementPuissance.when.ts
@@ -7,42 +7,8 @@ import { PotentielWorld } from '../../../../../potentiel.world';
 import { UtilisateurWorld } from '../../../../../utilisateur/utilisateur.world';
 
 Quand(
-  'le porteur demande le changement de puissance avec la même valeur pour le projet lauréat',
-  async function (this: PotentielWorld) {
-    try {
-      await demanderChangementPuissance.call(this, 'lauréat', 1);
-    } catch (error) {
-      this.error = error as Error;
-    }
-  },
-);
-
-Quand(
-  'le porteur demande le changement de puissance à la baisse pour le projet {lauréat-éliminé}',
-  async function (this: PotentielWorld, statutProjet: 'lauréat' | 'éliminé') {
-    try {
-      await demanderChangementPuissance.call(this, statutProjet, undefined);
-    } catch (error) {
-      this.error = error as Error;
-    }
-  },
-);
-
-Quand(
-  'le porteur demande le changement de puissance à la hausse pour le projet lauréat',
-  async function (this: PotentielWorld) {
-    const ratioALaHausse = 1.5;
-    try {
-      await demanderChangementPuissance.call(this, 'lauréat', ratioALaHausse);
-    } catch (error) {
-      this.error = error as Error;
-    }
-  },
-);
-
-Quand(
-  'le porteur demande le changement de puissance pour le projet lauréat avec :',
-  async function (this: PotentielWorld, dataTable: DataTable) {
+  'le porteur demande le changement de puissance pour le projet {lauréat-éliminé} avec :',
+  async function (this: PotentielWorld, statutProjet: 'lauréat' | 'éliminé', dataTable: DataTable) {
     const exemple = dataTable.rowsHash();
     const ratio =
       exemple['nouvelle puissance'] !== undefined
@@ -51,7 +17,7 @@ Quand(
         : Number(exemple['ratio puissance']);
 
     try {
-      await demanderChangementPuissance.call(this, 'lauréat', ratio);
+      await demanderChangementPuissance.call(this, statutProjet, ratio);
     } catch (error) {
       this.error = error as Error;
     }
@@ -59,21 +25,9 @@ Quand(
 );
 
 Quand(
-  'le porteur enregistre un changement de puissance pour le projet {lauréat-éliminé}',
-  async function (this: PotentielWorld, statutProjet: 'lauréat' | 'éliminé') {
-    try {
-      await enregistrerChangementPuissance.call(this, statutProjet);
-    } catch (error) {
-      this.error = error as Error;
-    }
-  },
-);
-
-Quand(
-  'le porteur enregistre un changement de puissance pour le projet lauréat avec :',
-  async function (this: PotentielWorld, dataTable: DataTable) {
+  'le porteur enregistre un changement de puissance pour le projet {lauréat-éliminé} avec :',
+  async function (this: PotentielWorld, statutProjet: 'lauréat' | 'éliminé', dataTable: DataTable) {
     const exemple = dataTable.rowsHash();
-
     const ratio =
       exemple['nouvelle puissance'] !== undefined
         ? Number(exemple['nouvelle puissance']) /
@@ -81,35 +35,7 @@ Quand(
         : Number(exemple['ratio puissance']);
 
     try {
-      await enregistrerChangementPuissance.call(this, 'lauréat', ratio);
-    } catch (error) {
-      this.error = error as Error;
-    }
-  },
-);
-
-Quand(
-  'le porteur enregistre un changement de puissance avec la même valeur pour le projet lauréat',
-  async function (this: PotentielWorld) {
-    try {
-      await enregistrerChangementPuissance.call(this, 'lauréat', 1);
-    } catch (error) {
-      this.error = error as Error;
-    }
-  },
-);
-
-Quand(
-  'le porteur enregistre le changement de puissance pour le projet lauréat avec :',
-  async function (this: PotentielWorld, dataTable: DataTable) {
-    const exemple = dataTable.rowsHash();
-
-    try {
-      await enregistrerChangementPuissance.call(
-        this,
-        'lauréat',
-        Number(exemple['ratio puissance']),
-      );
+      await enregistrerChangementPuissance.call(this, statutProjet, ratio);
     } catch (error) {
       this.error = error as Error;
     }

--- a/packages/specifications/src/projet/lauréat/puissance/changement/stepDefinitions/changementPuissance.when.ts
+++ b/packages/specifications/src/projet/lauréat/puissance/changement/stepDefinitions/changementPuissance.when.ts
@@ -44,9 +44,14 @@ Quand(
   'le porteur demande le changement de puissance pour le projet lauréat avec :',
   async function (this: PotentielWorld, dataTable: DataTable) {
     const exemple = dataTable.rowsHash();
+    const ratio =
+      exemple['nouvelle puissance'] !== undefined
+        ? Number(exemple['nouvelle puissance']) /
+          this.lauréatWorld.puissanceWorld.importerPuissanceFixture.puissance
+        : Number(exemple['ratio puissance']);
 
     try {
-      await demanderChangementPuissance.call(this, 'lauréat', Number(exemple['ratio puissance']));
+      await demanderChangementPuissance.call(this, 'lauréat', ratio);
     } catch (error) {
       this.error = error as Error;
     }
@@ -57,7 +62,26 @@ Quand(
   'le porteur enregistre un changement de puissance pour le projet {lauréat-éliminé}',
   async function (this: PotentielWorld, statutProjet: 'lauréat' | 'éliminé') {
     try {
-      await enregistrerChangementPuissance.call(this, statutProjet, undefined);
+      await enregistrerChangementPuissance.call(this, statutProjet);
+    } catch (error) {
+      this.error = error as Error;
+    }
+  },
+);
+
+Quand(
+  'le porteur enregistre un changement de puissance pour le projet lauréat avec :',
+  async function (this: PotentielWorld, dataTable: DataTable) {
+    const exemple = dataTable.rowsHash();
+
+    const ratio =
+      exemple['nouvelle puissance'] !== undefined
+        ? Number(exemple['nouvelle puissance']) /
+          this.lauréatWorld.puissanceWorld.importerPuissanceFixture.puissance
+        : Number(exemple['ratio puissance']);
+
+    try {
+      await enregistrerChangementPuissance.call(this, 'lauréat', ratio);
     } catch (error) {
       this.error = error as Error;
     }

--- a/packages/specifications/src/projet/lauréat/puissance/changement/supprimerChangementPuissance.feature
+++ b/packages/specifications/src/projet/lauréat/puissance/changement/supprimerChangementPuissance.feature
@@ -2,14 +2,14 @@
 Fonctionnalité: Supprimer la demande de changement de puissance
 
     Contexte:
-        # on est obligés de cibler un AO et une période spécifique pour simplifier les fixtures
         Etant donné le projet lauréat "Du boulodrome de Marseille" avec :
             | appel d'offre | PPE2 - Eolien |
             | période       | 1             |
         Et le porteur "Marcel Patoulatchi" ayant accés au projet lauréat "Du boulodrome de Marseille"
 
     Scénario: Le système supprime la demande de changement de puissance si le projet est abandonné
-        Etant donné une demande de changement de puissance à la baisse pour le projet lauréat
+        Etant donné une demande de changement de puissance pour le projet lauréat avec :
+            | ratio puissance | 0.75 |
         Et une demande d'abandon en cours pour le projet lauréat
         Quand le DGEC validateur accorde l'abandon pour le projet lauréat
         Alors la demande de changement de puissance ne devrait plus être consultable

--- a/packages/specifications/src/projet/lauréat/puissance/changement/supprimerChangementPuissance.feature
+++ b/packages/specifications/src/projet/lauréat/puissance/changement/supprimerChangementPuissance.feature
@@ -2,7 +2,10 @@
 Fonctionnalité: Supprimer la demande de changement de puissance
 
     Contexte:
-        Etant donné le projet lauréat "Du boulodrome de Marseille"
+        # on est obligés de cibler un AO et une période spécifique pour simplifier les fixtures
+        Etant donné le projet lauréat "Du boulodrome de Marseille" avec :
+            | appel d'offre | PPE2 - Eolien |
+            | période       | 1             |
         Et le porteur "Marcel Patoulatchi" ayant accés au projet lauréat "Du boulodrome de Marseille"
 
     Scénario: Le système supprime la demande de changement de puissance si le projet est abandonné

--- a/packages/specifications/src/projet/lauréat/puissance/modifierPuissance.feature
+++ b/packages/specifications/src/projet/lauréat/puissance/modifierPuissance.feature
@@ -52,6 +52,7 @@ Fonctionnalité: Modifier la puissance d'un projet lauréat
         Alors l'utilisateur devrait être informé que "La puissance n'existe pas"
 
     Scénario: Impossible de modifier la puissance d'un projet lauréat alors qu'un changement de puissance est en cours
-        Etant donné une demande de changement de puissance à la baisse pour le projet lauréat
+        Etant donné une demande de changement de puissance pour le projet lauréat avec :
+            | ratio puissance | 0.75 |
         Quand le DGEC validateur modifie la puissance pour le projet lauréat
         Alors l'utilisateur devrait être informé que "Une demande de changement de puissance est déjà en cours"


### PR DESCRIPTION
# Description

- Application des règles de ratio dans un value type dédié
- Simplification des fonctions du legacy, et des props
- Décalage du value type autorité compétente dans un dédié
- Specs
- Refacto rapide des specs puissance pour éviter la flakiness dû à des ratios aléatoires - j'ai simplifié pour ne pas à avoir à récupérer la donnée côté AO à chaque fois, et commenté pour plus de clarté 
- A faire ensuite : affichage des alertes sur le formulaire de demande en fonction, bloquer si ratio > famill

## Type de changement

Veuillez supprimer les options qui ne sont pas pertinentes.

- [x] Refacto de code

# Comment cela a-t-il été testé?

Specs