### PR TITLE
🎨 Historique installateur

### DIFF
--- a/packages/applications/bootstrap/src/setupProjet/setupLauréat/setupInstallateur.ts
+++ b/packages/applications/bootstrap/src/setupProjet/setupLauréat/setupInstallateur.ts
@@ -1,4 +1,4 @@
-import { InstallateurProjector } from '@potentiel-applications/projectors';
+import { HistoriqueProjector, InstallateurProjector } from '@potentiel-applications/projectors';
 import { InstallateurNotification } from '@potentiel-applications/notifications';
 
 import { createSubscriptionSetup } from '../createSubscriptionSetup';
@@ -26,6 +26,15 @@ export const setupInstallateur: SetupProjet = async ({ sendEmail }) => {
     name: 'notifications',
     eventType: ['InstallateurModifié-V1'],
     messageType: 'System.Notification.Lauréat.Installateur',
+  });
+
+  await installateur.setupSubscription<
+    HistoriqueProjector.SubscriptionEvent,
+    HistoriqueProjector.Execute
+  >({
+    name: 'history',
+    eventType: 'all',
+    messageType: 'System.Projector.Historique',
   });
 
   return installateur.clearSubscriptions;

--- a/packages/applications/projectors/src/subscribers/historique/historique.projector.ts
+++ b/packages/applications/projectors/src/subscribers/historique/historique.projector.ts
@@ -14,6 +14,7 @@ export type SubscriptionEvent =
   | (Lauréat.ReprésentantLégal.ReprésentantLégalEvent & Event)
   | (Lauréat.Puissance.PuissanceEvent & Event)
   | (Lauréat.Producteur.ProducteurEvent & Event)
+  | (Lauréat.Installateur.InstallateurEvent & Event)
   | (Lauréat.GarantiesFinancières.GarantiesFinancièresEvent & Event)
   | (Lauréat.GarantiesFinancières.GarantiesFinancièresEvent & Event)
   | (Lauréat.Raccordement.RaccordementEvent & Event)

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/historique/page.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/historique/page.tsx
@@ -28,6 +28,7 @@ import { mapToÉliminéTimelineItemProps } from '@/utils/historique/mapToProps/�
 
 import { getLauréatInfos } from '../_helpers/getLauréat';
 import { mapToFournisseurTimelineItemProps } from '../../../../utils/historique/mapToProps/fournisseur';
+import { mapToInstallateurTimelineItemProps } from '../../../../utils/historique/mapToProps/installateur/mapToInstallateurTimelineItemProps';
 
 import { HistoriqueLauréatAction, HistoriqueLauréatPage } from './HistoriqueLauréat.page';
 
@@ -45,6 +46,7 @@ const categoriesDisponibles = [
   'recours',
   'représentant-légal',
   'raccordement',
+  'installateur',
 ] as const;
 
 type PageProps = IdentifiantParameter & {
@@ -120,7 +122,7 @@ export default async function Page({ params: { identifiant }, searchParams }: Pa
           actions={mapToActions(utilisateur.role)}
           filters={[
             {
-              label: 'Categorie',
+              label: 'Catégorie',
               searchParamKey: 'categorie',
               options,
             },
@@ -156,6 +158,7 @@ const categoryToIconProps: Record<(typeof categoriesDisponibles)[number], IconPr
   recours: 'ri-scales-3-line',
   délai: 'ri-time-line',
   fournisseur: 'ri-draft-line',
+  installateur: 'ri-shake-hands-line',
 };
 
 const filtrerImportsEtRecoursLegacy = (
@@ -219,6 +222,7 @@ const mapToTimelineItemProps = (
     .with({ category: 'raccordement' }, mapToRaccordementTimelineItemProps)
     .with({ category: 'délai' }, mapToDélaiTimelineItemProps)
     .with({ category: 'fournisseur' }, mapToFournisseurTimelineItemProps)
+    .with({ category: 'installateur' }, mapToInstallateurTimelineItemProps)
     .exhaustive(() => undefined);
   if (props) {
     return {

--- a/packages/applications/ssr/src/components/molecules/Filter.tsx
+++ b/packages/applications/ssr/src/components/molecules/Filter.tsx
@@ -9,6 +9,7 @@ type FilterProps = {
   onValueSelected?: (value: string | undefined) => void;
   disabled?: boolean;
 };
+
 export const Filter: FC<FilterProps> = ({ label, options, value, disabled, onValueSelected }) => (
   <SelectNext
     label={label}

--- a/packages/applications/ssr/src/utils/historique/mapToProps/installateur/events/index.ts
+++ b/packages/applications/ssr/src/utils/historique/mapToProps/installateur/events/index.ts
@@ -1,0 +1,2 @@
+export { mapToInstallateurImportéTimelineItemProps } from './mapToInstallateurImportéTimelineItemProps';
+export { mapToInstallateurModifiéTimelineItemsProps } from './mapToInstallateurModifiéTimelineItemsProps';

--- a/packages/applications/ssr/src/utils/historique/mapToProps/installateur/events/mapToInstallateurImportéTimelineItemProps.tsx
+++ b/packages/applications/ssr/src/utils/historique/mapToProps/installateur/events/mapToInstallateurImportéTimelineItemProps.tsx
@@ -1,0 +1,11 @@
+import { Lauréat } from '@potentiel-domain/projet';
+
+export const mapToInstallateurImportéTimelineItemProps = (
+  record: Lauréat.Installateur.InstallateurImportéEvent,
+) => {
+  const { importéLe, installateur } = record.payload;
+  return {
+    date: importéLe,
+    title: <div>Candidature : {<span className="font-semibold">{installateur}</span>}</div>,
+  };
+};

--- a/packages/applications/ssr/src/utils/historique/mapToProps/installateur/events/mapToInstallateurModifiéTimelineItemsProps.tsx
+++ b/packages/applications/ssr/src/utils/historique/mapToProps/installateur/events/mapToInstallateurModifiéTimelineItemsProps.tsx
@@ -1,0 +1,21 @@
+import { Lauréat } from '@potentiel-domain/projet';
+
+export const mapToInstallateurModifiéTimelineItemsProps = (
+  record: Lauréat.Installateur.InstallateurModifiéEvent,
+) => {
+  const { modifiéLe, modifiéPar, installateur } = record.payload;
+
+  return {
+    date: modifiéLe,
+    title: (
+      <div>Installateur modifié par {<span className="font-semibold">{modifiéPar}</span>}</div>
+    ),
+    content: (
+      <div className="flex flex-col gap-2">
+        <div>
+          Nouvel installateur : <span className="font-semibold">{installateur}</span>
+        </div>
+      </div>
+    ),
+  };
+};

--- a/packages/applications/ssr/src/utils/historique/mapToProps/installateur/mapToInstallateurTimelineItemProps.tsx
+++ b/packages/applications/ssr/src/utils/historique/mapToProps/installateur/mapToInstallateurTimelineItemProps.tsx
@@ -1,0 +1,24 @@
+import { match } from 'ts-pattern';
+
+import { Lauréat } from '@potentiel-domain/projet';
+
+import { TimelineItemProps } from '@/components/organisms/Timeline';
+
+import {
+  mapToInstallateurImportéTimelineItemProps,
+  mapToInstallateurModifiéTimelineItemsProps,
+} from './events';
+
+export const mapToInstallateurTimelineItemProps = (
+  readmodel: Lauréat.Installateur.HistoriqueInstallateurProjetListItemReadModel,
+) =>
+  match(readmodel)
+    .returnType<TimelineItemProps>()
+    .with({ type: 'InstallateurImporté-V1' }, (readmodel) =>
+      mapToInstallateurImportéTimelineItemProps(readmodel),
+    )
+    .with({ type: 'InstallateurModifié-V1' }, (readmodel) =>
+      mapToInstallateurModifiéTimelineItemsProps(readmodel),
+    )
+
+    .exhaustive();

--- a/packages/domain/projet/src/lauréat/historique/lister/listerHistoriqueProjet.query.ts
+++ b/packages/domain/projet/src/lauréat/historique/lister/listerHistoriqueProjet.query.ts
@@ -20,6 +20,7 @@ import { HistoriqueDélaiProjetListItemReadModel } from '../../délai';
 import { HistoriqueFournisseurProjetListItemReadModel } from '../../fournisseur';
 import { AchèvementEvent } from '../../achèvement';
 import { ÉliminéEvent } from '../../../éliminé';
+import { HistoriqueInstallateurProjetListItemReadModel } from '../../installateur/listerHistorique/listerHistoriqueInstallateurProjet.query';
 
 export type HistoriqueLauréatProjetListItemReadModel = HistoryRecord<'lauréat', LauréatEvent>;
 export type HistoriqueÉliminéProjetListItemReadModel = HistoryRecord<'éliminé', ÉliminéEvent>;
@@ -47,7 +48,8 @@ export type HistoriqueListItemReadModels =
   | HistoriqueAchèvementProjetListItemReadModel
   | HistoriqueRaccordementProjetListItemReadModel
   | HistoriqueDélaiProjetListItemReadModel
-  | HistoriqueFournisseurProjetListItemReadModel;
+  | HistoriqueFournisseurProjetListItemReadModel
+  | HistoriqueInstallateurProjetListItemReadModel;
 
 export type ListerHistoriqueProjetReadModel = ListHistoryResult<HistoriqueListItemReadModels>;
 

--- a/packages/domain/projet/src/lauréat/installateur/index.ts
+++ b/packages/domain/projet/src/lauréat/installateur/index.ts
@@ -2,15 +2,20 @@ import {
   ConsulterInstallateurQuery,
   ConsulterInstallateurReadModel,
 } from './consulter/consulterInstallateur.query';
+import {
+  HistoriqueInstallateurProjetListItemReadModel,
+  ListerHistoriqueInstallateurProjetQuery,
+} from './listerHistorique/listerHistoriqueInstallateurProjet.query';
 import { ModifierInstallateurUseCase } from './modifier/modifierInstallateur.usecase';
 
 // Query
-export type InstallateurQuery = ConsulterInstallateurQuery;
-
-export { ConsulterInstallateurQuery };
+export type InstallateurQuery =
+  | ConsulterInstallateurQuery
+  | ListerHistoriqueInstallateurProjetQuery;
+export { ConsulterInstallateurQuery, ListerHistoriqueInstallateurProjetQuery };
 
 // ReadModel
-export { ConsulterInstallateurReadModel };
+export { ConsulterInstallateurReadModel, HistoriqueInstallateurProjetListItemReadModel };
 
 // UseCase
 export type InstallateurUseCase = ModifierInstallateurUseCase;

--- a/packages/domain/projet/src/lauréat/installateur/listerHistorique/listerHistoriqueInstallateurProjet.query.ts
+++ b/packages/domain/projet/src/lauréat/installateur/listerHistorique/listerHistoriqueInstallateurProjet.query.ts
@@ -1,0 +1,45 @@
+import { Message, MessageHandler, mediator } from 'mediateur';
+
+import { HistoryRecord, ListHistory, RangeOptions } from '@potentiel-domain/entity';
+
+import { InstallateurEvent } from '../installateur.event';
+
+export type HistoriqueInstallateurProjetListItemReadModel = HistoryRecord<
+  'installateur',
+  InstallateurEvent
+>;
+
+export type ListerHistoriqueInstallateurProjetReadModel = {
+  items: ReadonlyArray<HistoriqueInstallateurProjetListItemReadModel>;
+  range: RangeOptions;
+  total: number;
+};
+
+export type ListerHistoriqueInstallateurProjetQuery = Message<
+  'Lauréat.Installateur.Query.ListerHistoriqueInstallateurProjet',
+  {
+    identifiantProjet: string;
+    range?: RangeOptions;
+  },
+  ListerHistoriqueInstallateurProjetReadModel
+>;
+
+export type ListerHistoriqueInstallateurProjetDependencies = {
+  listHistory: ListHistory<HistoriqueInstallateurProjetListItemReadModel>;
+};
+
+export const registerListerHistoriqueInstallateurProjetQuery = ({
+  listHistory,
+}: ListerHistoriqueInstallateurProjetDependencies) => {
+  const handler: MessageHandler<ListerHistoriqueInstallateurProjetQuery> = ({
+    identifiantProjet,
+    range,
+  }) =>
+    listHistory({
+      id: identifiantProjet,
+      category: 'installateur',
+      range,
+    });
+
+  mediator.register('Lauréat.Installateur.Query.ListerHistoriqueInstallateurProjet', handler);
+};


### PR DESCRIPTION
- pas d'ajout dans une page détail car les pages détails sont utilisées quand il y a des changements (à différencier des modifications ETQ admin)

<img width="934" height="440" alt="Capture d’écran 2025-09-11 à 12 55 33" src="https://github.com/user-attachments/assets/63f74e30-8904-4f0e-9aec-f9366e7d18bc" />
