### PR TITLE
🐛  Hot fix proconnect email

### DIFF
--- a/packages/applications/request-context/src/helper/getBaseUrl.ts
+++ b/packages/applications/request-context/src/helper/getBaseUrl.ts
@@ -1,0 +1,11 @@
+export const getBaseUrl = () => {
+  const { BASE_URL: baseUrl } = process.env;
+
+  if (!baseUrl) {
+    throw new Error(`variable d'environnement BASE_URL non trouvée`);
+  }
+  if (baseUrl.endsWith('/')) {
+    return baseUrl.slice(0, -1);
+  }
+  return baseUrl;
+};

--- a/packages/applications/request-context/src/sendVerificationRequest.ts
+++ b/packages/applications/request-context/src/sendVerificationRequest.ts
@@ -6,6 +6,7 @@ import { Routes } from '@potentiel-applications/routes';
 
 import { GetUtilisateurFromEmail } from './getUtilisateur';
 import { canConnectWithProvider } from './canConnectWithProvider';
+import { getBaseUrl } from './helper/getBaseUrl';
 
 type BuildSendVerificationRequest = (
   sendEmail: SendEmail,
@@ -26,13 +27,15 @@ export const buildSendVerificationRequest: BuildSendVerificationRequest = (
       },
     });
 
+  const baseUrl = getBaseUrl();
+
   const envoyerEmailConnexionProConnectObligatoire = (email: string) =>
     sendEmail({
       templateId: 7103248,
       messageSubject: 'Potentiel - Connexion avec ProConnect obligatoire',
       recipients: [{ email, fullName: '' }],
       variables: {
-        url: Routes.Auth.signIn({ forceProConnect: true }),
+        url: `${baseUrl}${Routes.Auth.signIn({ forceProConnect: true })}`,
       },
     });
 


### PR DESCRIPTION
# Description

hot fix: il manquait la base url pour la redirect pour le mail "proconnect obligatoire", aujourd'hui le bouton n'est pas clicable (testé en prod)

## Type de changement

<img width="712" alt="Capture d’écran 2025-07-08 à 16 22 36" src="https://github.com/user-attachments/assets/24a88c06-1811-4f37-9f85-c7458a00ccef" />
