### PR TITLE
🚸 Afficher motif GF en attente sur la page projet

### DIFF
--- a/packages/applications/ssr/src/app/laureats/[identifiant]/(détails)/(sections)/GarantiesFinancières.section.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/(détails)/(sections)/GarantiesFinancières.section.tsx
@@ -68,7 +68,9 @@ export const getGarantiesFinancièresData = async ({
     return undefined;
   }
 
-  const { actuelles, dépôt } = await getGarantiesFinancières(identifiantProjet.formatter());
+  const { actuelles, dépôt, enAttente } = await getGarantiesFinancières(
+    identifiantProjet.formatter(),
+  );
 
   return {
     actuelles: actuelles
@@ -87,5 +89,6 @@ export const getGarantiesFinancièresData = async ({
             : undefined,
         }
       : undefined,
+    enAttente,
   };
 };

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/(détails)/(sections)/GarantiesFinancièresDétails.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/(détails)/(sections)/GarantiesFinancièresDétails.tsx
@@ -10,13 +10,13 @@ import { FormattedDate } from '@/components/atoms/FormattedDate';
 import { TertiaryLink } from '@/components/atoms/form/TertiaryLink';
 
 type GarantiesFinancièresData = {
-  actuelles?: PlainType<Lauréat.GarantiesFinancières.ConsulterGarantiesFinancièresReadModel> & {
+  actuelles?: PlainType<Lauréat.GarantiesFinancières.ConsulterGarantiesFinancièresActuellesReadModel> & {
     dateÉchéance?: DateTime.RawType;
   };
   dépôt?: PlainType<Lauréat.GarantiesFinancières.ConsulterDépôtGarantiesFinancièresReadModel> & {
     dateÉchéance?: DateTime.RawType;
   };
-  motifGarantiesFinancièresEnAttente?: Lauréat.GarantiesFinancières.MotifDemandeGarantiesFinancières.RawType;
+  enAttente?: PlainType<Lauréat.GarantiesFinancières.ConsulterGarantiesFinancièresEnAttenteReadModel>;
 };
 
 type GarantiesFinancièresDétailsProps = {
@@ -30,16 +30,15 @@ export const GarantiesFinancièresDétails = ({
   garantiesFinancières,
   estAchevé,
 }: GarantiesFinancièresDétailsProps) => {
-  const { dépôt, actuelles } = garantiesFinancières;
-  const motifDemandeGarantiesFinancières =
-    actuelles?.motifEnAttente &&
-    getMotifGarantiesFinancièresEnAttente(actuelles.motifEnAttente.motif);
+  const { dépôt, actuelles, enAttente } = garantiesFinancières;
+  const motifGarantiesFinancièresEnAttente =
+    enAttente && getMotifGarantiesFinancièresEnAttente(enAttente.motifEnAttente.motif);
 
   return (
     <>
-      {!estAchevé && motifDemandeGarantiesFinancières && (
+      {!estAchevé && motifGarantiesFinancièresEnAttente && (
         <Notice
-          description={`Des garanties financières sont en attente pour ce projet (${motifDemandeGarantiesFinancières})`}
+          description={`Des garanties financières sont en attente pour ce projet (${motifGarantiesFinancièresEnAttente})`}
           title=""
           severity="info"
           className="print:hidden"

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/_helpers/getGarantiesFinancières.ts
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/_helpers/getGarantiesFinancières.ts
@@ -7,10 +7,12 @@ import { Option } from '@potentiel-libraries/monads';
 export const getGarantiesFinancières = cache(
   async (identifiantProjet: IdentifiantProjet.RawType) => {
     const garantiesFinancièresActuelles =
-      await mediator.send<Lauréat.GarantiesFinancières.ConsulterGarantiesFinancièresQuery>({
-        type: 'Lauréat.GarantiesFinancières.Query.ConsulterGarantiesFinancières',
-        data: { identifiantProjetValue: identifiantProjet },
-      });
+      await mediator.send<Lauréat.GarantiesFinancières.ConsulterGarantiesFinancièresActuellesQuery>(
+        {
+          type: 'Lauréat.GarantiesFinancières.Query.ConsulterGarantiesFinancièresActuelles',
+          data: { identifiantProjetValue: identifiantProjet },
+        },
+      );
 
     const dépôt =
       await mediator.send<Lauréat.GarantiesFinancières.ConsulterDépôtGarantiesFinancièresQuery>({
@@ -18,11 +20,20 @@ export const getGarantiesFinancières = cache(
         data: { identifiantProjetValue: identifiantProjet },
       });
 
+    const enAttente =
+      await mediator.send<Lauréat.GarantiesFinancières.ConsulterGarantiesFinancièresEnAttenteQuery>(
+        {
+          type: 'Lauréat.GarantiesFinancières.Query.ConsulterGarantiesFinancièresEnAttente',
+          data: { identifiantProjetValue: identifiantProjet },
+        },
+      );
+
     return {
       actuelles: Option.isSome(garantiesFinancièresActuelles)
         ? garantiesFinancièresActuelles
         : undefined,
       dépôt: Option.isSome(dépôt) ? dépôt : undefined,
+      enAttente: Option.isSome(enAttente) ? enAttente : undefined,
     };
   },
 );

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/achevement/attestation-conformite/transmettre/page.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/achevement/attestation-conformite/transmettre/page.tsx
@@ -58,7 +58,7 @@ export default async function Page(props0: IdentifiantParameter) {
 
 type MapToProps = (params: {
   identifiantProjet: IdentifiantProjet.ValueType;
-  garantiesFinancières: Option.Type<Lauréat.GarantiesFinancières.ConsulterGarantiesFinancièresReadModel>;
+  garantiesFinancières: Option.Type<Lauréat.GarantiesFinancières.ConsulterGarantiesFinancièresActuellesReadModel>;
   notifiéLe: DateTime.ValueType;
 }) => TransmettreAttestationConformitéPageProps;
 

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/garanties-financieres/DétailsGarantiesFinancières.page.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/garanties-financieres/DétailsGarantiesFinancières.page.tsx
@@ -34,7 +34,7 @@ export type AlerteGarantiesFinancières = (typeof alertesGarantiesFinancières)[
 export type DétailsGarantiesFinancièresPageProps = {
   identifiantProjet: string;
   actuelles: PlainType<
-    Option.Type<Lauréat.GarantiesFinancières.ConsulterGarantiesFinancièresReadModel>
+    Option.Type<Lauréat.GarantiesFinancières.ConsulterGarantiesFinancièresActuellesReadModel>
   >;
   archivesGarantiesFinancières: PlainType<Lauréat.GarantiesFinancières.ListerArchivesGarantiesFinancièresReadModel>;
   actions: (ActionGarantiesFinancières | AlerteGarantiesFinancières)[];

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/garanties-financieres/_helpers/récupérerGarantiesFinancièresActuelles.ts
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/garanties-financieres/_helpers/récupérerGarantiesFinancièresActuelles.ts
@@ -5,8 +5,8 @@ import type { IdentifiantProjet, Lauréat } from '@potentiel-domain/projet';
 
 export const récuperérerGarantiesFinancièresActuelles = cache(
   async (identifiantProjet: IdentifiantProjet.RawType) => {
-    return mediator.send<Lauréat.GarantiesFinancières.ConsulterGarantiesFinancièresQuery>({
-      type: 'Lauréat.GarantiesFinancières.Query.ConsulterGarantiesFinancières',
+    return mediator.send<Lauréat.GarantiesFinancières.ConsulterGarantiesFinancièresActuellesQuery>({
+      type: 'Lauréat.GarantiesFinancières.Query.ConsulterGarantiesFinancièresActuelles',
       data: { identifiantProjetValue: identifiantProjet },
     });
   },

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/garanties-financieres/actuelles/enregistrer-attestation/EnregistrerAttestationGarantiesFinancières.form.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/garanties-financieres/actuelles/enregistrer-attestation/EnregistrerAttestationGarantiesFinancières.form.tsx
@@ -18,7 +18,7 @@ import {
 
 export type EnregistrerAttestationGarantiesFinancièresFormProps = {
   identifiantProjet: string;
-  garantiesFinancièresActuelles: PlainType<Lauréat.GarantiesFinancières.ConsulterGarantiesFinancièresReadModel>;
+  garantiesFinancièresActuelles: PlainType<Lauréat.GarantiesFinancières.ConsulterGarantiesFinancièresActuellesReadModel>;
 };
 
 export const EnregistrerAttestationGarantiesFinancièresForm: FC<

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/garanties-financieres/actuelles/modifier/ModifierGarantiesFinancièresActuelles.form.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/garanties-financieres/actuelles/modifier/ModifierGarantiesFinancièresActuelles.form.tsx
@@ -18,7 +18,7 @@ import {
 
 export type ModifierGarantiesFinancièresActuellesFormProps = {
   typesGarantiesFinancières: GarantiesFinancièresFormInputsProps['typesGarantiesFinancières'];
-  actuelles: PlainType<Lauréat.GarantiesFinancières.ConsulterGarantiesFinancièresReadModel>;
+  actuelles: PlainType<Lauréat.GarantiesFinancières.ConsulterGarantiesFinancièresActuellesReadModel>;
 };
 
 export const ModifierGarantiesFinancièresActuellesForm: FC<

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/garanties-financieres/actuelles/modifier/page.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/garanties-financieres/actuelles/modifier/page.tsx
@@ -58,7 +58,7 @@ export default async function Page(props0: IdentifiantParameter) {
 }
 
 type MapToProps = (
-  garantiesFinancières: Lauréat.GarantiesFinancières.ConsulterGarantiesFinancièresReadModel,
+  garantiesFinancières: Lauréat.GarantiesFinancières.ConsulterGarantiesFinancièresActuellesReadModel,
   cahierDesCharges: CahierDesCharges.ValueType,
 ) => ModifierGarantiesFinancièresActuellesPageProps;
 

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/garanties-financieres/components/GarantiesFinancièresFormInputs.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/garanties-financieres/components/GarantiesFinancièresFormInputs.tsx
@@ -16,7 +16,7 @@ export type GarantiesFinancièresFormInputsProps = {
   label?: string;
   validationErrors: ValidationErrors;
   actuelles?: Partial<
-    PlainType<Lauréat.GarantiesFinancières.ConsulterGarantiesFinancièresReadModel>
+    PlainType<Lauréat.GarantiesFinancières.ConsulterGarantiesFinancièresActuellesReadModel>
   >;
   typesGarantiesFinancières: Array<{
     label: string;

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/garanties-financieres/mainlevee/DétailsMainlevée.page.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/garanties-financieres/mainlevee/DétailsMainlevée.page.tsx
@@ -31,7 +31,7 @@ import { RejeterDemandeMainlevéeForm } from './rejeter/RejeterDemandeMainlevée
 
 export type DétailsMainlevéePageProps = MainlevéeEnCoursProps &
   ActionsMainlevéeProps & {
-    garantiesFinancières: PlainType<Lauréat.GarantiesFinancières.ConsulterGarantiesFinancièresReadModel>;
+    garantiesFinancières: PlainType<Lauréat.GarantiesFinancières.ConsulterGarantiesFinancièresActuellesReadModel>;
     achèvement?: PlainType<Lauréat.Achèvement.ConsulterAchèvementReadModel>;
     abandon?: PlainType<Lauréat.Abandon.ConsulterAbandonReadModel>;
     mainlevéesRejetées: PlainType<Lauréat.GarantiesFinancières.ListerMainlevéeItemReadModel>[];

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/garanties-financieres/mainlevee/modele-mise-en-demeure/route.ts
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/garanties-financieres/mainlevee/modele-mise-en-demeure/route.ts
@@ -34,13 +34,15 @@ export const GET = async (
         IdentifiantProjet.convertirEnValueType(identifiantProjetValue).formatter(),
       );
 
-      const garantiesFinancières =
-        await mediator.send<Lauréat.GarantiesFinancières.ConsulterGarantiesFinancièresQuery>({
-          type: 'Lauréat.GarantiesFinancières.Query.ConsulterGarantiesFinancières',
-          data: {
-            identifiantProjetValue,
+      const garantiesFinancièresEnAttente =
+        await mediator.send<Lauréat.GarantiesFinancières.ConsulterGarantiesFinancièresEnAttenteQuery>(
+          {
+            type: 'Lauréat.GarantiesFinancières.Query.ConsulterGarantiesFinancièresEnAttente',
+            data: {
+              identifiantProjetValue,
+            },
           },
-        });
+        );
 
       const garantieFinanciereEnMoisNumber =
         famille &&
@@ -86,8 +88,9 @@ export const GET = async (
               )
             : '!!! dateFinGarantieFinanciere non disponible !!!',
           dateLimiteDepotGF: formatDateForDocument(
-            Option.isSome(garantiesFinancières) && garantiesFinancières.dateLimiteSoumission
-              ? garantiesFinancières.dateLimiteSoumission.date
+            Option.isSome(garantiesFinancièresEnAttente) &&
+              garantiesFinancièresEnAttente.dateLimiteSoumission
+              ? garantiesFinancièresEnAttente.dateLimiteSoumission.date
               : undefined,
           ),
           // TODO vérifer

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/garanties-financieres/page.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/garanties-financieres/page.tsx
@@ -84,7 +84,7 @@ export default async function Page(props0: IdentifiantParameter) {
 }
 
 type MapToActionsAndAlertesProps = {
-  actuelles: Option.Type<Lauréat.GarantiesFinancières.ConsulterGarantiesFinancièresReadModel>;
+  actuelles: Option.Type<Lauréat.GarantiesFinancières.ConsulterGarantiesFinancièresActuellesReadModel>;
   dépôtEnCours: Option.Type<Lauréat.GarantiesFinancières.ConsulterDépôtGarantiesFinancièresReadModel>;
   mainlevée: Option.Type<Lauréat.GarantiesFinancières.ConsulterMainlevéeEnCoursReadModel>;
   utilisateur: Utilisateur.ValueType;

--- a/packages/domain/projet/src/lauréat/garanties-financières/actuelles/consulter/consulterGarantiesFinancièresActuelles.query.ts
+++ b/packages/domain/projet/src/lauréat/garanties-financières/actuelles/consulter/consulterGarantiesFinancièresActuelles.query.ts
@@ -9,16 +9,13 @@ import type { GarantiesFinancièresEntity } from '../../garantiesFinancières.en
 import {
   DocumentGarantiesFinancières,
   GarantiesFinancières,
-  MotifDemandeGarantiesFinancières,
   StatutGarantiesFinancières,
 } from '../../index.js';
 
-export type ConsulterGarantiesFinancièresReadModel = {
+export type ConsulterGarantiesFinancièresActuellesReadModel = {
   identifiantProjet: IdentifiantProjet.ValueType;
   garantiesFinancières: GarantiesFinancières.ValueType;
   statut: StatutGarantiesFinancières.ValueType;
-  motifEnAttente?: MotifDemandeGarantiesFinancières.ValueType;
-  dateLimiteSoumission?: DateTime.ValueType;
   document?: DocumentProjet.ValueType;
   soumisLe?: DateTime.ValueType;
   validéLe?: DateTime.ValueType;
@@ -28,22 +25,22 @@ export type ConsulterGarantiesFinancièresReadModel = {
   };
 };
 
-export type ConsulterGarantiesFinancièresQuery = Message<
-  'Lauréat.GarantiesFinancières.Query.ConsulterGarantiesFinancières',
+export type ConsulterGarantiesFinancièresActuellesQuery = Message<
+  'Lauréat.GarantiesFinancières.Query.ConsulterGarantiesFinancièresActuelles',
   {
     identifiantProjetValue: string;
   },
-  Option.Type<ConsulterGarantiesFinancièresReadModel>
+  Option.Type<ConsulterGarantiesFinancièresActuellesReadModel>
 >;
 
-export type ConsulterGarantiesFinancièresDependencies = {
+export type ConsulterGarantiesFinancièresActuellesDependencies = {
   find: Find;
 };
 
-export const registerConsulterGarantiesFinancièresQuery = ({
+export const registerConsulterGarantiesFinancièresActuellesQuery = ({
   find,
-}: ConsulterGarantiesFinancièresDependencies) => {
-  const handler: MessageHandler<ConsulterGarantiesFinancièresQuery> = async ({
+}: ConsulterGarantiesFinancièresActuellesDependencies) => {
+  const handler: MessageHandler<ConsulterGarantiesFinancièresActuellesQuery> = async ({
     identifiantProjetValue,
   }) => {
     const identifiantProjet = IdentifiantProjet.convertirEnValueType(identifiantProjetValue);
@@ -58,7 +55,10 @@ export const registerConsulterGarantiesFinancièresQuery = ({
 
     return mapToReadModel({ ...result, actuelles: result.actuelles });
   };
-  mediator.register('Lauréat.GarantiesFinancières.Query.ConsulterGarantiesFinancières', handler);
+  mediator.register(
+    'Lauréat.GarantiesFinancières.Query.ConsulterGarantiesFinancièresActuelles',
+    handler,
+  );
 };
 
 type MapToReadModelProps = GarantiesFinancièresEntity & { actuelles: GarantiesFinancières.RawType };
@@ -66,10 +66,9 @@ export const mapToReadModel = ({
   identifiantProjet,
   dernièreMiseÀJour,
   statut,
-  enAttente,
   actuelles,
   soumisLe,
-}: MapToReadModelProps): ConsulterGarantiesFinancièresReadModel => {
+}: MapToReadModelProps): ConsulterGarantiesFinancièresActuellesReadModel => {
   const garantiesFinancières = GarantiesFinancières.convertirEnValueType(actuelles);
   return {
     identifiantProjet: IdentifiantProjet.convertirEnValueType(identifiantProjet),
@@ -88,11 +87,5 @@ export const mapToReadModel = ({
       date: DateTime.convertirEnValueType(dernièreMiseÀJour.date),
       par: dernièreMiseÀJour.par ? Email.convertirEnValueType(dernièreMiseÀJour.par) : undefined,
     },
-    motifEnAttente: enAttente
-      ? MotifDemandeGarantiesFinancières.convertirEnValueType(enAttente.motif)
-      : undefined,
-    dateLimiteSoumission: enAttente?.dateLimiteSoumission
-      ? DateTime.convertirEnValueType(enAttente.dateLimiteSoumission)
-      : undefined,
   };
 };

--- a/packages/domain/projet/src/lauréat/garanties-financières/actuelles/garantiesFinancièresActuelles.queries.ts
+++ b/packages/domain/projet/src/lauréat/garanties-financières/actuelles/garantiesFinancièresActuelles.queries.ts
@@ -4,23 +4,26 @@ import type {
   ListerArchivesGarantiesFinancièresReadModel,
 } from './archives/lister/listerArchivesGarantiesFinancières.query.js';
 import type {
-  ConsulterGarantiesFinancièresQuery,
-  ConsulterGarantiesFinancièresReadModel,
-} from './consulter/consulterGarantiesFinancières.query.js';
+  ConsulterGarantiesFinancièresActuellesQuery,
+  ConsulterGarantiesFinancièresActuellesReadModel,
+} from './consulter/consulterGarantiesFinancièresActuelles.query.js';
 
 export type GarantiesFinancièresActuellesQuery =
-  | ConsulterGarantiesFinancièresQuery
+  | ConsulterGarantiesFinancièresActuellesQuery
   | ListerArchivesGarantiesFinancièresQuery;
 
-export type { ConsulterGarantiesFinancièresQuery, ListerArchivesGarantiesFinancièresQuery };
+export type {
+  ConsulterGarantiesFinancièresActuellesQuery,
+  ListerArchivesGarantiesFinancièresQuery,
+};
 
 export type GarantiesFinancièresActuellesReadModel =
-  | ConsulterGarantiesFinancièresReadModel
+  | ConsulterGarantiesFinancièresActuellesReadModel
   | ListerArchivesGarantiesFinancièresReadModel
   | ArchiveGarantiesFinancièresListItemReadModel;
 
 export type {
   ArchiveGarantiesFinancièresListItemReadModel,
-  ConsulterGarantiesFinancièresReadModel,
+  ConsulterGarantiesFinancièresActuellesReadModel,
   ListerArchivesGarantiesFinancièresReadModel,
 };

--- a/packages/domain/projet/src/lauréat/garanties-financières/actuelles/garantiesFinancièresActuelles.register.ts
+++ b/packages/domain/projet/src/lauréat/garanties-financières/actuelles/garantiesFinancièresActuelles.register.ts
@@ -2,7 +2,7 @@ import type { Find } from '@potentiel-domain/entity';
 
 import type { GetProjetAggregateRoot } from '../../../index.js';
 import { registerListerArchivesGarantiesFinancièresQuery } from './archives/lister/listerArchivesGarantiesFinancières.query.js';
-import { registerConsulterGarantiesFinancièresQuery } from './consulter/consulterGarantiesFinancières.query.js';
+import { registerConsulterGarantiesFinancièresActuellesQuery } from './consulter/consulterGarantiesFinancièresActuelles.query.js';
 import { registerEnregistrerGarantiesFinancièresCommand } from './enregistrer/enregistrerGarantiesFinancières.command.js';
 import { registerEnregistrerGarantiesFinancièresUseCase } from './enregistrer/enregistrerGarantiesFinancières.usecase.js';
 import { registerEnregistrerAttestationGarantiesFinancièresCommand } from './enregistrerAttestation/enregistrerAttestationGarantiesFinancières.command.js';
@@ -40,6 +40,6 @@ export const registerGarantiesFinancièresActuellesUseCases = ({
 export const registerGarantiesFinancièresActuellesQueries = (
   dependencies: GarantiesFinancièresActuellesQueryDependencies,
 ) => {
-  registerConsulterGarantiesFinancièresQuery(dependencies);
+  registerConsulterGarantiesFinancièresActuellesQuery(dependencies);
   registerListerArchivesGarantiesFinancièresQuery(dependencies);
 };

--- a/packages/domain/projet/src/lauréat/garanties-financières/en-attente/consulter/consulterGarantiesFinancièresEnAttente.query.ts
+++ b/packages/domain/projet/src/lauréat/garanties-financières/en-attente/consulter/consulterGarantiesFinancièresEnAttente.query.ts
@@ -1,0 +1,74 @@
+import { type Message, type MessageHandler, mediator } from 'mediateur';
+
+import { DateTime, Email } from '@potentiel-domain/common';
+import type { Find } from '@potentiel-domain/entity';
+import { Option } from '@potentiel-libraries/monads';
+
+import { IdentifiantProjet } from '../../../../index.js';
+import type { GarantiesFinancièresEntity } from '../../garantiesFinancières.entity.js';
+import { MotifDemandeGarantiesFinancières } from '../../index.js';
+
+export type ConsulterGarantiesFinancièresEnAttenteReadModel = {
+  identifiantProjet: IdentifiantProjet.ValueType;
+  motifEnAttente: MotifDemandeGarantiesFinancières.ValueType;
+  dateLimiteSoumission: DateTime.ValueType;
+  dernièreMiseÀJour: {
+    date: DateTime.ValueType;
+    par?: Email.ValueType;
+  };
+};
+
+export type ConsulterGarantiesFinancièresEnAttenteQuery = Message<
+  'Lauréat.GarantiesFinancières.Query.ConsulterGarantiesFinancièresEnAttente',
+  {
+    identifiantProjetValue: string;
+  },
+  Option.Type<ConsulterGarantiesFinancièresEnAttenteReadModel>
+>;
+
+export type ConsulterGarantiesFinancièresEnAttenteDependencies = {
+  find: Find;
+};
+
+export const registerConsulterGarantiesFinancièresEnAttenteQuery = ({
+  find,
+}: ConsulterGarantiesFinancièresEnAttenteDependencies) => {
+  const handler: MessageHandler<ConsulterGarantiesFinancièresEnAttenteQuery> = async ({
+    identifiantProjetValue,
+  }) => {
+    const identifiantProjet = IdentifiantProjet.convertirEnValueType(identifiantProjetValue);
+
+    const result = await find<GarantiesFinancièresEntity>(
+      `garanties-financieres|${identifiantProjet.formatter()}`,
+    );
+
+    if (Option.isNone(result) || !result.enAttente) {
+      return Option.none;
+    }
+
+    return mapToReadModel({ ...result, enAttente: result.enAttente });
+  };
+  mediator.register(
+    'Lauréat.GarantiesFinancières.Query.ConsulterGarantiesFinancièresEnAttente',
+    handler,
+  );
+};
+
+type MapToReadModelProps = GarantiesFinancièresEntity & {
+  enAttente: Exclude<GarantiesFinancièresEntity['enAttente'], undefined>;
+};
+export const mapToReadModel = ({
+  identifiantProjet,
+  dernièreMiseÀJour,
+  enAttente,
+}: MapToReadModelProps): ConsulterGarantiesFinancièresEnAttenteReadModel => {
+  return {
+    identifiantProjet: IdentifiantProjet.convertirEnValueType(identifiantProjet),
+    motifEnAttente: MotifDemandeGarantiesFinancières.convertirEnValueType(enAttente.motif),
+    dateLimiteSoumission: DateTime.convertirEnValueType(enAttente.dateLimiteSoumission),
+    dernièreMiseÀJour: {
+      date: DateTime.convertirEnValueType(dernièreMiseÀJour.date),
+      par: dernièreMiseÀJour.par ? Email.convertirEnValueType(dernièreMiseÀJour.par) : undefined,
+    },
+  };
+};

--- a/packages/domain/projet/src/lauréat/garanties-financières/en-attente/garantiesFinancièresEnAttente.queries.ts
+++ b/packages/domain/projet/src/lauréat/garanties-financières/en-attente/garantiesFinancièresEnAttente.queries.ts
@@ -1,12 +1,20 @@
 import type {
+  ConsulterGarantiesFinancièresEnAttenteQuery,
+  ConsulterGarantiesFinancièresEnAttenteReadModel,
+} from './consulter/consulterGarantiesFinancièresEnAttente.query.js';
+import type {
   GarantiesFinancièresEnAttenteListItemReadModel,
   ListerGarantiesFinancièresEnAttenteQuery,
   ListerGarantiesFinancièresEnAttenteReadModel,
 } from './lister/listerProjetsAvecGarantiesFinancièresEnAttente.query.js';
 
-export type GarantiesFinancièresEnAttenteQuery = ListerGarantiesFinancièresEnAttenteQuery;
+export type GarantiesFinancièresEnAttenteQuery =
+  | ListerGarantiesFinancièresEnAttenteQuery
+  | ConsulterGarantiesFinancièresEnAttenteQuery;
 
 export type {
+  ConsulterGarantiesFinancièresEnAttenteQuery,
+  ConsulterGarantiesFinancièresEnAttenteReadModel,
   GarantiesFinancièresEnAttenteListItemReadModel,
   ListerGarantiesFinancièresEnAttenteQuery,
   ListerGarantiesFinancièresEnAttenteReadModel,

--- a/packages/domain/projet/src/lauréat/garanties-financières/en-attente/garantiesFinancièresEnAttente.register.ts
+++ b/packages/domain/projet/src/lauréat/garanties-financières/en-attente/garantiesFinancièresEnAttente.register.ts
@@ -1,13 +1,19 @@
 import {
+  type ConsulterGarantiesFinancièresEnAttenteDependencies,
+  registerConsulterGarantiesFinancièresEnAttenteQuery,
+} from './consulter/consulterGarantiesFinancièresEnAttente.query.js';
+import {
   type ListerGarantiesFinancièresEnAttenteDependencies,
   registerListerGarantiesFinancièresEnAttenteQuery,
 } from './lister/listerProjetsAvecGarantiesFinancièresEnAttente.query.js';
 
 export type GarantiesFinancièresEnAttenteQueryDependencies =
-  ListerGarantiesFinancièresEnAttenteDependencies;
+  ListerGarantiesFinancièresEnAttenteDependencies &
+    ConsulterGarantiesFinancièresEnAttenteDependencies;
 
 export const registerGarantiesFinancièresEnAttenteQueries = (
   dependencies: GarantiesFinancièresEnAttenteQueryDependencies,
 ) => {
   registerListerGarantiesFinancièresEnAttenteQuery(dependencies);
+  registerConsulterGarantiesFinancièresEnAttenteQuery(dependencies);
 };

--- a/packages/domain/utilisateur/src/role.valueType.ts
+++ b/packages/domain/utilisateur/src/role.valueType.ts
@@ -203,7 +203,7 @@ const référencielPermissions = {
     garantiesFinancières: {
       query: {
         consulterGarantiesFinancièresActuelles:
-          'Lauréat.GarantiesFinancières.Query.ConsulterGarantiesFinancières',
+          'Lauréat.GarantiesFinancières.Query.ConsulterGarantiesFinancièresActuelles',
         listerArchivesGarantiesFinancières:
           'Lauréat.GarantiesFinancières.Query.ListerArchivesGarantiesFinancières',
         consulterDépôtGarantiesFinancières:

--- a/packages/specifications/src/projet/lauréat/garantiesFinancières/actuelles/fixtures/enregistrerAttestationGarantiesFinancières.fixture.ts
+++ b/packages/specifications/src/projet/lauréat/garantiesFinancières/actuelles/fixtures/enregistrerAttestationGarantiesFinancières.fixture.ts
@@ -4,7 +4,7 @@ import { Lauréat } from '@potentiel-domain/projet';
 import { EnregistrerGarantiesFinancièresFixture } from './enregistrerGarantiesFinancières.fixture.js';
 
 export class EnregistrerAttestationGarantiesFinancièresFixture extends EnregistrerGarantiesFinancièresFixture {
-  mapToExpected(): Lauréat.GarantiesFinancières.ConsulterGarantiesFinancièresReadModel {
+  mapToExpected(): Lauréat.GarantiesFinancières.ConsulterGarantiesFinancièresActuellesReadModel {
     const expected = super.mapToExpected();
 
     const dépôtCandidature =

--- a/packages/specifications/src/projet/lauréat/garantiesFinancières/actuelles/fixtures/enregistrerGarantiesFinancières.fixture.ts
+++ b/packages/specifications/src/projet/lauréat/garantiesFinancières/actuelles/fixtures/enregistrerGarantiesFinancières.fixture.ts
@@ -88,7 +88,7 @@ export class EnregistrerGarantiesFinancièresFixture extends AbstractFixture<Enr
     return fixture;
   }
 
-  mapToExpected(): Lauréat.GarantiesFinancières.ConsulterGarantiesFinancièresReadModel {
+  mapToExpected(): Lauréat.GarantiesFinancières.ConsulterGarantiesFinancièresActuellesReadModel {
     return {
       identifiantProjet:
         this.garantiesFinancièresActuellesWorld.garantiesFinancièresWorld.lauréatWorld
@@ -113,8 +113,6 @@ export class EnregistrerGarantiesFinancièresFixture extends AbstractFixture<Enr
         par: Email.convertirEnValueType(this.enregistréPar),
       },
       validéLe: DateTime.convertirEnValueType(this.#enregistréLe),
-      dateLimiteSoumission: undefined,
-      motifEnAttente: undefined,
     };
   }
 }

--- a/packages/specifications/src/projet/lauréat/garantiesFinancières/actuelles/fixtures/modifierGarantiesFinancières.fixture.ts
+++ b/packages/specifications/src/projet/lauréat/garantiesFinancières/actuelles/fixtures/modifierGarantiesFinancières.fixture.ts
@@ -95,7 +95,7 @@ export class ModifierGarantiesFinancièresFixture extends AbstractFixture<Modifi
     return fixture;
   }
 
-  mapToExpected(): Lauréat.GarantiesFinancières.ConsulterGarantiesFinancièresReadModel {
+  mapToExpected(): Lauréat.GarantiesFinancières.ConsulterGarantiesFinancièresActuellesReadModel {
     return {
       identifiantProjet:
         this.garantiesFinancièresActuellesWorld.garantiesFinancièresWorld.lauréatWorld
@@ -120,8 +120,6 @@ export class ModifierGarantiesFinancièresFixture extends AbstractFixture<Modifi
         par: Email.convertirEnValueType(this.enregistréPar),
       },
       validéLe: DateTime.convertirEnValueType(this.#enregistréLe),
-      dateLimiteSoumission: undefined,
-      motifEnAttente: undefined,
     };
   }
 }

--- a/packages/specifications/src/projet/lauréat/garantiesFinancières/actuelles/garantiesFinancièresActuelles.world.ts
+++ b/packages/specifications/src/projet/lauréat/garantiesFinancières/actuelles/garantiesFinancièresActuelles.world.ts
@@ -48,7 +48,7 @@ export class GarantiesFinancièresActuellesWorld {
     return mapToExemple(exemple, garantiesFinancièresMap);
   }
 
-  mapToExpected(): Lauréat.GarantiesFinancières.ConsulterGarantiesFinancièresReadModel {
+  mapToExpected(): Lauréat.GarantiesFinancières.ConsulterGarantiesFinancièresActuellesReadModel {
     const identifiantProjet = this.garantiesFinancièresWorld.lauréatWorld.identifiantProjet;
 
     const actions = [this.enregistrer, this.modifier, this.enregistrerAttestation]
@@ -71,7 +71,7 @@ export class GarantiesFinancièresActuellesWorld {
       attestationConstitutionGf,
     } = candidatureInitiale.dépôtValue;
 
-    let gfReadModel: Lauréat.GarantiesFinancières.ConsulterGarantiesFinancièresReadModel =
+    let gfReadModel: Lauréat.GarantiesFinancières.ConsulterGarantiesFinancièresActuellesReadModel =
       typeGarantiesFinancières
         ? {
             identifiantProjet,
@@ -98,7 +98,7 @@ export class GarantiesFinancièresActuellesWorld {
             validéLe: DateTime.convertirEnValueType(notifiéLe),
             document: this.importer.aÉtéCréé ? this.importer.mapToExpected().document : undefined,
           }
-        : ({} as Lauréat.GarantiesFinancières.ConsulterGarantiesFinancièresReadModel);
+        : ({} as Lauréat.GarantiesFinancières.ConsulterGarantiesFinancièresActuellesReadModel);
 
     for (const action of actions) {
       gfReadModel = action.mapToExpected();
@@ -111,9 +111,6 @@ export class GarantiesFinancièresActuellesWorld {
 
     if (sontÉchues && gfReadModel.garantiesFinancières.estAvecDateÉchéance()) {
       gfReadModel.statut = Lauréat.GarantiesFinancières.StatutGarantiesFinancières.échu;
-      gfReadModel.dateLimiteSoumission = gfReadModel.dernièreMiseÀJour.date.ajouterNombreDeMois(2);
-      gfReadModel.motifEnAttente =
-        Lauréat.GarantiesFinancières.MotifDemandeGarantiesFinancières.échéanceGarantiesFinancièresActuelles;
     }
 
     return gfReadModel;

--- a/packages/specifications/src/projet/lauréat/garantiesFinancières/actuelles/stepDefinitions/garantiesFinancièresActuelles.then.ts
+++ b/packages/specifications/src/projet/lauréat/garantiesFinancières/actuelles/stepDefinitions/garantiesFinancièresActuelles.then.ts
@@ -15,12 +15,14 @@ Alors(
     const { identifiantProjet } = this.lauréatWorld;
     await waitForExpect(async () => {
       const actualReadModel =
-        await mediator.send<Lauréat.GarantiesFinancières.ConsulterGarantiesFinancièresQuery>({
-          type: 'Lauréat.GarantiesFinancières.Query.ConsulterGarantiesFinancières',
-          data: {
-            identifiantProjetValue: identifiantProjet.formatter(),
+        await mediator.send<Lauréat.GarantiesFinancières.ConsulterGarantiesFinancièresActuellesQuery>(
+          {
+            type: 'Lauréat.GarantiesFinancières.Query.ConsulterGarantiesFinancièresActuelles',
+            data: {
+              identifiantProjetValue: identifiantProjet.formatter(),
+            },
           },
-        });
+        );
 
       assert(Option.isSome(actualReadModel), 'Pas de garanties financières actuelles trouvées');
 
@@ -49,12 +51,14 @@ Alors(
 
     await waitForExpect(async () => {
       const garantiesFinancièresActuelles =
-        await mediator.send<Lauréat.GarantiesFinancières.ConsulterGarantiesFinancièresQuery>({
-          type: 'Lauréat.GarantiesFinancières.Query.ConsulterGarantiesFinancières',
-          data: {
-            identifiantProjetValue: identifiantProjet.formatter(),
+        await mediator.send<Lauréat.GarantiesFinancières.ConsulterGarantiesFinancièresActuellesQuery>(
+          {
+            type: 'Lauréat.GarantiesFinancières.Query.ConsulterGarantiesFinancièresActuelles',
+            data: {
+              identifiantProjetValue: identifiantProjet.formatter(),
+            },
           },
-        });
+        );
       expect(Option.isNone(garantiesFinancièresActuelles)).to.be.true;
     });
   },
@@ -111,12 +115,14 @@ Alors(
 
     await waitForExpect(async () => {
       const actualReadModel =
-        await mediator.send<Lauréat.GarantiesFinancières.ConsulterGarantiesFinancièresQuery>({
-          type: 'Lauréat.GarantiesFinancières.Query.ConsulterGarantiesFinancières',
-          data: {
-            identifiantProjetValue: identifiantProjet.formatter(),
+        await mediator.send<Lauréat.GarantiesFinancières.ConsulterGarantiesFinancièresActuellesQuery>(
+          {
+            type: 'Lauréat.GarantiesFinancières.Query.ConsulterGarantiesFinancièresActuelles',
+            data: {
+              identifiantProjetValue: identifiantProjet.formatter(),
+            },
           },
-        });
+        );
 
       expect(Option.isSome(actualReadModel)).to.be.true;
       assert(Option.isSome(actualReadModel), 'Pas de garanties financières actuelles trouvées');
@@ -133,12 +139,14 @@ Alors(
 
     await waitForExpect(async () => {
       const actualReadModel =
-        await mediator.send<Lauréat.GarantiesFinancières.ConsulterGarantiesFinancièresQuery>({
-          type: 'Lauréat.GarantiesFinancières.Query.ConsulterGarantiesFinancières',
-          data: {
-            identifiantProjetValue: identifiantProjet.formatter(),
+        await mediator.send<Lauréat.GarantiesFinancières.ConsulterGarantiesFinancièresActuellesQuery>(
+          {
+            type: 'Lauréat.GarantiesFinancières.Query.ConsulterGarantiesFinancièresActuelles',
+            data: {
+              identifiantProjetValue: identifiantProjet.formatter(),
+            },
           },
-        });
+        );
 
       expect(Option.isSome(actualReadModel)).to.be.true;
       assert(Option.isSome(actualReadModel), 'Pas de garanties financières actuelles trouvées');

--- a/packages/specifications/src/projet/lauréat/garantiesFinancières/en-attente/stepDefinitions/garantiesFinancièresEnAttente.then.ts
+++ b/packages/specifications/src/projet/lauréat/garantiesFinancières/en-attente/stepDefinitions/garantiesFinancièresEnAttente.then.ts
@@ -3,6 +3,7 @@ import { assert, expect } from 'chai';
 import { mediator } from 'mediateur';
 
 import type { IdentifiantProjet, Lauréat } from '@potentiel-domain/projet';
+import { Option } from '@potentiel-libraries/monads';
 
 import { waitForExpect } from '#helpers';
 import type { PotentielWorld } from '../../../../../potentiel.world.js';
@@ -47,13 +48,16 @@ Alors(
     const { identifiantProjet } = this.lauréatWorld;
 
     await waitForExpect(async () => {
-      const actual = await récupérerGarantiesFinancièresEnAttente.call(this, identifiantProjet);
+      const actual = await récupérerGarantiesFinancièresEnAttenteDansLaListe.call(
+        this,
+        identifiantProjet,
+      );
       expect(actual).to.be.undefined;
     });
   },
 );
 
-async function récupérerGarantiesFinancièresEnAttente(
+async function récupérerGarantiesFinancièresEnAttenteDansLaListe(
   this: PotentielWorld,
   identifiantProjet: IdentifiantProjet.ValueType,
 ) {
@@ -75,22 +79,50 @@ async function vérifierGarantiesFinancièresAttendues(
   dateLimiteSoumission?: string,
 ) {
   await waitForExpect(async () => {
-    const actualReadModel = await récupérerGarantiesFinancièresEnAttente.call(
+    const actuelReadModelForLister = await récupérerGarantiesFinancièresEnAttenteDansLaListe.call(
       this,
       identifiantProjet,
     );
 
-    assert(actualReadModel, 'Aucune garantie financière en attente trouvée pour le projet');
-    assert(actualReadModel.motif, 'Le motif des garanties financières en attente doit être défini');
-    expect(actualReadModel.motif.formatter()).to.equal(motif);
+    assert(
+      actuelReadModelForLister,
+      'Aucune garantie financière en attente trouvée pour le projet',
+    );
+    assert(
+      actuelReadModelForLister.motif,
+      'Le motif des garanties financières en attente doit être défini',
+    );
+    expect(actuelReadModelForLister.motif.formatter()).to.equal(motif);
 
     if (dateLimiteSoumission) {
       assert(
-        actualReadModel.dateLimiteSoumission,
+        actuelReadModelForLister.dateLimiteSoumission,
         'La date limite de soumission des garanties financières en attente doit être définie',
       );
 
-      expect(actualReadModel.dateLimiteSoumission.formatter()).to.equal(
+      expect(actuelReadModelForLister.dateLimiteSoumission.formatter()).to.equal(
+        new Date(dateLimiteSoumission).toISOString(),
+      );
+    }
+
+    const actualReadModelForConsulter =
+      await mediator.send<Lauréat.GarantiesFinancières.ConsulterGarantiesFinancièresEnAttenteQuery>(
+        {
+          type: 'Lauréat.GarantiesFinancières.Query.ConsulterGarantiesFinancièresEnAttente',
+          data: {
+            identifiantProjetValue: identifiantProjet.formatter(),
+          },
+        },
+      );
+
+    assert(
+      Option.isSome(actualReadModelForConsulter),
+      'Aucune garantie financière en attente trouvée pour le projet lors de la consultation',
+    );
+    expect(actualReadModelForConsulter.motifEnAttente.motif).to.equal(motif);
+
+    if (dateLimiteSoumission) {
+      expect(actualReadModelForConsulter.dateLimiteSoumission.formatter()).to.equal(
         new Date(dateLimiteSoumission).toISOString(),
       );
     }


### PR DESCRIPTION
Sur la page d'un projet, nous n'avions plus l'info concernant les GF en attente (+ motif en attente).
La query actuelle consulterGarantiesFinancières dans le sous domaine GF/actuelles ne retournait jamais de GF dans le cas de GF en attente, c'est la raison pour laquelle nous n'avions jamais de motif de GF en attente. 
J'ai donc ajouté une nouvelle query pour distinguer les deux cas : consulterGFActuelles, consulterGFEnAttente (d'ailleurs la permission pour cette seconde query existait déjà).
