### PR TITLE
✨ Providers d'authentification configurables pour DGEC et DREAL

### DIFF
--- a/packages/applications/legacy/.env.template
+++ b/packages/applications/legacy/.env.template
@@ -54,6 +54,7 @@ METABASE_SECRET_KEY=fake
 
 # NEXT
 NEXTAUTH_PROVIDERS=proconnect,email,keycloak
+NEXTAUTH_PROVIDERS_DREAL_DGEC=proconnect,keycloak
 NEXTAUTH_URL=http://localhost:3000
 NEXTAUTH_SECRET=fake-secret
 NEXT_AUTH_SESSION_TOKEN_COOKIE_NAME=next-auth.session-token

--- a/packages/applications/request-context/src/canConnectWithProvider.ts
+++ b/packages/applications/request-context/src/canConnectWithProvider.ts
@@ -6,11 +6,10 @@ export const canConnectWithProvider = (provider: string, role: Role.RawType) => 
   const tousSaufDgecDreal = P.not(P.union(Role.admin.nom, Role.dreal.nom, Role.dgecValidateur.nom));
   return match({ provider, role })
     .with({ role: tousSaufDgecDreal }, () => true)
-    .with({ provider: 'proconnect' }, () => true)
-    .otherwise(
-      ({ provider }) =>
-        process.env.NEXTAUTH_PROVIDERS_DREAL_DGEC?.split(',')
-          .map((str) => str.trim().toLowerCase())
-          ?.includes(provider) ?? false,
-    );
+    .otherwise(({ provider }) => {
+      const providers = process.env.NEXTAUTH_PROVIDERS_DREAL_DGEC?.split(',').map((str) =>
+        str.trim().toLowerCase(),
+      ) ?? ['proconnect'];
+      return providers.includes(provider);
+    });
 };

--- a/packages/applications/request-context/src/canConnectWithProvider.ts
+++ b/packages/applications/request-context/src/canConnectWithProvider.ts
@@ -5,8 +5,12 @@ import { Role } from '@potentiel-domain/utilisateur';
 export const canConnectWithProvider = (provider: string, role: Role.RawType) => {
   const tousSaufDgecDreal = P.not(P.union(Role.admin.nom, Role.dreal.nom, Role.dgecValidateur.nom));
   return match({ provider, role })
-    .with({ provider: 'email', role: tousSaufDgecDreal }, () => true)
-    .with({ provider: 'keycloak' }, () => true)
+    .with({ role: tousSaufDgecDreal }, () => true)
     .with({ provider: 'proconnect' }, () => true)
-    .otherwise(() => false);
+    .otherwise(
+      ({ provider }) =>
+        process.env.NEXTAUTH_PROVIDERS_DREAL_DGEC?.split(',')
+          .map((str) => str.trim().toLowerCase())
+          ?.includes(provider) ?? false,
+    );
 };

--- a/packages/applications/request-context/src/types.ts
+++ b/packages/applications/request-context/src/types.ts
@@ -7,6 +7,7 @@ export interface PotentielJWT {
   refreshToken?: string;
   expiresAt?: number;
   provider?: string;
+  providerAuthorized?: boolean;
   job?: string;
 }
 

--- a/packages/applications/ssr/.env.template
+++ b/packages/applications/ssr/.env.template
@@ -68,6 +68,7 @@ FILIGRANE_FACILE_ENDPOINT=https://api.filigrane.beta.gouv.fr
 
 # NEXTAUTH
 NEXTAUTH_PROVIDERS=proconnect,email,keycloak
+NEXTAUTH_PROVIDERS_DREAL_DGEC=proconnect,keycloak
 NEXTAUTH_URL=http://localhost:3000
 NEXTAUTH_SECRET=fake-secret
 NEXT_AUTH_SESSION_TOKEN_COOKIE_NAME=next-auth.session-token

--- a/packages/applications/ssr/src/app/auth/error/page.tsx
+++ b/packages/applications/ssr/src/app/auth/error/page.tsx
@@ -20,6 +20,13 @@ const getError = (
   error: string,
 ): { type: ErrorType; message: string; statusCode: CustomErrorProps['statusCode'] } => {
   switch (error) {
+    case 'ProviderUnauthorized':
+      return {
+        statusCode: '403',
+        type: 'ProviderUnauthorized',
+        message:
+          "Cette méthode d'authentification n'est pas disponible, veuillez vous déconnecter et en choisir une autre.",
+      };
     case 'Verification':
     case 'AccessDenied':
       return {

--- a/packages/applications/ssr/src/app/auth/verifyRequest/page.tsx
+++ b/packages/applications/ssr/src/app/auth/verifyRequest/page.tsx
@@ -1,11 +1,8 @@
-'use client';
-
-import { useSession } from 'next-auth/react';
-import { useEffect } from 'react';
 import { redirect } from 'next/navigation';
 import Button from '@codegouvfr/react-dsfr/Button';
 
 import { Routes } from '@potentiel-applications/routes';
+import { getContext } from '@potentiel-applications/request-context';
 
 import { Heading1 } from '@/components/atoms/headings';
 import { PageTemplate } from '@/components/templates/Page.template';
@@ -13,13 +10,10 @@ import { PageWithErrorHandling } from '@/utils/PageWithErrorHandling';
 
 export default function VerifyRequest() {
   return PageWithErrorHandling(async () => {
-    const { status, data } = useSession();
-
-    useEffect(() => {
-      if (status === 'authenticated' && data.utilisateur) {
-        redirect(Routes.Auth.redirectToDashboard());
-      }
-    }, [status, data]);
+    const utilisateur = getContext()?.utilisateur;
+    if (utilisateur) {
+      redirect(Routes.Auth.redirectToDashboard());
+    }
 
     return (
       <PageTemplate>

--- a/packages/applications/ssr/src/components/pages/custom-error/CustomError.page.tsx
+++ b/packages/applications/ssr/src/components/pages/custom-error/CustomError.page.tsx
@@ -2,6 +2,8 @@ import Image from 'next/image';
 import { FC } from 'react';
 import { fr } from '@codegouvfr/react-dsfr';
 
+import { Routes } from '@potentiel-applications/routes';
+
 import { Heading1 } from '@/components/atoms/headings';
 
 import { DefaultError } from './DefaultError';
@@ -10,7 +12,8 @@ export type ErrorType =
   | 'NotFoundError'
   | 'InvalidOperationError'
   | 'OperationRejectedError'
-  | 'ServerError';
+  | 'ServerError'
+  | 'ProviderUnauthorized';
 
 export type CustomErrorProps = {
   type: ErrorType;
@@ -19,7 +22,12 @@ export type CustomErrorProps = {
 };
 
 export const CustomErrorPage: FC<CustomErrorProps> = ({ type, statusCode, message }) => {
-  const title = type === 'NotFoundError' ? 'Page non trouvée' : 'Une erreur est survenue';
+  const title =
+    type === 'ProviderUnauthorized'
+      ? 'Connexion impossible'
+      : type === 'NotFoundError'
+        ? 'Page non trouvée'
+        : 'Une erreur est survenue';
   const description = getDescription(type, message);
 
   return (
@@ -41,9 +49,15 @@ export const CustomErrorPage: FC<CustomErrorProps> = ({ type, statusCode, messag
           {description}
           <ul className={fr.cx('fr-btns-group', 'fr-btns-group--inline-md')}>
             <li>
-              <a className={fr.cx('fr-btn')} href="/">
-                Page d'accueil
-              </a>
+              {type === 'ProviderUnauthorized' ? (
+                <a className={fr.cx('fr-btn')} href={Routes.Auth.signOut()}>
+                  Se déconnecter
+                </a>
+              ) : (
+                <a className={fr.cx('fr-btn')} href="/">
+                  Page d'accueil
+                </a>
+              )}
             </li>
           </ul>
         </div>
@@ -104,6 +118,7 @@ function getDescription(type: ErrorType, message?: CustomErrorProps['message']) 
         </>
       );
 
+    case 'ProviderUnauthorized':
     case 'InvalidOperationError':
       return message ? <p className={fr.cx('fr-text--lead')}>{message}</p> : <DefaultError />;
 

--- a/packages/applications/ssr/src/middlewares/withNextAuth.ts
+++ b/packages/applications/ssr/src/middlewares/withNextAuth.ts
@@ -12,6 +12,12 @@ export function withNextAuth(middleware: CustomMiddleware) {
       return NextResponse.redirect(redirectUrl);
     }
 
+    if (token.providerAuthorized === false) {
+      const redirectUrl = new URL('/auth/error', request.url);
+      redirectUrl.searchParams.set('error', 'ProviderUnauthorized');
+      return NextResponse.redirect(redirectUrl);
+    }
+
     return middleware(request, event, NextResponse.next());
   };
 }


### PR DESCRIPTION
Proconnect, Email et keycloak toujours dispo pour les roles non Agents
Proconnect dispo par défaut pour les agents. On peut override quels providers son dispos pour les agents avec  `NEXTAUTH_PROVIDERS_DREAL_DGEC` 


Cette PR modifie également le fonctionnement des providers autorisés pour une meilleure ergonomie. 
Explication : 
En gérant cela dans le callback signin, on ne peut pas mettre de message d'erreur personnalisé, car on donne l'information que le compte existe (un utilisateur malintentionné peut connaitre l'existence d'un compte en utilisant le formulaire magic link).
On ne peut pas throw d'erreur directement dans les callbacks jwt ou session, car le code d'erreur n'est pas personalisable.

La solution revient donc à stocker dans le token l'information qui indique que le provider n'est pas disponible afin de le vérifier dans le middleware et afficher un message clair à l'utilisateur (cette fois ci, l'utilisateur étant authentifié, on peut afficher le message , pas de risque de fuite d'information)

