### PR TITLE
♻️ Affichage des événement de suppression de demandes suite à abandon dans la frise

### DIFF
--- a/packages/applications/ssr/src/app/laureats/[identifiant]/historique/page.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/historique/page.tsx
@@ -144,21 +144,23 @@ const mapToActions = (rôle: Role.ValueType) => {
   return actions;
 };
 
+const DEMANDE_GENERIQUE_ICONE = 'ri-draft-line';
+
 const categoryToIconProps: Record<(typeof categoriesDisponibles)[number], IconProps['id']> = {
   'garanties-financieres': 'ri-bank-line',
-  'représentant-légal': 'ri-user-star-line',
-  abandon: 'ri-draft-line',
+  'représentant-légal': DEMANDE_GENERIQUE_ICONE,
+  abandon: 'ri-logout-box-line',
   achevement: 'ri-verified-badge-line',
-  actionnaire: 'ri-percent-line',
+  actionnaire: DEMANDE_GENERIQUE_ICONE,
   lauréat: 'ri-notification-3-line',
   éliminé: 'ri-notification-3-line',
-  producteur: 'ri-building-3-line',
+  producteur: DEMANDE_GENERIQUE_ICONE,
   puissance: 'ri-flashlight-line',
   raccordement: 'ri-plug-line',
   recours: 'ri-scales-3-line',
   délai: 'ri-time-line',
-  fournisseur: 'ri-truck-line',
-  installateur: 'ri-shake-hands-line',
+  fournisseur: DEMANDE_GENERIQUE_ICONE,
+  installateur: DEMANDE_GENERIQUE_ICONE,
 };
 
 const filtrerImportsEtRecoursLegacy = (

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/historique/page.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/historique/page.tsx
@@ -146,18 +146,18 @@ const mapToActions = (rôle: Role.ValueType) => {
 
 const categoryToIconProps: Record<(typeof categoriesDisponibles)[number], IconProps['id']> = {
   'garanties-financieres': 'ri-bank-line',
-  'représentant-légal': 'ri-draft-line',
+  'représentant-légal': 'ri-user-star-line',
   abandon: 'ri-draft-line',
   achevement: 'ri-verified-badge-line',
-  actionnaire: 'ri-draft-line',
+  actionnaire: 'ri-percent-line',
   lauréat: 'ri-notification-3-line',
   éliminé: 'ri-notification-3-line',
-  producteur: 'ri-draft-line',
-  puissance: 'ri-draft-line',
+  producteur: 'ri-building-3-line',
+  puissance: 'ri-flashlight-line',
   raccordement: 'ri-plug-line',
   recours: 'ri-scales-3-line',
   délai: 'ri-time-line',
-  fournisseur: 'ri-draft-line',
+  fournisseur: 'ri-truck-line',
   installateur: 'ri-shake-hands-line',
 };
 

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/historique/page.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/historique/page.tsx
@@ -166,6 +166,8 @@ const filtrerImportsEtRecoursLegacy = (
   _: number,
   historique: Readonly<Lauréat.HistoriqueListItemReadModels[]>,
 ) => {
+  // on ne veut pas afficher dans l'historique complet les événements d'import de chaque domaine
+  // qui arrive en rebond de la désignation
   if (event.type?.includes('Import')) {
     return false;
   }
@@ -180,6 +182,7 @@ const filtrerImportsEtRecoursLegacy = (
   }
   return true;
 };
+
 const isLauréatNotifié = (
   item: Lauréat.HistoriqueListItemReadModels,
 ): item is HistoryRecord<

--- a/packages/applications/ssr/src/utils/historique/mapToProps/actionnaire/events/mapToActionnaireModifiéTimelineItemsProps.tsx
+++ b/packages/applications/ssr/src/utils/historique/mapToProps/actionnaire/events/mapToActionnaireModifiéTimelineItemsProps.tsx
@@ -1,9 +1,14 @@
+import { Routes } from '@potentiel-applications/routes';
+import { DocumentProjet } from '@potentiel-domain/document';
 import { Lauréat } from '@potentiel-domain/projet';
 
+import { DownloadDocument } from '@/components/atoms/form/document/DownloadDocument';
+
 export const mapToActionnaireModifiéTimelineItemProps = (
-  record: Lauréat.Actionnaire.ActionnaireModifiéEvent,
+  modification: Lauréat.Actionnaire.ActionnaireModifiéEvent,
 ) => {
-  const { modifiéLe, modifiéPar, actionnaire } = record.payload;
+  const { modifiéLe, modifiéPar, identifiantProjet, pièceJustificative, actionnaire } =
+    modification.payload;
 
   return {
     date: modifiéLe,
@@ -13,6 +18,21 @@ export const mapToActionnaireModifiéTimelineItemProps = (
         <div>
           Nouvel actionnaire : <span className="font-semibold">{actionnaire}</span>
         </div>
+        {pièceJustificative && (
+          <DownloadDocument
+            className="mb-0"
+            label="Télécharger la pièce justificative"
+            format="pdf"
+            url={Routes.Document.télécharger(
+              DocumentProjet.convertirEnValueType(
+                identifiantProjet,
+                Lauréat.Actionnaire.TypeDocumentActionnaire.pièceJustificative.formatter(),
+                modifiéLe,
+                pièceJustificative.format,
+              ).formatter(),
+            )}
+          />
+        )}
       </div>
     ),
   };

--- a/packages/applications/ssr/src/utils/historique/mapToProps/actionnaire/events/mapToActionnaireModifiéTimelineItemsProps.tsx
+++ b/packages/applications/ssr/src/utils/historique/mapToProps/actionnaire/events/mapToActionnaireModifiéTimelineItemsProps.tsx
@@ -1,14 +1,9 @@
-import { Routes } from '@potentiel-applications/routes';
-import { DocumentProjet } from '@potentiel-domain/document';
 import { Lauréat } from '@potentiel-domain/projet';
 
-import { DownloadDocument } from '@/components/atoms/form/document/DownloadDocument';
-
 export const mapToActionnaireModifiéTimelineItemProps = (
-  modification: Lauréat.Actionnaire.ActionnaireModifiéEvent,
+  record: Lauréat.Actionnaire.ActionnaireModifiéEvent,
 ) => {
-  const { modifiéLe, modifiéPar, identifiantProjet, pièceJustificative, actionnaire } =
-    modification.payload;
+  const { modifiéLe, modifiéPar, actionnaire } = record.payload;
 
   return {
     date: modifiéLe,
@@ -18,21 +13,6 @@ export const mapToActionnaireModifiéTimelineItemProps = (
         <div>
           Nouvel actionnaire : <span className="font-semibold">{actionnaire}</span>
         </div>
-        {pièceJustificative && (
-          <DownloadDocument
-            className="mb-0"
-            label="Télécharger la pièce justificative"
-            format="pdf"
-            url={Routes.Document.télécharger(
-              DocumentProjet.convertirEnValueType(
-                identifiantProjet,
-                Lauréat.Actionnaire.TypeDocumentActionnaire.pièceJustificative.formatter(),
-                modifiéLe,
-                pièceJustificative.format,
-              ).formatter(),
-            )}
-          />
-        )}
       </div>
     ),
   };

--- a/packages/applications/ssr/src/utils/historique/mapToProps/actionnaire/events/mapToChangementActionnaireSuppriméTimelineItemProps.tsx
+++ b/packages/applications/ssr/src/utils/historique/mapToProps/actionnaire/events/mapToChangementActionnaireSuppriméTimelineItemProps.tsx
@@ -1,0 +1,14 @@
+import { Lauréat } from '@potentiel-domain/projet';
+
+export const mapToChangementActionnaireSuppriméTimelineItemProps = (
+  event: Lauréat.Actionnaire.ChangementActionnaireSuppriméEvent,
+) => {
+  const { suppriméLe } = event.payload;
+
+  return {
+    date: suppriméLe,
+    title: (
+      <div>Demande de modification de l'actionnaire supprimée suite à l'accord de l'abandon</div>
+    ),
+  };
+};

--- a/packages/applications/ssr/src/utils/historique/mapToProps/actionnaire/mapToActionnaireTimelineItemProps.tsx
+++ b/packages/applications/ssr/src/utils/historique/mapToProps/actionnaire/mapToActionnaireTimelineItemProps.tsx
@@ -4,8 +4,6 @@ import { Lauréat } from '@potentiel-domain/projet';
 
 import { TimelineItemProps } from '@/components/organisms/Timeline';
 
-import { mapToÉtapeInconnueOuIgnoréeTimelineItemProps } from '../mapToÉtapeInconnueOuIgnoréeTimelineItemProps';
-
 import {
   mapToActionnaireImportéTimelineItemProps,
   mapToActionnaireModifiéTimelineItemProps,
@@ -15,6 +13,7 @@ import {
   mapToChangementActionnaireRejetéTimelineItemProps,
   mapToChangementActionnaireAnnuléTimelineItemProps,
 } from './events';
+import { mapToChangementActionnaireSuppriméTimelineItemProps } from './events/mapToChangementActionnaireSuppriméTimelineItemProps';
 
 export const mapToActionnaireTimelineItemProps = (
   readmodel: Lauréat.Actionnaire.HistoriqueActionnaireProjetListItemReadModel,
@@ -67,6 +66,6 @@ export const mapToActionnaireTimelineItemProps = (
       {
         type: 'ChangementActionnaireSupprimé-V1',
       },
-      mapToÉtapeInconnueOuIgnoréeTimelineItemProps,
+      mapToChangementActionnaireSuppriméTimelineItemProps,
     )
     .exhaustive();

--- a/packages/applications/ssr/src/utils/historique/mapToProps/délai/events/mapToDemandeDélaiSuppriméeTimelineItemProps.tsx
+++ b/packages/applications/ssr/src/utils/historique/mapToProps/délai/events/mapToDemandeDélaiSuppriméeTimelineItemProps.tsx
@@ -3,14 +3,10 @@ import { Lauréat } from '@potentiel-domain/projet';
 export const mapToDemandeDélaiSuppriméeTimelineItemProps = (
   record: Lauréat.Délai.DemandeDélaiSuppriméeEvent,
 ) => {
-  const { suppriméLe, suppriméPar } = record.payload;
+  const { suppriméLe } = record.payload;
 
   return {
     date: suppriméLe,
-    title: (
-      <div>
-        Demande de délai supprimée par {<span className="font-semibold">{suppriméPar}</span>}
-      </div>
-    ),
+    title: <div>Demande de délai supprimée suite à l'accord de l'abandon</div>,
   };
 };

--- a/packages/applications/ssr/src/utils/historique/mapToProps/puissance/events/mapToChangementPuissanceAnnuléTimelineItemProps.tsx
+++ b/packages/applications/ssr/src/utils/historique/mapToProps/puissance/events/mapToChangementPuissanceAnnuléTimelineItemProps.tsx
@@ -9,7 +9,8 @@ export const mapToChangementPuissanceAnnuléTimelineItemProps = (
     date: annuléLe,
     title: (
       <div>
-        Changement de puissance annulé par {<span className="font-semibold">{annuléPar}</span>}
+        Demande de changement de puissance annulée par{' '}
+        {<span className="font-semibold">{annuléPar}</span>}
       </div>
     ),
   };

--- a/packages/applications/ssr/src/utils/historique/mapToProps/puissance/events/mapToChangementPuissanceSuppriméTimelineItemProps.tsx
+++ b/packages/applications/ssr/src/utils/historique/mapToProps/puissance/events/mapToChangementPuissanceSuppriméTimelineItemProps.tsx
@@ -1,0 +1,12 @@
+import { Lauréat } from '@potentiel-domain/projet';
+
+export const mapToChangementPuissanceSuppriméTimelineItemProps = (
+  event: Lauréat.Puissance.ChangementPuissanceSuppriméEvent,
+) => {
+  const { suppriméLe } = event.payload;
+
+  return {
+    date: suppriméLe,
+    title: <div>Demande de modification de puissance supprimée suite à l'accord de l'abandon</div>,
+  };
+};

--- a/packages/applications/ssr/src/utils/historique/mapToProps/puissance/index.tsx
+++ b/packages/applications/ssr/src/utils/historique/mapToProps/puissance/index.tsx
@@ -4,8 +4,6 @@ import { Lauréat } from '@potentiel-domain/projet';
 
 import { TimelineItemProps } from '@/components/organisms/Timeline';
 
-import { mapToÉtapeInconnueOuIgnoréeTimelineItemProps } from '../mapToÉtapeInconnueOuIgnoréeTimelineItemProps';
-
 import { mapToChangementPuissanceDemandéTimelineItemProps } from './events/mapToChangementPuissanceDemandéTimelineItemProps';
 import { mapToPuissanceImportéeTimelineItemsProps } from './events/mapToPuissanceImportéeTimelineItemsProps';
 import { mapToPuissanceModifiéeTimelineItemsProps } from './events/mapToPuissanceModifiéeTimelineItemsProps';
@@ -13,6 +11,7 @@ import { mapToChangementPuissanceAnnuléTimelineItemProps } from './events/mapTo
 import { mapToChangementPuissanceEnregistréTimelineItemProps } from './events/mapToChangementPuissanceEnregistréTimelineItemProps';
 import { mapToChangementPuissanceAccordéTimelineItemProps } from './events/mapToChangementPuissanceAccordéTimelineItemProps';
 import { mapToChangementPuissanceRejetéTimelineItemProps } from './events/mapToChangementPuissanceRejetéTimelineItemProps';
+import { mapToChangementPuissanceSuppriméTimelineItemProps } from './events/mapToChangementPuissanceSuppriméTimelineItemProps';
 
 export const mapToPuissanceTimelineItemProps = (
   record: Lauréat.Puissance.HistoriquePuissanceProjetListItemReadModel,
@@ -53,5 +52,8 @@ export const mapToPuissanceTimelineItemProps = (
       },
       (record) => mapToChangementPuissanceRejetéTimelineItemProps(record),
     )
-    .with({ type: 'ChangementPuissanceSupprimé-V1' }, mapToÉtapeInconnueOuIgnoréeTimelineItemProps)
+    .with(
+      { type: 'ChangementPuissanceSupprimé-V1' },
+      mapToChangementPuissanceSuppriméTimelineItemProps,
+    )
     .exhaustive();

--- a/packages/applications/ssr/src/utils/historique/mapToProps/représentant-légal/events/mapToChangementReprésentantLégalSuppriméTimelineItemProps.tsx
+++ b/packages/applications/ssr/src/utils/historique/mapToProps/représentant-légal/events/mapToChangementReprésentantLégalSuppriméTimelineItemProps.tsx
@@ -1,0 +1,16 @@
+import { Lauréat } from '@potentiel-domain/projet';
+
+export const mapToChangementReprésentantLégalSuppriméTimelineItemProps = (
+  event: Lauréat.ReprésentantLégal.ChangementReprésentantLégalSuppriméEvent,
+) => {
+  const { suppriméLe } = event.payload;
+
+  return {
+    date: suppriméLe,
+    title: (
+      <div>
+        Demande de modification de représentant légal supprimée suite à l'accord de l'abandon
+      </div>
+    ),
+  };
+};

--- a/packages/applications/ssr/src/utils/historique/mapToProps/représentant-légal/mapToReprésentantLégalTimelineItemProps.tsx
+++ b/packages/applications/ssr/src/utils/historique/mapToProps/représentant-légal/mapToReprésentantLégalTimelineItemProps.tsx
@@ -4,8 +4,6 @@ import { Lauréat } from '@potentiel-domain/projet';
 
 import { TimelineItemProps } from '@/components/organisms/Timeline';
 
-import { mapToÉtapeInconnueOuIgnoréeTimelineItemProps } from '../mapToÉtapeInconnueOuIgnoréeTimelineItemProps';
-
 import {
   mapToReprésentantLégalImportéTimelineItemProps,
   mapToReprésentantLégalModifiéTimelineItemProps,
@@ -16,6 +14,7 @@ import {
   mapToChangementReprésentantLégalAnnuléTimelineItemProps,
   mapToChangementReprésentantLégalEnregistréTimelineItemProps,
 } from './events';
+import { mapToChangementReprésentantLégalSuppriméTimelineItemProps } from './events/mapToChangementReprésentantLégalSuppriméTimelineItemProps';
 
 export const mapToReprésentantLégalTimelineItemProps = (
   readmodel: Lauréat.ReprésentantLégal.HistoriqueReprésentantLégalProjetListItemReadModel,
@@ -74,6 +73,6 @@ export const mapToReprésentantLégalTimelineItemProps = (
       {
         type: 'ChangementReprésentantLégalSupprimé-V1',
       },
-      mapToÉtapeInconnueOuIgnoréeTimelineItemProps,
+      mapToChangementReprésentantLégalSuppriméTimelineItemProps,
     )
     .exhaustive();


### PR DESCRIPTION
Changement des icônes en passant, [carte](https://linear.app/startup-potentiel/issue/POT-1818/historisation-de-lannulation-des-demandes-en-cours-suite-a-validation)

<img width="893" height="536" alt="Capture d’écran 2025-09-11 à 16 09 47" src="https://github.com/user-attachments/assets/7dd1ec43-bee8-4625-9a7b-7fca5fc06d64" />

