### PR TITLE
💄 Améliorations de l'affichage de l'historique d'un projet

### DIFF
--- a/packages/applications/legacy/src/views/pages/projectDetailsPage/sections/EtapesProjet.tsx
+++ b/packages/applications/legacy/src/views/pages/projectDetailsPage/sections/EtapesProjet.tsx
@@ -30,8 +30,10 @@ export const EtapesProjet: FC<EtapesProjetProps> = ({ identifiantProjet, isLegac
       <ol className="pl-0 overflow-hidden list-none">
         {étapes
           .sort((a, b) => a.date - b.date)
-          .map((étape) =>
-            match(étape)
+          .map((étape, index) => {
+            const isLastItem = index === étapes.length - 1;
+
+            return match(étape)
               .with({ type: 'designation' }, ({ type, date }) => (
                 <ÉtapeTerminée
                   key={`project-step-${type}`}
@@ -56,7 +58,7 @@ export const EtapesProjet: FC<EtapesProjetProps> = ({ identifiantProjet, isLegac
               ))
               .with({ type: 'abandon' }, ({ type, date }) => (
                 <ÉtapeTerminée
-                  isLastItem
+                  isLastItem={isLastItem}
                   key={`project-step-${type}`}
                   titre="Abandon accordé"
                   date={date}
@@ -78,14 +80,14 @@ export const EtapesProjet: FC<EtapesProjetProps> = ({ identifiantProjet, isLegac
               ))
               .with({ type: 'achèvement-réel' }, ({ type, date }) => (
                 <ÉtapeTerminée
-                  isLastItem={!!étapes.find((étape) => étape.type === 'mise-en-service')}
+                  isLastItem={isLastItem}
                   key={`project-step-${type}`}
                   titre="Date d'achèvement réelle"
                   date={date}
                 />
               ))
-              .exhaustive(),
-          )}
+              .exhaustive();
+          })}
 
         {!étapes.find((étape) => étape.type === 'abandon') && (
           <>

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/historique/page.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/historique/page.tsx
@@ -86,9 +86,9 @@ export default async function Page({ params: { identifiant }, searchParams }: Pa
           ]}
           historique={historique.items
             .filter((historique) => !historique.type.includes('Import'))
+            .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
             .map((item) => mapToTimelineItemProps(item, candidature.unitéPuissance.formatter()))
-            .filter((item) => item !== undefined)
-            .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())}
+            .filter((item) => item !== undefined)}
         />
       );
     }),

--- a/packages/applications/ssr/src/utils/historique/mapToProps/achèvement/events/mapToAttestationConformitéTransmiseTimelineItemProps.tsx
+++ b/packages/applications/ssr/src/utils/historique/mapToProps/achèvement/events/mapToAttestationConformitéTransmiseTimelineItemProps.tsx
@@ -11,6 +11,8 @@ export const mapToAttestationConformitéTransmiseTimelineItemProps = (
   const {
     identifiantProjet,
     attestation: { format },
+    preuveTransmissionAuCocontractant,
+    dateTransmissionAuCocontractant,
     date,
   } = abandonAccordé.payload as Lauréat.Achèvement.AttestationConformitéTransmiseEvent['payload'];
 
@@ -21,16 +23,31 @@ export const mapToAttestationConformitéTransmiseTimelineItemProps = (
     format,
   ).formatter();
 
+  const preuveTransmission = DocumentProjet.convertirEnValueType(
+    identifiantProjet,
+    Lauréat.Achèvement.TypeDocumentAchèvement.attestationConformitéPreuveTransmissionValueType.formatter(),
+    dateTransmissionAuCocontractant,
+    preuveTransmissionAuCocontractant.format,
+  ).formatter();
+
   return {
     date,
     title: <div>Projet achevé</div>,
     content: (
-      <DownloadDocument
-        className="mb-0"
-        label="Télécharger l'attestation de conformité'"
-        format="pdf"
-        url={Routes.Document.télécharger(attestation)}
-      />
+      <>
+        <DownloadDocument
+          className="mb-0"
+          label="Télécharger l'attestation de conformité"
+          format="pdf"
+          url={Routes.Document.télécharger(attestation)}
+        />
+        <DownloadDocument
+          className="mb-0"
+          label="Télécharger la preuve de transmission au cocontractant"
+          format="pdf"
+          url={Routes.Document.télécharger(preuveTransmission)}
+        />
+      </>
     ),
   };
 };

--- a/packages/applications/ssr/src/utils/historique/mapToProps/garanties-financières/events/mainlevée/mapToDemandeMainlevéeGarantiesFinancièresAccordéeTimelineItemsProps.tsx
+++ b/packages/applications/ssr/src/utils/historique/mapToProps/garanties-financières/events/mainlevée/mapToDemandeMainlevéeGarantiesFinancièresAccordéeTimelineItemsProps.tsx
@@ -1,11 +1,26 @@
 import { Historique } from '@potentiel-domain/historique';
 import { GarantiesFinancières } from '@potentiel-domain/laureat';
+import { Routes } from '@potentiel-applications/routes';
+import { DocumentProjet } from '@potentiel-domain/document';
+
+import { DownloadDocument } from '@/components/atoms/form/document/DownloadDocument';
 
 export const mapToDemandeMainlevéeGarantiesFinancièresAccordéeTimelineItemsProps = (
   modification: Historique.ListerHistoriqueProjetReadModel['items'][number],
 ) => {
-  const { accordéLe, accordéPar } =
-    modification.payload as GarantiesFinancières.DemandeMainlevéeGarantiesFinancièresAccordéeEvent['payload'];
+  const {
+    accordéLe,
+    accordéPar,
+    identifiantProjet,
+    réponseSignée: { format },
+  } = modification.payload as GarantiesFinancières.DemandeMainlevéeGarantiesFinancièresAccordéeEvent['payload'];
+
+  const réponseSignée = DocumentProjet.convertirEnValueType(
+    identifiantProjet,
+    GarantiesFinancières.TypeDocumentRéponseDemandeMainlevée.courrierRéponseDemandeMainlevéeAccordéeValueType.formatter(),
+    accordéLe,
+    format,
+  ).formatter();
 
   return {
     date: accordéLe,
@@ -14,6 +29,14 @@ export const mapToDemandeMainlevéeGarantiesFinancièresAccordéeTimelineItemsPr
         La demande de mainlevée des garanties financières a été accordée par{' '}
         <span className="font-semibold">{accordéPar}</span>{' '}
       </div>
+    ),
+    content: (
+      <DownloadDocument
+        className="mb-0"
+        label="Télécharger la réponse signée"
+        format="pdf"
+        url={Routes.Document.télécharger(réponseSignée)}
+      />
     ),
   };
 };

--- a/packages/applications/ssr/src/utils/historique/mapToProps/raccordement/events/gestionnaire-réseau/mapToGestionnaireRéseauAttribuéTimelineItemProps.tsx
+++ b/packages/applications/ssr/src/utils/historique/mapToProps/raccordement/events/gestionnaire-réseau/mapToGestionnaireRéseauAttribuéTimelineItemProps.tsx
@@ -1,25 +1,13 @@
-import Link from 'next/link';
-
-import { Routes } from '@potentiel-applications/routes';
 import { DateTime } from '@potentiel-domain/common';
 import { Historique } from '@potentiel-domain/historique';
-import { Raccordement } from '@potentiel-domain/laureat';
 
 export const mapToGestionnaireRéseauAttribuéTimelineItemProps = (
   attribution: Historique.ListerHistoriqueProjetReadModel['items'][number],
 ) => {
-  const { identifiantGestionnaireRéseau } =
-    attribution.payload as Raccordement.GestionnaireRéseauAttribuéEvent['payload'];
-
   return {
     date: attribution.createdAt as DateTime.RawType,
     title: (
       <div>Un gestionnaire de réseau de raccordement a été attribué au raccordement du projet</div>
-    ),
-    content: (
-      <Link href={Routes.Gestionnaire.détail(identifiantGestionnaireRéseau)}>
-        Voir le gestionnaire
-      </Link>
     ),
   };
 };

--- a/packages/applications/ssr/src/utils/historique/mapToProps/raccordement/events/gestionnaire-réseau/mapToGestionnaireRéseauRaccordementModifiéTimelineItemProps.tsx
+++ b/packages/applications/ssr/src/utils/historique/mapToProps/raccordement/events/gestionnaire-réseau/mapToGestionnaireRéseauRaccordementModifiéTimelineItemProps.tsx
@@ -1,23 +1,11 @@
-import Link from 'next/link';
-
-import { Routes } from '@potentiel-applications/routes';
 import { DateTime } from '@potentiel-domain/common';
 import { Historique } from '@potentiel-domain/historique';
-import { Raccordement } from '@potentiel-domain/laureat';
 
 export const mapToGestionnaireRéseauRaccordementModifiéTimelineItemProps = (
   modification: Historique.ListerHistoriqueProjetReadModel['items'][number],
 ) => {
-  const { identifiantGestionnaireRéseau } =
-    modification.payload as Raccordement.GestionnaireRéseauRaccordementModifiéEvent['payload'];
-
   return {
     date: modification.createdAt as DateTime.RawType,
     title: <div>Le gestionnaire de réseau de raccordement du projet a été modifié</div>,
-    content: (
-      <Link href={Routes.Gestionnaire.détail(identifiantGestionnaireRéseau)}>
-        Voir le nouveau gestionnaire
-      </Link>
-    ),
   };
 };


### PR DESCRIPTION
- **🐛 Ordonner correctement les éléments de l'historique avant leur mapping**
- **✨ Affichage du courrier de main levée accordée**
- **💄 Ne pas afficher le liens pour accéder au référentiel de gestionnaire de réseau**
- **💄 Ajout du lien pour accéder à la preuve de transmission au cocontractant**
- **💄 Meilleure identification du dernier élément des étapes du projet**
