### PR TITLE
🐛 Retourner la bonne page d'erreur dans le cas d'une erreur de droit sur la page de redirection lauréat / éliminé

### DIFF
--- a/packages/applications/ssr/src/app/projets/[identifiant]/page.tsx
+++ b/packages/applications/ssr/src/app/projets/[identifiant]/page.tsx
@@ -6,6 +6,7 @@ import { IdentifiantProjet } from '@potentiel-domain/projet';
 import { getÉliminé } from '@/app/_helpers/getÉliminé';
 import { decodeParameter } from '@/utils/decodeParameter';
 import type { IdentifiantParameter } from '@/utils/identifiantParameter';
+import { PageWithErrorHandling } from '@/utils/PageWithErrorHandling';
 
 type ProjetPageProps = IdentifiantParameter & {
   searchParams?: Promise<Record<string, string>>;
@@ -22,17 +23,19 @@ export default async function ProjetPage(props: ProjetPageProps) {
     decodeParameter(identifiant),
   ).formatter();
 
-  const éliminé = await getÉliminé(identifiantProjet);
+  return PageWithErrorHandling(async () => {
+    const éliminé = await getÉliminé(identifiantProjet);
 
-  if (éliminé) {
-    redirect(Routes.Éliminé.détails.tableauDeBord(identifiantProjet));
-  }
+    if (éliminé) {
+      redirect(Routes.Éliminé.détails.tableauDeBord(identifiantProjet));
+    }
 
-  const urlSearchParams = new URLSearchParams(searchParams);
-  if (urlSearchParams.size === 0) {
-    return redirect(Routes.Lauréat.détails.tableauDeBord(identifiantProjet));
-  }
-  return redirect(
-    `${Routes.Lauréat.détails.tableauDeBord(identifiantProjet)}?${urlSearchParams.toString()}`,
-  );
+    const urlSearchParams = new URLSearchParams(searchParams);
+    if (urlSearchParams.size === 0) {
+      return redirect(Routes.Lauréat.détails.tableauDeBord(identifiantProjet));
+    }
+    return redirect(
+      `${Routes.Lauréat.détails.tableauDeBord(identifiantProjet)}?${urlSearchParams.toString()}`,
+    );
+  });
 }


### PR DESCRIPTION
En faisant des tests, j'ai spotté un bug : 

Suite à un changement de producteur, le PP pert ses droits d'accès au projet. Si je recherche le projet par son identifiant technique, alors je tombe sur la page de redirection éliminé ou lauréat (/projects/:id/page.tsx).

Si j'ai perdu les droits d'accès on m'affiche l'erreur serveur par défaut, qui ne correspond pas à la charte DSFR.

Cette PR fixe ce problème en wrappant avec PageWithErrorHandling