### PR TITLE
🎨 Affichage de l'autorité compétente dans la demande d'abandon

### DIFF
--- a/packages/applications/ssr/src/app/laureats/[identifiant]/abandon/(détails)/DétailsAbandon.page.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/abandon/(détails)/DétailsAbandon.page.tsx
@@ -96,7 +96,7 @@ export const DétailsAbandonPage: FC<DétailsAbandonPageProps> = ({
                 {abandon.demande.autoritéCompétente.autoritéCompétente.toLocaleUpperCase()}
               </div>
               <div className="flex gap-2">
-                <div className="whitespace-nowrap font-semibold">Explications :</div>
+                <div className="whitespace-nowrap font-semibold">Raison :</div>
                 <blockquote>"{abandon.demande.raison}"</blockquote>
               </div>
             </div>


### PR DESCRIPTION
<img width="1831" height="958" alt="Capture d’écran 2025-09-15 à 16 41 06" src="https://github.com/user-attachments/assets/dad67010-1fa0-40d8-8bc2-55015c886123" />
