### PR TITLE
🐛 Correction d'un bug de visibilité de filtre sur puissance, abandon et délai

### DIFF
--- a/packages/applications/ssr/src/app/laureats/changements/abandon/page.tsx
+++ b/packages/applications/ssr/src/app/laureats/changements/abandon/page.tsx
@@ -116,10 +116,7 @@ export default async function Page({ searchParams }: PageProps) {
               value: statut,
             })),
         },
-      ];
-
-      if (utilisateur.role.estDGEC() || utilisateur.role.estDreal()) {
-        filters.push({
+        {
           label: 'Autorité instructrice',
           searchParamKey: 'autorite',
           options: Lauréat.Abandon.AutoritéCompétente.autoritésCompétentes.map((autorité) => ({
@@ -129,8 +126,8 @@ export default async function Page({ searchParams }: PageProps) {
               .exhaustive(),
             value: autorité,
           })),
-        });
-      }
+        },
+      ];
 
       return <AbandonListPage list={mapToListProps(abandons)} filters={filters} />;
     }),

--- a/packages/applications/ssr/src/app/laureats/changements/delai/page.tsx
+++ b/packages/applications/ssr/src/app/laureats/changements/delai/page.tsx
@@ -77,10 +77,7 @@ export default async function Page({ searchParams }: PageProps) {
               value: statut,
             })),
         },
-      ];
-
-      if (utilisateur.role.estDGEC() || utilisateur.role.estDreal()) {
-        filters.push({
+        {
           label: 'Autorité instructrice',
           searchParamKey: 'autoriteInstructrice',
           options: Lauréat.Délai.AutoritéCompétente.autoritésCompétentes.map((autorité) => ({
@@ -90,8 +87,8 @@ export default async function Page({ searchParams }: PageProps) {
               .exhaustive(),
             value: autorité,
           })),
-        });
-      }
+        },
+      ];
 
       return <DemandeDélaiListPage list={mapToListProps(changements)} filters={filters} />;
     }),

--- a/packages/applications/ssr/src/app/laureats/changements/puissance/page.tsx
+++ b/packages/applications/ssr/src/app/laureats/changements/puissance/page.tsx
@@ -80,10 +80,7 @@ export default async function Page({ searchParams }: PageProps) {
               value: statut,
             })),
         },
-      ];
-
-      if (utilisateur.role.estDGEC() || utilisateur.role.estDreal()) {
-        filters.push({
+        {
           label: 'Autorité instructrice',
           searchParamKey: 'autoriteInstructrice',
           options: Lauréat.Puissance.AutoritéCompétente.autoritésCompétentes.map((autorité) => ({
@@ -93,8 +90,8 @@ export default async function Page({ searchParams }: PageProps) {
               .exhaustive(),
             value: autorité,
           })),
-        });
-      }
+        },
+      ];
 
       return <ChangementPuissanceListPage list={mapToListProps(changements)} filters={filters} />;
     }),


### PR DESCRIPTION
Discussion avec le métier

Vio : très facile de changer, pour info on a le même comportement sur puissance et abandon (seuls DGEC et DREAL peuvent filtrer), qu'en dis tu ? Devrait on autoriser tous les utilisateurs à voir le filtre ?

Mat : Je pense que l'on devait autoriser tous les utilisateurs ayant accès à la page d'avoir également accès au filtre