### PR TITLE
🐛 [bugfix] Permettre de modifier le lauréat sans modifier la candidature

### DIFF
--- a/packages/applications/ssr/src/app/laureats/[identifiant]/(détails)/modifier/components/fields/DateDAutorisationDUrbanismeField.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/(détails)/modifier/components/fields/DateDAutorisationDUrbanismeField.tsx
@@ -26,7 +26,7 @@ export const DateDAutorisationDUrbanismeField = ({
           name="candidature.dateDAutorisationDUrbanisme"
           type="hidden"
           value={candidatureValue}
-          disabled={candidatureValue === value}
+          disabled={new Date(candidatureValue).getTime() === new Date(value).getTime()}
         />
         <Input
           className="w-full"


### PR DESCRIPTION
Concerne les projets qui ont une date d'autorisation d'urbanisme. 
On "disable" le champ date d'autorisation d'urbanisme du formulaire si la valeur est inchangée. Le souci étant qu'on comparait 2 dates au format différent. 