### PR TITLE
🐛 Correction du proxy withAuth

### DIFF
--- a/packages/applications/ssr/src/middlewares/withAuth.ts
+++ b/packages/applications/ssr/src/middlewares/withAuth.ts
@@ -7,8 +7,6 @@ import type { CustomMiddleware } from './middleware';
 
 export function withAuth(nextMiddleware: CustomMiddleware) {
   return async (request: NextRequest, event: NextFetchEvent) => {
-    // NB this does not validate the session, it merely checks for its presence.
-    // This is acceptable because session validation is performed by getSessionUser / getApiUser.
     const utilisateur = await getSessionUser(request);
     if (!utilisateur) {
       const url = new URL('/auth/signIn', request.url);

--- a/packages/applications/ssr/src/middlewares/withAuth.ts
+++ b/packages/applications/ssr/src/middlewares/withAuth.ts
@@ -1,16 +1,16 @@
 import { parse } from 'node:url';
 
-import { getSessionCookie } from 'better-auth/cookies';
 import { type NextFetchEvent, type NextRequest, NextResponse } from 'next/server';
 
+import { getSessionUser } from '@/auth/getSessionUser';
 import type { CustomMiddleware } from './middleware';
 
 export function withAuth(nextMiddleware: CustomMiddleware) {
   return async (request: NextRequest, event: NextFetchEvent) => {
     // NB this does not validate the session, it merely checks for its presence.
     // This is acceptable because session validation is performed by getSessionUser / getApiUser.
-    const session = getSessionCookie(request);
-    if (!session) {
+    const utilisateur = await getSessionUser(request);
+    if (!utilisateur) {
       const url = new URL('/auth/signIn', request.url);
       const { path } = parse(request.url, true);
       if (path) {


### PR DESCRIPTION
On ne valide pas la session, donc une session expirée ne redirige pas vers la page de login. Ceci ne fonctionnait pas en Next 14, mais est OK en Next 16.
