### PR TITLE
🥅 Clarifier les erreurs dans l'API et harmoniser le type d'erreur

### DIFF
--- a/packages/applications/ssr/src/app/reseaux/gestionnaires/[identifiant]/raccordements/mise-en-service-en-attente:exporter/route.ts
+++ b/packages/applications/ssr/src/app/reseaux/gestionnaires/[identifiant]/raccordements/mise-en-service-en-attente:exporter/route.ts
@@ -128,5 +128,5 @@ function vérifierAccèsAuGestionnaireRéseau(
   ) {
     return;
   }
-  throw new OperationRejectedError(`Accès refusé`);
+  throw new OperationRejectedError(`L'accès au gestionnaire réseau n'est pas permis`);
 }

--- a/packages/applications/ssr/src/utils/apiAction.ts
+++ b/packages/applications/ssr/src/utils/apiAction.ts
@@ -17,7 +17,7 @@ const mapDomainError = (e: DomainError) => {
     return mapTo400(e);
   }
   if (e instanceof OperationRejectedError) {
-    return mapTo403();
+    return mapTo403(e);
   }
   if (e instanceof AggregateNotFoundError) {
     return mapTo404(e);
@@ -40,6 +40,7 @@ const mapToHttpError = (status: number, message: string) =>
 
 const mapTo400 = (e: Error) => mapToHttpError(400, e.message);
 const mapTo401 = () => mapToHttpError(401, "L'authentification a échoué");
-const mapTo403 = () => mapToHttpError(403, 'Opération rejetée');
+const mapTo403 = (e: Error) =>
+  mapToHttpError(403, e.message ? `Opération rejetée : ${e.message}` : `Opération rejetée`);
 const mapTo404 = (e: Error) => mapToHttpError(404, e.message);
 const mapTo500 = () => mapToHttpError(500, 'Une erreur est survenue');

--- a/packages/domain/projet/src/accès/accès.error.ts
+++ b/packages/domain/projet/src/accès/accès.error.ts
@@ -1,4 +1,4 @@
-import { InvalidOperationError, OperationRejectedError } from '@potentiel-domain/core';
+import { InvalidOperationError } from '@potentiel-domain/core';
 
 export class EmailNonCorrespondantError extends InvalidOperationError {
   constructor() {
@@ -30,13 +30,13 @@ export class UtilisateurAPasAccèsAuProjetError extends InvalidOperationError {
   }
 }
 
-export class AccèsProjetDéjàAutoriséError extends OperationRejectedError {
+export class AccèsProjetDéjàAutoriséError extends InvalidOperationError {
   constructor() {
     super(`L'utilisateur a déjà accès à ce projet`);
   }
 }
 
-export class ProjetNonRéclamableError extends OperationRejectedError {
+export class ProjetNonRéclamableError extends InvalidOperationError {
   constructor() {
     super(`Le projet ne peut être réclamé`);
   }

--- a/packages/domain/projet/src/lauréat/raccordement/errors.ts
+++ b/packages/domain/projet/src/lauréat/raccordement/errors.ts
@@ -1,5 +1,5 @@
 import { IdentifiantProjet } from '@potentiel-domain/common';
-import { InvalidOperationError, OperationRejectedError } from '@potentiel-domain/core';
+import { InvalidOperationError } from '@potentiel-domain/core';
 import { GestionnaireRéseau } from '@potentiel-domain/reseau';
 
 export class DateDansLeFuturError extends InvalidOperationError {
@@ -28,7 +28,7 @@ export class GestionnaireRéseauDéjàExistantError extends InvalidOperationErro
   }
 }
 
-export class RéférenceDossierRaccordementDéjàExistantePourLeProjetError extends OperationRejectedError {
+export class RéférenceDossierRaccordementDéjàExistantePourLeProjetError extends InvalidOperationError {
   constructor() {
     super(
       `Il est impossible d'avoir plusieurs dossiers de raccordement avec la même référence pour un projet`,

--- a/packages/domain/utilisateur/src/errors.ts
+++ b/packages/domain/utilisateur/src/errors.ts
@@ -22,21 +22,8 @@ export class AccèsFonctionnalitéRefuséError extends OperationRejectedError {
     });
   }
 }
-export class GroupeRefuséError extends OperationRejectedError {
-  constructor(value: string) {
-    super(`Le groupe ne correspond à aucun format connu`, {
-      value,
-    });
-  }
-}
 
-export class AuMoinsUnProjetRequisError extends OperationRejectedError {
-  constructor() {
-    super('Au moins un projet doit être spécifié');
-  }
-}
-
-export class UtilisateurNonPorteurError extends OperationRejectedError {
+export class UtilisateurNonPorteurError extends InvalidOperationError {
   constructor() {
     super(`L'utilisateur ne peut être invité sur ce projet`);
   }


### PR DESCRIPTION
L'erreur API est systématiquement `Opération rejetée`, ce qui restreint la compréhension. 

Par ailleurs,  de nombreuses erreurs `OperationRejectedError` ne sont pas des problèmes de permissions mais simplement une opération impossible, donc une `InvalidOperationError`.