### PR TITLE
♻️ Date limite transmission DCR

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23094,6 +23094,7 @@
       "dependencies": {
         "@potentiel-domain/appel-offre": "*",
         "@potentiel-domain/common": "*",
+        "@potentiel-domain/inmemory-referential": "*",
         "@potentiel-domain/projet": "*",
         "@potentiel-infrastructure/pg-event-sourcing": "*",
         "@potentiel-libraries/monads": "*",

--- a/packages/applications/cli/src/commands/tache-planifiee/executer.ts
+++ b/packages/applications/cli/src/commands/tache-planifiee/executer.ts
@@ -54,12 +54,14 @@ export class Executer extends Command {
 
   async run() {
     const { APPLICATION_STAGE } = envSchema.parse(process.env);
-    if (!['production'].includes(APPLICATION_STAGE)) {
-      console.log(`This job can't be executed on ${APPLICATION_STAGE} environment`);
+    const { flags } = await this.parse(Executer);
+    if (!flags.date && APPLICATION_STAGE !== 'production') {
+      console.log(
+        `This job only runs in production. For other environments, please specify a date with the --date flag.`,
+      );
       return;
     }
 
-    const { flags } = await this.parse(Executer);
     const àExécuterLe = DateTime.convertirEnValueType(new Date(flags.date));
     const logger = getLogger('Scheduler');
     logger.info('Lancement du script...');

--- a/packages/applications/document-builder/package.json
+++ b/packages/applications/document-builder/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@potentiel-domain/appel-offre": "*",
     "@potentiel-domain/common": "*",
+    "@potentiel-domain/inmemory-referential": "*",
     "@potentiel-domain/projet": "*",
     "@potentiel-infrastructure/pg-event-sourcing": "*",
     "@potentiel-libraries/monads": "*",

--- a/packages/applications/document-builder/src/candidature/attestation/attestation.stories.tsx
+++ b/packages/applications/document-builder/src/candidature/attestation/attestation.stories.tsx
@@ -9,12 +9,13 @@ import { makeCertificate } from './makeCertificate.js';
 
 const meta = {
   title: 'Attestations PDF',
-  component: ({ appelOffre, isClasse, periode, ...customData }) => {
+  component: ({ appelOffre, isClasse, periode, typeActionnariat, ...customData }) => {
     const data: AttestationCandidatureOptions = {
-      ...fakeProject(appelOffre, periode),
+      ...fakeProject(appelOffre, periode, typeActionnariat),
       ...customData,
       isClasse,
     };
+
     return makeCertificate({
       data,
       validateur,
@@ -26,6 +27,7 @@ const meta = {
       control: 'select',
       options: appelsOffreData.map((x) => x.id),
     },
+
     periode: {
       control: 'select',
       options: [...new Set(appelsOffreData.flatMap((x) => x.periodes.map((p) => p.id)))],
@@ -47,11 +49,18 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-const fakeProject = (appelOffreId: string, périodeId?: string): AttestationCandidatureOptions => {
+const fakeProject = (
+  appelOffreId: string,
+  périodeId: string | undefined,
+  typeActionnariat: Candidature.TypeActionnariat.RawType | undefined,
+): AttestationCandidatureOptions => {
   const appelOffre = appelsOffreData.find((x) => x.id === appelOffreId)!;
   const période =
     appelOffre.periodes.find((x) => x.id === périodeId) ??
     appelOffre.periodes[appelOffre.periodes.length - 1];
+  const actionnariat = typeActionnariat
+    ? Candidature.TypeActionnariat.convertirEnValueType(typeActionnariat)
+    : undefined;
 
   const data = {
     appelOffre,
@@ -60,10 +69,6 @@ const fakeProject = (appelOffreId: string, périodeId?: string): AttestationCand
     isClasse: true,
     prixReference: 42,
     evaluationCarbone: 42,
-    isFinancementParticipatif: true,
-    isInvestissementParticipatif: true,
-    isGouvernancePartagée: true,
-    isFinancementCollectif: true,
     engagementFournitureDePuissanceAlaPointe: true,
     motifsElimination: 'motifsElimination',
     notifiedOn: Date.now(),
@@ -83,15 +88,20 @@ const fakeProject = (appelOffreId: string, périodeId?: string): AttestationCand
     estDansLeVolumeRéservé: undefined,
   } satisfies Partial<AttestationCandidatureOptions>;
 
-  if (!période.certificateTemplate || période.certificateTemplate === 'ppe2.v2') {
+  if (période.certificateTemplate === 'cre4.v0' || période.certificateTemplate === 'cre4.v1') {
     return {
-      template: 'ppe2.v2',
-      logo: période.certificateTemplate === 'ppe2.v2' ? période.logo : 'MCE',
+      template: période.certificateTemplate,
+      isFinancementParticipatif: actionnariat?.estFinancementParticipatif() ?? false,
+      isInvestissementParticipatif: actionnariat?.estInvestissementParticipatif() ?? false,
       ...data,
     };
   }
+
   return {
-    template: période.certificateTemplate,
+    template: période.certificateTemplate ?? 'ppe2.v2',
+    logo: période.certificateTemplate === 'ppe2.v2' ? période.logo : 'MCE',
+    isFinancementCollectif: actionnariat?.estFinancementCollectif() ?? false,
+    isGouvernancePartagée: actionnariat?.estGouvernancePartagée() ?? false,
     ...data,
   };
 };

--- a/packages/applications/document-builder/src/candidature/attestation/cre4/v0/makeCertificate.tsx
+++ b/packages/applications/document-builder/src/candidature/attestation/cre4/v0/makeCertificate.tsx
@@ -6,12 +6,12 @@ import type { AppelOffre } from '@potentiel-domain/appel-offre';
 
 import type { AttestationCRE4Options } from '../../AttestationCandidatureOptions.js';
 import { formatDateForPdf } from '../../helpers/formatDateForPdf.js';
-import { formatNumber } from '../../helpers/index.js';
+import { formatNumber, formatterEnToutesLettres } from '../../helpers/index.js';
 import { type Footnote, makeAddFootnote } from '../../helpers/makeAddFootnotes.js';
 
 const Laureat = (project: AttestationCRE4Options) => {
   const { appelOffre, période, famille } = project;
-  const { delaiDcrEnMois } = période;
+  const délaiDCREnMois = période.délaiDCR ?? appelOffre.délaiDCR;
 
   const objet = `Désignation des lauréats de la ${période.title} période de l'appel d'offres ${période.cahierDesCharges.référence} ${appelOffre.title}`;
 
@@ -103,7 +103,7 @@ const Laureat = (project: AttestationCRE4Options) => {
         }}
       >
         - si ce n’est déjà fait, déposer une demande complète de raccordement dans les{' '}
-        {delaiDcrEnMois.texte} ({delaiDcrEnMois.valeur}) mois à compter de la présente notification
+        {formatterEnToutesLettres(délaiDCREnMois.grd)} mois à compter de la présente notification
         {addFootNote(appelOffre.renvoiDemandeCompleteRaccordement)}.
       </Text>
       {garantieFinanciereEnMois ? (
@@ -115,12 +115,12 @@ const Laureat = (project: AttestationCRE4Options) => {
             marginLeft: 20,
           }}
         >
-          - constituer une garantie d’exécution dans un délai de deux (2) mois à compter de la
-          présente notification. Les candidats retenus n’ayant pas adressé au préfet de région du
-          site d’implantation l’attestation de constitution de garantie financière dans le délai
-          prévu feront l’objet d’une procédure de mise en demeure. En l’absence d’exécution dans un
-          délai d’un mois après réception de la mise en demeure, le candidat pourra faire l’objet
-          d’un retrait de la présente décision le désignant lauréat
+          - constituer une garantie d’exécution dans un délai de {formatterEnToutesLettres(2)} mois
+          à compter de la présente notification. Les candidats retenus n’ayant pas adressé au préfet
+          de région du site d’implantation l’attestation de constitution de garantie financière dans
+          le délai prévu feront l’objet d’une procédure de mise en demeure. En l’absence d’exécution
+          dans un délai d’un mois après réception de la mise en demeure, le candidat pourra faire
+          l’objet d’un retrait de la présente décision le désignant lauréat
           <Text>
             {addFootNote(
               appelOffre.garantiesFinancières.renvoiRetraitDesignationGarantieFinancieres,

--- a/packages/applications/document-builder/src/candidature/attestation/cre4/v0/makeCertificate.tsx
+++ b/packages/applications/document-builder/src/candidature/attestation/cre4/v0/makeCertificate.tsx
@@ -3,6 +3,7 @@ import type React from 'react';
 import type { JSX } from 'react';
 
 import type { AppelOffre } from '@potentiel-domain/appel-offre';
+import { CahierDesCharges } from '@potentiel-domain/projet';
 
 import type { AttestationCRE4Options } from '../../AttestationCandidatureOptions.js';
 import { formatDateForPdf } from '../../helpers/formatDateForPdf.js';
@@ -11,7 +12,13 @@ import { type Footnote, makeAddFootnote } from '../../helpers/makeAddFootnotes.j
 
 const Laureat = (project: AttestationCRE4Options) => {
   const { appelOffre, période, famille } = project;
-  const délaiDCREnMois = période.délaiDCR ?? appelOffre.délaiDCR;
+  const cahierDesCharges = CahierDesCharges.bind({
+    ...project,
+    // pas de CDC modificatif possible à la désignation
+    cahierDesChargesModificatif: undefined,
+  });
+
+  const délaiDCREnMois = cahierDesCharges.getDélaiDCR();
 
   const objet = `Désignation des lauréats de la ${période.title} période de l'appel d'offres ${période.cahierDesCharges.référence} ${appelOffre.title}`;
 

--- a/packages/applications/document-builder/src/candidature/attestation/cre4/v0/makeCertificate.tsx
+++ b/packages/applications/document-builder/src/candidature/attestation/cre4/v0/makeCertificate.tsx
@@ -7,7 +7,7 @@ import { CahierDesCharges } from '@potentiel-domain/projet';
 
 import type { AttestationCRE4Options } from '../../AttestationCandidatureOptions.js';
 import { formatDateForPdf } from '../../helpers/formatDateForPdf.js';
-import { formatNumber, formatterEnToutesLettres } from '../../helpers/index.js';
+import { formatNumber, formatterNombreEnToutesLettres } from '../../helpers/index.js';
 import { type Footnote, makeAddFootnote } from '../../helpers/makeAddFootnotes.js';
 
 const Laureat = (project: AttestationCRE4Options) => {
@@ -110,7 +110,8 @@ const Laureat = (project: AttestationCRE4Options) => {
         }}
       >
         - si ce n’est déjà fait, déposer une demande complète de raccordement dans les{' '}
-        {formatterEnToutesLettres(délaiDCREnMois.grd)} mois à compter de la présente notification
+        {formatterNombreEnToutesLettres(délaiDCREnMois.grd)} mois à compter de la présente
+        notification
         {addFootNote(appelOffre.renvoiDemandeCompleteRaccordement)}.
       </Text>
       {garantieFinanciereEnMois ? (
@@ -122,12 +123,12 @@ const Laureat = (project: AttestationCRE4Options) => {
             marginLeft: 20,
           }}
         >
-          - constituer une garantie d’exécution dans un délai de {formatterEnToutesLettres(2)} mois
-          à compter de la présente notification. Les candidats retenus n’ayant pas adressé au préfet
-          de région du site d’implantation l’attestation de constitution de garantie financière dans
-          le délai prévu feront l’objet d’une procédure de mise en demeure. En l’absence d’exécution
-          dans un délai d’un mois après réception de la mise en demeure, le candidat pourra faire
-          l’objet d’un retrait de la présente décision le désignant lauréat
+          - constituer une garantie d’exécution dans un délai de {formatterNombreEnToutesLettres(2)}{' '}
+          mois à compter de la présente notification. Les candidats retenus n’ayant pas adressé au
+          préfet de région du site d’implantation l’attestation de constitution de garantie
+          financière dans le délai prévu feront l’objet d’une procédure de mise en demeure. En
+          l’absence d’exécution dans un délai d’un mois après réception de la mise en demeure, le
+          candidat pourra faire l’objet d’un retrait de la présente décision le désignant lauréat
           <Text>
             {addFootNote(
               appelOffre.garantiesFinancières.renvoiRetraitDesignationGarantieFinancieres,

--- a/packages/applications/document-builder/src/candidature/attestation/cre4/v1/makeCertificate.tsx
+++ b/packages/applications/document-builder/src/candidature/attestation/cre4/v1/makeCertificate.tsx
@@ -4,6 +4,7 @@ import type { JSX } from 'react';
 
 import type { AppelOffre } from '@potentiel-domain/appel-offre';
 import { nombresEnToutesLettres } from '@potentiel-domain/inmemory-referential';
+import { CahierDesCharges } from '@potentiel-domain/projet';
 
 import type { AttestationCRE4Options } from '../../AttestationCandidatureOptions.js';
 import { formatDateForPdf } from '../../helpers/formatDateForPdf.js';
@@ -12,7 +13,13 @@ import { type Footnote, makeAddFootnote } from '../../helpers/makeAddFootnotes.j
 
 const Laureat = (project: AttestationCRE4Options) => {
   const { appelOffre, période, famille } = project;
-  const délaiDcrEnMois = période.délaiDCR || appelOffre.délaiDCR;
+  const cahierDesCharges = CahierDesCharges.bind({
+    ...project,
+    // pas de CDC modificatif possible à la désignation
+    cahierDesChargesModificatif: undefined,
+  });
+  const délaiDCREnMois = cahierDesCharges.getDélaiDCR();
+
   const objet = `Désignation des lauréats de la ${période.title} période de l'appel d'offres ${période.cahierDesCharges.référence} ${appelOffre.title}`;
 
   const soumisAuxGarantiesFinancieres =

--- a/packages/applications/document-builder/src/candidature/attestation/cre4/v1/makeCertificate.tsx
+++ b/packages/applications/document-builder/src/candidature/attestation/cre4/v1/makeCertificate.tsx
@@ -3,15 +3,16 @@ import type React from 'react';
 import type { JSX } from 'react';
 
 import type { AppelOffre } from '@potentiel-domain/appel-offre';
+import { nombresEnToutesLettres } from '@potentiel-domain/inmemory-referential';
 
 import type { AttestationCRE4Options } from '../../AttestationCandidatureOptions.js';
 import { formatDateForPdf } from '../../helpers/formatDateForPdf.js';
-import { formatNumber } from '../../helpers/index.js';
+import { formatNumber, formatterEnToutesLettres } from '../../helpers/index.js';
 import { type Footnote, makeAddFootnote } from '../../helpers/makeAddFootnotes.js';
 
 const Laureat = (project: AttestationCRE4Options) => {
   const { appelOffre, période, famille } = project;
-  const { delaiDcrEnMois } = période;
+  const délaiDcrEnMois = période.délaiDCR || appelOffre.délaiDCR;
   const objet = `Désignation des lauréats de la ${période.title} période de l'appel d'offres ${période.cahierDesCharges.référence} ${appelOffre.title}`;
 
   const soumisAuxGarantiesFinancieres =
@@ -99,10 +100,10 @@ const Laureat = (project: AttestationCRE4Options) => {
         }}
       >
         - si ce n’est déjà fait, déposer une demande complète de raccordement dans les{' '}
-        {delaiDcrEnMois.texte} ({delaiDcrEnMois.valeur}) mois à compter de la présente notification
+        {formatterEnToutesLettres(délaiDcrEnMois.grd)} mois à compter de la présente notification
         {addFootNote(appelOffre.renvoiDemandeCompleteRaccordement)}
         {appelOffre.typeAppelOffre === 'eolien'
-          ? ` ou dans les ${delaiDcrEnMois.texte} mois suivant la délivrance de l’autorisation environnementale pour les cas de candidature sans autorisation environnementale`
+          ? ` ou dans les ${nombresEnToutesLettres[délaiDcrEnMois.grd]} mois suivant la délivrance de l’autorisation environnementale pour les cas de candidature sans autorisation environnementale`
           : ''}
         ;
       </Text>
@@ -117,12 +118,12 @@ const Laureat = (project: AttestationCRE4Options) => {
           }}
         >
           - constituer une garantie {appelOffre.typeAppelOffre === 'eolien' ? 'bancaire ' : ''}
-          d’exécution dans un délai de deux (2) mois à compter de la présente notification. Les
-          candidats retenus n’ayant pas adressé au préfet de région du site d’implantation
-          l’attestation de constitution de garantie financière dans le délai prévu feront l’objet
-          d’une procédure de mise en demeure. En l’absence d’exécution dans un délai d’un mois après
-          réception de la mise en demeure, le candidat pourra faire l’objet d’un retrait de la
-          présente décision le désignant lauréat
+          d’exécution dans un délai de {formatterEnToutesLettres(2)} mois à compter de la présente
+          notification. Les candidats retenus n’ayant pas adressé au préfet de région du site
+          d’implantation l’attestation de constitution de garantie financière dans le délai prévu
+          feront l’objet d’une procédure de mise en demeure. En l’absence d’exécution dans un délai
+          d’un mois après réception de la mise en demeure, le candidat pourra faire l’objet d’un
+          retrait de la présente décision le désignant lauréat
           <Text>
             {addFootNote(
               appelOffre.garantiesFinancières.renvoiRetraitDesignationGarantieFinancieres,

--- a/packages/applications/document-builder/src/candidature/attestation/cre4/v1/makeCertificate.tsx
+++ b/packages/applications/document-builder/src/candidature/attestation/cre4/v1/makeCertificate.tsx
@@ -8,7 +8,7 @@ import { CahierDesCharges } from '@potentiel-domain/projet';
 
 import type { AttestationCRE4Options } from '../../AttestationCandidatureOptions.js';
 import { formatDateForPdf } from '../../helpers/formatDateForPdf.js';
-import { formatNumber, formatterEnToutesLettres } from '../../helpers/index.js';
+import { formatNumber, formatterNombreEnToutesLettres } from '../../helpers/index.js';
 import { type Footnote, makeAddFootnote } from '../../helpers/makeAddFootnotes.js';
 
 const Laureat = (project: AttestationCRE4Options) => {
@@ -107,7 +107,8 @@ const Laureat = (project: AttestationCRE4Options) => {
         }}
       >
         - si ce n’est déjà fait, déposer une demande complète de raccordement dans les{' '}
-        {formatterEnToutesLettres(délaiDCREnMois.grd)} mois à compter de la présente notification
+        {formatterNombreEnToutesLettres(délaiDCREnMois.grd)} mois à compter de la présente
+        notification
         {addFootNote(appelOffre.renvoiDemandeCompleteRaccordement)}
         {appelOffre.typeAppelOffre === 'eolien'
           ? ` ou dans les ${nombresEnToutesLettres[délaiDCREnMois.grd]} mois suivant la délivrance de l’autorisation environnementale pour les cas de candidature sans autorisation environnementale`
@@ -125,12 +126,12 @@ const Laureat = (project: AttestationCRE4Options) => {
           }}
         >
           - constituer une garantie {appelOffre.typeAppelOffre === 'eolien' ? 'bancaire ' : ''}
-          d’exécution dans un délai de {formatterEnToutesLettres(2)} mois à compter de la présente
-          notification. Les candidats retenus n’ayant pas adressé au préfet de région du site
-          d’implantation l’attestation de constitution de garantie financière dans le délai prévu
-          feront l’objet d’une procédure de mise en demeure. En l’absence d’exécution dans un délai
-          d’un mois après réception de la mise en demeure, le candidat pourra faire l’objet d’un
-          retrait de la présente décision le désignant lauréat
+          d’exécution dans un délai de {formatterNombreEnToutesLettres(2)} mois à compter de la
+          présente notification. Les candidats retenus n’ayant pas adressé au préfet de région du
+          site d’implantation l’attestation de constitution de garantie financière dans le délai
+          prévu feront l’objet d’une procédure de mise en demeure. En l’absence d’exécution dans un
+          délai d’un mois après réception de la mise en demeure, le candidat pourra faire l’objet
+          d’un retrait de la présente décision le désignant lauréat
           <Text>
             {addFootNote(
               appelOffre.garantiesFinancières.renvoiRetraitDesignationGarantieFinancieres,

--- a/packages/applications/document-builder/src/candidature/attestation/cre4/v1/makeCertificate.tsx
+++ b/packages/applications/document-builder/src/candidature/attestation/cre4/v1/makeCertificate.tsx
@@ -107,10 +107,10 @@ const Laureat = (project: AttestationCRE4Options) => {
         }}
       >
         - si ce n’est déjà fait, déposer une demande complète de raccordement dans les{' '}
-        {formatterEnToutesLettres(délaiDcrEnMois.grd)} mois à compter de la présente notification
+        {formatterEnToutesLettres(délaiDCREnMois.grd)} mois à compter de la présente notification
         {addFootNote(appelOffre.renvoiDemandeCompleteRaccordement)}
         {appelOffre.typeAppelOffre === 'eolien'
-          ? ` ou dans les ${nombresEnToutesLettres[délaiDcrEnMois.grd]} mois suivant la délivrance de l’autorisation environnementale pour les cas de candidature sans autorisation environnementale`
+          ? ` ou dans les ${nombresEnToutesLettres[délaiDCREnMois.grd]} mois suivant la délivrance de l’autorisation environnementale pour les cas de candidature sans autorisation environnementale`
           : ''}
         ;
       </Text>

--- a/packages/applications/document-builder/src/candidature/attestation/helpers/formatNumber.ts
+++ b/packages/applications/document-builder/src/candidature/attestation/helpers/formatNumber.ts
@@ -7,5 +7,5 @@ export const formatNumber = (n: number, precisionOverride?: number) => {
 };
 
 // Retourne le nombre en toutes lettres, suivi de sa valeur entre parenthèses
-export const formatterEnToutesLettres = (value: AppelOffre.Nombres) =>
+export const formatterNombreEnToutesLettres = (value: AppelOffre.Nombres) =>
   `${nombresEnToutesLettres[value]} (${value})`;

--- a/packages/applications/document-builder/src/candidature/attestation/helpers/formatNumber.ts
+++ b/packages/applications/document-builder/src/candidature/attestation/helpers/formatNumber.ts
@@ -1,4 +1,11 @@
+import type { AppelOffre } from '@potentiel-domain/appel-offre';
+import { nombresEnToutesLettres } from '@potentiel-domain/inmemory-referential';
+
 export const formatNumber = (n: number, precisionOverride?: number) => {
   const precision = precisionOverride || 100;
   return (Math.round(n * precision) / precision).toString().replace('.', ',');
 };
+
+// Retourne le nombre en toutes lettres, suivi de sa valeur entre parenthèses
+export const formatterEnToutesLettres = (value: AppelOffre.Nombres) =>
+  `${nombresEnToutesLettres[value]} (${value})`;

--- a/packages/applications/document-builder/src/candidature/attestation/ppe2/v1/Laureat.tsx
+++ b/packages/applications/document-builder/src/candidature/attestation/ppe2/v1/Laureat.tsx
@@ -1,9 +1,10 @@
 import { Text, View } from '@react-pdf/renderer';
 
+import { nombresEnToutesLettres } from '@potentiel-domain/inmemory-referential';
 import type { CahierDesCharges } from '@potentiel-domain/projet';
 
 import type { AttestationPPE2Options } from '../../AttestationCandidatureOptions.js';
-import { formatNumber } from '../../helpers/index.js';
+import { formatNumber, formatterEnToutesLettres } from '../../helpers/index.js';
 import { type Footnote, makeAddFootnote } from '../../helpers/makeAddFootnotes.js';
 
 type MakeLaureatProps = {
@@ -14,7 +15,7 @@ type MakeLaureatProps = {
 export const buildLauréat = ({ project, cahierDesCharges }: MakeLaureatProps) => {
   const { appelOffre, période } = project;
   const { soumisAuxGarantiesFinancieres } = appelOffre.garantiesFinancières || {};
-  const { delaiDcrEnMois } = période;
+  const délaiDCREnMois = cahierDesCharges.getDélaiDCR();
   const footnotes: Array<Footnote> = [];
   const addFootNote = makeAddFootnote(footnotes);
 
@@ -86,11 +87,11 @@ export const buildLauréat = ({ project, cahierDesCharges }: MakeLaureatProps) =
             }}
           >
             - si ce n’est déjà fait, déposer une demande complète de raccordement dans les{' '}
-            {delaiDcrEnMois.texte} ({delaiDcrEnMois.valeur}) mois à compter de la présente
+            {formatterEnToutesLettres(délaiDCREnMois.grd)} mois à compter de la présente
             notification
             {addFootNote(appelOffre.renvoiDemandeCompleteRaccordement)}
             {appelOffre.typeAppelOffre === 'eolien' &&
-              ` ou dans les ${delaiDcrEnMois.texte} mois suivant la délivrance de l’autorisation environnementale pour les cas de candidature sans autorisation environnementale`}
+              ` ou dans les ${nombresEnToutesLettres[délaiDCREnMois.grd]} mois suivant la délivrance de l’autorisation environnementale pour les cas de candidature sans autorisation environnementale`}
             ;
           </Text>
 

--- a/packages/applications/document-builder/src/candidature/attestation/ppe2/v1/Laureat.tsx
+++ b/packages/applications/document-builder/src/candidature/attestation/ppe2/v1/Laureat.tsx
@@ -4,7 +4,7 @@ import { nombresEnToutesLettres } from '@potentiel-domain/inmemory-referential';
 import type { CahierDesCharges } from '@potentiel-domain/projet';
 
 import type { AttestationPPE2Options } from '../../AttestationCandidatureOptions.js';
-import { formatNumber, formatterEnToutesLettres } from '../../helpers/index.js';
+import { formatNumber, formatterNombreEnToutesLettres } from '../../helpers/index.js';
 import { type Footnote, makeAddFootnote } from '../../helpers/makeAddFootnotes.js';
 
 type MakeLaureatProps = {
@@ -87,7 +87,7 @@ export const buildLauréat = ({ project, cahierDesCharges }: MakeLaureatProps) =
             }}
           >
             - si ce n’est déjà fait, déposer une demande complète de raccordement dans les{' '}
-            {formatterEnToutesLettres(délaiDCREnMois.grd)} mois à compter de la présente
+            {formatterNombreEnToutesLettres(délaiDCREnMois.grd)} mois à compter de la présente
             notification
             {addFootNote(appelOffre.renvoiDemandeCompleteRaccordement)}
             {appelOffre.typeAppelOffre === 'eolien' &&

--- a/packages/applications/document-builder/src/candidature/attestation/ppe2/v2/Laureat.tsx
+++ b/packages/applications/document-builder/src/candidature/attestation/ppe2/v2/Laureat.tsx
@@ -1,9 +1,10 @@
 import { Text, View } from '@react-pdf/renderer';
 
+import { nombresEnToutesLettres } from '@potentiel-domain/inmemory-referential';
 import type { CahierDesCharges } from '@potentiel-domain/projet';
 
 import type { AttestationPPE2Options } from '../../AttestationCandidatureOptions.js';
-import { formatNumber } from '../../helpers/index.js';
+import { formatNumber, formatterEnToutesLettres } from '../../helpers/formatNumber.js';
 
 type LaureatProps = {
   project: AttestationPPE2Options;
@@ -12,7 +13,7 @@ type LaureatProps = {
 
 export const buildLauréat = ({ project, cahierDesCharges }: LaureatProps) => {
   const { appelOffre, période } = project;
-  const { delaiDcrEnMois } = période;
+  const délaiDCREnMois = cahierDesCharges.getDélaiDCR();
 
   const paragrapheEngagementIPFPGPFC =
     période.paragrapheEngagementIPFPGPFC ?? appelOffre.paragrapheEngagementIPFPGPFC;
@@ -101,16 +102,18 @@ export const buildLauréat = ({ project, cahierDesCharges }: LaureatProps) => {
 
           <Text>
             - {!appelOffre.dépôtDCRPossibleSeulementAprèsDésignation && `si ce n’est déjà fait, `}
-            déposer une demande complète de raccordement dans les {delaiDcrEnMois.texte} (
-            {delaiDcrEnMois.valeur}) mois à compter de la présente notification
+            déposer une demande complète de raccordement dans les{' '}
+            {formatterEnToutesLettres(délaiDCREnMois.grd)} mois à compter de la présente
+            notification
             {appelOffre.typeAppelOffre === 'eolien' &&
-              ` ou dans les ${delaiDcrEnMois.texte} mois suivant la délivrance de l’autorisation environnementale pour les cas de candidature sans autorisation environnementale`}
+              ` ou dans les ${nombresEnToutesLettres[délaiDCREnMois.grd]} mois suivant la délivrance de l’autorisation environnementale pour les cas de candidature sans autorisation environnementale`}
             &thinsp;;
           </Text>
-          {appelOffre.transmissionAutomatiséeDesDonnéesDeContractualisationAuCocontractant && (
+          {délaiDCREnMois.potentiel && (
             <Text>
               - renseigner dans votre espace Potentiel la référence de l’affaire de raccordement
-              dans les quatre (4) mois à compter de la présente notification&thinsp;;
+              dans les {formatterEnToutesLettres(délaiDCREnMois.potentiel)} mois à compter de la
+              présente notification&thinsp;;
             </Text>
           )}
           {afficherObligationGarantiesFinancières6MoisAprèsAchèvement && (
@@ -140,8 +143,7 @@ export const buildLauréat = ({ project, cahierDesCharges }: LaureatProps) => {
 
           <Text>
             - fournir à EDF
-            {appelOffre.transmissionAutomatiséeDesDonnéesDeContractualisationAuCocontractant &&
-              `, par voie dématérialisée dans votre espace Potentiel,`}{' '}
+            {!!délaiDCREnMois.potentiel && `, par voie dématérialisée dans votre espace Potentiel,`}{' '}
             l’attestation de conformité de l’installation prévue au paragraphe{' '}
             {appelOffre.paragrapheAttestationConformite} du cahier des charges&thinsp;;
           </Text>

--- a/packages/applications/document-builder/src/candidature/attestation/ppe2/v2/Laureat.tsx
+++ b/packages/applications/document-builder/src/candidature/attestation/ppe2/v2/Laureat.tsx
@@ -4,7 +4,7 @@ import { nombresEnToutesLettres } from '@potentiel-domain/inmemory-referential';
 import type { CahierDesCharges } from '@potentiel-domain/projet';
 
 import type { AttestationPPE2Options } from '../../AttestationCandidatureOptions.js';
-import { formatNumber, formatterEnToutesLettres } from '../../helpers/formatNumber.js';
+import { formatNumber, formatterNombreEnToutesLettres } from '../../helpers/formatNumber.js';
 
 type LaureatProps = {
   project: AttestationPPE2Options;
@@ -103,7 +103,7 @@ export const buildLauréat = ({ project, cahierDesCharges }: LaureatProps) => {
           <Text>
             - {!appelOffre.dépôtDCRPossibleSeulementAprèsDésignation && `si ce n’est déjà fait, `}
             déposer une demande complète de raccordement dans les{' '}
-            {formatterEnToutesLettres(délaiDCREnMois.grd)} mois à compter de la présente
+            {formatterNombreEnToutesLettres(délaiDCREnMois.grd)} mois à compter de la présente
             notification
             {appelOffre.typeAppelOffre === 'eolien' &&
               ` ou dans les ${nombresEnToutesLettres[délaiDCREnMois.grd]} mois suivant la délivrance de l’autorisation environnementale pour les cas de candidature sans autorisation environnementale`}
@@ -112,8 +112,8 @@ export const buildLauréat = ({ project, cahierDesCharges }: LaureatProps) => {
           {délaiDCREnMois.potentiel && (
             <Text>
               - renseigner dans votre espace Potentiel la référence de l’affaire de raccordement
-              dans les {formatterEnToutesLettres(délaiDCREnMois.potentiel)} mois à compter de la
-              présente notification&thinsp;;
+              dans les {formatterNombreEnToutesLettres(délaiDCREnMois.potentiel)} mois à compter de
+              la présente notification&thinsp;;
             </Text>
           )}
           {afficherObligationGarantiesFinancières6MoisAprèsAchèvement && (

--- a/packages/applications/document-builder/tsconfig.json
+++ b/packages/applications/document-builder/tsconfig.json
@@ -13,6 +13,9 @@
       "path": "../../domain/common"
     },
     {
+      "path": "../../domain/inmemory-referential"
+    },
+    {
       "path": "../../domain/projet"
     },
     {

--- a/packages/applications/notifications/scripts/build-templates.ts
+++ b/packages/applications/notifications/scripts/build-templates.ts
@@ -24,25 +24,27 @@ const outDirRoot = path.join(__dirname, '../dist/templates');
 const layoutPath = path.join(__dirname, '../src/templates/layouts/email.layout.html');
 
 const extractVariables = (template: string) => {
-  const { body } = Handlebars.parse(template);
-
-  return body.reduce((acc, curr) => {
-    const node = curr as hbs.AST.MustacheStatement;
-    if (node.type !== 'MustacheStatement') {
+  const extractVariablesFromBody = (body: hbs.AST.Statement[]): string[] =>
+    body.reduce((acc, curr) => {
+      const node = curr as hbs.AST.MustacheStatement | hbs.AST.BlockStatement;
+      if (node.type === 'BlockStatement') {
+        acc.push(...extractVariablesFromBody(node.program.body));
+      } else if (node.type !== 'MustacheStatement') {
+        return acc;
+      }
+      if (node.params.length > 0) {
+        acc.push(
+          ...node.params
+            .filter((p) => p.type === 'PathExpression')
+            .map((p) => (p as hbs.AST.PathExpression).original),
+        );
+      } else if (node.path.type === 'PathExpression') {
+        acc.push((node.path as hbs.AST.PathExpression).original);
+      }
       return acc;
-    }
+    }, [] as string[]);
 
-    if (node.params.length > 0) {
-      acc.push(
-        ...node.params
-          .filter((p) => p.type === 'PathExpression')
-          .map((p) => (p as hbs.AST.PathExpression).original),
-      );
-    } else if (node.path.type === 'PathExpression') {
-      acc.push((node.path as hbs.AST.PathExpression).original);
-    }
-    return acc;
-  }, [] as string[]);
+  return extractVariablesFromBody(Handlebars.parse(template).body);
 };
 
 const extractTemplates = (name: string, layout?: string) => {

--- a/packages/applications/notifications/src/subscribers/lauréat/tâche-planifiée/raccordement/handlers/demandeComplèteRaccordementAttendueRelance.handler.ts
+++ b/packages/applications/notifications/src/subscribers/lauréat/tâche-planifiée/raccordement/handlers/demandeComplèteRaccordementAttendueRelance.handler.ts
@@ -1,6 +1,12 @@
 import { Routes } from '@potentiel-applications/routes';
+import { nombresEnToutesLettres } from '@potentiel-domain/inmemory-referential';
 
-import { buildUrl, getLauréat, listerPorteursRecipients } from '#helpers';
+import {
+  buildUrl,
+  getCahierDesChargesLauréat,
+  getLauréat,
+  listerPorteursRecipients,
+} from '#helpers';
 import { sendEmail } from '#sendEmail';
 import type { TâchePlanifiéeRaccordementNotificationProps } from '../tâche-planifiée.raccordement.notifications.js';
 
@@ -8,6 +14,7 @@ export const handleDemandeComplèteRaccordementAttendueRelance = async ({
   identifiantProjet,
 }: TâchePlanifiéeRaccordementNotificationProps) => {
   const lauréat = await getLauréat(identifiantProjet.formatter());
+  const délaiDCR = (await getCahierDesChargesLauréat(identifiantProjet)).getDélaiDCR();
 
   const recipients = await listerPorteursRecipients(identifiantProjet);
 
@@ -19,6 +26,10 @@ export const handleDemandeComplèteRaccordementAttendueRelance = async ({
       appel_offre: lauréat.identifiantProjet.appelOffre,
       période: lauréat.identifiantProjet.période,
       departement_projet: lauréat.département,
+      délai_transmission_dcr_grd: délaiDCR.grd ? nombresEnToutesLettres[délaiDCR.grd] : '',
+      délai_transmission_dcr_potentiel: délaiDCR.potentiel
+        ? nombresEnToutesLettres[délaiDCR.potentiel]
+        : '',
       url: buildUrl(
         Routes.Raccordement.transmettreDemandeComplèteRaccordement(identifiantProjet.formatter()),
       ),

--- a/packages/applications/notifications/src/templates/emails/lauréat/raccordement/rappel_transmission_dcr.md
+++ b/packages/applications/notifications/src/templates/emails/lauréat/raccordement/rappel_transmission_dcr.md
@@ -6,7 +6,7 @@ Madame, Monsieur,
 
 La demande complète de raccordement du projet **{{ nom_projet }} ({{ appel_offre }} période {{ période }})** situé dans le département **{{ departement_projet }}**, est en attente de transmission.
 
-{{#if délai_transmission_dcr_grd}}
+{{#if délai_transmission_dcr_potentiel}}
 **Pour rappel**, vous disposez à compter de la désignation ou de l’accord de recours, d’un délai de :
 
 - **{{délai_transmission_dcr_grd}} mois pour transmettre une demande complète de raccordement** au gestionnaire de réseau (sous peine de risque de prélèvement des garanties financières ou à défaut une sanction pécuniaire au titre de l'article L311-15 du code de l'énergie).

--- a/packages/applications/notifications/src/templates/emails/lauréat/raccordement/rappel_transmission_dcr.md
+++ b/packages/applications/notifications/src/templates/emails/lauréat/raccordement/rappel_transmission_dcr.md
@@ -6,12 +6,16 @@ Madame, Monsieur,
 
 La demande complète de raccordement du projet **{{ nom_projet }} ({{ appel_offre }} période {{ période }})** situé dans le département **{{ departement_projet }}**, est en attente de transmission.
 
+{{#if délai_transmission_dcr_grd}}
 **Pour rappel**, vous disposez à compter de la désignation ou de l’accord de recours, d’un délai de :
 
-- **3 mois pour transmettre une demande complète de raccordement** au gestionnaire de réseau (sous peine de risque de prélèvement des garanties financières ou à défaut une sanction pécuniaire au titre de l'article L311-15 du code de l'énergie).
-- **4 mois pour saisir ces informations sur Potentiel** afin de permettre la contractualisation avec EDF OA.
+- **{{délai_transmission_dcr_grd}} mois pour transmettre une demande complète de raccordement** au gestionnaire de réseau (sous peine de risque de prélèvement des garanties financières ou à défaut une sanction pécuniaire au titre de l'article L311-15 du code de l'énergie).
+- **{{délai_transmission_dcr_potentiel}} mois pour saisir ces informations sur Potentiel** afin de permettre la contractualisation avec EDF OA.
 
 Merci de régulariser la situation dès que possible.
+{{else}}
+Pour rappel, la saisie de ces informations permettra de faciliter le processus de **contractualisation**.
+{{/if}}
 
 Pour le consulter, connectez-vous à Potentiel.
 

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/(détails)/(sections)/Raccordement.section.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/(détails)/(sections)/Raccordement.section.tsx
@@ -3,7 +3,7 @@ import type { DateTime } from '@potentiel-domain/common';
 import { mapToPlainObject } from '@potentiel-domain/core';
 import type { IdentifiantProjet, Lauréat } from '@potentiel-domain/projet';
 
-import { getCahierDesCharges, getLauréatInfos } from '@/app/_helpers';
+import { formatDateToText, getCahierDesCharges, getLauréatInfos } from '@/app/_helpers';
 import { Section } from '@/components/atoms/section/Section';
 import { SectionWithErrorHandling } from '@/components/atoms/section/SectionWithErrorHandling';
 import { withUtilisateur } from '@/utils/withUtilisateur';
@@ -49,6 +49,7 @@ export const RaccordementSection = ({ identifiantProjet }: RaccordementSectionPr
               url: Routes.Raccordement.détail(identifiantProjet),
             }
           : undefined;
+      const délaiDCR = cahierDesCharges.getDélaiDCR();
       const alertes =
         rôle.estPorteur() && peutModifierRaccordement
           ? getAlertesRaccordement({
@@ -56,12 +57,12 @@ export const RaccordementSection = ({ identifiantProjet }: RaccordementSectionPr
                 !!cahierDesCharges.cahierDesChargesModificatif &&
                 cahierDesCharges.cahierDesChargesModificatif.paruLe === '30/08/2022',
               raccordement,
-              dcrAttendueAvantLe: lauréat.notifiéLe.ajouterNombreDeMois(
-                cahierDesCharges.période.delaiDcrEnMois.valeur,
-              ),
-              transmissionAutomatiséeDesDonnéesDeContractualisationAuCocontractant:
-                !!cahierDesCharges.appelOffre
-                  .transmissionAutomatiséeDesDonnéesDeContractualisationAuCocontractant,
+              dateLimiteDCRAuprèsGRD: lauréat.notifiéLe
+                .ajouterNombreDeMois(délaiDCR.grd)
+                .formatter(),
+              dateLimiteDCRSurPotentiel: délaiDCR.potentiel
+                ? lauréat.notifiéLe.ajouterNombreDeMois(délaiDCR.potentiel).formatter()
+                : undefined,
             })
           : [];
 
@@ -79,31 +80,23 @@ export const RaccordementSection = ({ identifiantProjet }: RaccordementSectionPr
 const getAlertesRaccordement = ({
   CDC2022Choisi,
   raccordement,
-  dcrAttendueAvantLe,
-  transmissionAutomatiséeDesDonnéesDeContractualisationAuCocontractant,
+  dateLimiteDCRAuprèsGRD,
+  dateLimiteDCRSurPotentiel,
 }: {
   CDC2022Choisi: boolean;
   raccordement?: Lauréat.Raccordement.ConsulterRaccordementReadModel;
-  dcrAttendueAvantLe: DateTime.ValueType;
-  transmissionAutomatiséeDesDonnéesDeContractualisationAuCocontractant: boolean;
+  dateLimiteDCRAuprèsGRD: DateTime.RawType;
+  dateLimiteDCRSurPotentiel?: DateTime.RawType;
 }): RaccordementDétailsProps['alertes'] => {
-  const formattedDcrAttendueParLeGestionnaireAvantLe = Intl.DateTimeFormat('fr').format(
-    new Date(dcrAttendueAvantLe.formatter()),
-  );
-
-  const formattedDcrAttendueParPotentielAvantLe = Intl.DateTimeFormat('fr').format(
-    new Date(dcrAttendueAvantLe.ajouterNombreDeMois(1).formatter()),
-  );
-
-  const demandeComplèteRaccordementManquanteAlerte = `
-    Vous devez déposer une demande de raccordement auprès de votre gestionnaire de réseau avant le ${formattedDcrAttendueParLeGestionnaireAvantLe}. 
+  const labelAlerte = dateLimiteDCRSurPotentiel
+    ? `
+    Vous devez déposer une demande complète de raccordement avant le ${formatDateToText(dateLimiteDCRAuprèsGRD)} auprès de votre gestionnaire de réseau (sous peine de risque de prélèvement des garanties financières ou à défaut une sanction pécuniaire au titre de l'article L311-15 du code de l'énergie). 
     
-    L'accusé de réception de cette demande ainsi que les documents complémentaires (proposition technique et financière…) transmis sur Potentiel faciliteront vos démarches administratives avec les différents acteurs connectés à Potentiel (DGEC, services de l'Etat en région, Cocontractant, etc.).`;
-
-  const demandeComplèteRaccordementManquanteAlerteSiTransmissionAutomatiséeAuCocontractant = `
-    Vous devez déposer une demande complète de raccordement avant le ${formattedDcrAttendueParLeGestionnaireAvantLe} auprès de votre gestionnaire de réseau (sous peine de risque de prélèvement des garanties financières ou à défaut une sanction pécuniaire au titre de l'article L311-15 du code de l'énergie). 
+    Vous devez déposer cette demande complète de raccordement avant le ${formatDateToText(dateLimiteDCRSurPotentiel)} sur Potentiel afin de permettre la contractualisation du projet.
     
-    Vous devez déposer cette demande complète de raccordement avant le ${formattedDcrAttendueParPotentielAvantLe} sur Potentiel afin de permettre la contractualisation du projet.
+    L'accusé de réception de cette demande ainsi que les documents complémentaires (proposition technique et financière…) transmis sur Potentiel faciliteront vos démarches administratives avec les différents acteurs connectés à Potentiel (DGEC, services de l'Etat en région, Cocontractant, etc.).`
+    : `
+    Vous devez déposer une demande de raccordement auprès de votre gestionnaire de réseau avant le ${formatDateToText(dateLimiteDCRAuprèsGRD)}. 
     
     L'accusé de réception de cette demande ainsi que les documents complémentaires (proposition technique et financière…) transmis sur Potentiel faciliteront vos démarches administratives avec les différents acteurs connectés à Potentiel (DGEC, services de l'Etat en région, Cocontractant, etc.).`;
 
@@ -114,9 +107,7 @@ const getAlertesRaccordement = ({
 
   if ((raccordement && raccordement.dossiers.length === 0) || !raccordement) {
     alertes.push({
-      label: transmissionAutomatiséeDesDonnéesDeContractualisationAuCocontractant
-        ? demandeComplèteRaccordementManquanteAlerteSiTransmissionAutomatiséeAuCocontractant
-        : demandeComplèteRaccordementManquanteAlerte,
+      label: labelAlerte,
     });
     if (CDC2022Choisi) {
       alertes.push({ label: référenceDossierManquantePourDélaiCDC2022Alerte });

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/raccordements/(dossier-de-raccordement)/[reference]/(demande-complète-raccordement)/demande-complete-raccordement:modifier/page.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/raccordements/(dossier-de-raccordement)/[reference]/(demande-complète-raccordement)/demande-complete-raccordement:modifier/page.tsx
@@ -2,14 +2,14 @@ import { mediator } from 'mediateur';
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 
-import type { AppelOffre } from '@potentiel-domain/appel-offre';
 import { mapToPlainObject } from '@potentiel-domain/core';
-import { IdentifiantProjet, type Lauréat } from '@potentiel-domain/projet';
+import { nombresEnToutesLettres } from '@potentiel-domain/inmemory-referential';
+import { type CahierDesCharges, IdentifiantProjet, type Lauréat } from '@potentiel-domain/projet';
 import type { GestionnaireRéseau } from '@potentiel-domain/reseau';
 import type { Role } from '@potentiel-domain/utilisateur';
 import { Option } from '@potentiel-libraries/monads';
 
-import { getPériodeAppelOffres } from '@/app/_helpers';
+import { getCahierDesCharges } from '@/app/_helpers';
 import { decodeParameter } from '@/utils/decodeParameter';
 import { PageWithErrorHandling } from '@/utils/PageWithErrorHandling';
 import { withUtilisateur } from '@/utils/withUtilisateur';
@@ -52,7 +52,7 @@ export default async function Page(props0: PageProps) {
 
       const referenceDossierRaccordement = decodeParameter(reference);
 
-      const { période } = await getPériodeAppelOffres(identifiantProjet);
+      const cahierDesCharges = await getCahierDesCharges(identifiantProjet);
 
       const gestionnaireRéseau =
         await mediator.send<Lauréat.Raccordement.ConsulterGestionnaireRéseauRaccordementQuery>({
@@ -82,7 +82,7 @@ export default async function Page(props0: PageProps) {
 
       const props = mapToProps({
         role: utilisateur.rôle,
-        période,
+        cahierDesCharges,
         gestionnaireRéseau: Option.isSome(gestionnaireRéseau) ? gestionnaireRéseau : undefined,
         identifiantProjet,
         dossierRaccordement,
@@ -103,17 +103,17 @@ export default async function Page(props0: PageProps) {
 }
 
 type MapToProps = (args: {
-  période: AppelOffre.Periode;
   role: Role.ValueType;
   gestionnaireRéseau?: Lauréat.Raccordement.ConsulterGestionnaireRéseauRaccordementReadModel;
   dossierRaccordement: Lauréat.Raccordement.ConsulterDossierRaccordementReadModel;
   identifiantProjet: IdentifiantProjet.RawType;
   listeGestionnairesRéseau: GestionnaireRéseau.ListerGestionnaireRéseauReadModel | undefined;
+  cahierDesCharges: CahierDesCharges.ValueType;
 }) => ModifierDemandeComplèteRaccordementPageProps;
 
 const mapToProps: MapToProps = ({
   role,
-  période,
+  cahierDesCharges,
   gestionnaireRéseau,
   dossierRaccordement,
   identifiantProjet,
@@ -138,7 +138,10 @@ const mapToProps: MapToProps = ({
           dossierRaccordement.demandeComplèteRaccordement.accuséRéception?.formatter(),
       },
     },
-    delaiDemandeDeRaccordementEnMois: période.delaiDcrEnMois,
+    delaiDemandeDeRaccordementEnMois: {
+      valeur: cahierDesCharges.getDélaiDCR().grd,
+      texte: nombresEnToutesLettres[cahierDesCharges.getDélaiDCR().grd],
+    },
     gestionnaireRéseauActuel: gestionnaireRéseau && {
       identifiantGestionnaireRéseau: gestionnaireRéseau.identifiantGestionnaireRéseau.formatter(),
       raisonSociale: gestionnaireRéseau.raisonSociale,

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/raccordements/(dossier-de-raccordement)/demande-complete-raccordement:transmettre/page.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/raccordements/(dossier-de-raccordement)/demande-complete-raccordement:transmettre/page.tsx
@@ -2,11 +2,12 @@ import { mediator } from 'mediateur';
 import type { Metadata } from 'next';
 
 import { mapToPlainObject } from '@potentiel-domain/core';
+import { nombresEnToutesLettres } from '@potentiel-domain/inmemory-referential';
 import { IdentifiantProjet, type Lauréat } from '@potentiel-domain/projet';
 import type { GestionnaireRéseau } from '@potentiel-domain/reseau';
 import { Option } from '@potentiel-libraries/monads';
 
-import { getPériodeAppelOffres } from '@/app/_helpers';
+import { getCahierDesCharges } from '@/app/_helpers';
 import { decodeParameter } from '@/utils/decodeParameter';
 import type { IdentifiantParameter } from '@/utils/identifiantParameter';
 import { PageWithErrorHandling } from '@/utils/PageWithErrorHandling';
@@ -40,7 +41,7 @@ export default async function Page(props: PageProps) {
 
       await getLauréatOrRedirect(identifiantProjet);
 
-      const { période } = await getPériodeAppelOffres(identifiantProjet);
+      const délaiDCR = (await getCahierDesCharges(identifiantProjet)).getDélaiDCR();
 
       const gestionnairesRéseau =
         await mediator.send<GestionnaireRéseau.ListerGestionnaireRéseauQuery>({
@@ -70,7 +71,10 @@ export default async function Page(props: PageProps) {
           identifiantProjet={mapToPlainObject(identifiantProjet)}
           listeGestionnairesRéseau={mapToPlainObject(gestionnairesRéseau.items)}
           gestionnaireRéseauActuel={mapToPlainObject(gestionnaireRéseauActuel)}
-          delaiDemandeDeRaccordementEnMois={période.delaiDcrEnMois}
+          delaiDemandeDeRaccordementEnMois={{
+            valeur: délaiDCR.grd,
+            texte: nombresEnToutesLettres[délaiDCR.grd],
+          }}
         />
       );
     }),

--- a/packages/domain/appel-offre/src/appelOffre.entity.ts
+++ b/packages/domain/appel-offre/src/appelOffre.entity.ts
@@ -281,7 +281,7 @@ export type Nombres = 1 | 2 | 3 | 4;
 export type DélaiDCR = {
   /** Auprès du GRD, en mois */
   grd: Nombres;
-  /** Auprès du GRD, en mois. Omis si non requis par le CDC. */
+  /** Dans Potentiel, en mois. Omis si non requis par le CDC. */
   potentiel?: Nombres;
 };
 

--- a/packages/domain/appel-offre/src/appelOffre.entity.ts
+++ b/packages/domain/appel-offre/src/appelOffre.entity.ts
@@ -277,6 +277,14 @@ export type ChampsSupplémentairesCandidature = Partial<
   Record<ChampCandidature, TypeChampSupplémentaire>
 >;
 
+export type Nombres = 1 | 2 | 3 | 4;
+export type DélaiDCR = {
+  /** Auprès du GRD, en mois */
+  grd: Nombres;
+  /** Auprès du GRD, en mois. Omis si non requis par le CDC. */
+  potentiel?: Nombres;
+};
+
 export type Periode = {
   id: string;
   title: string;
@@ -289,10 +297,7 @@ export type Periode = {
    **/
   paragrapheEngagementIPFPGPFC?: string;
   cahierDesCharges: { référence: string };
-  delaiDcrEnMois: {
-    valeur: number;
-    texte: string;
-  };
+  délaiDCR?: DélaiDCR;
   cahiersDesChargesModifiésDisponibles: ReadonlyArray<CahierDesChargesModifié>;
   abandonAvecRecandidature?: true;
   familles: Array<Famille>;
@@ -362,7 +367,7 @@ export type AppelOffreReadModel = {
   dépôtDCRPossibleSeulementAprèsDésignation?: true;
   donnéesCourriersRéponse: Partial<DonnéesCourriersRéponseParDomaine>;
   doitPouvoirChoisirCDCInitial?: true;
-  transmissionAutomatiséeDesDonnéesDeContractualisationAuCocontractant?: true;
+  délaiDCR: DélaiDCR;
   miseÀJour: RèglesMiseÀJour;
   champsSupplémentaires?: ChampsSupplémentairesCandidature;
   garantiesFinancières: GarantiesFinancièresAppelOffre;

--- a/packages/domain/inmemory-referential/src/appelOffre/CRE4/autoconsommationMetropole.cre4.ts
+++ b/packages/domain/inmemory-referential/src/appelOffre/CRE4/autoconsommationMetropole.cre4.ts
@@ -117,6 +117,7 @@ Il en informe dans ce cas le Préfet en joignant les pièces justificatives. La 
 Le Candidat peut également être délié de cette obligation selon appréciation du ministre chargé de l’énergie  suite  à  une  demande  dûment  justifiée.  Le  Ministre  peut  accompagner  son accord  de conditions. L’accord du Ministre et les conditions imposées le cas échéant, ne limitent pas la possibilité de recours de l’Etat aux sanctions du 8.2.`,
     },
   },
+  délaiDCR: { grd: 2 },
   periodes: [
     {
       id: '1',
@@ -125,7 +126,6 @@ Le Candidat peut également être délié de cette obligation selon appréciatio
       cahierDesCharges: {
         référence: '2017/S 054-100223',
       },
-      delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       familles: [],
       donnéesCourriersRéponse: {
         texteChangementDePuissance: {
@@ -158,7 +158,6 @@ Ces retards sont réputés autorisés sous réserve de pouvoir les justifier aup
       cahierDesCharges: {
         référence: '2017/S 054-100223',
       },
-      delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       familles: [],
       donnéesCourriersRéponse: {
         texteChangementDePuissance: {
@@ -189,7 +188,6 @@ Ces retards sont réputés autorisés sous réserve de pouvoir les justifier aup
       cahierDesCharges: {
         référence: '2017/S 054-100223',
       },
-      delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       familles: [],
       donnéesCourriersRéponse: {
         texteChangementDePuissance: {
@@ -220,7 +218,6 @@ Ces retards sont réputés autorisés sous réserve de pouvoir les justifier aup
       cahierDesCharges: {
         référence: '2017/S 054-100223',
       },
-      delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       familles: [],
       donnéesCourriersRéponse: {
         texteChangementDePuissance: {
@@ -251,7 +248,6 @@ Ces retards sont réputés autorisés sous réserve de pouvoir les justifier aup
       cahierDesCharges: {
         référence: '2017/S 054-100223',
       },
-      delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       familles: [],
       donnéesCourriersRéponse: {
         texteChangementDePuissance: {
@@ -282,7 +278,6 @@ Ces retards sont réputés autorisés sous réserve de pouvoir les justifier aup
       cahierDesCharges: {
         référence: '2017/S 054-100223',
       },
-      delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       familles: [],
       donnéesCourriersRéponse: {
         texteChangementDePuissance: {
@@ -313,7 +308,6 @@ Ces retards sont réputés autorisés sous réserve de pouvoir les justifier aup
       cahierDesCharges: {
         référence: '2017/S 054-100223',
       },
-      delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       familles: [],
       donnéesCourriersRéponse: {
         texteChangementDePuissance: {
@@ -344,7 +338,6 @@ Ces retards sont réputés autorisés sous réserve de pouvoir les justifier aup
       cahierDesCharges: {
         référence: '2017/S 054-100223',
       },
-      delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       familles: [],
       donnéesCourriersRéponse: {
         texteChangementDePuissance: {
@@ -375,7 +368,6 @@ Ces retards sont réputés autorisés sous réserve de pouvoir les justifier aup
       cahierDesCharges: {
         référence: '2017/S 054-100223',
       },
-      delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       familles: [],
       donnéesCourriersRéponse: {
         texteChangementDePuissance: {
@@ -406,7 +398,6 @@ Ces retards sont réputés autorisés sous réserve de pouvoir les justifier aup
       cahierDesCharges: {
         référence: '2017/S 054-100223',
       },
-      delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       familles: [],
       donnéesCourriersRéponse: {
         texteChangementDePuissance: {

--- a/packages/domain/inmemory-referential/src/appelOffre/CRE4/autoconsommationMetropole2016.cre4.ts
+++ b/packages/domain/inmemory-referential/src/appelOffre/CRE4/autoconsommationMetropole2016.cre4.ts
@@ -131,6 +131,7 @@ En cas de dépassement de ce délai, la durée de contrat mentionnée au 7.1 est
 Ces retards sont réputés autorisés sous réserve de pouvoir les justifier auprès de l’acheteur obligé. Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent être accordés en cas d’événement imprévisible à la Date de désignation et extérieur au Producteur, dûment justifié.`,
     },
   },
+  délaiDCR: { grd: 2 },
   periodes: [
     {
       id: '1',
@@ -139,7 +140,6 @@ Ces retards sont réputés autorisés sous réserve de pouvoir les justifier aup
       cahierDesCharges: {
         référence: '2016/S 146-264282',
       },
-      delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       familles: [],
       cahiersDesChargesModifiésDisponibles: [CDCModifié30072021],
       abandonAvecRecandidature: true,
@@ -152,7 +152,6 @@ Ces retards sont réputés autorisés sous réserve de pouvoir les justifier aup
       cahierDesCharges: {
         référence: '2016/S 146-264282',
       },
-      delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       familles: [],
       cahiersDesChargesModifiésDisponibles: [CDCModifié30072021],
       abandonAvecRecandidature: true,

--- a/packages/domain/inmemory-referential/src/appelOffre/CRE4/autoconsommationZNI.cre4.ts
+++ b/packages/domain/inmemory-referential/src/appelOffre/CRE4/autoconsommationZNI.cre4.ts
@@ -157,6 +157,7 @@ En cas de dépassement de ce délai, la durée de contrat mentionnée au 7.1 est
 Ces retards sont réputés autorisés sous réserve de pouvoir les justifier auprès de l’acheteur obligé. Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent être accordés en cas d’événement imprévisible à la Date de désignation et extérieur au Producteur, dûment justifié.`,
     },
   },
+  délaiDCR: { grd: 2 },
   periodes: [
     {
       id: '1',
@@ -165,7 +166,6 @@ Ces retards sont réputés autorisés sous réserve de pouvoir les justifier aup
       cahierDesCharges: {
         référence: '2019/S 113-276257',
       },
-      delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       familles: [],
       donnéesCourriersRéponse: {
         texteChangementDePuissance: {
@@ -184,7 +184,6 @@ Ces retards sont réputés autorisés sous réserve de pouvoir les justifier aup
       cahierDesCharges: {
         référence: '2019/S 113-276257',
       },
-      delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       familles: [],
       donnéesCourriersRéponse: {
         texteChangementDePuissance: {

--- a/packages/domain/inmemory-referential/src/appelOffre/CRE4/autoconsommationZNI2017.cre4.ts
+++ b/packages/domain/inmemory-referential/src/appelOffre/CRE4/autoconsommationZNI2017.cre4.ts
@@ -161,6 +161,7 @@ En cas de dépassement de ce délai, la durée de contrat mentionnée au 7.1 est
 Ces retards sont réputés autorisés sous réserve de pouvoir les justifier auprès de l’acheteur obligé. Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent être accordés en cas d’événement imprévisible à la Date de désignation et extérieur au Producteur, dûment justifié.`,
     },
   },
+  délaiDCR: { grd: 2 },
   periodes: [
     {
       id: '1',
@@ -169,7 +170,6 @@ Ces retards sont réputés autorisés sous réserve de pouvoir les justifier aup
       cahierDesCharges: {
         référence: '2016/S 242-441979',
       },
-      delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       familles: [],
       cahiersDesChargesModifiésDisponibles: [CDCModifié30072021, CDCModifié30082022],
       abandonAvecRecandidature: true,

--- a/packages/domain/inmemory-referential/src/appelOffre/CRE4/batiment.cre4.ts
+++ b/packages/domain/inmemory-referential/src/appelOffre/CRE4/batiment.cre4.ts
@@ -165,6 +165,7 @@ Le Candidat peut également être délié de cette obligation selon appréciatio
       `,
     },
   },
+  délaiDCR: { grd: 2 },
   periodes: [
     {
       id: '1',
@@ -173,7 +174,6 @@ Le Candidat peut également être délié de cette obligation selon appréciatio
       cahierDesCharges: {
         référence: '2016/S 174-312851',
       },
-      delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       familles: [
         {
           id: '1',
@@ -230,7 +230,6 @@ Ces retards sont réputés autorisés sous réserve de pouvoir les justifier aup
       cahierDesCharges: {
         référence: '2016/S 174-312851',
       },
-      delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       familles: [
         {
           id: '1',
@@ -287,7 +286,6 @@ Ces retards sont réputés autorisés sous réserve de pouvoir les justifier aup
       cahierDesCharges: {
         référence: '2016/S 174-312851',
       },
-      delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       familles: [
         {
           id: '1',
@@ -344,7 +342,6 @@ Ces retards sont réputés autorisés sous réserve de pouvoir les justifier aup
       cahierDesCharges: {
         référence: '2016/S 174-312851',
       },
-      delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       familles: [
         {
           id: '1',
@@ -401,7 +398,6 @@ Ces retards sont réputés autorisés sous réserve de pouvoir les justifier aup
       cahierDesCharges: {
         référence: '2016/S 174-312851',
       },
-      delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       familles: [
         {
           id: '1',
@@ -458,7 +454,6 @@ Ces retards sont réputés autorisés sous réserve de pouvoir les justifier aup
       cahierDesCharges: {
         référence: '2016/S 174-312851',
       },
-      delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       familles: [
         {
           id: '1',
@@ -515,7 +510,6 @@ Ces retards sont réputés autorisés sous réserve de pouvoir les justifier aup
       cahierDesCharges: {
         référence: '2016/S 174-312851',
       },
-      delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       familles: [
         {
           id: '1',
@@ -572,7 +566,6 @@ Ces retards sont réputés autorisés sous réserve de pouvoir les justifier aup
       cahierDesCharges: {
         référence: '2016/S 174-312851',
       },
-      delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       familles: [
         {
           id: '1',
@@ -629,7 +622,6 @@ Ces retards sont réputés autorisés sous réserve de pouvoir les justifier aup
       cahierDesCharges: {
         référence: '2016/S 174-312851',
       },
-      delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       familles: [
         {
           id: '1',
@@ -686,7 +678,6 @@ Ces retards sont réputés autorisés sous réserve de pouvoir les justifier aup
       cahierDesCharges: {
         référence: '2016/S 174-312851',
       },
-      delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       familles: [
         {
           id: '1',
@@ -743,7 +734,6 @@ Ces retards sont réputés autorisés sous réserve de pouvoir les justifier aup
       cahierDesCharges: {
         référence: '2016/S 174-312851',
       },
-      delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       familles: [
         {
           id: '1',
@@ -800,7 +790,6 @@ Ces retards sont réputés autorisés sous réserve de pouvoir les justifier aup
       cahierDesCharges: {
         référence: '2016/S 174-312851',
       },
-      delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       familles: [
         {
           id: '1',
@@ -857,7 +846,6 @@ Ces retards sont réputés autorisés sous réserve de pouvoir les justifier aup
       cahierDesCharges: {
         référence: '2016/S 174-312851',
       },
-      delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       familles: [
         {
           id: '1',

--- a/packages/domain/inmemory-referential/src/appelOffre/CRE4/eolien.cre4.ts
+++ b/packages/domain/inmemory-referential/src/appelOffre/CRE4/eolien.cre4.ts
@@ -144,6 +144,7 @@ Par dérogation, les modifications à la baisse de la Puissance installée qui s
 Après constitution des garanties financières, si le Candidat n’a pas joint à son offre la lettre d’engagement du 3.3.6, les modifications de la structure du Capital du Candidat sont réputées autorisées. Elles doivent faire l’objet d’une information au Préfet dans un délai d’un (1) mois. Si le Candidat a joint à son offre la lettre d’engagement du 3.3.6, les modifications de la structure du Capital du Candidat doivent être autorisées par le Préfet.`,
     },
   },
+  délaiDCR: { grd: 2 },
   periodes: [
     {
       id: '1',
@@ -152,7 +153,6 @@ Après constitution des garanties financières, si le Candidat n’a pas joint �
       cahierDesCharges: {
         référence: '2017/S 083-161855',
       },
-      delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       familles: [],
       donnéesCourriersRéponse: {
         texteDélaisDAchèvement: {
@@ -205,7 +205,6 @@ Dans tous les cas, l’attribution des délais est soumis à la prolongation de 
       cahierDesCharges: {
         référence: '2017/S 083-161855',
       },
-      delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       familles: [],
       donnéesCourriersRéponse: {
         texteDélaisDAchèvement: {
@@ -257,7 +256,6 @@ Dans tous les cas, l’attribution des délais est soumis à la prolongation de 
       cahierDesCharges: {
         référence: '2017/S 083-161855',
       },
-      delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       familles: [],
       donnéesCourriersRéponse: {
         texteDélaisDAchèvement: {
@@ -308,7 +306,6 @@ Dans tous les cas, l’attribution des délais supplémentaires est conditionné
       cahierDesCharges: {
         référence: '2017/S 083-161855',
       },
-      delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       familles: [],
       donnéesCourriersRéponse: {
         texteDélaisDAchèvement: {
@@ -359,7 +356,6 @@ Dans tous les cas, l’attribution des délais supplémentaires est conditionné
       cahierDesCharges: {
         référence: '2017/S 083-161855',
       },
-      delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       familles: [],
       donnéesCourriersRéponse: {
         texteDélaisDAchèvement: {
@@ -410,7 +406,6 @@ Dans tous les cas, l’attribution des délais supplémentaires est conditionné
       cahierDesCharges: {
         référence: '2017/S 083-161855',
       },
-      delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       familles: [],
       donnéesCourriersRéponse: {
         texteDélaisDAchèvement: {
@@ -461,7 +456,6 @@ Dans tous les cas, l’attribution des délais supplémentaires est conditionné
       cahierDesCharges: {
         référence: '2017/S 083-161855',
       },
-      delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       familles: [],
       donnéesCourriersRéponse: {
         texteDélaisDAchèvement: {
@@ -512,7 +506,6 @@ Dans tous les cas, l’attribution des délais supplémentaires est conditionné
       cahierDesCharges: {
         référence: '2017/S 083-161855',
       },
-      delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       familles: [],
       donnéesCourriersRéponse: {
         texteDélaisDAchèvement: {

--- a/packages/domain/inmemory-referential/src/appelOffre/CRE4/fessenheim.cre4.ts
+++ b/packages/domain/inmemory-referential/src/appelOffre/CRE4/fessenheim.cre4.ts
@@ -184,6 +184,7 @@ Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent 
 `,
     },
   },
+  délaiDCR: { grd: 2 },
   periodes: [
     {
       id: '1',
@@ -192,7 +193,6 @@ Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent 
       cahierDesCharges: {
         référence: '2019/S 019-040037',
       },
-      delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       familles: [
         {
           id: '1',
@@ -236,7 +236,6 @@ Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent 
       cahierDesCharges: {
         référence: '2019/S 019-040037',
       },
-      delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       familles: [
         {
           id: '1',
@@ -280,7 +279,6 @@ Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent 
       cahierDesCharges: {
         référence: '2019/S 019-040037',
       },
-      delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       familles: [
         {
           id: '1',

--- a/packages/domain/inmemory-referential/src/appelOffre/CRE4/innovation.cre4.ts
+++ b/packages/domain/inmemory-referential/src/appelOffre/CRE4/innovation.cre4.ts
@@ -186,6 +186,7 @@ Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent 
 `,
     },
   },
+  délaiDCR: { grd: 2 },
   periodes: [
     {
       id: '1',
@@ -194,7 +195,6 @@ Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent 
       cahierDesCharges: {
         référence: '2017/S 051-094731',
       },
-      delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       familles: [
         {
           id: '1a',
@@ -245,7 +245,6 @@ Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent 
       cahierDesCharges: {
         référence: '2017/S 051-094731',
       },
-      delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       familles: [
         {
           id: '1',
@@ -277,7 +276,6 @@ Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent 
       cahierDesCharges: {
         référence: '2017/S 051-094731',
       },
-      delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       familles: [
         {
           id: '1',

--- a/packages/domain/inmemory-referential/src/appelOffre/CRE4/pvEolien.cre4.ts
+++ b/packages/domain/inmemory-referential/src/appelOffre/CRE4/pvEolien.cre4.ts
@@ -164,6 +164,7 @@ Des délais supplémentaires, laissés à l’appréciation du ministre chargé 
 `,
     },
   },
+  délaiDCR: { grd: 2 },
   periodes: [
     {
       id: '1',
@@ -172,7 +173,6 @@ Des délais supplémentaires, laissés à l’appréciation du ministre chargé 
       cahierDesCharges: {
         référence: '2017/S 238-494941',
       },
-      delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       familles: [],
       donnéesCourriersRéponse: {
         texteChangementDePuissance: {

--- a/packages/domain/inmemory-referential/src/appelOffre/CRE4/sol.cre4.ts
+++ b/packages/domain/inmemory-referential/src/appelOffre/CRE4/sol.cre4.ts
@@ -173,6 +173,7 @@ Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent 
 `,
     },
   },
+  délaiDCR: { grd: 2 },
   periodes: [
     {
       id: '1',
@@ -181,7 +182,6 @@ Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent 
       cahierDesCharges: {
         référence: '2016/S 148-268152',
       },
-      delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       familles: [
         {
           id: '1',
@@ -248,7 +248,6 @@ Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent 
       cahierDesCharges: {
         référence: '2016/S 148-268152',
       },
-      delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       familles: [
         {
           id: '1',
@@ -315,7 +314,6 @@ Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent 
       cahierDesCharges: {
         référence: '2016/S 148-268152',
       },
-      delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       familles: [
         {
           id: '1',
@@ -382,7 +380,6 @@ Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent 
       cahierDesCharges: {
         référence: '2016/S 148-268152',
       },
-      delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       familles: [
         {
           id: '1',
@@ -449,7 +446,6 @@ Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent 
       cahierDesCharges: {
         référence: '2016/S 148-268152',
       },
-      delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       familles: [
         {
           id: '1',
@@ -516,7 +512,6 @@ Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent 
       cahierDesCharges: {
         référence: '2016/S 148-268152',
       },
-      delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       familles: [
         {
           id: '1',
@@ -582,7 +577,6 @@ Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent 
       cahierDesCharges: {
         référence: '2016/S 148-268152',
       },
-      delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       familles: [
         {
           id: '1',
@@ -648,7 +642,6 @@ Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent 
       cahierDesCharges: {
         référence: '2016/S 148-268152',
       },
-      delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       familles: [
         {
           id: '1',
@@ -714,7 +707,6 @@ Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent 
       cahierDesCharges: {
         référence: '2016/S 148-268152',
       },
-      delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       familles: [
         {
           id: '1',
@@ -780,7 +772,6 @@ Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent 
       cahierDesCharges: {
         référence: '2016/S 148-268152',
       },
-      delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       familles: [
         {
           id: '1',

--- a/packages/domain/inmemory-referential/src/appelOffre/CRE4/zni.cre4.ts
+++ b/packages/domain/inmemory-referential/src/appelOffre/CRE4/zni.cre4.ts
@@ -214,6 +214,7 @@ Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent 
 `,
     },
   },
+  délaiDCR: { grd: 2 },
   periodes: [
     {
       id: '1',
@@ -222,7 +223,6 @@ Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent 
       cahierDesCharges: {
         référence: '2019/S 113-276264',
       },
-      delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       familles: [
         // 2017 ZNI avec stockage
         {
@@ -311,7 +311,6 @@ Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent 
       cahierDesCharges: {
         référence: '2019/S 113-276264',
       },
-      delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       familles: [
         // 2017 ZNI avec stockage
         {
@@ -400,7 +399,6 @@ Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent 
       cahierDesCharges: {
         référence: '2019/S 113-276264',
       },
-      delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       familles: [
         // 2017 ZNI avec stockage
         {
@@ -489,7 +487,6 @@ Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent 
       cahierDesCharges: {
         référence: '2019/S 113-276264',
       },
-      delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       familles: [
         // 2017 ZNI avec stockage
         {
@@ -578,7 +575,6 @@ Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent 
       cahierDesCharges: {
         référence: '2019/S 113-276264',
       },
-      delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       familles: [
         // 2017 ZNI avec stockage
         {
@@ -667,7 +663,6 @@ Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent 
       cahierDesCharges: {
         référence: '2020/S 202-487521',
       },
-      delaiDcrEnMois: { valeur: 2, texte: 'deux' }, // à confirmer si c'est bien deux mois ici
       familles: [
         // 2017 ZNI avec stockage
         {

--- a/packages/domain/inmemory-referential/src/appelOffre/CRE4/zni2017.cre4.ts
+++ b/packages/domain/inmemory-referential/src/appelOffre/CRE4/zni2017.cre4.ts
@@ -171,6 +171,7 @@ Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent 
 `,
     },
   },
+  délaiDCR: { grd: 2 },
   periodes: [
     {
       id: '1',
@@ -179,7 +180,6 @@ Des délais supplémentaires, laissés à l’appréciation du Préfet, peuvent 
       cahierDesCharges: {
         référence: '2016/S 242-441980',
       },
-      delaiDcrEnMois: { valeur: 2, texte: 'deux' },
       familles: [
         {
           id: '1',

--- a/packages/domain/inmemory-referential/src/appelOffre/PPE2/autoconsommationMetropole.ppe2.ts
+++ b/packages/domain/inmemory-referential/src/appelOffre/PPE2/autoconsommationMetropole.ppe2.ts
@@ -209,6 +209,7 @@ Ces retards sont réputés autorisés sous réserve de pouvoir les justifier aup
 Des délais supplémentaires peuvent être accordés par le Préfet, à son appréciation, en cas d’événement imprévisible à la Date de désignation et extérieur au Producteur, dûment justifié.`,
     },
   },
+  délaiDCR: { grd: 3 },
   periodes: [
     {
       id: '1',
@@ -219,7 +220,7 @@ Des délais supplémentaires peuvent être accordés par le Préfet, à son appr
       cahierDesCharges: {
         référence: '2021 S 176-457526',
       },
-      delaiDcrEnMois: { valeur: 2, texte: 'deux' },
+      délaiDCR: { grd: 2 },
       familles: [],
       cahiersDesChargesModifiésDisponibles: [CDCModifié30082022],
       abandonAvecRecandidature: true,
@@ -234,7 +235,7 @@ Des délais supplémentaires peuvent être accordés par le Préfet, à son appr
       cahierDesCharges: {
         référence: '2022 S 038 098159',
       },
-      delaiDcrEnMois: { valeur: 2, texte: 'deux' },
+      délaiDCR: { grd: 2 },
       familles: [],
       cahiersDesChargesModifiésDisponibles: [CDCModifié30082022],
       abandonAvecRecandidature: true,
@@ -250,7 +251,6 @@ Des délais supplémentaires peuvent être accordés par le Préfet, à son appr
       cahierDesCharges: {
         référence: '2022 S 150-427955',
       },
-      delaiDcrEnMois: { valeur: 3, texte: 'trois' },
       familles: [],
       cahiersDesChargesModifiésDisponibles: [],
       abandonAvecRecandidature: true,
@@ -266,7 +266,6 @@ Des délais supplémentaires peuvent être accordés par le Préfet, à son appr
       cahierDesCharges: {
         référence: '2023/S 176-551607',
       },
-      delaiDcrEnMois: { valeur: 3, texte: 'trois' },
       familles: [],
       cahiersDesChargesModifiésDisponibles: [],
       typeImport: 'csv',

--- a/packages/domain/inmemory-referential/src/appelOffre/PPE2/batiment.ppe2.ts
+++ b/packages/domain/inmemory-referential/src/appelOffre/PPE2/batiment.ppe2.ts
@@ -181,6 +181,7 @@ Ces retards sont réputés autorisés sous réserve de pouvoir les justifier aup
 Des délais supplémentaires peuvent être accordés par le Préfet, à son appréciation, en cas d’événement imprévisible à la Date de désignation et extérieur au Producteur, dûment justifié.`,
     },
   },
+  délaiDCR: { grd: 3 },
   periodes: [
     {
       id: '1',
@@ -191,7 +192,6 @@ Des délais supplémentaires peuvent être accordés par le Préfet, à son appr
       },
       // Les périodes 1 à 10 ont utilisé MW
       unitéPuissance: 'MW',
-      delaiDcrEnMois: { valeur: 3, texte: 'trois' },
       familles: [],
       volumeRéservé: {
         noteMin: 18.79,
@@ -222,7 +222,6 @@ Des délais supplémentaires peuvent être accordés par le Préfet, à son appr
       },
       // Les périodes 1 à 10 ont utilisé MW
       unitéPuissance: 'MW',
-      delaiDcrEnMois: { valeur: 3, texte: 'trois' },
       familles: [],
       volumeRéservé: {
         noteMin: 12.9244110177221,
@@ -254,7 +253,6 @@ Des délais supplémentaires peuvent être accordés par le Préfet, à son appr
       },
       // Les périodes 1 à 10 ont utilisé MW
       unitéPuissance: 'MW',
-      delaiDcrEnMois: { valeur: 3, texte: 'trois' },
       familles: [],
       volumeRéservé: {
         noteMin: 11.72,
@@ -291,7 +289,6 @@ Des délais supplémentaires peuvent être accordés par le Préfet, à son appr
       },
       // Les périodes 1 à 10 ont utilisé MW
       unitéPuissance: 'MW',
-      delaiDcrEnMois: { valeur: 3, texte: 'trois' },
       familles: [],
       volumeRéservé: {
         noteMin: 7.14,
@@ -322,7 +319,6 @@ Des délais supplémentaires peuvent être accordés par le Préfet, à son appr
       },
       // Les périodes 1 à 10 ont utilisé MW
       unitéPuissance: 'MW',
-      delaiDcrEnMois: { valeur: 3, texte: 'trois' },
       familles: [],
       volumeRéservé: {
         noteMin: 16.69,
@@ -364,7 +360,6 @@ Des délais supplémentaires peuvent être accordés par le Préfet, à son appr
       },
       // Les périodes 1 à 10 ont utilisé MW
       unitéPuissance: 'MW',
-      delaiDcrEnMois: { valeur: 3, texte: 'trois' },
       familles: [],
       volumeRéservé: {
         noteMin: 23.45,
@@ -406,7 +401,6 @@ Des délais supplémentaires peuvent être accordés par le Préfet, à son appr
       },
       // Les périodes 1 à 10 ont utilisé MW
       unitéPuissance: 'MW',
-      delaiDcrEnMois: { valeur: 3, texte: 'trois' },
       familles: [],
       volumeRéservé: {
         noteMin: 90.08,
@@ -449,7 +443,6 @@ Des délais supplémentaires peuvent être accordés par le Préfet, à son appr
       },
       // Les périodes 1 à 10 ont utilisé MW
       unitéPuissance: 'MW',
-      delaiDcrEnMois: { valeur: 3, texte: 'trois' },
       familles: [],
       volumeRéservé: {
         noteMin: 27.31,
@@ -493,7 +486,6 @@ Des délais supplémentaires peuvent être accordés par le Préfet, à son appr
       },
       // Les périodes 1 à 10 ont utilisé MW
       unitéPuissance: 'MW',
-      delaiDcrEnMois: { valeur: 3, texte: 'trois' },
       familles: [],
       volumeRéservé: {
         noteMin: 40.32,
@@ -536,7 +528,6 @@ Des délais supplémentaires peuvent être accordés par le Préfet, à son appr
       },
       // Les périodes 1 à 10 ont utilisé MW
       unitéPuissance: 'MW',
-      delaiDcrEnMois: { valeur: 3, texte: 'trois' },
       familles: [],
       volumeRéservé: {
         noteMin: 21.6,
@@ -573,7 +564,6 @@ Des délais supplémentaires peuvent être accordés par le Préfet, à son appr
       cahierDesCharges: {
         référence: '2025/S 93-00311732',
       },
-      delaiDcrEnMois: { valeur: 3, texte: 'trois' },
       familles: [],
       volumeRéservé: {
         noteMin: 35.77,
@@ -610,7 +600,6 @@ Des délais supplémentaires peuvent être accordés par le Préfet, à son appr
       cahierDesCharges: {
         référence: '2026/S 33-110771',
       },
-      delaiDcrEnMois: { valeur: 3, texte: 'trois' },
       familles: [],
       volumeRéservé: {
         noteMin: 55.99,

--- a/packages/domain/inmemory-referential/src/appelOffre/PPE2/eolien.ppe2.ts
+++ b/packages/domain/inmemory-referential/src/appelOffre/PPE2/eolien.ppe2.ts
@@ -186,6 +186,7 @@ Ces retards sont réputés autorisés sous réserve de pouvoir les justifier aup
 Des délais supplémentaires peuvent être accordés par le Préfet, à son appréciation, en cas d’événement imprévisible à la Date de désignation et extérieur au Producteur, dûment justifié.`,
     },
   },
+  délaiDCR: { grd: 3 },
   periodes: [
     {
       id: '1',
@@ -194,7 +195,6 @@ Des délais supplémentaires peuvent être accordés par le Préfet, à son appr
       cahierDesCharges: {
         référence: '2021/S 146-386083',
       },
-      delaiDcrEnMois: { valeur: 3, texte: 'trois' },
       familles: [],
       cahiersDesChargesModifiésDisponibles: [CDCModifié30082022],
       abandonAvecRecandidature: true,
@@ -227,7 +227,6 @@ Des délais supplémentaires peuvent être accordés par le Préfet, à son appr
       cahierDesCharges: {
         référence: '2022/S 035-088651',
       },
-      delaiDcrEnMois: { valeur: 3, texte: 'trois' },
       familles: [],
       cahiersDesChargesModifiésDisponibles: [
         {
@@ -277,7 +276,6 @@ Le Candidat peut également être délié de cette obligation selon l’appréci
       cahierDesCharges: {
         référence: '2022/S 214-614410',
       },
-      delaiDcrEnMois: { valeur: 3, texte: 'trois' },
       familles: [],
       donnéesCourriersRéponse: {
         texteEngagementRéalisationEtModalitésAbandon: {
@@ -322,7 +320,6 @@ Le Candidat peut également être délié de cette obligation selon l’appréci
       cahierDesCharges: {
         référence: '2023/S 063-187148',
       },
-      delaiDcrEnMois: { valeur: 3, texte: 'trois' },
       familles: [],
       donnéesCourriersRéponse: {
         texteEngagementRéalisationEtModalitésAbandon:
@@ -359,7 +356,6 @@ Le Candidat peut également être délié de cette obligation selon l’appréci
       cahierDesCharges: {
         référence: '2023/S 183-570186',
       },
-      delaiDcrEnMois: { valeur: 3, texte: 'trois' },
       familles: [],
       donnéesCourriersRéponse: {
         texteEngagementRéalisationEtModalitésAbandon:
@@ -396,7 +392,6 @@ Le Candidat peut également être délié de cette obligation selon l’appréci
       cahierDesCharges: {
         référence: '2023/S 215-677967',
       },
-      delaiDcrEnMois: { valeur: 3, texte: 'trois' },
       familles: [],
       donnéesCourriersRéponse: {
         texteEngagementRéalisationEtModalitésAbandon:
@@ -433,7 +428,6 @@ Le Candidat peut également être délié de cette obligation selon l’appréci
       cahierDesCharges: {
         référence: '2024/S 64-189193',
       },
-      delaiDcrEnMois: { valeur: 3, texte: 'trois' },
       familles: [],
       donnéesCourriersRéponse: {
         texteEngagementRéalisationEtModalitésAbandon:
@@ -470,7 +464,6 @@ Le Candidat peut également être délié de cette obligation selon l’appréci
       cahierDesCharges: {
         référence: '2024/S 419522-2024',
       },
-      delaiDcrEnMois: { valeur: 3, texte: 'trois' },
       familles: [],
       donnéesCourriersRéponse: {
         texteEngagementRéalisationEtModalitésAbandon:
@@ -506,7 +499,6 @@ Le Candidat peut également être délié de cette obligation selon l’appréci
       cahierDesCharges: {
         référence: '2025/S 10841-2025',
       },
-      delaiDcrEnMois: { valeur: 3, texte: 'trois' },
       familles: [],
       donnéesCourriersRéponse: {
         texteEngagementRéalisationEtModalitésAbandon:
@@ -539,7 +531,6 @@ Le Candidat peut également être délié de cette obligation selon l’appréci
       cahierDesCharges: {
         référence: '2025/S 322887-2025',
       },
-      delaiDcrEnMois: { valeur: 3, texte: 'trois' },
       familles: [],
       donnéesCourriersRéponse: {
         texteEngagementRéalisationEtModalitésAbandon:
@@ -572,7 +563,6 @@ Le Candidat peut également être délié de cette obligation selon l’appréci
       cahierDesCharges: {
         référence: '2026/S 233003-2026',
       },
-      delaiDcrEnMois: { valeur: 3, texte: 'trois' },
       familles: [],
       donnéesCourriersRéponse: {
         texteEngagementRéalisationEtModalitésAbandon:

--- a/packages/domain/inmemory-referential/src/appelOffre/PPE2/innovation.ppe2.ts
+++ b/packages/domain/inmemory-referential/src/appelOffre/PPE2/innovation.ppe2.ts
@@ -170,6 +170,7 @@ Des délais supplémentaires peuvent être accordés par le Préfet, à son appr
 `,
     },
   },
+  délaiDCR: { grd: 3 },
   periodes: [
     {
       id: '1',
@@ -180,7 +181,6 @@ Des délais supplémentaires peuvent être accordés par le Préfet, à son appr
       cahierDesCharges: {
         référence: '2021 S 203-530267',
       },
-      delaiDcrEnMois: { valeur: 3, texte: 'trois' },
       familles: [
         {
           id: '1',

--- a/packages/domain/inmemory-referential/src/appelOffre/PPE2/neutre.ppe2.ts
+++ b/packages/domain/inmemory-referential/src/appelOffre/PPE2/neutre.ppe2.ts
@@ -124,6 +124,7 @@ Des délais supplémentaires peuvent être accordés par le Préfet, à son appr
 `,
     },
   },
+  délaiDCR: { grd: 3 },
   periodes: [
     {
       id: '1',
@@ -135,7 +136,6 @@ Des délais supplémentaires peuvent être accordés par le Préfet, à son appr
       cahierDesCharges: {
         référence: '2022 S 100-276861',
       },
-      delaiDcrEnMois: { valeur: 3, texte: 'trois' },
       familles: [],
       donnéesCourriersRéponse: {
         texteEngagementRéalisationEtModalitésAbandon: {
@@ -179,7 +179,6 @@ Le Candidat peut également être délié de cette obligation selon l’appréci
       cahierDesCharges: {
         référence: '2023 S 147-469153',
       },
-      delaiDcrEnMois: { valeur: 3, texte: 'trois' },
       familles: [],
       donnéesCourriersRéponse: {
         texteEngagementRéalisationEtModalitésAbandon: {
@@ -222,7 +221,6 @@ Le Candidat peut également être délié de cette obligation selon l’appréci
       cahierDesCharges: {
         référence: '2024/S 489025-2024',
       },
-      delaiDcrEnMois: { valeur: 3, texte: 'trois' },
       familles: [],
       donnéesCourriersRéponse: {
         texteEngagementRéalisationEtModalitésAbandon: {
@@ -263,7 +261,6 @@ Le Candidat peut également être délié de cette obligation selon l’appréci
       cahierDesCharges: {
         référence: '2025/S 125-430892',
       },
-      delaiDcrEnMois: { valeur: 3, texte: 'trois' },
       familles: [],
       donnéesCourriersRéponse: {
         texteEngagementRéalisationEtModalitésAbandon: {

--- a/packages/domain/inmemory-referential/src/appelOffre/PPE2/petitPV.ppe2.ts
+++ b/packages/domain/inmemory-referential/src/appelOffre/PPE2/petitPV.ppe2.ts
@@ -17,7 +17,6 @@ export const petitPVPPE2: AppelOffre.AppelOffreReadModel = {
       cahierDesCharges: {
         référence: '🦺 A COMPLETER 🦺',
       },
-      delaiDcrEnMois: { valeur: 3, texte: 'trois' },
       familles: [],
       cahiersDesChargesModifiésDisponibles: [],
       // si CDC modifié ajouté, vérifier si retour au CDC initial possible

--- a/packages/domain/inmemory-referential/src/appelOffre/PPE2/petitPVBâtiment.ppe2.ts
+++ b/packages/domain/inmemory-referential/src/appelOffre/PPE2/petitPVBâtiment.ppe2.ts
@@ -20,7 +20,7 @@ export const petitPVBâtimentPPE2: AppelOffre.AppelOffreReadModel = {
   délaiRéalisationEnMois: 34,
   delaiRealisationTexte: 'trente-quatre (34) mois',
   activerRappelsEchéanceAchèvement: true,
-  transmissionAutomatiséeDesDonnéesDeContractualisationAuCocontractant: true,
+  délaiDCR: { grd: 3, potentiel: 4 },
   miseÀJour: {
     changement: {
       typologieInstallation: {},
@@ -151,7 +151,6 @@ De plus, dans le cas où le Candidat a fourni une garantie à première demande 
       cahierDesCharges: {
         référence: '2025/S 513616-2025',
       },
-      delaiDcrEnMois: { valeur: 3, texte: 'trois' },
       familles: [],
       cahiersDesChargesModifiésDisponibles: [],
       // si CDC modifié ajouté, vérifier si retour au CDC initial possible

--- a/packages/domain/inmemory-referential/src/appelOffre/PPE2/sol.ppe2.ts
+++ b/packages/domain/inmemory-referential/src/appelOffre/PPE2/sol.ppe2.ts
@@ -175,6 +175,7 @@ Des délais supplémentaires peuvent être accordés par le Préfet, à son appr
     typologieInstallation: { type: 'optionnel' as const },
     ...champsSupplémentairesAPartirDeP8,
   },
+  délaiDCR: { grd: 3 },
   periodes: [
     {
       id: '1',
@@ -185,7 +186,6 @@ Des délais supplémentaires peuvent être accordés par le Préfet, à son appr
       cahierDesCharges: {
         référence: '2021 S 211-553136',
       },
-      delaiDcrEnMois: { valeur: 3, texte: 'trois' },
       familles: [],
       volumeRéservé: {
         noteMin: 46.95,
@@ -216,7 +216,6 @@ Des délais supplémentaires peuvent être accordés par le Préfet, à son appr
       cahierDesCharges: {
         référence: '2022/S 061-160516',
       },
-      delaiDcrEnMois: { valeur: 3, texte: 'trois' },
       familles: [],
       volumeRéservé: {
         noteMin: 35.25,
@@ -253,7 +252,6 @@ Des délais supplémentaires peuvent être accordés par le Préfet, à son appr
       cahierDesCharges: {
         référence: '2022 S 214-614411',
       },
-      delaiDcrEnMois: { valeur: 3, texte: 'trois' },
       familles: [],
       volumeRéservé: {
         noteMin: 33.95,
@@ -284,7 +282,6 @@ Des délais supplémentaires peuvent être accordés par le Préfet, à son appr
       cahierDesCharges: {
         référence: '2023 S 063-187860',
       },
-      delaiDcrEnMois: { valeur: 3, texte: 'trois' },
       familles: [],
       volumeRéservé: {
         noteMin: 17.96,
@@ -326,7 +323,6 @@ Le Candidat peut également être délié de cette obligation selon l’appréci
       cahierDesCharges: {
         référence: '2023/S 217-681379',
       },
-      delaiDcrEnMois: { valeur: 3, texte: 'trois' },
       familles: [],
       volumeRéservé: {
         noteMin: 15.57,
@@ -368,7 +364,6 @@ Le Candidat peut également être délié de cette obligation selon l’appréci
       cahierDesCharges: {
         référence: '2024/S 422369-2024',
       },
-      delaiDcrEnMois: { valeur: 3, texte: 'trois' },
       familles: [],
       volumeRéservé: {
         noteMin: 18.97,
@@ -410,7 +405,6 @@ Le Candidat peut également être délié de cette obligation selon l’appréci
       cahierDesCharges: {
         référence: '2021/S 146-385911',
       },
-      delaiDcrEnMois: { valeur: 3, texte: 'trois' },
       familles: [],
       volumeRéservé: {
         noteMin: 25.98,
@@ -450,7 +444,6 @@ Le Candidat peut également être délié de cette obligation selon l’appréci
       cahierDesCharges: {
         référence: '2025/S 059-190628',
       },
-      delaiDcrEnMois: { valeur: 3, texte: 'trois' },
       familles: [],
       volumeRéservé: {
         noteMin: 25.08,

--- a/packages/domain/inmemory-referential/src/appelOffre/PPE2/zni.ppe2.ts
+++ b/packages/domain/inmemory-referential/src/appelOffre/PPE2/zni.ppe2.ts
@@ -116,6 +116,7 @@ export const zniPPE2: AppelOffre.AppelOffreReadModel = {
       dispositions: `Les modifications de la structure du capital du Candidat sont réputées autorisées. Elles doivent faire l’objet d’une information au Préfet dans un délai d’un (1) mois. Si le Candidat s’est engagé au Financement Collectif ou à la Gouvernance Partagée du projet prévu au 3.2.7, il est de sa responsabilité́ de s’assurer du respect de son engagement.`,
     },
   },
+  délaiDCR: { grd: 3 },
   periodes: [
     {
       id: '1',
@@ -125,7 +126,6 @@ export const zniPPE2: AppelOffre.AppelOffreReadModel = {
       cahierDesCharges: {
         référence: '2023/S 183-570186',
       },
-      delaiDcrEnMois: { valeur: 3, texte: 'trois' },
       familles: [
         {
           id: '1',
@@ -157,7 +157,6 @@ du paragraphe 2.6.`,
       cahierDesCharges: {
         référence: '2024/S 490218-2024',
       },
-      delaiDcrEnMois: { valeur: 3, texte: 'trois' },
       familles: [
         {
           id: '1',
@@ -189,7 +188,6 @@ du paragraphe 2.6.`,
       cahierDesCharges: {
         référence: '2023/S 183-570186',
       },
-      delaiDcrEnMois: { valeur: 3, texte: 'trois' },
       familles: [
         {
           id: '1',
@@ -221,7 +219,6 @@ du paragraphe 2.6.`,
       cahierDesCharges: {
         référence: '2025/S 146-503744',
       },
-      delaiDcrEnMois: { valeur: 3, texte: 'trois' },
       familles: [
         {
           id: '1',

--- a/packages/domain/inmemory-referential/src/index.ts
+++ b/packages/domain/inmemory-referential/src/index.ts
@@ -1,2 +1,3 @@
 export * from './appelOffre/index.js';
 export * from './géographie/index.js';
+export * from './nombresEnToutesLettres.js';

--- a/packages/domain/inmemory-referential/src/nombresEnToutesLettres.ts
+++ b/packages/domain/inmemory-referential/src/nombresEnToutesLettres.ts
@@ -1,0 +1,8 @@
+import type { AppelOffre } from '@potentiel-domain/appel-offre';
+
+export const nombresEnToutesLettres: Record<AppelOffre.Nombres, string> = {
+  '1': 'un',
+  '2': 'deux',
+  '3': 'trois',
+  '4': 'quatre',
+};

--- a/packages/domain/projet/src/cahierDesCharges.valueType.ts
+++ b/packages/domain/projet/src/cahierDesCharges.valueType.ts
@@ -44,6 +44,7 @@ export namespace CahierDesCharges {
     estChampRequisOuOptionnel(champ: AppelOffre.ChampCandidature): boolean;
     estChampRequis(champ: AppelOffre.ChampCandidature): boolean;
     getTypesActionnariat(): TypeActionnariat.RawType[];
+    getDélaiDCR(): AppelOffre.DélaiDCR;
   };
 
   export const bind = ({
@@ -212,6 +213,9 @@ export namespace CahierDesCharges {
           ? TypeActionnariat.ppe2Types
           : TypeActionnariat.cre4Types),
       ];
+    },
+    getDélaiDCR() {
+      return this.période.délaiDCR ?? this.appelOffre.délaiDCR;
     },
   });
 

--- a/packages/domain/projet/src/lauréat/raccordement/raccordement.aggregate.ts
+++ b/packages/domain/projet/src/lauréat/raccordement/raccordement.aggregate.ts
@@ -194,24 +194,6 @@ export class RaccordementAggregate extends AbstractAggregate<
     return false;
   }
 
-  //#endregion helpers
-
-  private async planifierRelanceDemandeComplèteRaccordement(àExécuterLe: DateTime.ValueType) {
-    if (
-      !this.lauréat.parent.appelOffre
-        .transmissionAutomatiséeDesDonnéesDeContractualisationAuCocontractant
-    ) {
-      return;
-    }
-    await this.#tâchePlanifiéeRelanceDemandeComplèteRaccordement.ajouter({
-      àExécuterLe,
-    });
-  }
-
-  private async annulerTâchePlanifiéeRelanceDCR() {
-    await this.#tâchePlanifiéeRelanceDemandeComplèteRaccordement.annuler();
-  }
-
   async annulerTâchesEtTâchesPlanifiées() {
     await this.#tâchePlanifiéeRelanceDemandeComplèteRaccordement.annuler();
     await this.#tâcheGestionnaireRéseauInconnuAttribué.achever();
@@ -220,25 +202,33 @@ export class RaccordementAggregate extends AbstractAggregate<
   }
 
   async ajouterTâchesEtTâchesPlanifiées() {
-    const demandeComplèteDeRaccordementManquante = this.#dossiers.size === 0;
-    if (demandeComplèteDeRaccordementManquante) {
+    const dossiersRaccordements = [...this.#dossiers.values()];
+    if (dossiersRaccordements.length === 0) {
       await this.#tâcheTransmettreRéférenceRaccordement.ajouter();
-      await this.planifierRelanceDemandeComplèteRaccordement(
-        this.lauréat.notifiéLe.ajouterNombreDeMois(2),
-      );
+
+      let àExécuterLe = this.lauréat.notifiéLe.ajouterNombreDeMois(2);
+      if (this.lauréat.notifiéLe.estPassée()) {
+        àExécuterLe = DateTime.now().ajouterNombreDeJours(1);
+      }
+      await this.#tâchePlanifiéeRelanceDemandeComplèteRaccordement.ajouter({
+        àExécuterLe,
+      });
     }
 
-    const dossierRaccordementSansAccuséDeRéception = [...this.#dossiers.values()].filter(
-      (dossier) => Option.isNone(dossier.demandeComplèteRaccordement.format),
+    const dossierRaccordementSansAccuséDeRéception = dossiersRaccordements.filter((dossier) =>
+      Option.isNone(dossier.demandeComplèteRaccordement.format),
     );
     if (dossierRaccordementSansAccuséDeRéception.length > 0) {
       await this.#tâcheRenseignerAccuséRéceptionDemandeComplèteRaccordement.ajouter();
+    } else {
+      await this.#tâcheRenseignerAccuséRéceptionDemandeComplèteRaccordement.achever();
     }
 
     if (this.#gestionnaireRéseau.identifiantGestionnaireRéseau.estInconnu()) {
       await this.#tâcheGestionnaireRéseauInconnuAttribué.ajouter();
     }
   }
+  //#endregion helpers
 
   //#region gestionnaire de réseau
 
@@ -285,16 +275,7 @@ export class RaccordementAggregate extends AbstractAggregate<
 
       await this.publish(event);
     }
-    await this.#tâcheTransmettreRéférenceRaccordement.ajouter();
-
-    if (
-      this.parent.projet.appelOffre
-        .transmissionAutomatiséeDesDonnéesDeContractualisationAuCocontractant
-    ) {
-      await this.planifierRelanceDemandeComplèteRaccordement(
-        this.lauréat.notifiéLe.ajouterNombreDeMois(2),
-      );
-    }
+    await this.ajouterTâchesEtTâchesPlanifiées();
   }
   private applyGestionnaireRéseauRaccordemenInconnuEventV1(
     _: GestionnaireRéseauInconnuAttribuéEvent,
@@ -485,20 +466,9 @@ export class RaccordementAggregate extends AbstractAggregate<
     };
 
     await this.publish(dossierDuRaccordementSupprimé);
-
-    const dossiersRestants = [...this.#dossiers.values()];
-
-    if (dossiersRestants.length === 0) {
-      await this.#tâcheTransmettreRéférenceRaccordement.ajouter();
-    }
-    const dossiersSansAccuséDeRéception = dossiersRestants.filter((dossier) =>
-      Option.isSome(dossier.demandeComplèteRaccordement.format),
-    );
-
-    if (dossiersSansAccuséDeRéception.length > 0) {
-      await this.#tâcheRenseignerAccuséRéceptionDemandeComplèteRaccordement.achever();
-    }
+    await this.ajouterTâchesEtTâchesPlanifiées();
   }
+
   private applyDossierDuRaccordementSuppriméEventV1({
     payload,
   }: DossierDuRaccordementSuppriméEventV1) {
@@ -785,7 +755,7 @@ export class RaccordementAggregate extends AbstractAggregate<
       await this.#tâcheRenseignerAccuséRéceptionDemandeComplèteRaccordement.ajouter();
     }
 
-    await this.annulerTâchePlanifiéeRelanceDCR();
+    await this.#tâchePlanifiéeRelanceDemandeComplèteRaccordement.annuler();
   }
   private applyDemandeComplèteDeRaccordementTransmiseEventV1({
     payload: { identifiantGestionnaireRéseau, référenceDossierRaccordement, dateQualification },
@@ -1157,7 +1127,6 @@ export class RaccordementAggregate extends AbstractAggregate<
 
   //#endregion date de mise en service
 
-  //#region apply
   apply(event: RaccordementEvent) {
     return match(event)
       .with(

--- a/packages/specifications/src/projet/lauréat/raccordement/dossierRaccordement/supprimerDossierDuRaccordement.feature
+++ b/packages/specifications/src/projet/lauréat/raccordement/dossierRaccordement/supprimerDossierDuRaccordement.feature
@@ -31,6 +31,7 @@ Fonctionnalité: Supprimer un dossier du raccordement d'un projet
         Quand le porteur supprime le dossier de raccordement pour le projet lauréat
         Alors le dossier ne devrait plus être consultable dans la liste des dossiers du raccordement pour le projet
         Et une tâche indiquant de "transmettre une référence de raccordement" est consultable dans la liste des tâches du porteur pour le projet
+        Et une tâche "relance transmission de la demande complète raccordement" est planifiée pour le projet lauréat
 
     Scénario: Le système supprime la tâche liée à l'accusé de réception d'un dossier de raccordement si celui-ci est supprimé
         Etant donné une demande complète de raccordement sans accusé de réception pour le projet lauréat


### PR DESCRIPTION
Contexte : la fonctionalité a été implémentée pour AOS mais oubliée pour les autres AO

La différence entre les 2 : pour les projets AOS, la transmission sur Potentiel est requise. Pour les autres, elle est optionnelle.

J'ai choisi de modéliser dans l'AO (ou la période) la **date limite** de transmission, plutôt que d'avoir un booléen qui indiquait qqchose d'indirectement lié : `transmissionAutomatiséeDesDonnéesDeContractualisationAuCocontractant`. En effet on a la notion d'achèvement qui _nécessite_ que la donnée de raccordement soit transmise, mais l'obligation exprimée dans le CDC est bien celle de la transmission _sur potentiel_ de la référence de raccordement

 