### PR TITLE
🎨 Afficher le type d'actionnariat dans la page lauréat et éliminé (#3521)

### DIFF
--- a/packages/applications/legacy/src/views/pages/projectDetailsPage/sections/InfoGenerales/index.tsx
+++ b/packages/applications/legacy/src/views/pages/projectDetailsPage/sections/InfoGenerales/index.tsx
@@ -58,6 +58,9 @@ export const InfoGenerales = ({
     isClasse,
     désignationCatégorie,
     prixReference,
+    actionnariat,
+    isFinancementParticipatif,
+    isInvestissementParticipatif,
   },
   raccordement,
   role,
@@ -88,13 +91,21 @@ export const InfoGenerales = ({
     !!garantiesFinancières?.actuelles &&
     garantiesFinancières.actuelles.type !== 'exemption' &&
     role.aLaPermission('garantiesFinancières.actuelles.modifier');
+
   const peutModifierDépôt =
     garantiesFinancières?.actuelles?.type !== 'exemption' &&
     role.aLaPermission('garantiesFinancières.dépôt.modifier');
+
   const peutDemanderMainlevée =
     !!garantiesFinancières?.actuelles &&
     garantiesFinancières.actuelles.type !== 'exemption' &&
     role.aLaPermission('garantiesFinancières.mainlevée.demander');
+
+  const typeActionnariat = getTypeActionnariat({
+    actionnariat,
+    isFinancementParticipatif,
+    isInvestissementParticipatif,
+  });
 
   return (
     <Section title="Informations générales" icon={<BuildingIcon />} className="flex gap-4 flex-col">
@@ -179,6 +190,12 @@ export const InfoGenerales = ({
           role={role}
           identifiantProjet={identifiantProjet}
         />
+      )}
+      {typeActionnariat && (
+        <div className="flex flex-col">
+          <Heading3 className="m-0">Type d'actionnariat</Heading3>
+          <span>{typeActionnariat}</span>
+        </div>
       )}
     </Section>
   );
@@ -335,4 +352,34 @@ const AlertMessage = ({ children }: AlertMessageProps) => {
       <WarningIcon title="Information alerte" className="text-lg -mb-1 shrink-0" /> {children}
     </div>
   );
+};
+
+type GetTypeActionnariatProps = {
+  actionnariat?: ProjectDataForProjectPage['actionnariat'];
+  isFinancementParticipatif: ProjectDataForProjectPage['isFinancementParticipatif'];
+  isInvestissementParticipatif: ProjectDataForProjectPage['isInvestissementParticipatif'];
+};
+const getTypeActionnariat = ({
+  actionnariat,
+  isFinancementParticipatif,
+  isInvestissementParticipatif,
+}: GetTypeActionnariatProps) => {
+  if (actionnariat) {
+    if (actionnariat === 'financement-collectif') {
+      return 'Financement collectif';
+    }
+    if (actionnariat === 'gouvernance-partagee') {
+      return 'Gouvernance partagée';
+    }
+  }
+
+  if (isFinancementParticipatif) {
+    return 'Financement participatif';
+  }
+
+  if (isInvestissementParticipatif) {
+    return 'Investissement participatif';
+  }
+
+  return undefined;
 };

--- a/packages/applications/ssr/src/app/projets/[identifiant]/(détails)/DétailsProjetÉliminé.page.tsx
+++ b/packages/applications/ssr/src/app/projets/[identifiant]/(détails)/DétailsProjetÉliminé.page.tsx
@@ -12,6 +12,7 @@ import { ColumnPageTemplate } from '@/components/templates/ColumnPage.template';
 import { ActionsList } from '@/components/templates/ActionsList.template';
 import { FormattedDate } from '@/components/atoms/FormattedDate';
 import { ProjetÉliminéBanner } from '@/components/molecules/projet/éliminé/ProjetÉliminéBanner';
+import { getActionnariatTypeLabel } from '@/app/_helpers';
 
 export type DétailsProjetÉliminéPageProps = {
   identifiantProjet: IdentifiantProjet.RawType;
@@ -44,6 +45,7 @@ export const DétailsProjetÉliminéPage: FC<DétailsProjetÉliminéPageProps> =
     nomCandidat,
     nomReprésentantLégal,
     autorisationDUrbanisme,
+    actionnariat,
   },
   utilisateursAyantAccèsAuProjet,
   actions,
@@ -100,6 +102,12 @@ export const DétailsProjetÉliminéPage: FC<DétailsProjetÉliminéPageProps> =
             <li>
               <span className="font-bold">Actionnaire :</span> {sociétéMère}
             </li>
+            {actionnariat && (
+              <li>
+                <span className="font-bold">Type d'actionnariat :</span>{' '}
+                {getActionnariatTypeLabel(actionnariat.type)}
+              </li>
+            )}
             <li>
               <span className="font-bold">Puissance :</span> {puissanceProductionAnnuelle}{' '}
               {Candidature.UnitéPuissance.bind(unitéPuissance).formatter()}

--- a/packages/domain/projet/src/éliminé/consulter/consulterÉliminé.query.ts
+++ b/packages/domain/projet/src/éliminé/consulter/consulterÉliminé.query.ts
@@ -27,6 +27,7 @@ export type ConsulterÉliminéReadModel = {
   | 'nomReprésentantLégal'
   | 'sociétéMère'
   | 'autorisationDUrbanisme'
+  | 'actionnariat'
 >;
 
 export type ConsulterÉliminéQuery = Message<
@@ -86,4 +87,5 @@ const mapToReadModel: MapToReadModel = (
         numéro: candidature.dépôt.autorisationDUrbanisme.numéro,
       }
     : undefined,
+  actionnariat: candidature.dépôt.actionnariat,
 });

--- a/packages/specifications/src/projet/éliminé/éliminé.world.ts
+++ b/packages/specifications/src/projet/éliminé/éliminé.world.ts
@@ -80,6 +80,7 @@ export class ÉliminéWorld {
         prixReference,
         nomReprésentantLégal,
         sociétéMère,
+        actionnariat,
       },
       unitéPuissance,
     } = this.potentielWorld.candidatureWorld.mapToExpected();
@@ -96,6 +97,7 @@ export class ÉliminéWorld {
       prixReference,
       nomProjet,
       puissanceProductionAnnuelle,
+      actionnariat,
       attestationDésignation: this.potentielWorld.éliminéWorld.recoursWorld.accorderRecoursFixture
         .aÉtéCréé
         ? undefined


### PR DESCRIPTION
* 🎨 Afficher le type d'actionnariait dans la page lauréat et éliminé

* 🎨 Affichage du type d'actionnariat dans la page éliminé (utilisation via la query des données candidatures)