### PR TITLE
🐛 Corrections sur les tâches de raccordement + CLI pour achever une tâche

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29023,6 +29023,7 @@
         "@potentiel-libraries/file-storage": "*",
         "@potentiel-libraries/monitoring": "*",
         "@potentiel-statistiques/statistiques-publiques": "*",
+        "mediateur": "^0.3.0",
         "zod": "^3.24.2"
       },
       "bin": {

--- a/packages/applications/cli/package.json
+++ b/packages/applications/cli/package.json
@@ -27,6 +27,7 @@
     "@potentiel-libraries/file-storage": "*",
     "@potentiel-libraries/monitoring": "*",
     "@potentiel-statistiques/statistiques-publiques": "*",
+    "mediateur": "^0.3.0",
     "zod": "^3.24.2"
   },
   "devDependencies": {

--- a/packages/applications/cli/src/commands/tache/achever.ts
+++ b/packages/applications/cli/src/commands/tache/achever.ts
@@ -1,0 +1,37 @@
+import { Command, Flags, getLogger } from '@oclif/core';
+import { mediator } from 'mediateur';
+
+import { IdentifiantProjet } from '@potentiel-domain/projet';
+import { registerTâcheCommand, Tâche } from '@potentiel-domain/tache';
+import { loadAggregate } from '@potentiel-infrastructure/pg-event-sourcing';
+import { killPool } from '@potentiel-libraries/pg-helpers';
+
+export class AcheverTâche extends Command {
+  static flags = {
+    projet: Flags.string({ char: 'p', description: 'identifiant du projet', required: true }),
+    type: Flags.string({ char: 't', description: 'type de tâche', required: true }),
+  };
+  async init() {
+    registerTâcheCommand({ loadAggregate });
+  }
+  async finally() {
+    await killPool();
+  }
+
+  async run() {
+    const { flags } = await this.parse(AcheverTâche);
+    const identifiantProjet = IdentifiantProjet.convertirEnValueType(flags.projet);
+    const typeTâche = Tâche.TypeTâche.convertirEnValueType(flags.type);
+    await mediator.send<Tâche.AcheverTâcheCommand>({
+      type: 'System.Tâche.Command.AcheverTâche',
+      data: {
+        identifiantProjet,
+        typeTâche,
+      },
+    });
+    getLogger().info('Tâche achevée', {
+      identifiantProjet: identifiantProjet.formatter(),
+      typeTâche: typeTâche.type,
+    });
+  }
+}

--- a/packages/applications/ssr/src/components/pages/tâche/TâcheListItem.tsx
+++ b/packages/applications/ssr/src/components/pages/tâche/TâcheListItem.tsx
@@ -76,9 +76,9 @@ const getDescriptionTâche = (
     .with('raccordement.gestionnaire-réseau-inconnu-attribué', () => ({
       titre: 'Gestionnaire réseau inconnu',
       description: `Le gestionnaire réseau pour le projet ${nomProjet} n'a pas pu être automatiquement attribué.`,
-      lien: Routes.Raccordement.modifierGestionnaireDeRéseau(identifiant),
-      action: 'Modifier le gestionnaire réseau attribué',
-      ariaLabel: `Modifier le gestionnaire réseau attribué au projet ${nomProjet}`,
+      lien: Routes.Raccordement.détail(identifiant),
+      action: 'Ajouter le gestionnaire de réseau',
+      ariaLabel: `Ajouter le gestionnaire de réseau au projet ${nomProjet}`,
     }))
     .with('garanties-financières.demander', () => ({
       titre: 'Garanties financières demandées',

--- a/packages/domain/tâche/src/tâche.ts
+++ b/packages/domain/tâche/src/tâche.ts
@@ -8,6 +8,9 @@ import { ListerTâchesQuery, ListerTâchesReadModel } from './lister/listerTâch
 export type TâcheQuery = ConsulterNombreTâchesQuery | ListerTâchesQuery;
 export { ConsulterNombreTâchesQuery, ListerTâchesQuery };
 
+// Command
+export { AcheverTâcheCommand } from './achever/acheverTâche.command';
+
 // ReadModel
 export { ConsulterNombreTâchesReadModel, ListerTâchesReadModel };
 


### PR DESCRIPTION
Changer le lien en cas de gestionnaire réseau inconnu afin de rediriger vers la page de DCR

CLI pour achever une tâche, pour permettre de supprimer des tâches qui ne devraient pas exister