### PR TITLE
🐛 Fix value "false" in filters

### DIFF
--- a/packages/infrastructure/pg-projection-read/src/getWhereClause.ts
+++ b/packages/infrastructure/pg-projection-read/src/getWhereClause.ts
@@ -64,7 +64,7 @@ const buildWhereClause = (
     ['', 2 + startIndex] as [string, number],
   );
   const values = conditions.reduce((prev, { value, multiple }) => {
-    if (value) {
+    if (value !== undefined && value !== null) {
       if (Array.isArray(value) && !multiple) {
         prev.push(...value);
       } else {


### PR DESCRIPTION
Quand on veut filtrer sur le filtre Recandidaturen "sans recandidature" on a une 500 car la valeur "false" passée est pas acceptée dans le getWhereClause. Ce qu'on veut c'est vérifier qu'on a bien une valeur, "false" est étant une dans le cadre d'un filtrage de données


<img width="1243" height="775" alt="Capture d’écran 2026-06-16 à 10 33 09" src="https://github.com/user-attachments/assets/19c2ed48-f5f1-4dcd-a515-439f313fc27e" />

<img width="1255" height="626" alt="Capture d’écran 2026-06-16 à 10 33 15" src="https://github.com/user-attachments/assets/5b21f0bb-3cc1-4484-8884-a1e28cc155ef" />

