### PR TITLE
✨ Gestion des métadonnées par défaut dans le logger, et ajout de métadonnées à la CLI

### DIFF
--- a/packages/applications/cli/src/hooks/init/config.ts
+++ b/packages/applications/cli/src/hooks/init/config.ts
@@ -3,9 +3,13 @@ import dotenv from 'dotenv';
 
 import { createLogger, initLogger } from '@potentiel-libraries/monitoring';
 
-const hook: Hook<'init'> = async function () {
+const hook: Hook<'init'> = async function ({ argv, id }) {
   dotenv.config();
-  initLogger(createLogger({}));
+  initLogger(
+    createLogger({
+      defaultMeta: { application: 'cli', argv, command: id },
+    }),
+  );
 };
 
 export default hook;

--- a/packages/libraries/monitoring/src/logger.test.ts
+++ b/packages/libraries/monitoring/src/logger.test.ts
@@ -16,7 +16,22 @@ describe('winston-logger', () => {
     resetLogger();
   });
 
-  it('logs the correct format', () => {
+  it('logs the correct format without meta', () => {
+    const calls: string[] = [];
+    initLogger(
+      createLogger({
+        level: 'debug',
+        transports: [consoleTransport({ log: logMock(calls) })],
+      }),
+    );
+    const logger = getLogger('serviceName');
+
+    logger.info('hello');
+
+    expect(calls[0].trim()).to.eq('hello | Service(serviceName) | Metadata({})');
+  });
+
+  it('logs the correct format with meta', () => {
     const calls: string[] = [];
     initLogger(
       createLogger({
@@ -28,10 +43,30 @@ describe('winston-logger', () => {
 
     logger.info('hello', { foo: 'bar', baz: 1 });
 
-    expect(calls[0].trim()).to.eq('hello | Service(serviceName) | Metadata({foo="bar"} {baz=1})');
+    expect(calls[0].trim()).to.eq('hello | Service(serviceName) | Metadata({"foo":"bar","baz":1})');
   });
 
-  it('logs the correct level', async () => {
+  it('logs the correct format with default meta', () => {
+    const calls: string[] = [];
+    initLogger(
+      createLogger({
+        level: 'debug',
+        transports: [consoleTransport({ log: logMock(calls) })],
+        defaultMeta: {
+          appName: 'test',
+        },
+      }),
+    );
+    const logger = getLogger('serviceName');
+
+    logger.info('hello', { foo: 'bar', baz: 1 });
+
+    expect(calls[0].trim()).to.eq(
+      `hello | Service(serviceName) | Metadata({"appName":"test","foo":"bar","baz":1})`,
+    );
+  });
+
+  it('logs the correct level', () => {
     const calls: string[] = [];
     initLogger(
       createLogger({

--- a/packages/libraries/monitoring/src/logger.ts
+++ b/packages/libraries/monitoring/src/logger.ts
@@ -5,12 +5,14 @@ export type Logger = {
   error(error: Error | string, meta?: Record<string, unknown>): void;
 };
 
-let logger: (Logger & { child?: (props: Object) => Logger }) | undefined;
+let logger:
+  | (Logger & { child?: (props: Object) => Logger; defaultMeta?: Record<string, unknown> })
+  | undefined;
 
 export const forkLogger = (service?: string): Logger => {
   if (!logger) return console;
   if (!logger.child) return logger;
-  return logger.child({ service });
+  return logger.child({ service, defaultMeta: logger.defaultMeta });
 };
 
 export const initLogger = (newLogger: Logger) => {

--- a/packages/libraries/monitoring/src/winston/console.transport.ts
+++ b/packages/libraries/monitoring/src/winston/console.transport.ts
@@ -3,21 +3,29 @@ import winston from 'winston';
 declare module 'logform' {
   interface TransformableInfo {
     meta: Record<string, unknown>;
+    defaultMeta?: Record<string, unknown>;
   }
 }
+
+/** Merge and format Meta  */
+const getMeta = (info: winston.Logform.TransformableInfo) => {
+  if ('error' in info && info.error instanceof Error && info.error.cause) {
+    info.meta.cause = String(info.error.cause);
+  }
+
+  return {
+    ...info.defaultMeta,
+    ...info.meta,
+  };
+};
 
 /**
  * We are currently using a custom formatter because we don't really have monitoring capabilities.
  * In the futur, we can switch to logstash if beta.gouv.fr setup something like ELK
  */
 const customFormat = winston.format((info) => {
-  if ('error' in info && info.error instanceof Error && info.error.cause) {
-    info.meta.cause = String(info.error.cause);
-  }
-  const meta = Object.keys(info.meta)
-    .map((k) => `{${k}=${JSON.stringify(info.meta[k])}}`)
-    .join(' ');
-  info.message = `${info.message} | Service(${info.service}) | Metadata(${meta})`;
+  const meta = getMeta(info);
+  info.message = `${info.message} | Service(${info.service}) | Metadata(${JSON.stringify(meta)})`;
   return info;
 });
 


### PR DESCRIPTION
:warning: Modification du format par défaut des métadonnées, pas très exploitable actuellement. 

Cette PR améliore la gestion des métadonnées dans les logs, en permettant par exemple d'en précisant des globales qui seront toujours spécifiées. 

C'est utile dans le contexte de la CLI, où on aimerait pouvoir trouver les logs d'une éxecution donnée,  et savoir à quelle commande celà correspond. 
