### PR TITLE
🎨 Alignement des actions (dreal, admin, pp) dans le legacy pour les demandes

### DIFF
--- a/packages/applications/legacy/src/controllers/project/getProjectPage/_utils/getActionnaire.ts
+++ b/packages/applications/legacy/src/controllers/project/getProjectPage/_utils/getActionnaire.ts
@@ -11,7 +11,7 @@ import { checkAbandonAndAchèvement } from './checkAbandonAndAchèvement';
 
 export type GetActionnaireAffichageForProjectPage = {
   label: string;
-  labelActions?: string;
+  labelActions: string;
   url: string;
 };
 export type GetActionnaireForProjectPage = {
@@ -128,6 +128,7 @@ export const getActionnaire = async ({
           ? {
               url: Routes.Candidature.corriger(identifiantProjet.formatter()),
               label: 'Modifier la candidature',
+              labelActions: 'Modifier la candidature',
             }
           : undefined,
       };

--- a/packages/applications/legacy/src/controllers/project/getProjectPage/_utils/getActionnaire.ts
+++ b/packages/applications/legacy/src/controllers/project/getProjectPage/_utils/getActionnaire.ts
@@ -56,7 +56,7 @@ export const getActionnaire = async ({
                   dateDemandeEnCours.formatter(),
                 ),
                 label: 'Voir la demande de modification',
-                labelActions: 'Demande de modification d’actionnaire',
+                labelActions: 'Demande de modification d’actionnaire(s)',
               }
             : undefined,
         };
@@ -83,7 +83,7 @@ export const getActionnaire = async ({
           affichage: {
             url: Routes.Actionnaire.modifier(identifiantProjet.formatter()),
             label: 'Modifier',
-            labelActions: 'Modifier l’actionnaire',
+            labelActions: 'Modifier l’actionnaire(s)',
           },
         };
       }
@@ -94,7 +94,7 @@ export const getActionnaire = async ({
           affichage: {
             url: Routes.Actionnaire.changement.enregistrer(identifiantProjet.formatter()),
             label: 'Faire un changement',
-            labelActions: "Changer d'actionnaire",
+            labelActions: "Changer d'actionnaire(s)",
           },
         };
       }

--- a/packages/applications/legacy/src/controllers/project/getProjectPage/_utils/getActionnaire.ts
+++ b/packages/applications/legacy/src/controllers/project/getProjectPage/_utils/getActionnaire.ts
@@ -10,8 +10,8 @@ import { IdentifiantProjet } from '@potentiel-domain/common';
 import { checkAbandonAndAchèvement } from './checkAbandonAndAchèvement';
 
 export type GetActionnaireAffichageForProjectPage = {
-  projectPageLabel: string;
-  porteurProjetActionLabel?: string;
+  label: string;
+  labelActions?: string;
   url: string;
 };
 export type GetActionnaireForProjectPage = {
@@ -55,7 +55,8 @@ export const getActionnaire = async ({
                   identifiantProjet.formatter(),
                   dateDemandeEnCours.formatter(),
                 ),
-                projectPageLabel: 'Voir la demande de modification',
+                label: 'Voir la demande de modification',
+                labelActions: 'Demande de modification d’actionnaire',
               }
             : undefined,
         };
@@ -81,7 +82,8 @@ export const getActionnaire = async ({
           nom,
           affichage: {
             url: Routes.Actionnaire.modifier(identifiantProjet.formatter()),
-            projectPageLabel: 'Modifier',
+            label: 'Modifier',
+            labelActions: 'Modifier l’actionnaire',
           },
         };
       }
@@ -91,8 +93,8 @@ export const getActionnaire = async ({
           nom,
           affichage: {
             url: Routes.Actionnaire.changement.enregistrer(identifiantProjet.formatter()),
-            projectPageLabel: 'Faire un changement',
-            porteurProjetActionLabel: "Changer d'actionnaire(s)",
+            label: 'Faire un changement',
+            labelActions: "Changer d'actionnaire",
           },
         };
       }
@@ -102,8 +104,8 @@ export const getActionnaire = async ({
           nom,
           affichage: {
             url: Routes.Actionnaire.changement.demander(identifiantProjet.formatter()),
-            projectPageLabel: 'Faire une demande de changement',
-            porteurProjetActionLabel: 'Demander un changement d’actionnaire(s)',
+            label: 'Faire une demande de changement',
+            labelActions: 'Demander un changement d’actionnaire(s)',
           },
         };
       }
@@ -125,7 +127,7 @@ export const getActionnaire = async ({
         affichage: role.aLaPermission('candidature.corriger')
           ? {
               url: Routes.Candidature.corriger(identifiantProjet.formatter()),
-              projectPageLabel: 'Modifier la candidature',
+              label: 'Modifier la candidature',
             }
           : undefined,
       };

--- a/packages/applications/legacy/src/controllers/project/getProjectPage/_utils/getProducteur.ts
+++ b/packages/applications/legacy/src/controllers/project/getProjectPage/_utils/getProducteur.ts
@@ -13,7 +13,7 @@ import { getContext } from '@potentiel-applications/request-context';
 export type GetProducteurForProjectPage = {
   producteur: string;
   affichage?: {
-    labelActions?: string;
+    labelActions: string;
     label: string;
     url: string;
   };
@@ -99,6 +99,7 @@ export const getProducteur = async ({
           ? {
               url: Routes.Candidature.corriger(identifiantProjet.formatter()),
               label: 'Modifier la candidature',
+              labelActions: 'Modifier la candidature',
             }
           : undefined,
       };

--- a/packages/applications/legacy/src/controllers/project/getProjectPage/_utils/getPuissance.ts
+++ b/packages/applications/legacy/src/controllers/project/getProjectPage/_utils/getPuissance.ts
@@ -81,6 +81,7 @@ export const getPuissance = async ({
           affichage: {
             url: Routes.Puissance.changement.demander(identifiantProjet.formatter()),
             label: 'Changer de puissance',
+            labelActions: 'Changer de puissance',
           },
         };
       }

--- a/packages/applications/legacy/src/controllers/project/getProjectPage/_utils/getPuissance.ts
+++ b/packages/applications/legacy/src/controllers/project/getProjectPage/_utils/getPuissance.ts
@@ -12,7 +12,7 @@ import { mediator } from 'mediateur';
 export type GetPuissanceForProjectPage = {
   puissance: number;
   affichage?: {
-    labelActions?: string;
+    labelActions: string;
     label: string;
     url: string;
   };
@@ -105,6 +105,7 @@ export const getPuissance = async ({
           ? {
               url: Routes.Candidature.corriger(identifiantProjet.formatter()),
               label: 'Modifier la candidature',
+              labelActions: 'Modifier la candidature',
             }
           : undefined,
       };

--- a/packages/applications/legacy/src/controllers/project/getProjectPage/_utils/getPuissance.ts
+++ b/packages/applications/legacy/src/controllers/project/getProjectPage/_utils/getPuissance.ts
@@ -65,6 +65,7 @@ export const getPuissance = async ({
           affichage: {
             url: Routes.Puissance.modifier(identifiantProjet.formatter()),
             label: 'Modifier',
+            labelActions: 'Modifier la puissance',
           },
         };
       }

--- a/packages/applications/legacy/src/controllers/project/getProjectPage/_utils/getReprésentantLégal.ts
+++ b/packages/applications/legacy/src/controllers/project/getProjectPage/_utils/getReprésentantLégal.ts
@@ -8,27 +8,24 @@ import { Role } from '@potentiel-domain/utilisateur';
 import { getLogger } from '@potentiel-libraries/monitoring';
 import { checkAbandonAndAchèvement } from './checkAbandonAndAchèvement';
 
-export type GetReprésentantLégalForProjectPage =
-  | {
-      nom: string;
-      modification?: {
-        type: 'lauréat' | 'candidature';
-        url: string;
-      };
-      demandeDeModification?: {
-        demandéLe: string;
-        peutConsulterLaDemandeExistante: boolean;
-        peutFaireUneDemande: boolean;
-      };
-    }
-  | undefined;
+export type GetReprésentantLégalForProjectPage = {
+  nom: string;
+  affichage?: {
+    labelActions?: string;
+    label: string;
+    url: string;
+  };
+};
 
-type GetReprésentantLégal = (
-  identifiantProjet: IdentifiantProjet.ValueType,
-  role: string,
-) => Promise<GetReprésentantLégalForProjectPage>;
+type Props = {
+  identifiantProjet: IdentifiantProjet.ValueType;
+  rôle: string;
+};
 
-export const getReprésentantLégal: GetReprésentantLégal = async (identifiantProjet, rôle) => {
+export const getReprésentantLégal = async ({
+  identifiantProjet,
+  rôle,
+}: Props): Promise<GetReprésentantLégalForProjectPage | undefined> => {
   try {
     const utilisateur = Role.convertirEnValueType(rôle);
 
@@ -52,9 +49,9 @@ export const getReprésentantLégal: GetReprésentantLégal = async (identifiant
 
       return {
         nom: candidature.nomReprésentantLégal,
-        modification: utilisateur.aLaPermission('candidature.corriger')
+        affichage: utilisateur.aLaPermission('candidature.corriger')
           ? {
-              type: 'candidature',
+              label: 'Modifier la candidature',
               url: Routes.Candidature.corriger(identifiantProjet.formatter()),
             }
           : undefined,
@@ -72,44 +69,57 @@ export const getReprésentantLégal: GetReprésentantLégal = async (identifiant
 
     const demandeChangementExistante = Option.isSome(demandeEnCours);
 
+    if (demandeChangementExistante) {
+      return {
+        nom: représentantLégal.nomReprésentantLégal,
+        affichage: utilisateur.aLaPermission('représentantLégal.consulterChangement')
+          ? {
+              url: Routes.ReprésentantLégal.changement.détail(
+                identifiantProjet.formatter(),
+                demandeEnCours.demandéLe.formatter(),
+              ),
+              label: 'Voir la demande de modification',
+              labelActions: 'Demande de modification de représentant légal',
+            }
+          : undefined,
+      };
+    }
+
+    if (utilisateur.aLaPermission('représentantLégal.modifier')) {
+      return {
+        nom: représentantLégal.nomReprésentantLégal,
+        affichage: {
+          url: Routes.ReprésentantLégal.modifier(identifiantProjet.formatter()),
+          label: 'Modifier',
+          labelActions: 'Modifier le représentant légal',
+        },
+      };
+    }
+
     const { aUnAbandonEnCours, estAbandonné, estAchevé } = await checkAbandonAndAchèvement(
       identifiantProjet,
       rôle,
     );
 
-    const peutConsulterLaDemandeExistante = demandeChangementExistante && !estAbandonné;
-
-    const peutFaireUneDemande =
+    if (
       utilisateur.aLaPermission('représentantLégal.demanderChangement') &&
-      !demandeChangementExistante &&
       !aUnAbandonEnCours &&
       !estAbandonné &&
-      !estAchevé;
+      !estAchevé
+    ) {
+      return {
+        nom: représentantLégal.nomReprésentantLégal,
+        affichage: {
+          url: Routes.ReprésentantLégal.changement.demander(identifiantProjet.formatter()),
+          label: 'Changer de représentant légal',
+          labelActions: 'Changer de représentant légal',
+        },
+      };
+    }
 
-    const peutModifier =
-      utilisateur.aLaPermission('représentantLégal.modifier') && !demandeChangementExistante;
-
-    return {
-      nom: représentantLégal.nomReprésentantLégal,
-      modification: peutModifier
-        ? {
-            type: 'lauréat',
-            url: Routes.ReprésentantLégal.modifier(identifiantProjet.formatter()),
-          }
-        : undefined,
-      demandeDeModification: {
-        demandéLe: Option.isSome(demandeEnCours) ? demandeEnCours.demandéLe.formatter() : '',
-        peutConsulterLaDemandeExistante,
-        peutFaireUneDemande,
-      },
-    };
+    return undefined;
   } catch (error) {
-    getLogger('Legacy|getProjectPage|getReprésentantLégal').error(
-      `Impossible de consulter le représentant légal`,
-      {
-        identifiantProjet: identifiantProjet.formatter(),
-      },
-    );
+    getLogger('Legacy|getProjectPage|getReprésentantLégal').error(error);
     return undefined;
   }
 };

--- a/packages/applications/legacy/src/controllers/project/getProjectPage/_utils/getReprésentantLégal.ts
+++ b/packages/applications/legacy/src/controllers/project/getProjectPage/_utils/getReprésentantLégal.ts
@@ -11,7 +11,7 @@ import { checkAbandonAndAchèvement } from './checkAbandonAndAchèvement';
 export type GetReprésentantLégalForProjectPage = {
   nom: string;
   affichage?: {
-    labelActions?: string;
+    labelActions: string;
     label: string;
     url: string;
   };
@@ -52,6 +52,7 @@ export const getReprésentantLégal = async ({
         affichage: utilisateur.aLaPermission('candidature.corriger')
           ? {
               label: 'Modifier la candidature',
+              labelActions: 'Modifier la candidature',
               url: Routes.Candidature.corriger(identifiantProjet.formatter()),
             }
           : undefined,

--- a/packages/applications/legacy/src/controllers/project/getProjectPage/index.ts
+++ b/packages/applications/legacy/src/controllers/project/getProjectPage/index.ts
@@ -207,7 +207,10 @@ v1Router.get(
           alertesRaccordement,
           abandon,
           garantiesFinancières,
-          représentantLégal: await getReprésentantLégal(identifiantProjetValueType, user.role),
+          représentantLégal: await getReprésentantLégal({
+            identifiantProjet: identifiantProjetValueType,
+            rôle: user.role,
+          }),
           demandeRecours: await getRecours(identifiantProjetValueType),
           actionnaire: await getActionnaire({
             identifiantProjet: identifiantProjetValueType,

--- a/packages/applications/legacy/src/views/pages/projectDetailsPage/ProjectDetails.tsx
+++ b/packages/applications/legacy/src/views/pages/projectDetailsPage/ProjectDetails.tsx
@@ -108,9 +108,7 @@ export const ProjectDetails = ({
         modificationsNonPermisesParLeCDCActuel={modificationsNonPermisesParLeCDCActuel}
         estAchevé={estAchevé}
         demandeRecours={demandeRecours}
-        peutFaireDemandeChangementReprésentantLégal={
-          !!représentantLégal?.demandeDeModification?.peutFaireUneDemande
-        }
+        représentantLégalAffichage={représentantLégal?.affichage}
         puissanceAffichage={puissance?.affichage}
         actionnaireAffichage={actionnaire?.affichage}
         producteurAffichage={producteur?.affichage}

--- a/packages/applications/legacy/src/views/pages/projectDetailsPage/components/ProjectActions.tsx
+++ b/packages/applications/legacy/src/views/pages/projectDetailsPage/components/ProjectActions.tsx
@@ -77,7 +77,7 @@ const PorteurProjetActions = ({
   demandeRecours,
   modificationsNonPermisesParLeCDCActuel,
   estAchevé,
-  peutFaireDemandeChangementReprésentantLégal,
+  représentantLégalAffichage,
   actionnaireAffichage,
   puissanceAffichage,
   producteurAffichage,
@@ -135,12 +135,12 @@ const PorteurProjetActions = ({
             >
               <span>Demander un délai</span>
             </DropdownMenuSecondaryButton.DropdownItem>
-            {peutFaireDemandeChangementReprésentantLégal && (
+            {!!représentantLégalAffichage && (
               <DropdownMenuSecondaryButton.DropdownItem
-                href={Routes.ReprésentantLégal.changement.demander(identifiantProjet)}
+                href={représentantLégalAffichage.url}
                 disabled={demandesDisabled}
               >
-                <span>Demander un changement de représentant légal</span>
+                <span>{représentantLégalAffichage.labelActions}</span>
               </DropdownMenuSecondaryButton.DropdownItem>
             )}
             {peutDemanderAbandon && (
@@ -262,7 +262,7 @@ export const ProjectActions = ({
   demandeRecours,
   modificationsNonPermisesParLeCDCActuel,
   estAchevé,
-  peutFaireDemandeChangementReprésentantLégal,
+  représentantLégalAffichage,
   puissanceAffichage,
   actionnaireAffichage,
   producteurAffichage,
@@ -290,7 +290,7 @@ export const ProjectActions = ({
           demandeRecours={demandeRecours}
           modificationsNonPermisesParLeCDCActuel={modificationsNonPermisesParLeCDCActuel}
           estAchevé={estAchevé}
-          peutFaireDemandeChangementReprésentantLégal={peutFaireDemandeChangementReprésentantLégal}
+          représentantLégalAffichage={représentantLégalAffichage}
           puissanceAffichage={puissanceAffichage}
           actionnaireAffichage={actionnaireAffichage}
           producteurAffichage={producteurAffichage}

--- a/packages/applications/legacy/src/views/pages/projectDetailsPage/components/ProjectActions.tsx
+++ b/packages/applications/legacy/src/views/pages/projectDetailsPage/components/ProjectActions.tsx
@@ -18,22 +18,25 @@ import { formatProjectDataToIdentifiantProjetValueType } from '../../../../helpe
 import { ProjectHeaderProps } from './ProjectHeader';
 import { GetProducteurForProjectPage } from '../../../../controllers/project/getProjectPage/_utils/getProducteur';
 import { GetPuissanceForProjectPage } from '../../../../controllers/project/getProjectPage/_utils/getPuissance';
-import { GetActionnaireForProjectPage } from '../../../../controllers/project/getProjectPage/_utils';
+import {
+  GetActionnaireForProjectPage,
+  GetReprésentantLégalForProjectPage,
+} from '../../../../controllers/project/getProjectPage/_utils';
 
 type EnregistrerUneModificationProps = {
   projectId: ProjectDataForProjectPage['id'];
-  identifiantProjet: IdentifiantProjet.RawType;
   producteurAffichage?: GetProducteurForProjectPage['affichage'];
   puissanceAffichage?: GetPuissanceForProjectPage['affichage'];
   actionnaireAffichage?: GetActionnaireForProjectPage['affichage'];
+  représentantLégalAffichage?: GetReprésentantLégalForProjectPage['affichage'];
 };
 
 const EnregistrerUneModification = ({
   projectId,
-  identifiantProjet,
   producteurAffichage,
   puissanceAffichage,
   actionnaireAffichage,
+  représentantLégalAffichage,
 }: EnregistrerUneModificationProps) => {
   return (
     <DropdownMenuSecondaryButton buttonChildren="Enregistrer une modification">
@@ -57,11 +60,11 @@ const EnregistrerUneModification = ({
           <span>{actionnaireAffichage.labelActions}</span>
         </DropdownMenuSecondaryButton.DropdownItem>
       )}
-      <DropdownMenuSecondaryButton.DropdownItem
-        href={Routes.ReprésentantLégal.modifier(identifiantProjet)}
-      >
-        <span>Modifier le représentant légal</span>
-      </DropdownMenuSecondaryButton.DropdownItem>
+      {!!représentantLégalAffichage && (
+        <DropdownMenuSecondaryButton.DropdownItem href={représentantLégalAffichage.url}>
+          <span>{représentantLégalAffichage.labelActions}</span>
+        </DropdownMenuSecondaryButton.DropdownItem>
+      )}
     </DropdownMenuSecondaryButton>
   );
 };
@@ -82,7 +85,7 @@ const PorteurProjetActions = ({
   puissanceAffichage,
   producteurAffichage,
 }: PorteurProjetActionsProps) => {
-  const peutDemanderAbandon = !abandonEnCoursOuAccordé && !estAchevé;
+  const peutDemanderAbandonOuAchèvement = !abandonEnCoursOuAccordé && !estAchevé;
   const demandesDisabled = modificationsNonPermisesParLeCDCActuel ? true : undefined;
 
   return (
@@ -129,12 +132,6 @@ const PorteurProjetActions = ({
                 <span>{puissanceAffichage.labelActions ?? puissanceAffichage.label}</span>
               </DropdownMenuSecondaryButton.DropdownItem>
             )}
-            <DropdownMenuSecondaryButton.DropdownItem
-              href={routes.DEMANDER_DELAI(project.id)}
-              disabled={demandesDisabled}
-            >
-              <span>Demander un délai</span>
-            </DropdownMenuSecondaryButton.DropdownItem>
             {!!représentantLégalAffichage && (
               <DropdownMenuSecondaryButton.DropdownItem
                 href={représentantLégalAffichage.url}
@@ -143,7 +140,13 @@ const PorteurProjetActions = ({
                 <span>{représentantLégalAffichage.labelActions}</span>
               </DropdownMenuSecondaryButton.DropdownItem>
             )}
-            {peutDemanderAbandon && (
+            <DropdownMenuSecondaryButton.DropdownItem
+              href={routes.DEMANDER_DELAI(project.id)}
+              disabled={demandesDisabled}
+            >
+              <span>Demander un délai</span>
+            </DropdownMenuSecondaryButton.DropdownItem>
+            {peutDemanderAbandonOuAchèvement && (
               <>
                 <DropdownMenuSecondaryButton.DropdownItem
                   href={Routes.Abandon.demander(identifiantProjet)}
@@ -184,19 +187,27 @@ type AdminActionsProps = {
   project: ProjectDataForProjectPage;
   identifiantProjet: IdentifiantProjet.RawType;
   producteurAffichage?: GetProducteurForProjectPage['affichage'];
+  puissanceAffichage?: GetPuissanceForProjectPage['affichage'];
+  actionnaireAffichage?: GetActionnaireForProjectPage['affichage'];
+  représentantLégalAffichage?: GetReprésentantLégalForProjectPage['affichage'];
 };
 
 const AdminActions = ({
   project: { id, notifiedOn, isLegacy, isClasse },
   identifiantProjet,
   producteurAffichage,
+  puissanceAffichage,
+  actionnaireAffichage,
+  représentantLégalAffichage,
 }: AdminActionsProps) => {
   return (
     <div className="flex flex-col md:flex-row gap-2">
       <EnregistrerUneModification
         projectId={id}
-        identifiantProjet={identifiantProjet}
         producteurAffichage={producteurAffichage}
+        puissanceAffichage={puissanceAffichage}
+        actionnaireAffichage={actionnaireAffichage}
+        représentantLégalAffichage={représentantLégalAffichage}
       />
       {notifiedOn && isClasse ? (
         <LinkButton href={Routes.Lauréat.modifier(identifiantProjet)}>
@@ -240,11 +251,26 @@ type DrealActionsProps = {
   project: ProjectDataForProjectPage;
   identifiantProjet: IdentifiantProjet.RawType;
   producteurAffichage?: GetProducteurForProjectPage['affichage'];
+  puissanceAffichage?: GetPuissanceForProjectPage['affichage'];
+  actionnaireAffichage?: GetActionnaireForProjectPage['affichage'];
+  représentantLégalAffichage?: GetReprésentantLégalForProjectPage['affichage'];
 };
-const DrealActions = ({ project, identifiantProjet }: DrealActionsProps) => {
+const DrealActions = ({
+  project,
+  représentantLégalAffichage,
+  puissanceAffichage,
+  actionnaireAffichage,
+  producteurAffichage,
+}: DrealActionsProps) => {
   return (
     <div className="flex flex-col md:flex-row gap-2">
-      <EnregistrerUneModification projectId={project.id} identifiantProjet={identifiantProjet} />
+      <EnregistrerUneModification
+        projectId={project.id}
+        producteurAffichage={producteurAffichage}
+        puissanceAffichage={puissanceAffichage}
+        actionnaireAffichage={actionnaireAffichage}
+        représentantLégalAffichage={représentantLégalAffichage}
+      />
       <PrimaryButton onClick={() => window.print()}>
         <PrintIcon className="text-white mr-2" aria-hidden />
         Imprimer la page
@@ -281,6 +307,9 @@ export const ProjectActions = ({
           project={project}
           identifiantProjet={identifiantProjet}
           producteurAffichage={producteurAffichage}
+          puissanceAffichage={puissanceAffichage}
+          actionnaireAffichage={actionnaireAffichage}
+          représentantLégalAffichage={représentantLégalAffichage}
         />
       )}
       {userIs(['porteur-projet'])(user) && (
@@ -302,6 +331,9 @@ export const ProjectActions = ({
           project={project}
           identifiantProjet={identifiantProjet}
           producteurAffichage={producteurAffichage}
+          puissanceAffichage={puissanceAffichage}
+          actionnaireAffichage={actionnaireAffichage}
+          représentantLégalAffichage={représentantLégalAffichage}
         />
       )}
     </div>

--- a/packages/applications/legacy/src/views/pages/projectDetailsPage/components/ProjectActions.tsx
+++ b/packages/applications/legacy/src/views/pages/projectDetailsPage/components/ProjectActions.tsx
@@ -17,17 +17,23 @@ import { IdentifiantProjet } from '@potentiel-domain/common';
 import { formatProjectDataToIdentifiantProjetValueType } from '../../../../helpers/dataToValueTypes';
 import { ProjectHeaderProps } from './ProjectHeader';
 import { GetProducteurForProjectPage } from '../../../../controllers/project/getProjectPage/_utils/getProducteur';
+import { GetPuissanceForProjectPage } from '../../../../controllers/project/getProjectPage/_utils/getPuissance';
+import { GetActionnaireForProjectPage } from '../../../../controllers/project/getProjectPage/_utils';
 
 type EnregistrerUneModificationProps = {
   projectId: ProjectDataForProjectPage['id'];
   identifiantProjet: IdentifiantProjet.RawType;
   producteurAffichage?: GetProducteurForProjectPage['affichage'];
+  puissanceAffichage?: GetPuissanceForProjectPage['affichage'];
+  actionnaireAffichage?: GetActionnaireForProjectPage['affichage'];
 };
 
 const EnregistrerUneModification = ({
   projectId,
   identifiantProjet,
   producteurAffichage,
+  puissanceAffichage,
+  actionnaireAffichage,
 }: EnregistrerUneModificationProps) => {
   return (
     <DropdownMenuSecondaryButton buttonChildren="Enregistrer une modification">
@@ -41,14 +47,16 @@ const EnregistrerUneModification = ({
           <span>{producteurAffichage.labelActions}</span>
         </DropdownMenuSecondaryButton.DropdownItem>
       )}
-      <DropdownMenuSecondaryButton.DropdownItem href={Routes.Puissance.modifier(identifiantProjet)}>
-        <span>Modifier la puissance</span>
-      </DropdownMenuSecondaryButton.DropdownItem>
-      <DropdownMenuSecondaryButton.DropdownItem
-        href={Routes.Actionnaire.modifier(identifiantProjet)}
-      >
-        <span>Modifier l'actionnaire(s)</span>
-      </DropdownMenuSecondaryButton.DropdownItem>
+      {!!puissanceAffichage && (
+        <DropdownMenuSecondaryButton.DropdownItem href={puissanceAffichage.url}>
+          <span>{puissanceAffichage.labelActions}</span>
+        </DropdownMenuSecondaryButton.DropdownItem>
+      )}
+      {!!actionnaireAffichage && (
+        <DropdownMenuSecondaryButton.DropdownItem href={actionnaireAffichage.url}>
+          <span>{actionnaireAffichage.labelActions}</span>
+        </DropdownMenuSecondaryButton.DropdownItem>
+      )}
       <DropdownMenuSecondaryButton.DropdownItem
         href={Routes.ReprésentantLégal.modifier(identifiantProjet)}
       >
@@ -110,7 +118,7 @@ const PorteurProjetActions = ({
                 href={actionnaireAffichage.url}
                 disabled={demandesDisabled}
               >
-                <span>{actionnaireAffichage.porteurProjetActionLabel}</span>
+                <span>{actionnaireAffichage.labelActions}</span>
               </DropdownMenuSecondaryButton.DropdownItem>
             )}
             {!!puissanceAffichage && (

--- a/packages/applications/legacy/src/views/pages/projectDetailsPage/components/ProjectHeader.tsx
+++ b/packages/applications/legacy/src/views/pages/projectDetailsPage/components/ProjectHeader.tsx
@@ -4,7 +4,10 @@ import { ProjectDataForProjectPage } from '../../../../modules/project/queries';
 import { Heading1 } from '../../../components';
 import { ProjectActions } from './ProjectActions';
 import { ProjectHeaderBadge } from './ProjectHeaderBadge';
-import { GetActionnaireAffichageForProjectPage } from '../../../../controllers/project/getProjectPage/_utils';
+import {
+  GetActionnaireAffichageForProjectPage,
+  GetReprésentantLégalForProjectPage,
+} from '../../../../controllers/project/getProjectPage/_utils';
 import { GetPuissanceForProjectPage } from '../../../../controllers/project/getProjectPage/_utils/getPuissance';
 import { GetProducteurForProjectPage } from '../../../../controllers/project/getProjectPage/_utils/getProducteur';
 
@@ -15,7 +18,7 @@ export type ProjectHeaderProps = {
   demandeRecours: ProjectDataForProjectPage['demandeRecours'];
   modificationsNonPermisesParLeCDCActuel: boolean;
   estAchevé: boolean;
-  peutFaireDemandeChangementReprésentantLégal: boolean;
+  représentantLégalAffichage?: GetReprésentantLégalForProjectPage['affichage'];
   puissanceAffichage?: GetPuissanceForProjectPage['affichage'];
   producteurAffichage?: GetProducteurForProjectPage['affichage'];
   actionnaireAffichage?: GetActionnaireAffichageForProjectPage;
@@ -28,7 +31,7 @@ export const ProjectHeader = ({
   demandeRecours,
   modificationsNonPermisesParLeCDCActuel,
   estAchevé,
-  peutFaireDemandeChangementReprésentantLégal,
+  représentantLégalAffichage,
   puissanceAffichage,
   actionnaireAffichage,
   producteurAffichage,
@@ -63,7 +66,7 @@ export const ProjectHeader = ({
         demandeRecours={demandeRecours}
         modificationsNonPermisesParLeCDCActuel={modificationsNonPermisesParLeCDCActuel}
         estAchevé={estAchevé}
-        peutFaireDemandeChangementReprésentantLégal={peutFaireDemandeChangementReprésentantLégal}
+        représentantLégalAffichage={représentantLégalAffichage}
         puissanceAffichage={puissanceAffichage}
         actionnaireAffichage={actionnaireAffichage}
         producteurAffichage={producteurAffichage}

--- a/packages/applications/legacy/src/views/pages/projectDetailsPage/sections/Contact.tsx
+++ b/packages/applications/legacy/src/views/pages/projectDetailsPage/sections/Contact.tsx
@@ -10,12 +10,14 @@ import { Routes } from '@potentiel-applications/routes';
 import { GetProducteurForProjectPage } from '../../../../controllers/project/getProjectPage/_utils/getProducteur';
 import { InfoProducteur } from './InfoProducteur';
 import { GetCandidatureForProjectPage } from '../../../../controllers/project/getProjectPage/_utils/getCandidature';
+import { InfoReprésentantLégal } from './InfoReprésentantLégal';
+import { Role } from '@potentiel-domain/utilisateur';
 
 export type ContactProps = {
   identifiantProjet: string;
   project: ProjectDataForProjectPage;
   user: Request['user'];
-  représentantLégal: GetReprésentantLégalForProjectPage;
+  représentantLégal?: GetReprésentantLégalForProjectPage;
   producteur?: GetProducteurForProjectPage;
   modificationsNonPermisesParLeCDCActuel: boolean;
   candidature: GetCandidatureForProjectPage;
@@ -35,46 +37,18 @@ export const Contact = ({
       <InfoProducteur
         producteur={producteur}
         modificationsPermisesParLeCDCActuel={!modificationsNonPermisesParLeCDCActuel}
+        role={Role.convertirEnValueType(user.role)}
       />
     )}
-    <div>
-      {représentantLégal && (
-        <>
-          <Heading3 className="mb-1">Représentant légal</Heading3>
-          <div>{représentantLégal.nom}</div>
-
-          {représentantLégal.modification && (
-            <Link href={représentantLégal.modification.url} aria-label="Modifier" className="mt-1">
-              Modifier {représentantLégal.modification.type === 'lauréat' ? '' : 'la candidature'}
-            </Link>
-          )}
-          {représentantLégal.demandeDeModification?.peutConsulterLaDemandeExistante && (
-            <Link
-              href={Routes.ReprésentantLégal.changement.détail(
-                identifiantProjet,
-                représentantLégal.demandeDeModification.demandéLe,
-              )}
-              aria-label="Voir la demande de changement en cours"
-              className="block"
-            >
-              Voir la demande de changement en cours
-            </Link>
-          )}
-          {représentantLégal.demandeDeModification?.peutFaireUneDemande &&
-            !modificationsNonPermisesParLeCDCActuel && (
-              <Link
-                href={Routes.ReprésentantLégal.changement.demander(identifiantProjet)}
-                aria-label="Demander un changement"
-                className="block"
-              >
-                Faire une demande de changement
-              </Link>
-            )}
-        </>
-      )}
-      <Heading3 className="mb-1">Adresse email de candidature</Heading3>
-      <div>{candidature.emailContact}</div>
-    </div>
+    {représentantLégal && (
+      <InfoReprésentantLégal
+        représentantLégal={représentantLégal}
+        modificationsPermisesParLeCDCActuel={!modificationsNonPermisesParLeCDCActuel}
+        role={Role.convertirEnValueType(user.role)}
+      />
+    )}
+    <Heading3 className="mb-1">Adresse email de candidature</Heading3>
+    <div>{candidature.emailContact}</div>
 
     {project.notifiedOn &&
       userIs(['admin', 'dgec-validateur', 'porteur-projet', 'dreal'])(user) && (

--- a/packages/applications/legacy/src/views/pages/projectDetailsPage/sections/InfoGenerales/InfoActionnaire.tsx
+++ b/packages/applications/legacy/src/views/pages/projectDetailsPage/sections/InfoGenerales/InfoActionnaire.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { Heading3, Link } from '../../../../components';
 
 import { GetActionnaireForProjectPage } from '../../../../../controllers/project/getProjectPage/_utils';
-import { IdentifiantProjet } from '@potentiel-domain/common';
 
 export type InfoActionnaireProps = {
   actionnaire: GetActionnaireForProjectPage;
@@ -20,10 +19,10 @@ export const InfoActionnaire = ({
       {modificationsPermisesParLeCDCActuel && actionnaire.affichage && (
         <Link
           href={actionnaire.affichage.url}
-          aria-label={actionnaire.affichage.projectPageLabel}
+          aria-label={actionnaire.affichage.label}
           className="mt-1"
         >
-          {actionnaire.affichage.projectPageLabel}
+          {actionnaire.affichage.label}
         </Link>
       )}
     </div>

--- a/packages/applications/legacy/src/views/pages/projectDetailsPage/sections/InfoGenerales/InfoActionnaire.tsx
+++ b/packages/applications/legacy/src/views/pages/projectDetailsPage/sections/InfoGenerales/InfoActionnaire.tsx
@@ -2,21 +2,27 @@ import React from 'react';
 import { Heading3, Link } from '../../../../components';
 
 import { GetActionnaireForProjectPage } from '../../../../../controllers/project/getProjectPage/_utils';
+import { Role } from '@potentiel-domain/utilisateur';
 
 export type InfoActionnaireProps = {
   actionnaire: GetActionnaireForProjectPage;
   modificationsPermisesParLeCDCActuel: boolean;
+  role: Role.ValueType;
 };
 
 export const InfoActionnaire = ({
   actionnaire,
   modificationsPermisesParLeCDCActuel,
+  role,
 }: InfoActionnaireProps) => {
+  const afficherSelonRole =
+    (role.estPorteur() && modificationsPermisesParLeCDCActuel) || !role.estPorteur();
+
   return (
     <div>
       <Heading3 className="m-0">Actionnaire</Heading3>
       <p className="m-0">{actionnaire.nom || 'Non renseigné'}</p>
-      {modificationsPermisesParLeCDCActuel && actionnaire.affichage && (
+      {afficherSelonRole && actionnaire.affichage && (
         <Link
           href={actionnaire.affichage.url}
           aria-label={actionnaire.affichage.label}

--- a/packages/applications/legacy/src/views/pages/projectDetailsPage/sections/InfoGenerales/InfoPuissance.tsx
+++ b/packages/applications/legacy/src/views/pages/projectDetailsPage/sections/InfoGenerales/InfoPuissance.tsx
@@ -3,6 +3,7 @@ import { Heading3, Link } from '../../../../components';
 
 import { GetPuissanceForProjectPage } from '../../../../../controllers/project/getProjectPage/_utils/getPuissance';
 import { DésignationCatégorie } from '../../../../../modules/project';
+import { Role } from '@potentiel-domain/utilisateur';
 
 export type InfoPuissanceProps = {
   puissance: GetPuissanceForProjectPage;
@@ -10,6 +11,7 @@ export type InfoPuissanceProps = {
   unitePuissance: string;
   désignationCatégorie: DésignationCatégorie | undefined;
   puissanceInférieurePuissanceMaxVolRéservé: boolean;
+  role: Role.ValueType;
 };
 
 export const InfoPuissance = ({
@@ -18,7 +20,11 @@ export const InfoPuissance = ({
   unitePuissance,
   désignationCatégorie,
   puissanceInférieurePuissanceMaxVolRéservé,
+  role,
 }: InfoPuissanceProps) => {
+  const afficherSelonRole =
+    (role.estPorteur() && modificationsPermisesParLeCDCActuel) || !role.estPorteur();
+
   return (
     <div>
       <Heading3 className="m-0">Performances</Heading3>
@@ -32,7 +38,7 @@ export const InfoPuissance = ({
         puissanceInférieurePuissanceMaxVolRéservé && (
           <p className="mb-0 mt-1">Ce projet ne fait pas partie du volume réservé de la période.</p>
         )}
-      {modificationsPermisesParLeCDCActuel && puissance.affichage && (
+      {afficherSelonRole && puissance.affichage && (
         <Link
           href={puissance.affichage.url}
           aria-label={puissance.affichage.label}

--- a/packages/applications/legacy/src/views/pages/projectDetailsPage/sections/InfoGenerales/index.tsx
+++ b/packages/applications/legacy/src/views/pages/projectDetailsPage/sections/InfoGenerales/index.tsx
@@ -6,7 +6,6 @@ import { afficherDate } from '../../../../helpers';
 import { Routes } from '@potentiel-applications/routes';
 import { match } from 'ts-pattern';
 
-import { GarantiesFinancières } from '@potentiel-domain/laureat';
 import type { Candidature, Lauréat } from '@potentiel-domain/projet';
 import type { Role } from '@potentiel-domain/utilisateur';
 import { Raccordement } from '@potentiel-domain/laureat';
@@ -128,6 +127,7 @@ export const InfoGenerales = ({
           unitePuissance={appelOffre.unitePuissance}
           désignationCatégorie={désignationCatégorie}
           puissanceInférieurePuissanceMaxVolRéservé={puissanceInférieurePuissanceMaxVolRéservé}
+          role={role}
         />
       )}
       <div>
@@ -144,6 +144,7 @@ export const InfoGenerales = ({
         <InfoActionnaire
           actionnaire={actionnaire}
           modificationsPermisesParLeCDCActuel={!modificationsNonPermisesParLeCDCActuel}
+          role={role}
         />
       )}
       {coefficientKChoisi !== undefined ? (

--- a/packages/applications/legacy/src/views/pages/projectDetailsPage/sections/InfoProducteur.tsx
+++ b/packages/applications/legacy/src/views/pages/projectDetailsPage/sections/InfoProducteur.tsx
@@ -1,21 +1,27 @@
 import React from 'react';
 import { Heading3, Link } from '../../../components';
 import { GetProducteurForProjectPage } from '../../../../controllers/project/getProjectPage/_utils/getProducteur';
+import { Role } from '@potentiel-domain/utilisateur';
 
 export type InfoProducteurProps = {
   producteur: GetProducteurForProjectPage;
   modificationsPermisesParLeCDCActuel: boolean;
+  role: Role.ValueType;
 };
 
 export const InfoProducteur = ({
   producteur,
   modificationsPermisesParLeCDCActuel,
+  role,
 }: InfoProducteurProps) => {
+  const afficherSelonRole =
+    (role.estPorteur() && modificationsPermisesParLeCDCActuel) || !role.estPorteur();
+
   return (
     <div>
       <Heading3 className="m-0">Producteur</Heading3>
       <p className="m-0">{producteur.producteur || 'Non renseigné'}</p>
-      {modificationsPermisesParLeCDCActuel && producteur.affichage && (
+      {afficherSelonRole && producteur.affichage && (
         <Link
           href={producteur.affichage.url}
           aria-label={producteur.affichage.label}

--- a/packages/applications/legacy/src/views/pages/projectDetailsPage/sections/InfoReprésentantLégal.tsx
+++ b/packages/applications/legacy/src/views/pages/projectDetailsPage/sections/InfoReprésentantLégal.tsx
@@ -1,0 +1,34 @@
+import Link from 'next/link';
+import React from 'react';
+import { GetReprésentantLégalForProjectPage } from '../../../../controllers/project/getProjectPage/_utils';
+import { Heading3 } from '../../../components';
+import { Role } from '@potentiel-domain/utilisateur';
+
+export const InfoReprésentantLégal = ({
+  représentantLégal,
+  modificationsPermisesParLeCDCActuel,
+  role,
+}: {
+  représentantLégal: GetReprésentantLégalForProjectPage;
+  modificationsPermisesParLeCDCActuel: boolean;
+  role: Role.ValueType;
+}) => {
+  const afficherSelonRole =
+    (role.estPorteur() && modificationsPermisesParLeCDCActuel) || !role.estPorteur();
+
+  return (
+    <>
+      <Heading3 className="mb-1">Représentant légal</Heading3>
+      <div>{représentantLégal.nom}</div>
+      {afficherSelonRole && représentantLégal.affichage && (
+        <Link
+          href={représentantLégal.affichage.url}
+          aria-label={représentantLégal.affichage.label}
+          className="mt-1"
+        >
+          {représentantLégal.affichage.label}
+        </Link>
+      )}
+    </>
+  );
+};

--- a/packages/applications/ssr/src/components/pages/puissance/changement/demander/DemanderChangementPuissanceFormErrors.tsx
+++ b/packages/applications/ssr/src/components/pages/puissance/changement/demander/DemanderChangementPuissanceFormErrors.tsx
@@ -49,7 +49,7 @@ export const DemanderChangementPuissanceFormErrors = ({
         !dépassePuissanceMaxFamille &&
         dépasseLesRatioDeAppelOffres && (
           <Alert
-            severity="error"
+            severity="warning"
             small
             description={
               <span>
@@ -69,7 +69,7 @@ export const DemanderChangementPuissanceFormErrors = ({
         dépasseRatiosChangementPuissanceDuCahierDesChargesInitial &&
         fourchetteRatioInitialEtCDC2022AlertMessage && (
           <Alert
-            severity="error"
+            severity="warning"
             small
             description={
               <div>

--- a/packages/domain/utilisateur/src/role.valueType.ts
+++ b/packages/domain/utilisateur/src/role.valueType.ts
@@ -32,6 +32,7 @@ export type ValueType = ReadonlyValueType<{
   aLaPermission(value: Policy): boolean;
   estDGEC(): boolean;
   estDreal(): boolean;
+  estPorteur(): boolean;
 }>;
 
 export const convertirEnValueType = (value: string): ValueType => {
@@ -60,6 +61,9 @@ export const convertirEnValueType = (value: string): ValueType => {
     },
     estDreal() {
       return this.nom === 'dreal';
+    },
+    estPorteur() {
+      return this.nom === 'porteur-projet';
     },
   };
 };


### PR DESCRIPTION
# Description

- ETQ PP, dans l'onglet Actions : Au lieu d'afficher la modification, afficher le lien vers une demande si demande présente (pour toutes les demandes)
- ETQ Admin et Dreal : avoir accès à mes vraies actions
- Alignement ReprésentantLégal sur les autres demandes (wording et fonctionnement)
- Petit fix avec les modificationscahierdescharges (les actions admin / dreal ne s'affichaient pas sur la page projet sinon)

## Type de changement

Veuillez supprimer les options qui ne sont pas pertinentes.

- [x] Correction de bug
- [ ] Nouvelle fonctionnalité
- [ ] Refacto de code
- [ ] Breaking changes (correction ou fonctionnalité qui ferait en sorte que la fonctionnalité existante ne fonctionne pas comme prévu)
- [ ] Ce changement nécessite une mise à jour de la documentation

# Comment cela a-t-il été testé?

Pas mal de tests visuels