### PR TITLE
🐛 Permettre de modifier la candidature depuis le projet lauréat

### DIFF
--- a/packages/applications/ssr/src/app/laureats/[identifiant]/(détails)/modifier/modifierLauréat.action.ts
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/(détails)/modifier/modifierLauréat.action.ts
@@ -195,18 +195,14 @@ const mapBodyToCandidatureUsecaseData = (
       actionnariat: data.actionnariat ?? previous.actionnariat?.formatter(),
       coefficientKChoisi: data.coefficientKChoisi ?? previous.coefficientKChoisi,
       puissanceDeSite: data.puissanceDeSite ?? previous.puissanceDeSite,
-      autorisationDUrbanisme:
-        (data.numeroDAutorisationDUrbanisme || data.dateDAutorisationDUrbanisme) &&
-        previous.autorisationDUrbanisme
-          ? {
-              numéro: data.numeroDAutorisationDUrbanisme ?? previous.autorisationDUrbanisme.numéro,
-              date:
-                data.dateDAutorisationDUrbanisme ??
-                DateTime.convertirEnValueType(
-                  previous.autorisationDUrbanisme.date.date,
-                ).formatter(),
-            }
-          : undefined,
+      autorisationDUrbanisme: previous.autorisationDUrbanisme
+        ? {
+            numéro: data.numeroDAutorisationDUrbanisme ?? previous.autorisationDUrbanisme.numéro,
+            date:
+              data.dateDAutorisationDUrbanisme ??
+              DateTime.convertirEnValueType(previous.autorisationDUrbanisme.date.date).formatter(),
+          }
+        : undefined,
       installateur: data.installateur ?? previous.installateur,
 
       // non-editable fields


### PR DESCRIPTION
Avant dans modifierLauréat action, concernant la partie "candidature", pour les informations relative à l'autorisation d'urbanisme on retournait `undefined` s'il n'y avait pas de modification sur ces données ce qui est une erreur. Avec cette correction on va récupérer les précédentes valeurs lorsqu'elles existent. 