### PR TITLE
Fix du padding dans le cas d'un HistoriqueListItem sans icon

### DIFF
--- a/packages/applications/ssr/src/components/organisms/Timeline.tsx
+++ b/packages/applications/ssr/src/components/organisms/Timeline.tsx
@@ -116,7 +116,7 @@ const TimelineItem: FC<TimelineItemProps> = ({
           alignContent: 'flex-start',
         }}
       >
-        <div className="pt-3 print:pt-0">
+        <div className={clsx('print:pt-0', icon && 'pt-3')}>
           {title}
           {isÉtapeInconnue && type && ` (${type})`}
           {content ? <div className={clsx(title && 'mt-2')}>{content}</div> : null}


### PR DESCRIPTION
<img width="412" height="238" alt="Capture d’écran 2025-10-03 à 14 45 13" src="https://github.com/user-attachments/assets/25f98fcc-9dd3-4650-826d-0b89c4dcc8c9" />
