### PR TITLE
✨ Ajouter 18 mois à la date d'achèvement prévisionnel si le CDC paru le 30/08/2022 est séléctionné

### DIFF
--- a/packages/domain/projet/src/lauréat/achèvement/achèvement.aggregate.ts
+++ b/packages/domain/projet/src/lauréat/achèvement/achèvement.aggregate.ts
@@ -72,7 +72,7 @@ export class AchèvementAggregate extends AbstractAggregate<
         .with({ type: 'délai-accordé' }, ({ nombreDeMois }) =>
           this.#dateAchèvementPrévisionnel.ajouterNombreDeMois(nombreDeMois).formatter(),
         )
-        .with({ type: 'ajout-cdc-30/08/2022' }, () =>
+        .with({ type: 'ajout-délai-cdc-30_08_2022' }, () =>
           this.#dateAchèvementPrévisionnel.ajouterNombreDeMois(18).formatter(),
         )
         .exhaustive();

--- a/packages/domain/projet/src/lauréat/achèvement/achèvement.aggregate.ts
+++ b/packages/domain/projet/src/lauréat/achèvement/achèvement.aggregate.ts
@@ -72,6 +72,9 @@ export class AchèvementAggregate extends AbstractAggregate<
         .with({ type: 'délai-accordé' }, ({ nombreDeMois }) =>
           this.#dateAchèvementPrévisionnel.ajouterNombreDeMois(nombreDeMois).formatter(),
         )
+        .with({ type: 'ajout-cdc-30/08/2022' }, () =>
+          this.#dateAchèvementPrévisionnel.ajouterNombreDeMois(18).formatter(),
+        )
         .exhaustive();
 
       const event: DateAchèvementPrévisionnelCalculéeEvent = {

--- a/packages/domain/projet/src/lauréat/achèvement/calculerDateAchèvementPrévisionnel/calculerDateAchèvementPrévisionnel.option.ts
+++ b/packages/domain/projet/src/lauréat/achèvement/calculerDateAchèvementPrévisionnel/calculerDateAchèvementPrévisionnel.option.ts
@@ -1,3 +1,4 @@
 export type CalculerDateAchèvementPrévisionnelOptions =
   | { type: 'notification' }
+  | { type: 'ajout-cdc-30/08/2022' }
   | { type: 'délai-accordé'; nombreDeMois: number };

--- a/packages/domain/projet/src/lauréat/achèvement/calculerDateAchèvementPrévisionnel/calculerDateAchèvementPrévisionnel.option.ts
+++ b/packages/domain/projet/src/lauréat/achèvement/calculerDateAchèvementPrévisionnel/calculerDateAchèvementPrévisionnel.option.ts
@@ -1,4 +1,4 @@
 export type CalculerDateAchèvementPrévisionnelOptions =
   | { type: 'notification' }
-  | { type: 'ajout-cdc-30/08/2022' }
+  | { type: 'ajout-délai-cdc-30_08_2022' }
   | { type: 'délai-accordé'; nombreDeMois: number };

--- a/packages/domain/projet/src/lauréat/cahierDesCharges/choisir/choisirCahierDesCharges.usecase.ts
+++ b/packages/domain/projet/src/lauréat/cahierDesCharges/choisir/choisirCahierDesCharges.usecase.ts
@@ -1,7 +1,9 @@
 import { Message, MessageHandler, mediator } from 'mediateur';
 
-import { DateTime, Email, IdentifiantProjet } from '@potentiel-domain/common';
+import { DateTime, Email } from '@potentiel-domain/common';
 import { AppelOffre } from '@potentiel-domain/appel-offre';
+
+import { IdentifiantProjet } from '../../..';
 
 import { ChoisirCahierDesChargesCommand } from './choisirCahierDesCharges.command';
 

--- a/packages/domain/projet/src/lauréat/lauréat.aggregate.ts
+++ b/packages/domain/projet/src/lauréat/lauréat.aggregate.ts
@@ -313,6 +313,12 @@ export class LauréatAggregate extends AbstractAggregate<
     };
 
     await this.publish(event);
+
+    if (cahierDesCharges.estCDC2022()) {
+      await this.achèvement.calculerDateAchèvementPrévisionnel({
+        type: 'ajout-cdc-30/08/2022',
+      });
+    }
   }
 
   private vérifierQueLeLauréatPeutÊtreNotifié() {

--- a/packages/domain/projet/src/lauréat/lauréat.aggregate.ts
+++ b/packages/domain/projet/src/lauréat/lauréat.aggregate.ts
@@ -316,7 +316,7 @@ export class LauréatAggregate extends AbstractAggregate<
 
     if (cahierDesCharges.estCDC2022()) {
       await this.achèvement.calculerDateAchèvementPrévisionnel({
-        type: 'ajout-cdc-30/08/2022',
+        type: 'ajout-délai-cdc-30_08_2022',
       });
     }
   }

--- a/packages/specifications/src/projet/lauréat/achèvement/calculerDateAchèvementPrévisionnel.feature
+++ b/packages/specifications/src/projet/lauréat/achèvement/calculerDateAchèvementPrévisionnel.feature
@@ -29,14 +29,10 @@ Fonctionnalité: Calculer la date d'achèvement prévisionnel
             | PPE2 - Neutre | eolien                | 2024-10-05        | 2027-10-05                            |
             | PPE2 - Neutre | hydraulique           | 2024-10-05        | 2027-10-05                            |
 
-    Plan du scénario: Calculer la date d'achèvement prévisionnel lorsqu'un projet lauréat change son cahier des charges par le CDC paru le 30/08/2022
+    Scénario: Calculer la date d'achèvement prévisionnel lorsqu'un projet lauréat change son cahier des charges par le CDC paru le 30/08/2022
         Etant donné le projet lauréat "Du boulodrome de Bordeaux" avec :
-            | appel d'offre | <appel d'offre> |
-            | période       | <période>       |
-        Et une date d'achèvement prévisionnel pour le projet lauréat au "<date achèvement prévisionnel actuelle>"
+            | appel d'offre | PPE2 - Bâtiment |
+            | période       | 1               |
+        Et une date d'achèvement prévisionnel pour le projet lauréat au "2020-01-01"
         Quand le porteur choisit le cahier des charges "30/08/2022"
-        Alors la date d'achèvement prévisionnel du projet lauréat devrait être au "<date achèvement prévisionnel attendue>"
-
-        Exemples:
-            | appel d'offre   | période | date achèvement prévisionnel actuelle | date achèvement prévisionnel attendue |
-            | PPE2 - Bâtiment | 1       | 2020-01-01                            | 2021-07-01                            |
+        Alors la date d'achèvement prévisionnel du projet lauréat devrait être au "2021-07-01"

--- a/packages/specifications/src/projet/lauréat/achèvement/calculerDateAchèvementPrévisionnel.feature
+++ b/packages/specifications/src/projet/lauréat/achèvement/calculerDateAchèvementPrévisionnel.feature
@@ -29,7 +29,7 @@ Fonctionnalité: Calculer la date d'achèvement prévisionnel
             | PPE2 - Neutre | eolien                | 2024-10-05        | 2027-10-05                            |
             | PPE2 - Neutre | hydraulique           | 2024-10-05        | 2027-10-05                            |
 
-    Plan du scénario: Calculer la date d'achèvement prévisionnel lorsqu'un projet lauréat change son cahier des charges par le CDC du 30/08/2022
+    Plan du scénario: Calculer la date d'achèvement prévisionnel lorsqu'un projet lauréat change son cahier des charges par le CDC paru le 30/08/2022
         Etant donné le projet lauréat "Du boulodrome de Bordeaux" avec :
             | appel d'offre | <appel d'offre> |
             | période       | <période>       |

--- a/packages/specifications/src/projet/lauréat/achèvement/calculerDateAchèvementPrévisionnel.feature
+++ b/packages/specifications/src/projet/lauréat/achèvement/calculerDateAchèvementPrévisionnel.feature
@@ -1,6 +1,6 @@
 # language: fr
 @achèvement
-@date-prévisionnelle-achèvement
+@calculer-date-prévisionnelle-achèvement
 Fonctionnalité: Calculer la date d'achèvement prévisionnel
 
     Plan du scénario: Calculer la date d'achèvement prévisionnel lorsqu'un projet lauréat est notifié
@@ -16,7 +16,7 @@ Fonctionnalité: Calculer la date d'achèvement prévisionnel
             | PPE2 - Bâtiment | 30                   | 2024-10-05        | 2027-04-05                            |
             | PPE2 - Eolien   | 36                   | 2024-10-05        | 2027-10-05                            |
 
-    Plan du scénario: Calculer la date d'achèvement prévisionnel lorsqu'un lauréat ayant un délai de réalisation par technologie est notifié
+    Plan du scénario: Calculer la date d'achèvement prévisionnel lorsqu'un projet lauréat ayant un délai de réalisation par technologie est notifié
         Etant donné la candidature lauréate "Du boulodrome de Marseille" avec :
             | appel d'offre | <appel d'offre>         |
             | technologie   | <technologie du projet> |
@@ -28,3 +28,15 @@ Fonctionnalité: Calculer la date d'achèvement prévisionnel
             | PPE2 - Neutre | pv                    | 2024-10-05        | 2027-04-05                            |
             | PPE2 - Neutre | eolien                | 2024-10-05        | 2027-10-05                            |
             | PPE2 - Neutre | hydraulique           | 2024-10-05        | 2027-10-05                            |
+
+    Plan du scénario: Calculer la date d'achèvement prévisionnel lorsqu'un projet lauréat change son cahier des charges par le CDC du 30/08/2022
+        Etant donné le projet lauréat "Du boulodrome de Bordeaux" avec :
+            | appel d'offre | <appel d'offre> |
+            | période       | <période>       |
+        Et une date d'achèvement prévisionnel pour le projet lauréat au "<date achèvement prévisionnel actuelle>"
+        Quand le porteur choisit le cahier des charges "30/08/2022"
+        Alors la date d'achèvement prévisionnel du projet lauréat devrait être au "<date achèvement prévisionnel attendue>"
+
+        Exemples:
+            | appel d'offre   | période | date achèvement prévisionnel actuelle | date achèvement prévisionnel attendue |
+            | PPE2 - Bâtiment | 1       | 2020-01-01                            | 2024-01-01                            |

--- a/packages/specifications/src/projet/lauréat/achèvement/calculerDateAchèvementPrévisionnel.feature
+++ b/packages/specifications/src/projet/lauréat/achèvement/calculerDateAchèvementPrévisionnel.feature
@@ -39,4 +39,4 @@ Fonctionnalité: Calculer la date d'achèvement prévisionnel
 
         Exemples:
             | appel d'offre   | période | date achèvement prévisionnel actuelle | date achèvement prévisionnel attendue |
-            | PPE2 - Bâtiment | 1       | 2020-01-01                            | 2024-01-01                            |
+            | PPE2 - Bâtiment | 1       | 2020-01-01                            | 2021-07-01                            |


### PR DESCRIPTION
- **🧪 Calculer la date d'achèvement prévisionnel lorsqu'un projet lauréat change son cahier des charges par le CDC du 30/08/2022**
- **✅ Calculer la date d'achèvement prévisionnel lorsqu'un projet lauréat change son cahier des charges par le CDC du 30/08/2022**
