### PR TITLE
✨ Ajout de l'operateur PG between

### DIFF
--- a/packages/domain/entity/src/where/between.ts
+++ b/packages/domain/entity/src/where/between.ts
@@ -1,0 +1,14 @@
+import type { BetweenCondition, WhereCondition } from '../whereOptions.js';
+
+export const between = <T>(
+  value: BetweenCondition<T>['value'] | undefined,
+): WhereCondition<T> | undefined => {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  return {
+    operator: 'between' as const,
+    value,
+  } satisfies BetweenCondition<T>;
+};

--- a/packages/domain/entity/src/where/index.ts
+++ b/packages/domain/entity/src/where/index.ts
@@ -1,3 +1,4 @@
+export * from './between.js';
 export * from './equal.js';
 export * from './equalNull.js';
 export * from './greaterOrEqual.js';

--- a/packages/domain/entity/src/where/matchAny.ts
+++ b/packages/domain/entity/src/where/matchAny.ts
@@ -11,5 +11,6 @@ export const matchAny = <T>(
   return {
     operator: 'matchAny' as const,
     value,
+    multiple: true,
   } satisfies MatchAnyWhereCondition<T>;
 };

--- a/packages/domain/entity/src/where/notMatchAny.ts
+++ b/packages/domain/entity/src/where/notMatchAny.ts
@@ -11,5 +11,6 @@ export const notMatchAny = <T>(
   return {
     operator: 'notMatchAny' as const,
     value,
+    multiple: true,
   } satisfies NotMatchAnyWhereCondition<T>;
 };

--- a/packages/domain/entity/src/whereOptions.ts
+++ b/packages/domain/entity/src/whereOptions.ts
@@ -3,10 +3,12 @@ export type NotEqualWhereCondition<T> = { operator: 'notEqual'; value: T };
 
 export type MatchAnyWhereCondition<T> = {
   operator: 'matchAny';
+  multiple: true;
   value: Array<T> | ReadonlyArray<T>;
 };
 export type NotMatchAnyWhereCondition<T> = {
   operator: 'notMatchAny';
+  multiple: true;
   value: Array<T> | ReadonlyArray<T>;
 };
 
@@ -28,6 +30,7 @@ export type NotEqualNullWhereCondition = { operator: 'notEqualNull' };
 
 export type LessOrEqualCondition<T> = { operator: 'lessOrEqual'; value: T };
 export type GreaterOrEqualCondition<T> = { operator: 'greaterOrEqual'; value: T };
+export type BetweenCondition<T> = { operator: 'between'; value: [T, T] };
 
 export type EmptyArrayCondition = { operator: 'emptyArray' };
 
@@ -42,6 +45,7 @@ export type WhereCondition<T = unknown> =
   | NotEqualNullWhereCondition
   | LessOrEqualCondition<T>
   | GreaterOrEqualCondition<T>
+  | BetweenCondition<T>
   | IncludeWhereCondition<T>
   | NotIncludeWhereCondition<T>
   | EmptyArrayCondition;

--- a/packages/infrastructure/pg-projection-read/src/getWhereClause.ts
+++ b/packages/infrastructure/pg-projection-read/src/getWhereClause.ts
@@ -11,7 +11,7 @@ import type {
   WhereOptions,
 } from '@potentiel-domain/entity';
 
-type Condition = { name: string; value?: unknown; operator: WhereOperator };
+type Condition = { name: string; value: unknown; operator: WhereOperator; multiple?: boolean };
 
 type GetWhereClauseOptions = {
   key: EqualWhereCondition<string> | LikeWhereCondition;
@@ -63,7 +63,17 @@ const buildWhereClause = (
     // - the key always being the first where condition
     ['', 2 + startIndex] as [string, number],
   );
-  return [sqlClause, conditions.map(({ value }) => value).filter((value) => value !== undefined)];
+  const values = conditions.reduce((prev, { value, multiple }) => {
+    if (value) {
+      if (Array.isArray(value) && !multiple) {
+        prev.push(...value);
+      } else {
+        prev.push(value);
+      }
+    }
+    return prev;
+  }, [] as unknown[]);
+  return [sqlClause, values];
 };
 
 const buildJoinWhereClause = (
@@ -102,6 +112,10 @@ const mapToConditions = (flattenWhere: Record<string, unknown>): Array<Condition
           const name = key.replace('.operator', '');
           prev[name] ??= { name };
           prev[name].operator = value as WhereOperator | undefined;
+        } else if (key.endsWith('.multiple')) {
+          const name = key.replace('.multiple', '');
+          prev[name] ??= { name };
+          prev[name].multiple = value as boolean;
         } else {
           const name = key.replace('.value', '');
           prev[name] ??= { name };
@@ -138,6 +152,7 @@ const mapOperatorToSqlCondition = (
     .with('notMatchAny', () => [`${field} <> ALL($${index})`, index + 1])
     .with('lessOrEqual', () => [`${field} <= $${index}`, index + 1])
     .with('greaterOrEqual', () => [`${field} >= $${index}`, index + 1])
+    .with('between', () => [`${field} BETWEEN $${index} AND $${index + 1}`, index + 2])
     .with('equalNull', () => [`${field} IS NULL`, index])
     .with('notEqualNull', () => [`${field} IS NOT NULL`, index])
     .with('include', () => [`${objectField} ? $${index}`, index])

--- a/packages/infrastructure/pg-projection-read/src/listProjection.test.ts
+++ b/packages/infrastructure/pg-projection-read/src/listProjection.test.ts
@@ -516,6 +516,46 @@ describe('listProjection', () => {
     actual.items.should.have.deep.members(expected.items);
   });
 
+  it('should find projections by their key and filter them according to a between condition option', async () => {
+    const fakeDataExcludedBefore = {
+      data: {
+        value: '2023-11-26T00:00:00.000Z',
+        name: 'lessThanTest',
+      },
+    };
+    const fakeDataExcludedAfter = {
+      data: {
+        value: '2023-11-30T00:00:00.000Z',
+        name: 'lessThanTest',
+      },
+    };
+
+    const betweenCaseFakeData = {
+      data: {
+        value: '2023-11-28T00:00:00.000Z',
+        name: 'lessThanTest',
+      },
+    };
+
+    await insertFakeData(betweenCaseFakeData);
+    await insertFakeData(fakeDataExcludedBefore);
+    await insertFakeData(fakeDataExcludedAfter);
+
+    const actual = await listProjection<FakeProjection1>(category1, {
+      where: {
+        data: {
+          value: Where.between(['2023-11-27T00:00:00.000Z', '2023-11-29T00:00:00.000Z']),
+        },
+      },
+    });
+
+    const expected = mapToListResultItems([betweenCaseFakeData]);
+
+    actual.should.have.all.keys(Object.keys(expected));
+
+    actual.items.should.have.deep.members(expected.items);
+  });
+
   it('should find projections by their key and filter them according to a is not null condition option', async () => {
     const nullCaseFakeData = {
       data: {


### PR DESCRIPTION
La particularité de cet opérateur est qu'il requiert deux valeurs, mais ne peut être passé en array (comme pour `matchAny`). On doit donc distinguer les opérateurs qui passent un array.