### PR TITLE
🔀 Intégration des modifications de la release 3.53

### DIFF
--- a/packages/applications/legacy/src/controllers/project/getProjectPage/index.ts
+++ b/packages/applications/legacy/src/controllers/project/getProjectPage/index.ts
@@ -188,10 +188,7 @@ v1Router.get(
           project.cahierDesChargesActuel.type === 'modifié' &&
           project.cahierDesChargesActuel.paruLe === '30/08/2022',
       });
-      const attestationConformité = await getAttestationDeConformité(
-        identifiantProjetValueType,
-        user.role,
-      );
+      const achèvement = await getAttestationDeConformité(identifiantProjetValueType, user.role);
 
       miseAJourStatistiquesUtilisation({
         type: 'projetConsulté',
@@ -258,8 +255,8 @@ v1Router.get(
               project.appelOffre.changementProducteurPossibleAvantAchèvement,
           }),
           candidature: await getCandidature({ identifiantProjet: identifiantProjetValueType }),
-          estAchevé: !!attestationConformité,
-          dateAchèvementRéelle: attestationConformité?.date,
+          estAchevé: !!achèvement,
+          achèvement,
           modificationsNonPermisesParLeCDCActuel:
             project.cahierDesChargesActuel.type === 'initial' &&
             !!project.appelOffre.periode.choisirNouveauCahierDesCharges,

--- a/packages/applications/legacy/src/views/pages/projectDetailsPage/ProjectDetails.tsx
+++ b/packages/applications/legacy/src/views/pages/projectDetailsPage/ProjectDetails.tsx
@@ -24,6 +24,7 @@ import {
   GarantiesFinancièresProjetProps,
   EtapesProjetProps,
   MaterielsEtTechnologiesProps,
+  AchevementProps,
 } from './sections';
 import { ProjectHeader } from './components';
 import { Routes } from '@potentiel-applications/routes';
@@ -55,8 +56,8 @@ type ProjectDetailsProps = {
   actionnaire?: InfoGeneralesProps['actionnaire'];
   puissance?: InfoGeneralesProps['puissance'];
   producteur?: ContactProps['producteur'];
+  achèvement?: AchevementProps;
   estAchevé: boolean;
-  dateAchèvementRéelle?: number;
   modificationsNonPermisesParLeCDCActuel: boolean;
   coefficientKChoisi: boolean | undefined;
   candidature: ContactProps['candidature'];
@@ -71,7 +72,7 @@ export const ProjectDetails = ({
   abandon,
   demandeRecours,
   estAchevé,
-  dateAchèvementRéelle,
+  achèvement,
   représentantLégal,
   actionnaire,
   garantiesFinancières,
@@ -133,10 +134,10 @@ export const ProjectDetails = ({
       });
     }
 
-    if (dateAchèvementRéelle) {
+    if (achèvement?.date) {
       étapes.push({
         type: 'achèvement-réel',
-        date: dateAchèvementRéelle,
+        date: achèvement.date,
       });
     }
   }
@@ -217,6 +218,7 @@ export const ProjectDetails = ({
               modificationsNonPermisesParLeCDCActuel={modificationsNonPermisesParLeCDCActuel}
               coefficientKChoisi={coefficientKChoisi}
               estAchevé={estAchevé}
+              achèvement={achèvement}
             />
             <Contact
               identifiantProjet={identifiantProjet}

--- a/packages/applications/legacy/src/views/pages/projectDetailsPage/sections/InfoGenerales/index.tsx
+++ b/packages/applications/legacy/src/views/pages/projectDetailsPage/sections/InfoGenerales/index.tsx
@@ -1,6 +1,13 @@
 import React, { ComponentProps } from 'react';
 import { ProjectDataForProjectPage } from '../../../../../modules/project';
-import { BuildingIcon, Heading3, Link, Section, WarningIcon } from '../../../../components';
+import {
+  BuildingIcon,
+  DownloadLink,
+  Heading3,
+  Link,
+  Section,
+  WarningIcon,
+} from '../../../../components';
 import { formatProjectDataToIdentifiantProjetValueType } from '../../../../../helpers/dataToValueTypes';
 import { afficherDate } from '../../../../helpers';
 import { Routes } from '@potentiel-applications/routes';
@@ -16,6 +23,15 @@ import { InfoPuissance } from './InfoPuissance';
 import { GetActionnaireForProjectPage } from '../../../../../controllers/project/getProjectPage/_utils';
 import { GetPuissanceForProjectPage } from '../../../../../controllers/project/getProjectPage/_utils/getPuissance';
 import { PlainType } from '@potentiel-domain/core';
+import { DocumentProjet } from '@potentiel-domain/document';
+
+export type AchevementProps = {
+  date: number;
+  attestation: DocumentProjet.RawType;
+  preuveTransmissionAuCocontractant: DocumentProjet.RawType;
+  identifiantProjet: IdentifiantProjet.RawType;
+  permissionModifier: boolean;
+};
 
 export type InfoGeneralesProps = {
   project: ProjectDataForProjectPage;
@@ -28,6 +44,7 @@ export type InfoGeneralesProps = {
   modificationsNonPermisesParLeCDCActuel: boolean;
   coefficientKChoisi: boolean | undefined;
   estAchevé: boolean;
+  achèvement?: AchevementProps;
 };
 
 export const InfoGenerales = ({
@@ -58,6 +75,7 @@ export const InfoGenerales = ({
   puissance,
   coefficientKChoisi,
   estAchevé,
+  achèvement,
 }: InfoGeneralesProps) => {
   const puissanceInférieurePuissanceMaxVolRéservé =
     appelOffre.periode.noteThresholdBy === 'category' &&
@@ -159,12 +177,38 @@ export const InfoGenerales = ({
           <span>{coefficientKChoisi ? 'Oui' : 'Non'}</span>
         </div>
       ) : null}
-      {prixReference ? (
+      {prixReference && (
         <div>
           <Heading3 className="m-0">Prix</Heading3>
           <span>{prixReference} €/MWh</span>
         </div>
-      ) : null}
+      )}
+      {achèvement && (
+        <div className="flex flex-col">
+          <Heading3 className="m-0">Achèvement</Heading3>
+          <DownloadLink
+            fileUrl={Routes.Document.télécharger(achèvement.attestation)}
+            className="m-0"
+          >
+            Télécharger l'attestation de conformité
+          </DownloadLink>
+          <DownloadLink
+            fileUrl={Routes.Document.télécharger(achèvement.preuveTransmissionAuCocontractant)}
+            className="m-0"
+          >
+            Télécharger la preuve de transmission au cocontractant
+          </DownloadLink>
+          {role.aLaPermission('achèvement.modifier') && (
+            <Link
+              href={Routes.Achèvement.modifierAttestationConformité(identifiantProjet.formatter())}
+              aria-label="Modifier les informations d'achèvement du projet"
+              className="mt-1"
+            >
+              Modifier
+            </Link>
+          )}
+        </div>
+      )}
     </Section>
   );
 };

--- a/packages/specifications/src/projet/lauréat/abandon/accorderAbandon.feature
+++ b/packages/specifications/src/projet/lauréat/abandon/accorderAbandon.feature
@@ -15,12 +15,12 @@ Fonctionnalité: Accorder l'abandon d'un projet lauréat
         Quand le DGEC validateur accorde l'abandon pour le projet lauréat
         Alors l'abandon du projet lauréat devrait être accordé
 
-    Scénario: Le porteur reçoit une demande de preuve de recandidature quand l'abandon avec recandidature d'un projet lauréat a été accordé
-        Etant donné une demande d'abandon en cours avec recandidature pour le projet lauréat
-        Quand le DGEC validateur accorde l'abandon pour le projet lauréat
-        Alors la preuve de recandidature a été demandée au porteur du projet lauréat
-        Et une tâche indiquant de "transmettre la preuve de recandidature" est consultable dans la liste des tâches du porteur pour le projet
-
+    # TODO : Vérifier avec le métier pour supprimer carrément la partie recandidature
+    # Scénario: Le porteur reçoit une demande de preuve de recandidature quand l'abandon avec recandidature d'un projet lauréat a été accordé
+    #     Etant donné une demande d'abandon en cours avec recandidature pour le projet lauréat
+    #     Quand le DGEC validateur accorde l'abandon pour le projet lauréat
+    #     Alors la preuve de recandidature a été demandée au porteur du projet lauréat
+    #     Et une tâche indiquant de "transmettre la preuve de recandidature" est consultable dans la liste des tâches du porteur pour le projet
     Scénario: Impossible d'accorder l'abandon d'un projet lauréat si l'abandon a déjà été accordé
         Etant donné un abandon accordé pour le projet lauréat
         Quand le DGEC validateur accorde l'abandon pour le projet lauréat

--- a/packages/specifications/src/projet/lauréat/abandon/demanderPreuveRecandidature.feature
+++ b/packages/specifications/src/projet/lauréat/abandon/demanderPreuveRecandidature.feature
@@ -1,21 +1,25 @@
 # language: fr
 Fonctionnalité: demander un porteur pour qu'il transmette une preuve de recandidature
 
-    Contexte:
-        Etant donné le projet lauréat "Du boulodrome de Marseille"
-        Et un cahier des charges modificatif choisi
 
-    Scénario: Demander la preuve de recandidature au porteur du projet
-        Etant donné un abandon accordé avec recandidature sans preuve transmise pour le projet lauréat
-        Quand le DGEC validateur demande au porteur du projet de transmettre une preuve de recandidature
-        Alors la preuve de recandidature a été demandée au porteur du projet lauréat
 
-    Scénario: Impossible de demander à un porteur de projet qui a déjà transmis sa preuve de recandidature
-        Etant donné un abandon accordé avec recandidature avec preuve transmise pour le projet lauréat
-        Quand le DGEC validateur demande au porteur du projet de transmettre une preuve de recandidature
-        Alors le DGEC validateur devrait être informé que "La preuve de recandidature a déjà été transmise"
 
-    Scénario: Impossible de demander à un porteur de projet si la date de demande dépasse le 30/06/2025
-        Etant donné un abandon accordé avec recandidature sans preuve transmise pour le projet lauréat
-        Quand le DGEC validateur demande au porteur du projet de transmettre une preuve de recandidature à la date du 01/07/2025
-        Alors le DGEC validateur devrait être informé que "Impossible de demander la preuve de recandidature au porteur après le 30/06/2025"
+# Contexte:
+#     Etant donné le projet lauréat "Du boulodrome de Marseille"
+#     Et un cahier des charges modificatif choisi
+
+# Scénario: Demander la preuve de recandidature au porteur du projet
+#     Etant donné un abandon accordé avec recandidature sans preuve transmise pour le projet lauréat
+#     Quand le DGEC validateur demande au porteur du projet de transmettre une preuve de recandidature
+#     Alors la preuve de recandidature a été demandée au porteur du projet lauréat
+
+# TODO : Vérifier avec le métier pour supprimer carrément la partie recandidature
+# Scénario: Impossible de demander à un porteur de projet qui a déjà transmis sa preuve de recandidature
+#     Etant donné un abandon accordé avec recandidature avec preuve transmise pour le projet lauréat
+#     Quand le DGEC validateur demande au porteur du projet de transmettre une preuve de recandidature
+#     Alors le DGEC validateur devrait être informé que "La preuve de recandidature a déjà été transmise"
+
+# Scénario: Impossible de demander à un porteur de projet si la date de demande dépasse le 30/06/2025
+#     Etant donné un abandon accordé avec recandidature sans preuve transmise pour le projet lauréat
+#     Quand le DGEC validateur demande au porteur du projet de transmettre une preuve de recandidature à la date du 01/07/2025
+#     Alors le DGEC validateur devrait être informé que "Impossible de demander la preuve de recandidature au porteur après le 30/06/2025"


### PR DESCRIPTION
- **🐛 Utilisation de la bonne date pour l'historique de la transmission de la PTF (#3185)**
- **Amélioration de l'impression de l'historique projet (#3188)**
- **🐛 Hotfix get laureat (#3195)**
- **✨ Permettre la modification depuis la page projet des données d'achèvement (#3200)**
