### PR TITLE
🚧 Modification de la date d'affichage de l'historique des délai covid

### DIFF
--- a/packages/applications/cli/src/commands/lauréat/modifier-date-creation-event-covid.ts
+++ b/packages/applications/cli/src/commands/lauréat/modifier-date-creation-event-covid.ts
@@ -1,0 +1,110 @@
+import { Command } from '@oclif/core';
+import z from 'zod';
+
+import { executeQuery, executeSelect } from '@potentiel-libraries/pg-helpers';
+import { IdentifiantProjet } from '@potentiel-domain/projet';
+import { DateTime } from '@potentiel-domain/common';
+
+import { dbSchema } from '#helpers';
+
+const envSchema = z.object({
+  ...dbSchema.shape,
+});
+
+export class ModifierDateCreationEventCovidCommand extends Command {
+  static override description = `Modification de la date de création de l'évènement d'attribution d'un délai covid pour qu'il arrive juste après la notification du lauréat.`;
+  async run() {
+    envSchema.parse(process.env);
+
+    const projetAvecUnEvenementCovid = `
+      with covidEvents as (
+        select
+        es.payload->>'identifiantProjet' as identifiant_projet,
+        es.version as event_covid_version,
+        es.created_at::date as event_covid_created_date
+        from event_store.event_stream es
+        where es.type = 'DateAchèvementPrévisionnelCalculée-V1'
+        and es.payload->>'raison' = 'covid'
+      ),
+      notificationEvents as (
+        select
+        es.payload->>'identifiantProjet' as identifiant_projet,
+        (es.payload->>'notifiéLe')::timestamp::date as notification_date,
+        es.payload->>'notifiéLe' as notifie_le
+        from event_store.event_stream es
+        where es.type in ('LauréatNotifié-V1', 'LauréatNotifié-V2')
+      )
+      select
+        c.identifiant_projet,
+        c.event_covid_version,
+        n.notifie_le
+      from covidEvents c
+      join notificationEvents n
+      on 
+        n.identifiant_projet = c.identifiant_projet
+      where 
+        c.event_covid_created_date IS DISTINCT FROM n.notification_date
+    `;
+
+    const stats = {
+      total: 0,
+      succès: 0,
+      erreurs: 0,
+    };
+
+    try {
+      const events = await executeSelect<{
+        identifiant_projet: IdentifiantProjet.RawType;
+        event_covid_version: number;
+        notifie_le: DateTime.RawType;
+      }>(projetAvecUnEvenementCovid);
+
+      if (!events.length) {
+        console.info(
+          'Aucun projet trouvé avec un événement covid, aucune modification à effectuer',
+        );
+        return;
+      }
+
+      await executeSelect(
+        `DROP RULE IF EXISTS prevent_update_on_event_stream on event_store.event_stream;`,
+      );
+
+      stats.total = events.length;
+
+      for (const { identifiant_projet, notifie_le } of events) {
+        await executeQuery(
+          `
+            update event_store.event_stream
+            set 
+              created_at = $1
+            where 
+              stream_id = $2 
+              and type = 'DateAchèvementPrévisionnelCalculée-V1' 
+              and payload->>'raison' = 'covid'
+          `,
+          DateTime.convertirEnValueType(notifie_le).ajouterNombreDeMillisecondes(500).formatter(),
+          `achevement|${identifiant_projet}`,
+        );
+
+        stats.succès += 1;
+      }
+
+      await executeQuery(`call event_store.rebuild('achevement');`);
+
+      await executeSelect(`
+        CREATE OR REPLACE RULE prevent_update_on_event_stream as on update to event_store.event_stream do instead
+        select event_store.throw_when_trying_to_update_event();
+      `);
+    } catch (error) {
+      console.error(
+        "Erreur lors de la modification de la date de création de l'événement covid :",
+        error,
+      );
+      stats.erreurs += 1;
+    } finally {
+      console.info('Statistiques :');
+      console.table(stats);
+    }
+  }
+}

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/achevement/(historique)/events/mapToDateAchèvementPrévisionnelCalculéeProps.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/achevement/(historique)/events/mapToDateAchèvementPrévisionnelCalculéeProps.tsx
@@ -7,12 +7,15 @@ import { FormattedDate } from '@/components/atoms/FormattedDate';
 import { TimelineItemProps } from '@/components/organisms/timeline';
 
 export const mapToDateAchèvementPrévisionnelCalculéeProps = (
-  event: Lauréat.Achèvement.DateAchèvementPrévisionnelCalculéeEvent,
+  event: Lauréat.Achèvement.DateAchèvementPrévisionnelCalculéeEvent & { created_at: string },
 ): TimelineItemProps => {
-  const { date, raison } = event.payload;
+  const {
+    created_at,
+    payload: { date, raison },
+  } = event;
 
   return {
-    date,
+    date: DateTime.convertirEnValueType(created_at).formatter(),
     title: getTitleFromRaison(raison),
     details: (
       <div className="flex flex-col gap-2">

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/achevement/(historique)/mapToAchèvementTimelineItemProps.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/achevement/(historique)/mapToAchèvementTimelineItemProps.tsx
@@ -37,7 +37,8 @@ export const mapToAchèvementTimelineItemProps: MapToAchèvementTimelineItemProp
           raison: P.union('ajout-délai-cdc-30_08_2022', 'retrait-délai-cdc-30_08_2022', 'covid'),
         },
       },
-      mapToDateAchèvementPrévisionnelCalculéeProps,
+      ({ type, payload, createdAt }) =>
+        mapToDateAchèvementPrévisionnelCalculéeProps({ type, payload, created_at: createdAt }),
     )
     .with(
       {

--- a/packages/domain/common/src/valueTypes/dateTime.valueType.ts
+++ b/packages/domain/common/src/valueTypes/dateTime.valueType.ts
@@ -1,4 +1,4 @@
-import { differenceInDays, addMonths, subMonths, addHours } from 'date-fns';
+import { differenceInDays, addMonths, subMonths, addHours, addMilliseconds } from 'date-fns';
 import { UTCDate } from '@date-fns/utc';
 
 import { ReadonlyValueType, InvalidOperationError, PlainType } from '@potentiel-domain/core';
@@ -18,6 +18,7 @@ export type ValueType = ReadonlyValueType<{
   retirerNombreDeJours(nombreDeMois: number): ValueType;
   ajouterNombreDeMois(nombreDeMois: number): ValueType;
   retirerNombreDeMois(nombreDeMois: number): ValueType;
+  ajouterNombreDeMillisecondes(nombreDeMillisecondes: number): ValueType;
   définirHeureÀMidi(): ValueType;
   formatter(): RawType;
   /** Retourne la date au format YYYY-MM-DD */
@@ -100,6 +101,11 @@ export const convertirEnValueType = (value: Date | string): ValueType => {
     définirHeureÀMidi() {
       const dateÀMidi = addHours(new Date(this.formatterDate()), 12);
       return convertirEnValueType(dateÀMidi);
+    },
+    ajouterNombreDeMillisecondes(nombreDeMillisecondes) {
+      const utcDate = new UTCDate(this.date);
+      const avecNombreDeMillisecondesAjouté = addMilliseconds(utcDate, nombreDeMillisecondes);
+      return convertirEnValueType(avecNombreDeMillisecondesAjouté);
     },
   };
 };


### PR DESCRIPTION
Cette PR est en draft car pour appliquer cette modification il faudrait retravailler les streams des projets concernés pour s'afficher que le created_at est juste après la date de notification du projet (ce qui n'est pas le cas auj, donc script à prévoir)