### PR TITLE
✨ Un cocontractant peut corriger une date d'achèvement réel

### DIFF
--- a/packages/applications/cli/src/commands/achèvement/transmission-date-achevement-reel-edf-oa.ts
+++ b/packages/applications/cli/src/commands/achèvement/transmission-date-achevement-reel-edf-oa.ts
@@ -32,13 +32,12 @@ type CsvLine = {
   identifiantProjet: string;
   statut: 'succès ✅' | 'erreur ❌';
   raison:
-    | 'Achèvement existant mais date identique'
+    | 'Correction de la date'
+    | "Date d'achèvement identique"
     | 'Transmission de la date'
     | 'Identifiant projet invalide'
-    | 'Date achèvement réel transmise inexistante'
-    | 'Achèvement aggrégat inexistant'
+    | 'Date achèvement réel invalide'
     | 'Achèvement inexistant'
-    | 'Correction date'
     | 'Opération métier impossible';
   dateAchèvementRéelTransmise: DateTime.RawType;
   dateMiseEnService?: DateTime.RawType;
@@ -58,8 +57,7 @@ type Stats = {
 
 export class VérifierTransmissionDateAchèvementRéelEDFOACommand extends Command {
   static override description =
-    `Vérification des données envoyées pour l'historique de transmission des dates d'achèvement réel par EDF OA.
-    Ici on va juste lire un fichier csv et valider les dates.`;
+    `Vérification des données envoyées pour l'historique de transmission des dates d'achèvement réel par EDF OA.`;
 
   static override flags = {
     path: Flags.file({
@@ -104,11 +102,12 @@ export class VérifierTransmissionDateAchèvementRéelEDFOACommand extends Comma
     const { parsedData: projets } = await parseCsvFile(flags.path, schema);
 
     if (!projets.length) {
-      throw new Error(`Aucun projet n'a été transmis dans le fichier ${flags.path}`);
+      throw new Error(`Aucun projet n'est à mettre à jour dans le fichier ${flags.path}`);
     }
 
     stats.total = projets.length;
-    console.log(`ℹ️ ${stats.total} projets concernés`);
+
+    console.log(`ℹ️ ${stats.total} projets concernés par une mise à jour`);
 
     let compteur = 0;
 
@@ -160,7 +159,7 @@ export class VérifierTransmissionDateAchèvementRéelEDFOACommand extends Comma
             stats.succès.push({
               identifiantProjet,
               statut: 'succès ✅',
-              raison: 'Achèvement existant mais date identique',
+              raison: "Date d'achèvement identique",
               dateAchèvementRéelTransmise,
               dateAchèvementRéelActuelle,
               écartEnJours: 0,
@@ -181,7 +180,7 @@ export class VérifierTransmissionDateAchèvementRéelEDFOACommand extends Comma
           stats.succès.push({
             identifiantProjet,
             statut: 'succès ✅',
-            raison: 'Correction date',
+            raison: 'Correction de la date',
             dateAchèvementRéelTransmise,
             dateAchèvementRéelActuelle,
             écartEnJours,
@@ -223,7 +222,7 @@ export class VérifierTransmissionDateAchèvementRéelEDFOACommand extends Comma
           stats.erreurs.push({
             identifiantProjet,
             statut: 'erreur ❌',
-            raison: 'Date achèvement réel transmise inexistante',
+            raison: 'Date achèvement réel invalide',
             dateAchèvementRéelTransmise,
             dateAchèvementRéelActuelle: undefined,
             écartEnJours: undefined,
@@ -251,12 +250,12 @@ export class VérifierTransmissionDateAchèvementRéelEDFOACommand extends Comma
 
     console.info(`\n📊 Résultat (cf ${RESULT_FILE}):`);
     console.info(
-      `  ✅ ${stats.succès.length} projets sont en succès suite à une tranmission ou date égale`,
+      `  ✅ ${stats.succès.length} mises à jour réussies (transmission, correction ou date identique)`,
     );
-    console.info(`  ❌ ${stats.erreurs.length} projets en erreur`);
+    console.info(`  ❌ ${stats.erreurs.length} mises à jour en échec`);
 
     if (!stats.succès.length && !stats.erreurs.length) {
-      console.info('Aucune résultat à ajouter dans le fichier');
+      console.info('Aucun résultat à ajouter au fichier');
       return;
     }
 
@@ -297,7 +296,11 @@ export class VérifierTransmissionDateAchèvementRéelEDFOACommand extends Comma
     const parRaisonPuisÉcart = (a: CsvLine, b: CsvLine) => {
       const parRaison = a.raison.localeCompare(b.raison);
 
-      if (parRaison === 0 && a.raison === 'Correction date' && b.raison === 'Correction date') {
+      if (
+        parRaison === 0 &&
+        a.raison === 'Correction de la date' &&
+        b.raison === 'Correction de la date'
+      ) {
         return (b.écartEnJours ?? 0) - (a.écartEnJours ?? 0);
       }
 

--- a/packages/applications/cli/src/commands/achèvement/transmission-date-achevement-reel-edf-oa.ts
+++ b/packages/applications/cli/src/commands/achèvement/transmission-date-achevement-reel-edf-oa.ts
@@ -104,7 +104,7 @@ export class VérifierTransmissionDateAchèvementRéelEDFOACommand extends Comma
     const { parsedData: projets } = await parseCsvFile(flags.path, schema);
 
     if (!projets.length) {
-      throw new Error(`Aucun projet n'a été transmis dans le fichie ${flags.path}`);
+      throw new Error(`Aucun projet n'a été transmis dans le fichier ${flags.path}`);
     }
 
     stats.total = projets.length;
@@ -114,6 +114,7 @@ export class VérifierTransmissionDateAchèvementRéelEDFOACommand extends Comma
 
     for (const { identifiantProjet, dateEDFOA } of projets) {
       compteur++;
+      process.stdout.clearLine(0);
       process.stdout.write(`\r⏳ [${compteur}/${stats.total}]`);
 
       const dateEDFOAIsoString = dateEDFOA.length ? `${dateEDFOA.replace(' ', 'T')}Z` : '';
@@ -183,30 +184,28 @@ export class VérifierTransmissionDateAchèvementRéelEDFOACommand extends Comma
             raison: 'Correction date',
             dateAchèvementRéelTransmise,
             dateAchèvementRéelActuelle,
-            écartEnJours: 0,
+            écartEnJours,
+          });
+        } else {
+          await mediator.send<Lauréat.Achèvement.TransmettreDateAchèvementUseCase>({
+            type: 'Lauréat.Achèvement.UseCase.TransmettreDateAchèvement',
+            data: {
+              identifiantProjetValue: identifiantProjetValueType.formatter(),
+              dateAchèvementValue: dateAchèvementRéelTransmise,
+              transmiseLeValue: DateTime.now().formatter(),
+              transmiseParValue: Email.edfOa.formatter(),
+            },
           });
 
-          continue;
+          stats.succès.push({
+            identifiantProjet,
+            statut: 'succès ✅',
+            raison: 'Transmission de la date',
+            dateAchèvementRéelTransmise,
+            dateAchèvementRéelActuelle: undefined,
+            écartEnJours: undefined,
+          });
         }
-
-        await mediator.send<Lauréat.Achèvement.TransmettreDateAchèvementUseCase>({
-          type: 'Lauréat.Achèvement.UseCase.TransmettreDateAchèvement',
-          data: {
-            identifiantProjetValue: identifiantProjetValueType.formatter(),
-            dateAchèvementValue: dateAchèvementRéelTransmise,
-            transmiseLeValue: DateTime.now().formatter(),
-            transmiseParValue: Email.edfOa.formatter(),
-          },
-        });
-
-        stats.succès.push({
-          identifiantProjet,
-          statut: 'succès ✅',
-          raison: 'Transmission de la date',
-          dateAchèvementRéelTransmise,
-          dateAchèvementRéelActuelle: undefined,
-          écartEnJours: undefined,
-        });
       } catch (error) {
         if (error instanceof IdentifiantProjet.IdentifiantProjetInvalideError) {
           stats.erreurs.push({
@@ -232,19 +231,10 @@ export class VérifierTransmissionDateAchèvementRéelEDFOACommand extends Comma
           continue;
         }
 
-        if (AggregateNotFoundError.isAggregateNotFoundError(error as Error)) {
-          stats.erreurs.push({
-            identifiantProjet,
-            statut: 'erreur ❌',
-            raison: 'Achèvement aggrégat inexistant',
-            dateAchèvementRéelTransmise,
-            dateAchèvementRéelActuelle: undefined,
-            écartEnJours: undefined,
-          });
-          continue;
-        }
-
-        if (OperationRejectedError.isOperationRejectedError(error as Error)) {
+        if (
+          AggregateNotFoundError.isAggregateNotFoundError(error as Error) ||
+          OperationRejectedError.isOperationRejectedError(error as Error)
+        ) {
           stats.erreurs.push({
             identifiantProjet,
             statut: 'erreur ❌',
@@ -255,7 +245,6 @@ export class VérifierTransmissionDateAchèvementRéelEDFOACommand extends Comma
           });
         }
       }
-      process.stdout.write('\n');
     }
 
     const RESULT_FILE = 'file_results_stats.csv';

--- a/packages/applications/cli/src/commands/achèvement/transmission-date-achevement-reel-edf-oa.ts
+++ b/packages/applications/cli/src/commands/achèvement/transmission-date-achevement-reel-edf-oa.ts
@@ -38,7 +38,7 @@ type CsvLine = {
     | 'Date achèvement réel transmise inexistante'
     | 'Achèvement aggrégat inexistant'
     | 'Achèvement inexistant'
-    | 'Achèvement existant avec date différente'
+    | 'Correction date'
     | 'Opération métier impossible';
   dateAchèvementRéelTransmise: DateTime.RawType;
   dateMiseEnService?: DateTime.RawType;
@@ -101,15 +101,6 @@ export class VérifierTransmissionDateAchèvementRéelEDFOACommand extends Comma
       dateEDFOA: z.string(),
     });
 
-    /***
-     * TODO :
-     * 1. Lire fichier (non gitté)
-     * 2. Pour chaque ligne il faut consulter achèvement et valider :
-     * - On en attend 1 ? La date fournie est-elle cohérente ?
-     * - On en a déjà 1 ? Date correspond ?
-     * - Cf les règles de l'aggrégat pour tracker tout les throw métier
-     */
-
     const { parsedData: projets } = await parseCsvFile(flags.path, schema);
 
     if (!projets.length) {
@@ -164,28 +155,7 @@ export class VérifierTransmissionDateAchèvementRéelEDFOACommand extends Comma
 
           const dateAchèvementRéelActuelle = achèvement.dateAchèvementRéel.formatter();
 
-          if (écartEnJours > 0) {
-            const raccordement =
-              await mediator.send<Lauréat.Raccordement.ConsulterRaccordementQuery>({
-                type: 'Lauréat.Raccordement.Query.ConsulterRaccordement',
-                data: { identifiantProjetValue: identifiantProjet },
-              });
-
-            const dateMiseEnService =
-              Option.isSome(raccordement) && raccordement.miseEnService?.date
-                ? raccordement.miseEnService.date.formatter()
-                : undefined;
-
-            stats.erreurs.push({
-              identifiantProjet,
-              statut: 'erreur ❌',
-              raison: 'Achèvement existant avec date différente',
-              dateAchèvementRéelTransmise,
-              dateAchèvementRéelActuelle,
-              dateMiseEnService,
-              écartEnJours,
-            });
-          } else {
+          if (écartEnJours === 0) {
             stats.succès.push({
               identifiantProjet,
               statut: 'succès ✅',
@@ -194,7 +164,28 @@ export class VérifierTransmissionDateAchèvementRéelEDFOACommand extends Comma
               dateAchèvementRéelActuelle,
               écartEnJours: 0,
             });
+            continue;
           }
+
+          await mediator.send<Lauréat.Achèvement.CorrigerDateAchèvementUseCase>({
+            type: 'Lauréat.Achèvement.UseCase.CorrigerDateAchèvement',
+            data: {
+              identifiantProjetValue: identifiantProjetValueType.formatter(),
+              dateAchèvementValue: dateAchèvementRéelTransmise,
+              corrigéeLeValue: DateTime.now().formatter(),
+              corrigéeParValue: Email.edfOa.formatter(),
+            },
+          });
+
+          stats.succès.push({
+            identifiantProjet,
+            statut: 'succès ✅',
+            raison: 'Correction date',
+            dateAchèvementRéelTransmise,
+            dateAchèvementRéelActuelle,
+            écartEnJours: 0,
+          });
+
           continue;
         }
 
@@ -204,7 +195,7 @@ export class VérifierTransmissionDateAchèvementRéelEDFOACommand extends Comma
             identifiantProjetValue: identifiantProjetValueType.formatter(),
             dateAchèvementValue: dateAchèvementRéelTransmise,
             transmiseLeValue: DateTime.now().formatter(),
-            transmiseParValue: Email.système.formatter(),
+            transmiseParValue: Email.edfOa.formatter(),
           },
         });
 
@@ -317,11 +308,7 @@ export class VérifierTransmissionDateAchèvementRéelEDFOACommand extends Comma
     const parRaisonPuisÉcart = (a: CsvLine, b: CsvLine) => {
       const parRaison = a.raison.localeCompare(b.raison);
 
-      if (
-        parRaison === 0 &&
-        a.raison === 'Achèvement existant avec date différente' &&
-        b.raison === 'Achèvement existant avec date différente'
-      ) {
+      if (parRaison === 0 && a.raison === 'Correction date' && b.raison === 'Correction date') {
         return (b.écartEnJours ?? 0) - (a.écartEnJours ?? 0);
       }
 

--- a/packages/applications/notifications/src/subscribers/lauréat/achèvement/achèvement.notifications.ts
+++ b/packages/applications/notifications/src/subscribers/lauréat/achèvement/achèvement.notifications.ts
@@ -35,6 +35,7 @@ export const register = () => {
             'AchèvementModifié-V1',
             'DateAchèvementPrévisionnelCalculée-V1',
             'AttestationConformitéModifiée-V1',
+            'DateAchèvementCorrigée-V1',
           ),
         },
         () => Promise.resolve(),

--- a/packages/applications/projectors/src/subscribers/lauréat/achèvement/dateAchèvementCorrigée.projector.ts
+++ b/packages/applications/projectors/src/subscribers/lauréat/achèvement/dateAchèvementCorrigée.projector.ts
@@ -1,0 +1,19 @@
+import type { Lauréat } from '@potentiel-domain/projet';
+import { updateOneProjection } from '@potentiel-infrastructure/pg-projection-write';
+
+export const dateAchèvementCorrigéeProjector = async ({
+  payload,
+}: Lauréat.Achèvement.DateAchèvementCorrigéeEvent) => {
+  await updateOneProjection<Lauréat.Achèvement.AchèvementEntity>(
+    `achèvement|${payload.identifiantProjet}`,
+    {
+      réel: {
+        date: payload.dateAchèvement,
+        dernièreMiseÀJour: {
+          date: payload.corrigéeLe,
+          utilisateur: payload.corrigéePar,
+        },
+      },
+    },
+  );
+};

--- a/packages/applications/projectors/src/subscribers/lauréat/achèvement/index.ts
+++ b/packages/applications/projectors/src/subscribers/lauréat/achèvement/index.ts
@@ -9,6 +9,7 @@ import { achèvementRebuildTriggered } from './achèvementRebuildTriggered.proje
 import { attestationConformitéEnregistréeProjector } from './attestationConformité/attestationConformitéEnregistrée.projector.js';
 import { attestationConformitéModifiéeProjector } from './attestationConformité/attestationConformitéModifiée.projector.js';
 import { attestationConformitéTransmiseProjector } from './attestationConformité/attestationConformitéTransmise.projector.js';
+import { dateAchèvementCorrigéeProjector } from './dateAchèvementCorrigée.projector.js';
 import { dateAchèvementPrévisionnelCalculéeProjector } from './dateAchèvementPrévisionnelCalculéeProjector.js';
 import { dateAchèvementTransmiseProjector } from './dateAchèvementTransmise.projector.js';
 
@@ -46,6 +47,7 @@ export const register = () => {
         dateAchèvementPrévisionnelCalculéeProjector,
       )
       .with({ type: 'DateAchèvementTransmise-V1' }, dateAchèvementTransmiseProjector)
+      .with({ type: 'DateAchèvementCorrigée-V1' }, dateAchèvementCorrigéeProjector)
       .exhaustive();
 
   mediator.register('System.Projector.Lauréat.Achèvement', handler);

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/achevement/(historique)/events/index.ts
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/achevement/(historique)/events/index.ts
@@ -1,4 +1,5 @@
 export { mapToAchèvementModifiéTimelineItemProps } from './mapToAchèvementModifiéTimelineItemProps';
 export { mapToAttestationConformitéTransmiseTimelineItemProps } from './mapToAttestationConformitéTransmiseTimelineItemProps';
+export { mapToDateAchèvementCorrigéeTimelineItemProps } from './mapToDateAchèvementCorrigéeTimelineItemProps';
 export { mapToDateAchèvementPrévisionnelCalculéeProps } from './mapToDateAchèvementPrévisionnelCalculéeProps';
 export { mapToDateAchèvementTransmiseTimelineItemProps } from './mapToDateAchèvementTransmiseTimelineItemProps';

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/achevement/(historique)/events/mapToDateAchèvementCorrigéeTimelineItemProps.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/achevement/(historique)/events/mapToDateAchèvementCorrigéeTimelineItemProps.tsx
@@ -7,8 +7,8 @@ export const mapToDateAchèvementCorrigéeTimelineItemProps = (
   event: Lauréat.Achèvement.DateAchèvementCorrigéeEvent,
 ): TimelineItemProps => {
   const { dateAchèvement, corrigéeLe } = event.payload;
-  // aujourd'hui seul le Cocontractant peut corriger la date d'achèvement
 
+  // aujourd'hui seul le Cocontractant peut corriger la date d'achèvement
   return {
     date: corrigéeLe,
     title: "Correction de la date d'achèvement par le Cocontractant",

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/achevement/(historique)/events/mapToDateAchèvementCorrigéeTimelineItemProps.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/achevement/(historique)/events/mapToDateAchèvementCorrigéeTimelineItemProps.tsx
@@ -6,12 +6,12 @@ import type { TimelineItemProps } from '@/components/organisms/timeline';
 export const mapToDateAchèvementCorrigéeTimelineItemProps = (
   event: Lauréat.Achèvement.DateAchèvementCorrigéeEvent,
 ): TimelineItemProps => {
-  const { dateAchèvement, corrigéeLe, corrigéePar } = event.payload;
+  const { dateAchèvement, corrigéeLe } = event.payload;
+  // aujourd'hui seul le Cocontractant peut corriger la date d'achèvement
 
   return {
     date: corrigéeLe,
-    title: "Correction de la date d'achèvement",
-    actor: corrigéePar,
+    title: "Correction de la date d'achèvement par le Cocontractant",
     details: (
       <div>
         Nouvelle date d'achèvement réel :{' '}

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/achevement/(historique)/events/mapToDateAchèvementCorrigéeTimelineItemProps.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/achevement/(historique)/events/mapToDateAchèvementCorrigéeTimelineItemProps.tsx
@@ -1,0 +1,22 @@
+import type { Lauréat } from '@potentiel-domain/projet';
+
+import { FormattedDate } from '@/components/atoms/FormattedDate';
+import type { TimelineItemProps } from '@/components/organisms/timeline';
+
+export const mapToDateAchèvementCorrigéeTimelineItemProps = (
+  event: Lauréat.Achèvement.DateAchèvementCorrigéeEvent,
+): TimelineItemProps => {
+  const { dateAchèvement, corrigéeLe, corrigéePar } = event.payload;
+
+  return {
+    date: corrigéeLe,
+    title: "Correction de la date d'achèvement",
+    actor: corrigéePar,
+    details: (
+      <div>
+        Nouvelle date d'achèvement réel :{' '}
+        <span className="font-semibold">{<FormattedDate date={dateAchèvement} />}</span>
+      </div>
+    ),
+  };
+};

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/achevement/(historique)/mapToAchèvementTimelineItemProps.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/achevement/(historique)/mapToAchèvementTimelineItemProps.tsx
@@ -7,6 +7,7 @@ import { mapToÉtapeInconnueOuIgnoréeTimelineItemProps } from '../../(détails)
 import {
   mapToAchèvementModifiéTimelineItemProps,
   mapToAttestationConformitéTransmiseTimelineItemProps,
+  mapToDateAchèvementCorrigéeTimelineItemProps,
   mapToDateAchèvementPrévisionnelCalculéeProps,
   mapToDateAchèvementTransmiseTimelineItemProps,
 } from './events';
@@ -20,6 +21,7 @@ type MapToAchèvementTimelineItemProps = (
 export const mapToAchèvementTimelineItemProps: MapToAchèvementTimelineItemProps = (readmodel) =>
   match(readmodel)
     .with({ type: 'DateAchèvementTransmise-V1' }, mapToDateAchèvementTransmiseTimelineItemProps)
+    .with({ type: 'DateAchèvementCorrigée-V1' }, mapToDateAchèvementCorrigéeTimelineItemProps)
     .with(
       { type: P.union('AttestationConformitéTransmise-V1', 'AttestationConformitéTransmise-V2') },
       mapToAttestationConformitéTransmiseTimelineItemProps,

--- a/packages/applications/subscribers/src/setup/setupProjet/setupLauréat/setupAchèvement.ts
+++ b/packages/applications/subscribers/src/setup/setupProjet/setupLauréat/setupAchèvement.ts
@@ -18,6 +18,7 @@ export const setupAchèvement = () => {
       'AchèvementModifié-V2',
       'DateAchèvementPrévisionnelCalculée-V1',
       'DateAchèvementTransmise-V1',
+      'DateAchèvementCorrigée-V1',
       'AttestationConformitéEnregistrée-V1',
       'AttestationConformitéEnregistrée-V2',
       'RebuildTriggered',

--- a/packages/domain/common/src/valueTypes/email.valueType.ts
+++ b/packages/domain/common/src/valueTypes/email.valueType.ts
@@ -48,7 +48,7 @@ export const système = convertirEnValueType('system@system');
 /**
  * Email générique pour les migrations de date d'achèvement EDF OA
  */
-export const edfOa = convertirEnValueType('system@edfoa');
+export const edfOa = convertirEnValueType('migration@edf-oa');
 export const inconnu = convertirEnValueType('unknown-user@unknown-email.com');
 
 function estValide(value: string): asserts value is RawType {

--- a/packages/domain/common/src/valueTypes/email.valueType.ts
+++ b/packages/domain/common/src/valueTypes/email.valueType.ts
@@ -11,6 +11,7 @@ export type ValueType = ReadonlyValueType<{
   formatter: () => RawType;
   estInconnu: () => boolean;
   estSystème: () => boolean;
+  estEdfOa: () => boolean;
 }>;
 
 export const bind = ({ email }: PlainType<ValueType>): ValueType => {
@@ -29,6 +30,9 @@ export const bind = ({ email }: PlainType<ValueType>): ValueType => {
     estSystème() {
       return this.estÉgaleÀ(système);
     },
+    estEdfOa() {
+      return this.estÉgaleÀ(edfOa);
+    },
   };
 };
 
@@ -41,6 +45,10 @@ export const convertirEnValueType = (value: string): ValueType => {
 const regexEmail = /^[a-z0-9.+/=?^_`{|}~-]+@[a-z0-9-]+(?:\.[a-z0-9-]+)*$/;
 
 export const système = convertirEnValueType('system@system');
+/**
+ * Email générique pour les migrations de date d'achèvement EDF OA
+ */
+export const edfOa = convertirEnValueType('system@edfoa');
 export const inconnu = convertirEnValueType('unknown-user@unknown-email.com');
 
 function estValide(value: string): asserts value is RawType {

--- a/packages/domain/projet/src/lauréat/achèvement/achèvement.aggregate.ts
+++ b/packages/domain/projet/src/lauréat/achèvement/achèvement.aggregate.ts
@@ -13,6 +13,7 @@ import {
   AttestationDeConformitéNonModifiéeError,
   DateAchèvementAntérieureÀDateNotificationError,
   DateAchèvementDansLeFuturError,
+  DateAchèvementNonModifiéeError,
   DateDeTransmissionAuCoContractantFuturError,
   MainlevéeAccordéeError,
   ProjetDéjàAchevéError,
@@ -25,6 +26,8 @@ import type {
 } from './achèvement.event.js';
 import type { DateAchèvementPrévisionnelCalculéeEvent } from './calculerDateAchèvementPrévisionnel/calculerDateAchèvementPrévisionnel.event.js';
 import type { CalculerDateAchèvementPrévisionnelOptions } from './calculerDateAchèvementPrévisionnel/calculerDateAchèvementPrévisionnel.option.js';
+import type { DateAchèvementCorrigéeEvent } from './corriger/corrigerDateAchèvement.event.js';
+import type { CorrigerDateAchèvementOptions } from './corriger/corrigerDateAchèvement.option.js';
 import type { EnregistrerAttestationConformitéOptions } from './enregistrer/enregistrerAttestationConformité.option.js';
 import { DateAchèvementPrévisionnel, TypeTâchePlanifiéeAchèvement } from './index.js';
 import type {
@@ -358,6 +361,40 @@ export class AchèvementAggregate extends AbstractAggregate<
     });
   }
 
+  async corrigerDateAchèvement({
+    dateAchèvement,
+    corrigéeLe,
+    corrigéePar,
+  }: CorrigerDateAchèvementOptions) {
+    this.lauréat.vérifierQueLeLauréatExiste();
+
+    if (!this.#estAchevé) {
+      throw new ProjetNonAchevéError();
+    }
+
+    if (dateAchèvement.estDansLeFutur()) {
+      throw new DateAchèvementDansLeFuturError();
+    }
+
+    this.vérifierDateAchèvementPostérieureDateNotification(dateAchèvement);
+
+    if (this.#dateAchèvementRéel && dateAchèvement.estÉgaleÀ(this.#dateAchèvementRéel)) {
+      throw new DateAchèvementNonModifiéeError();
+    }
+
+    const event: DateAchèvementCorrigéeEvent = {
+      type: 'DateAchèvementCorrigée-V1',
+      payload: {
+        identifiantProjet: this.identifiantProjet.formatter(),
+        dateAchèvement: dateAchèvement.formatter(),
+        corrigéeLe: corrigéeLe.formatter(),
+        corrigéePar: corrigéePar.formatter(),
+      },
+    };
+
+    await this.publish(event);
+  }
+
   async planifierTâchesRappelsÉchéance(dateAchèvementPrévisionnelle: DateTime.ValueType) {
     if (
       !this.lauréat.projet.cahierDesChargesActuel.appelOffre.activerRappelsEchéanceAchèvement ||
@@ -410,6 +447,7 @@ export class AchèvementAggregate extends AbstractAggregate<
         this.applyDateAchèvementPrévisionnelCalculéeV1.bind(this),
       )
       .with({ type: 'DateAchèvementTransmise-V1' }, this.applyDateAchèvementTransmiseV1.bind(this))
+      .with({ type: 'DateAchèvementCorrigée-V1' }, this.applyDateAchèvementCorrigée.bind(this))
       .with(
         { type: 'AttestationConformitéEnregistrée-V1' },
         this.applyAttestationConformitéEnregistréeV1.bind(this),
@@ -487,6 +525,12 @@ export class AchèvementAggregate extends AbstractAggregate<
     payload: { dateAchèvement },
   }: DateAchèvementTransmiseEvent) {
     this.#estAchevé = true;
+    this.#dateAchèvementRéel = DateTime.convertirEnValueType(dateAchèvement);
+  }
+
+  private applyDateAchèvementCorrigée({
+    payload: { dateAchèvement },
+  }: DateAchèvementCorrigéeEvent) {
     this.#dateAchèvementRéel = DateTime.convertirEnValueType(dateAchèvement);
   }
 }

--- a/packages/domain/projet/src/lauréat/achèvement/achèvement.error.ts
+++ b/packages/domain/projet/src/lauréat/achèvement/achèvement.error.ts
@@ -18,6 +18,12 @@ export class AttestationDeConformitéNonModifiéeError extends InvalidOperationE
   }
 }
 
+export class DateAchèvementNonModifiéeError extends InvalidOperationError {
+  constructor() {
+    super("Aucune modification n'a été transmise");
+  }
+}
+
 export class ImpossibleTransmettreAttestationDeConformitéProjetAbandonnéError extends InvalidOperationError {
   constructor() {
     super(

--- a/packages/domain/projet/src/lauréat/achèvement/achèvement.event.ts
+++ b/packages/domain/projet/src/lauréat/achèvement/achèvement.event.ts
@@ -1,4 +1,5 @@
 import type { DateAchèvementPrévisionnelCalculéeEvent } from './calculerDateAchèvementPrévisionnel/calculerDateAchèvementPrévisionnel.event.js';
+import type { DateAchèvementCorrigéeEvent } from './corriger/corrigerDateAchèvement.event.js';
 import type {
   AttestationConformitéEnregistréeEvent,
   AttestationConformitéEnregistréeEventV1,
@@ -27,7 +28,8 @@ export type AchèvementEvent =
   | AchèvementModifiéEventV1
   | AchèvementModifiéEvent
   | DateAchèvementPrévisionnelCalculéeEvent
-  | DateAchèvementTransmiseEvent;
+  | DateAchèvementTransmiseEvent
+  | DateAchèvementCorrigéeEvent;
 
 export type {
   AchèvementModifiéEvent,
@@ -38,6 +40,7 @@ export type {
   AttestationConformitéModifiéeEventV1,
   AttestationConformitéTransmiseEvent,
   AttestationConformitéTransmiseEventV1,
+  DateAchèvementCorrigéeEvent,
   DateAchèvementPrévisionnelCalculéeEvent,
   DateAchèvementTransmiseEvent,
 };

--- a/packages/domain/projet/src/lauréat/achèvement/achèvement.register.ts
+++ b/packages/domain/projet/src/lauréat/achèvement/achèvement.register.ts
@@ -3,6 +3,8 @@ import {
   type ConsulterAchèvementDependencies,
   registerConsulterAchèvementQuery,
 } from './consulter/consulterAchèvement.query.js';
+import { registerCorrigerDateAchèvementCommand } from './corriger/corrigerDateAchèvement.command.js';
+import { registerCorrigerDateAchèvementUseCase } from './corriger/corrigerDateAchèvement.usecase.js';
 import { registerEnregistrerAttestationConformitéCommand } from './enregistrer/enregistrerAttestationConformité.command.js';
 import { registerEnregistrerAttestationConformitéUseCase } from './enregistrer/enregistrerAttestationConformité.usecase.js';
 import {
@@ -31,6 +33,9 @@ export const registerAchèvementUseCases = (dependencies: AchèvementCommandDepe
 
   registerTransmettreDateAchèvementCommand(dependencies.getProjetAggregateRoot);
   registerTransmettreDateAchèvementUseCase();
+
+  registerCorrigerDateAchèvementCommand(dependencies.getProjetAggregateRoot);
+  registerCorrigerDateAchèvementUseCase();
 
   registerEnregistrerAttestationConformitéCommand(dependencies.getProjetAggregateRoot);
   registerEnregistrerAttestationConformitéUseCase();

--- a/packages/domain/projet/src/lauréat/achèvement/corriger/corrigerDateAchèvement.command.ts
+++ b/packages/domain/projet/src/lauréat/achèvement/corriger/corrigerDateAchèvement.command.ts
@@ -1,0 +1,25 @@
+import { type Message, type MessageHandler, mediator } from 'mediateur';
+
+import type { DateTime, Email } from '@potentiel-domain/common';
+
+import type { GetProjetAggregateRoot, IdentifiantProjet } from '../../../index.js';
+
+export type CorrigerDateAchèvementCommand = Message<
+  'Lauréat.Achèvement.Command.CorrigerDateAchèvement',
+  {
+    identifiantProjet: IdentifiantProjet.ValueType;
+    dateAchèvement: DateTime.ValueType;
+    corrigéeLe: DateTime.ValueType;
+    corrigéePar: Email.ValueType;
+  }
+>;
+
+export const registerCorrigerDateAchèvementCommand = (
+  getProjetAggregateRoot: GetProjetAggregateRoot,
+) => {
+  const handler: MessageHandler<CorrigerDateAchèvementCommand> = async (payload) => {
+    const projet = await getProjetAggregateRoot(payload.identifiantProjet);
+    await projet.lauréat.achèvement.corrigerDateAchèvement(payload);
+  };
+  mediator.register('Lauréat.Achèvement.Command.CorrigerDateAchèvement', handler);
+};

--- a/packages/domain/projet/src/lauréat/achèvement/corriger/corrigerDateAchèvement.event.ts
+++ b/packages/domain/projet/src/lauréat/achèvement/corriger/corrigerDateAchèvement.event.ts
@@ -1,0 +1,20 @@
+import type { DateTime, Email } from '@potentiel-domain/common';
+import type { DomainEvent } from '@potentiel-domain/core';
+
+import type { IdentifiantProjet } from '../../../index.js';
+
+/**
+ * Représente la correction de la date d'achèvement par le Cocontractant,
+ * quel que soit l'évènement initial
+ * (DateAchèvementTransmise ou AttestationConformitéTransmise).
+ **/
+export type DateAchèvementCorrigéeEvent = DomainEvent<
+  'DateAchèvementCorrigée-V1',
+  {
+    identifiantProjet: IdentifiantProjet.RawType;
+
+    dateAchèvement: DateTime.RawType;
+    corrigéeLe: DateTime.RawType;
+    corrigéePar: Email.RawType;
+  }
+>;

--- a/packages/domain/projet/src/lauréat/achèvement/corriger/corrigerDateAchèvement.event.ts
+++ b/packages/domain/projet/src/lauréat/achèvement/corriger/corrigerDateAchèvement.event.ts
@@ -3,11 +3,6 @@ import type { DomainEvent } from '@potentiel-domain/core';
 
 import type { IdentifiantProjet } from '../../../index.js';
 
-/**
- * Représente la correction de la date d'achèvement par le Cocontractant,
- * quel que soit l'évènement initial
- * (DateAchèvementTransmise ou AttestationConformitéTransmise).
- **/
 export type DateAchèvementCorrigéeEvent = DomainEvent<
   'DateAchèvementCorrigée-V1',
   {

--- a/packages/domain/projet/src/lauréat/achèvement/corriger/corrigerDateAchèvement.option.ts
+++ b/packages/domain/projet/src/lauréat/achèvement/corriger/corrigerDateAchèvement.option.ts
@@ -1,0 +1,7 @@
+import type { DateTime, Email } from '@potentiel-domain/common';
+
+export type CorrigerDateAchèvementOptions = {
+  dateAchèvement: DateTime.ValueType;
+  corrigéeLe: DateTime.ValueType;
+  corrigéePar: Email.ValueType;
+};

--- a/packages/domain/projet/src/lauréat/achèvement/corriger/corrigerDateAchèvement.usecase.ts
+++ b/packages/domain/projet/src/lauréat/achèvement/corriger/corrigerDateAchèvement.usecase.ts
@@ -1,0 +1,43 @@
+import { type Message, type MessageHandler, mediator } from 'mediateur';
+
+import { DateTime, Email } from '@potentiel-domain/common';
+
+import { IdentifiantProjet } from '../../../index.js';
+import type { CorrigerDateAchèvementCommand } from './corrigerDateAchèvement.command.js';
+
+export type CorrigerDateAchèvementUseCase = Message<
+  'Lauréat.Achèvement.UseCase.CorrigerDateAchèvement',
+  {
+    identifiantProjetValue: string;
+    dateAchèvementValue: string;
+    corrigéeLeValue: string;
+    corrigéeParValue: string;
+  }
+>;
+
+export const registerCorrigerDateAchèvementUseCase = () => {
+  const runner: MessageHandler<CorrigerDateAchèvementUseCase> = async ({
+    identifiantProjetValue,
+    dateAchèvementValue,
+    corrigéeLeValue,
+    corrigéeParValue,
+  }) => {
+    const identifiantProjet = IdentifiantProjet.convertirEnValueType(identifiantProjetValue);
+
+    const dateAchèvement = DateTime.convertirEnValueType(dateAchèvementValue);
+    const corrigéeLe = DateTime.convertirEnValueType(corrigéeLeValue);
+    const corrigéePar = Email.convertirEnValueType(corrigéeParValue);
+
+    await mediator.send<CorrigerDateAchèvementCommand>({
+      type: 'Lauréat.Achèvement.Command.CorrigerDateAchèvement',
+      data: {
+        identifiantProjet,
+        dateAchèvement,
+        corrigéeLe,
+        corrigéePar,
+      },
+    });
+  };
+
+  mediator.register('Lauréat.Achèvement.UseCase.CorrigerDateAchèvement', runner);
+};

--- a/packages/domain/projet/src/lauréat/achèvement/index.ts
+++ b/packages/domain/projet/src/lauréat/achèvement/index.ts
@@ -3,6 +3,7 @@ import type {
   ConsulterAchèvementQuery,
   ConsulterAchèvementReadModel,
 } from './consulter/consulterAchèvement.query.js';
+import type { CorrigerDateAchèvementUseCase } from './corriger/corrigerDateAchèvement.usecase.js';
 import type { EnregistrerAttestationConformitéUseCase } from './enregistrer/enregistrerAttestationConformité.usecase.js';
 import type {
   ListerProjetAvecAchevementATransmettreQuery,
@@ -14,6 +15,7 @@ import type { TransmettreAttestationConformitéUseCase } from './transmettre/tra
 import type { TransmettreDateAchèvementUseCase } from './transmettre/transmettreDateAchèvement.usecase.js';
 
 export type {
+  CorrigerDateAchèvementUseCase,
   EnregistrerAttestationConformitéUseCase,
   ModifierAchèvementUseCase,
   ModifierAttestationConformitéUseCase,

--- a/packages/specifications/src/projet/lauréat/achèvement/achèvement.world.ts
+++ b/packages/specifications/src/projet/lauréat/achèvement/achèvement.world.ts
@@ -5,6 +5,7 @@ import { Lauréat } from '@potentiel-domain/projet';
 import type { PièceJustificative } from '#helpers';
 import type { LauréatWorld } from '../lauréat.world.js';
 import { CalculerDateAchèvementPrévisionnelFixture } from './fixture/calculerDateAchèvementPrévisionnel.fixture.js';
+import { CorrigerDateAchèvementFixture } from './fixture/corrigerDateAchèvement.fixture.js';
 import { EnregistrerAttestationConformitéFixture } from './fixture/enregistrerAttestationConformité.fixture.js';
 import { ModifierAchèvementFixture } from './fixture/modifierAchèvement.fixture.js';
 import { ModifierAttestationConformitéFixture } from './fixture/modifierAttestationConformité.fixture.js';
@@ -18,6 +19,7 @@ export class AchèvementWorld {
   #modifierAchèvementFixture: ModifierAchèvementFixture;
   #calculerDateAchèvementPrévisionnelFixture: CalculerDateAchèvementPrévisionnelFixture;
   #transmettreDateAchèvementFixture: TransmettreDateAchèvementFixture;
+  #corrigerDateAchèvementFixture: CorrigerDateAchèvementFixture;
 
   get transmettreAttestationConformitéFixture() {
     return this.#transmettreAttestationConformitéFixture;
@@ -42,6 +44,10 @@ export class AchèvementWorld {
     return this.#transmettreDateAchèvementFixture;
   }
 
+  get corrigerDateAchèvementFixture() {
+    return this.#corrigerDateAchèvementFixture;
+  }
+
   constructor(private lauréat: LauréatWorld) {
     this.#transmettreAttestationConformitéFixture = new TransmettreAttestationConformitéFixture(
       lauréat,
@@ -55,6 +61,7 @@ export class AchèvementWorld {
       lauréat,
     );
     this.#transmettreDateAchèvementFixture = new TransmettreDateAchèvementFixture(lauréat);
+    this.#corrigerDateAchèvementFixture = new CorrigerDateAchèvementFixture(lauréat);
   }
 
   get dateAchèvementPrévisionnelCalculée() {
@@ -118,6 +125,17 @@ export class AchèvementWorld {
       result = {
         ...result,
         ...this.modifierAttestationConformitéFixture.mapToExpected(),
+      };
+    }
+
+    if (this.corrigerDateAchèvementFixture.aÉtéCréé) {
+      assert(
+        result.estAchevé,
+        `impossible de corriger la date d'achèvement réel si le projet n’est pas achevé`,
+      );
+      result = {
+        ...result,
+        ...this.corrigerDateAchèvementFixture.mapToExpected(),
       };
     }
 

--- a/packages/specifications/src/projet/lauréat/achèvement/corrigerDateAchèvement.feature
+++ b/packages/specifications/src/projet/lauréat/achèvement/corrigerDateAchèvement.feature
@@ -1,6 +1,6 @@
 # language: fr
 @achèvement
-Fonctionnalité: Corriger la date d'achèvement réel transmise par le Cocontractant
+Fonctionnalité: Corriger la date d'achèvement réel
 
     Contexte:
         Etant donné le projet lauréat "Du boulodrome de Marseille" avec :
@@ -8,33 +8,33 @@ Fonctionnalité: Corriger la date d'achèvement réel transmise par le Cocontrac
         Et un cahier des charges permettant la modification du projet
         Et la dreal "Dreal du sud" associée à la région du projet
 
-    Scénario: le Cocontractant corrige la date d'achèvement réel au du projet lauréat
+    Scénario: le Cocontractant corrige la date d'achèvement réel du projet lauréat
         Etant donné une date d'achèvement réel transmise pour le projet lauréat
-        Quand le Cocontractant corrige la date d'achèvement réel au "2025-11-20" pour le projet lauréat
+        Quand le Cocontractant corrige la date d'achèvement réel pour le projet lauréat avec :
+            | date d'achèvement | 2025-11-20 |
         Alors la date d'achèvement réel "2025-11-20" devrait être consultable pour le projet lauréat
 
-    Scénario: le Cocontractant corrige la date d'achèvement réel au d'un projet achevé via une attestation de conformité transmise par le porteur
-        Etant donné l'achèvement réel transmis pour le projet lauréat
-        Quand le Cocontractant corrige la date d'achèvement réel au "2025-11-20" pour le projet lauréat
-        Alors la date d'achèvement réel devrait être consultable pour le projet lauréat
-
-    Scénario: Impossible de corriger la date d'achèvement pour un projet lauréat inexistant
+    Scénario: Impossible de corriger la date d'achèvement d'un projet lauréat inexistant
         Etant donné le projet éliminé "Du boulodrome de Lyon"
-        Quand le Cocontractant corrige la date d'achèvement réel au "2025-11-20" pour le projet éliminé
+        Quand le Cocontractant corrige la date d'achèvement réel pour le projet éliminé avec :
+            | date d'achèvement | 2025-11-20 |
         Alors l'utilisateur devrait être informé que "Le projet lauréat n'existe pas"
 
-    Scénario: Impossible de corriger la date d'achèvement d'un projet qui n'est pas achevé
-        Quand le Cocontractant corrige la date d'achèvement réel au "2025-11-20" pour le projet lauréat
+    Scénario: Impossible de corriger la date d'achèvement d'un projet lauréat qui n'est pas achevé
+        Quand le Cocontractant corrige la date d'achèvement réel pour le projet lauréat avec :
+            | date d'achèvement | 2025-11-20 |
         Alors l'utilisateur devrait être informé que "Le projet n'est pas achevé"
 
     Scénario: Impossible de corriger la date d'achèvement avec une date antérieure à la date de notification du projet
         Etant donné une date d'achèvement réel transmise pour le projet lauréat
-        Quand le Cocontractant corrige la date d'achèvement réel au "2023-01-01" pour le projet lauréat
+        Quand le Cocontractant corrige la date d'achèvement réel pour le projet lauréat avec :
+            | date d'achèvement | 2023-01-01 |
         Alors l'utilisateur devrait être informé que "La date d'achèvement ne peut pas être antérieure à la date de notification du projet"
 
     Scénario: Impossible de corriger la date d'achèvement avec une date future
         Etant donné une date d'achèvement réel transmise pour le projet lauréat
-        Quand le Cocontractant corrige la date d'achèvement réel au "2050-09-01" pour le projet lauréat
+        Quand le Cocontractant corrige la date d'achèvement réel pour le projet lauréat avec :
+            | date d'achèvement | 2050-09-01 |
         Alors l'utilisateur devrait être informé que "La date d'achèvement ne peut pas être dans le futur"
 
     Scénario: Impossible de corriger la date d'achèvement si aucune modification n'est transmise

--- a/packages/specifications/src/projet/lauréat/achèvement/corrigerDateAchèvement.feature
+++ b/packages/specifications/src/projet/lauréat/achèvement/corrigerDateAchèvement.feature
@@ -1,6 +1,6 @@
 # language: fr
 @achèvement
-Fonctionnalité: Corriger la date d'achèvement réelle transmise par le Cocontractant
+Fonctionnalité: Corriger la date d'achèvement réel transmise par le Cocontractant
 
     Contexte:
         Etant donné le projet lauréat "Du boulodrome de Marseille" avec :
@@ -8,36 +8,36 @@ Fonctionnalité: Corriger la date d'achèvement réelle transmise par le Cocontr
         Et un cahier des charges permettant la modification du projet
         Et la dreal "Dreal du sud" associée à la région du projet
 
-    Scénario: le Cocontractant corrige la date d'achèvement réelle du projet lauréat
+    Scénario: le Cocontractant corrige la date d'achèvement réel au du projet lauréat
         Etant donné une date d'achèvement réel transmise pour le projet lauréat
-        Quand le Cocontractant corrige la date d'achèvement réelle "2025-11-20" pour le projet lauréat
-        Alors la date d'achèvement réelle devrait être consultable pour le projet lauréat
+        Quand le Cocontractant corrige la date d'achèvement réel au "2025-11-20" pour le projet lauréat
+        Alors la date d'achèvement réel "2025-11-20" devrait être consultable pour le projet lauréat
 
-    Scénario: le Cocontractant corrige la date d'achèvement réelle d'un projet achevé via une attestation de conformité transmise par le porteur
+    Scénario: le Cocontractant corrige la date d'achèvement réel au d'un projet achevé via une attestation de conformité transmise par le porteur
         Etant donné l'achèvement réel transmis pour le projet lauréat
-        Quand le Cocontractant corrige la date d'achèvement réelle "2025-11-20" pour le projet lauréat
-        Alors la date d'achèvement réelle devrait être consultable pour le projet lauréat
+        Quand le Cocontractant corrige la date d'achèvement réel au "2025-11-20" pour le projet lauréat
+        Alors la date d'achèvement réel devrait être consultable pour le projet lauréat
 
     Scénario: Impossible de corriger la date d'achèvement pour un projet lauréat inexistant
         Etant donné le projet éliminé "Du boulodrome de Lyon"
-        Quand le Cocontractant corrige la date d'achèvement réelle "2025-11-20" pour le projet éliminé
+        Quand le Cocontractant corrige la date d'achèvement réel au "2025-11-20" pour le projet éliminé
         Alors l'utilisateur devrait être informé que "Le projet lauréat n'existe pas"
 
     Scénario: Impossible de corriger la date d'achèvement d'un projet qui n'est pas achevé
-        Quand le Cocontractant corrige la date d'achèvement réelle "2025-11-20" pour le projet lauréat
+        Quand le Cocontractant corrige la date d'achèvement réel au "2025-11-20" pour le projet lauréat
         Alors l'utilisateur devrait être informé que "Le projet n'est pas achevé"
 
     Scénario: Impossible de corriger la date d'achèvement avec une date antérieure à la date de notification du projet
         Etant donné une date d'achèvement réel transmise pour le projet lauréat
-        Quand le Cocontractant corrige la date d'achèvement réelle "2023-01-01" pour le projet lauréat
+        Quand le Cocontractant corrige la date d'achèvement réel au "2023-01-01" pour le projet lauréat
         Alors l'utilisateur devrait être informé que "La date d'achèvement ne peut pas être antérieure à la date de notification du projet"
 
     Scénario: Impossible de corriger la date d'achèvement avec une date future
         Etant donné une date d'achèvement réel transmise pour le projet lauréat
-        Quand le Cocontractant corrige la date d'achèvement réelle "2050-09-01" pour le projet lauréat
+        Quand le Cocontractant corrige la date d'achèvement réel au "2050-09-01" pour le projet lauréat
         Alors l'utilisateur devrait être informé que "La date d'achèvement ne peut pas être dans le futur"
 
     Scénario: Impossible de corriger la date d'achèvement si aucune modification n'est transmise
         Etant donné une date d'achèvement réel transmise pour le projet lauréat
-        Quand le Cocontractant corrige la date d'achèvement réelle avec la même date pour le projet lauréat
+        Quand le Cocontractant corrige la date d'achèvement réel avec la même date
         Alors l'utilisateur devrait être informé que "Aucune modification n'a été transmise"

--- a/packages/specifications/src/projet/lauréat/achèvement/corrigerDateAchèvement.feature
+++ b/packages/specifications/src/projet/lauréat/achèvement/corrigerDateAchèvement.feature
@@ -1,0 +1,43 @@
+# language: fr
+@achèvement
+Fonctionnalité: Corriger la date d'achèvement réelle transmise par le Cocontractant
+
+    Contexte:
+        Etant donné le projet lauréat "Du boulodrome de Marseille" avec :
+            | date notification | 2024-01-01 |
+        Et un cahier des charges permettant la modification du projet
+        Et la dreal "Dreal du sud" associée à la région du projet
+
+    Scénario: le Cocontractant corrige la date d'achèvement réelle du projet lauréat
+        Etant donné une date d'achèvement réel transmise pour le projet lauréat
+        Quand le Cocontractant corrige la date d'achèvement réelle "2025-11-20" pour le projet lauréat
+        Alors la date d'achèvement réelle devrait être consultable pour le projet lauréat
+
+    Scénario: le Cocontractant corrige la date d'achèvement réelle d'un projet achevé via une attestation de conformité transmise par le porteur
+        Etant donné l'achèvement réel transmis pour le projet lauréat
+        Quand le Cocontractant corrige la date d'achèvement réelle "2025-11-20" pour le projet lauréat
+        Alors la date d'achèvement réelle devrait être consultable pour le projet lauréat
+
+    Scénario: Impossible de corriger la date d'achèvement pour un projet lauréat inexistant
+        Etant donné le projet éliminé "Du boulodrome de Lyon"
+        Quand le Cocontractant corrige la date d'achèvement réelle "2025-11-20" pour le projet éliminé
+        Alors l'utilisateur devrait être informé que "Le projet lauréat n'existe pas"
+
+    Scénario: Impossible de corriger la date d'achèvement d'un projet qui n'est pas achevé
+        Quand le Cocontractant corrige la date d'achèvement réelle "2025-11-20" pour le projet lauréat
+        Alors l'utilisateur devrait être informé que "Le projet n'est pas achevé"
+
+    Scénario: Impossible de corriger la date d'achèvement avec une date antérieure à la date de notification du projet
+        Etant donné une date d'achèvement réel transmise pour le projet lauréat
+        Quand le Cocontractant corrige la date d'achèvement réelle "2023-01-01" pour le projet lauréat
+        Alors l'utilisateur devrait être informé que "La date d'achèvement ne peut pas être antérieure à la date de notification du projet"
+
+    Scénario: Impossible de corriger la date d'achèvement avec une date future
+        Etant donné une date d'achèvement réel transmise pour le projet lauréat
+        Quand le Cocontractant corrige la date d'achèvement réelle "2050-09-01" pour le projet lauréat
+        Alors l'utilisateur devrait être informé que "La date d'achèvement ne peut pas être dans le futur"
+
+    Scénario: Impossible de corriger la date d'achèvement si aucune modification n'est transmise
+        Etant donné une date d'achèvement réel transmise pour le projet lauréat
+        Quand le Cocontractant corrige la date d'achèvement réelle avec la même date pour le projet lauréat
+        Alors l'utilisateur devrait être informé que "Aucune modification n'a été transmise"

--- a/packages/specifications/src/projet/lauréat/achèvement/fixture/corrigerDateAchèvement.fixture.ts
+++ b/packages/specifications/src/projet/lauréat/achèvement/fixture/corrigerDateAchèvement.fixture.ts
@@ -1,0 +1,72 @@
+import { faker } from '@faker-js/faker';
+
+import { DateTime, Email } from '@potentiel-domain/common';
+
+import { AbstractFixture } from '../../../../fixture.js';
+import type { LauréatWorld } from '../../lauréat.world.js';
+
+interface CorrigerDateAchèvement {
+  readonly dateAchèvement: string;
+  readonly corrigéeLe: string;
+  readonly corrigéePar: string;
+}
+
+export class CorrigerDateAchèvementFixture
+  extends AbstractFixture<CorrigerDateAchèvement>
+  implements CorrigerDateAchèvement
+{
+  #dateAchèvement!: string;
+
+  get dateAchèvement(): string {
+    return this.#dateAchèvement;
+  }
+
+  #corrigéeLe!: string;
+
+  get corrigéeLe(): string {
+    return this.#corrigéeLe;
+  }
+
+  #corrigéePar!: string;
+
+  get corrigéePar(): string {
+    return this.#corrigéePar;
+  }
+  constructor(public readonly lauréatWorld: LauréatWorld) {
+    super();
+  }
+
+  créer(partialFixture?: Partial<CorrigerDateAchèvement>): CorrigerDateAchèvement {
+    const fixture: CorrigerDateAchèvement = {
+      dateAchèvement: faker.date
+        .between({
+          from: DateTime.convertirEnValueType(
+            this.lauréatWorld.notifierLauréatFixture.notifiéLe,
+          ).ajouterNombreDeJours(1).date,
+          to: DateTime.now().date,
+        })
+        .toISOString(),
+      corrigéeLe: faker.date.recent().toISOString(),
+      corrigéePar: faker.internet.email(),
+      ...partialFixture,
+    };
+
+    this.#dateAchèvement = new Date(fixture.dateAchèvement).toISOString();
+    this.#corrigéeLe = new Date(fixture.corrigéeLe).toISOString();
+    this.#corrigéePar = fixture.corrigéePar;
+
+    this.aÉtéCréé = true;
+
+    return this;
+  }
+
+  // la correction ne porte que sur la date : l'attestation, le rapport associé et la preuve
+  // de transmission (le cas échéant) proviennent de la transmission initiale et sont inchangés
+  mapToExpected() {
+    return {
+      dateAchèvementRéel: DateTime.convertirEnValueType(this.dateAchèvement),
+      misÀJourLe: DateTime.convertirEnValueType(this.corrigéeLe),
+      misÀJourPar: Email.convertirEnValueType(this.corrigéePar),
+    };
+  }
+}

--- a/packages/specifications/src/projet/lauréat/achèvement/fixture/corrigerDateAchèvement.fixture.ts
+++ b/packages/specifications/src/projet/lauréat/achèvement/fixture/corrigerDateAchèvement.fixture.ts
@@ -60,8 +60,6 @@ export class CorrigerDateAchèvementFixture
     return this;
   }
 
-  // la correction ne porte que sur la date : l'attestation, le rapport associé et la preuve
-  // de transmission (le cas échéant) proviennent de la transmission initiale et sont inchangés
   mapToExpected() {
     return {
       dateAchèvementRéel: DateTime.convertirEnValueType(this.dateAchèvement),

--- a/packages/specifications/src/projet/lauréat/achèvement/stepDefinitions/achèvement.given.ts
+++ b/packages/specifications/src/projet/lauréat/achèvement/stepDefinitions/achèvement.given.ts
@@ -6,81 +6,40 @@ import { Lauréat } from '@potentiel-domain/projet';
 import { publish } from '@potentiel-infrastructure/pg-event-sourcing';
 import { upload } from '@potentiel-libraries/file-storage';
 
-import { convertFixtureFileToReadableStream } from '../../../../helpers/convertFixtureFileToReadable.js';
+import { convertFixtureFileToReadableStream } from '#helpers';
 import type { PotentielWorld } from '../../../../potentiel.world.js';
+import { transmettreDateAchèvement } from './achèvement.when.js';
 
+// #region Prévisionnel
 EtantDonné(
-  `l'achèvement réel transmis pour le projet lauréat`,
-  async function (this: PotentielWorld) {
-    const { identifiantProjet } = this.lauréatWorld;
+  "une date d'achèvement prévisionnel pour le projet lauréat au {string}",
+  async function (this: PotentielWorld, date: string) {
+    const identifiantProjet = this.lauréatWorld.identifiantProjet.formatter();
+    const dateAchèvementPrévisionnel = DateTime.convertirEnValueType(new Date(date).toISOString())
+      .définirHeureÀMidi()
+      .formatter();
 
-    const {
-      dateTransmissionAuCocontractant,
-      date,
-      attestation,
-      utilisateur,
-      rapportAssocié,
-      preuve,
-    } = this.lauréatWorld.achèvementWorld.transmettreAttestationConformitéFixture.créer({});
-
-    await mediator.send<Lauréat.Achèvement.TransmettreAttestationConformitéUseCase>({
-      type: 'Lauréat.Achèvement.UseCase.TransmettreAttestationConformité',
-      data: {
-        identifiantProjetValue: identifiantProjet.formatter(),
-        dateTransmissionAuCocontractantValue: dateTransmissionAuCocontractant,
-        dateValue: date,
-        identifiantUtilisateurValue: utilisateur,
-        attestationValue: convertFixtureFileToReadableStream(attestation),
-        rapportAssociéValue: convertFixtureFileToReadableStream(rapportAssocié),
-        preuveTransmissionAuCocontractantValue: convertFixtureFileToReadableStream(preuve),
-      },
+    this.lauréatWorld.achèvementWorld.calculerDateAchèvementPrévisionnelFixture.créer({
+      dateAchèvementPrévisionnel,
     });
-  },
-);
 
-// scénario possible avant la mise en place du rapport associé
-EtantDonné(
-  `l'achèvement réel transmis sans rapport associé pour le projet lauréat`,
-  async function (this: PotentielWorld) {
-    const { identifiantProjet } = this.lauréatWorld;
-
-    const { dateTransmissionAuCocontractant, date, attestation, utilisateur, preuve } =
-      this.lauréatWorld.achèvementWorld.transmettreAttestationConformitéFixture.créer({});
-
-    await upload(
-      Lauréat.Achèvement.DocumentAchèvement.attestationConformité({
-        enregistréLe: dateTransmissionAuCocontractant,
-        identifiantProjet: identifiantProjet.formatter(),
-        attestation,
-      }).formatter(),
-      convertFixtureFileToReadableStream(preuve).content,
-    );
-
-    await upload(
-      Lauréat.Achèvement.DocumentAchèvement.preuveTransmissionAttestationConformité({
-        dateTransmissionAuCocontractant,
-        identifiantProjet: identifiantProjet.formatter(),
-        preuveTransmissionAuCocontractant: preuve,
-      }).formatter(),
-      convertFixtureFileToReadableStream(preuve).content,
-    );
-
-    await publish(`achevement|${identifiantProjet.formatter()}`, {
-      type: 'AttestationConformitéTransmise-V1',
+    const event: Lauréat.Achèvement.DateAchèvementPrévisionnelCalculéeEvent = {
+      type: 'DateAchèvementPrévisionnelCalculée-V1',
       payload: {
-        identifiantProjet: identifiantProjet.formatter(),
-        dateTransmissionAuCocontractant: DateTime.convertirEnValueType(
-          dateTransmissionAuCocontractant,
-        ).formatter(),
-        date: DateTime.convertirEnValueType(date).formatter(),
-        utilisateur: Email.convertirEnValueType(utilisateur).formatter(),
-        attestation: { format: attestation.format },
-        preuveTransmissionAuCocontractant: { format: preuve.format },
+        identifiantProjet,
+        date: dateAchèvementPrévisionnel,
+        calculéeLe: DateTime.now().formatter(),
+        raison: 'inconnue',
       },
-    } satisfies Lauréat.Achèvement.AttestationConformitéTransmiseEventV1);
+    };
+
+    await publish(`achevement|${identifiantProjet}`, event);
   },
 );
+// #endregion Prévisionnel
 
+// #region Réel
+// scénario possible avant la mise en place du rapport associé
 EtantDonné(
   'une attestation de conformité enregistrée avec son rapport associé pour le projet lauréat',
   async function (this: PotentielWorld) {
@@ -127,47 +86,95 @@ EtantDonné(
 );
 
 EtantDonné(
-  "une date d'achèvement réel transmise pour le projet lauréat",
+  `l'achèvement réel transmis pour le projet lauréat`,
   async function (this: PotentielWorld) {
     const { identifiantProjet } = this.lauréatWorld;
 
-    const { dateAchèvement, transmiseLe, transmisePar } =
-      this.lauréatWorld.achèvementWorld.transmettreDateAchèvementFixture.créer();
+    const {
+      dateTransmissionAuCocontractant,
+      date,
+      attestation,
+      utilisateur,
+      rapportAssocié,
+      preuve,
+    } = this.lauréatWorld.achèvementWorld.transmettreAttestationConformitéFixture.créer();
 
-    await mediator.send<Lauréat.Achèvement.TransmettreDateAchèvementUseCase>({
-      type: 'Lauréat.Achèvement.UseCase.TransmettreDateAchèvement',
+    await mediator.send<Lauréat.Achèvement.TransmettreAttestationConformitéUseCase>({
+      type: 'Lauréat.Achèvement.UseCase.TransmettreAttestationConformité',
       data: {
         identifiantProjetValue: identifiantProjet.formatter(),
-        dateAchèvementValue: dateAchèvement,
-        transmiseLeValue: transmiseLe,
-        transmiseParValue: transmisePar,
+        dateTransmissionAuCocontractantValue: dateTransmissionAuCocontractant,
+        dateValue: date,
+        identifiantUtilisateurValue: utilisateur,
+        attestationValue: convertFixtureFileToReadableStream(attestation),
+        rapportAssociéValue: convertFixtureFileToReadableStream(rapportAssocié),
+        preuveTransmissionAuCocontractantValue: convertFixtureFileToReadableStream(preuve),
       },
     });
   },
 );
 
 EtantDonné(
-  "une date d'achèvement prévisionnel pour le projet lauréat au {string}",
+  `l'achèvement réel transmis sans rapport associé pour le projet lauréat`,
+  async function (this: PotentielWorld) {
+    const { identifiantProjet } = this.lauréatWorld;
+
+    const { dateTransmissionAuCocontractant, date, attestation, utilisateur, preuve } =
+      this.lauréatWorld.achèvementWorld.transmettreAttestationConformitéFixture.créer({});
+
+    await upload(
+      Lauréat.Achèvement.DocumentAchèvement.attestationConformité({
+        enregistréLe: dateTransmissionAuCocontractant,
+        identifiantProjet: identifiantProjet.formatter(),
+        attestation,
+      }).formatter(),
+      convertFixtureFileToReadableStream(preuve).content,
+    );
+
+    await upload(
+      Lauréat.Achèvement.DocumentAchèvement.preuveTransmissionAttestationConformité({
+        dateTransmissionAuCocontractant,
+        identifiantProjet: identifiantProjet.formatter(),
+        preuveTransmissionAuCocontractant: preuve,
+      }).formatter(),
+      convertFixtureFileToReadableStream(preuve).content,
+    );
+
+    await publish(`achevement|${identifiantProjet.formatter()}`, {
+      type: 'AttestationConformitéTransmise-V1',
+      payload: {
+        identifiantProjet: identifiantProjet.formatter(),
+        dateTransmissionAuCocontractant: DateTime.convertirEnValueType(
+          dateTransmissionAuCocontractant,
+        ).formatter(),
+        date: DateTime.convertirEnValueType(date).formatter(),
+        utilisateur: Email.convertirEnValueType(utilisateur).formatter(),
+        attestation: { format: attestation.format },
+        preuveTransmissionAuCocontractant: { format: preuve.format },
+      },
+    } satisfies Lauréat.Achèvement.AttestationConformitéTransmiseEventV1);
+  },
+);
+
+EtantDonné(
+  "une date d'achèvement réel transmise pour le projet lauréat",
+  async function (this: PotentielWorld) {
+    await transmettreDateAchèvement.call(this, this.lauréatWorld.identifiantProjet);
+  },
+);
+
+EtantDonné(
+  "une date d'achèvement réel {string} transmise pour le projet lauréat",
   async function (this: PotentielWorld, date: string) {
-    const identifiantProjet = this.lauréatWorld.identifiantProjet.formatter();
-    const dateAchèvementPrévisionnel = DateTime.convertirEnValueType(new Date(date).toISOString())
+    const dateAchèvementRéel = DateTime.convertirEnValueType(new Date(date).toISOString())
       .définirHeureÀMidi()
       .formatter();
 
-    this.lauréatWorld.achèvementWorld.calculerDateAchèvementPrévisionnelFixture.créer({
-      dateAchèvementPrévisionnel,
-    });
-
-    const event: Lauréat.Achèvement.DateAchèvementPrévisionnelCalculéeEvent = {
-      type: 'DateAchèvementPrévisionnelCalculée-V1',
-      payload: {
-        identifiantProjet,
-        date: dateAchèvementPrévisionnel,
-        calculéeLe: DateTime.now().formatter(),
-        raison: 'inconnue',
-      },
-    };
-
-    await publish(`achevement|${identifiantProjet}`, event);
+    await transmettreDateAchèvement.call(
+      this,
+      this.lauréatWorld.identifiantProjet,
+      dateAchèvementRéel,
+    );
   },
 );
+// #endregion Réel

--- a/packages/specifications/src/projet/lauréat/achèvement/stepDefinitions/achèvement.then.ts
+++ b/packages/specifications/src/projet/lauréat/achèvement/stepDefinitions/achèvement.then.ts
@@ -114,9 +114,6 @@ Alors(
       assert(Option.isSome(achèvement), `Aucun achèvement trouvé pour le projet`);
       assert(achèvement.estAchevé, `Le projet n'est pas achevé`);
 
-      // const expected = this.lauréatWorld.achèvementWorld.mapToExpected();
-      // assert(expected.estAchevé, `Le projet n'est pas achevé`);
-
       expect(
         achèvement.dateAchèvementRéel.estÉgaleÀ(
           DateTime.convertirEnValueType(new Date(date).toISOString()),

--- a/packages/specifications/src/projet/lauréat/achèvement/stepDefinitions/achèvement.then.ts
+++ b/packages/specifications/src/projet/lauréat/achèvement/stepDefinitions/achèvement.then.ts
@@ -90,11 +90,10 @@ Alors(
       assert(Option.isSome(achèvement), `Aucun achèvement trouvé pour le projet`);
       assert(achèvement.estAchevé, `Le projet n'est pas achevé`);
 
-      const actual = achèvement.dateAchèvementRéel;
-      const expected =
-        this.lauréatWorld.achèvementWorld.transmettreDateAchèvementFixture.dateAchèvement;
+      const expected = this.lauréatWorld.achèvementWorld.mapToExpected();
+      assert(expected.estAchevé, `Le projet n'est pas achevé`);
 
-      expect(actual.formatter()).to.be.equal(new Date(expected).toISOString());
+      expect(achèvement.dateAchèvementRéel.estÉgaleÀ(expected.dateAchèvementRéel)).to.be.true;
     });
   },
 );

--- a/packages/specifications/src/projet/lauréat/achèvement/stepDefinitions/achèvement.then.ts
+++ b/packages/specifications/src/projet/lauréat/achèvement/stepDefinitions/achèvement.then.ts
@@ -75,7 +75,7 @@ Alors(
 );
 
 Alors(
-  `la date d'achèvement réelle devrait être consultable pour le projet lauréat`,
+  `la date d'achèvement réel devrait être consultable pour le projet lauréat`,
   async function (this: PotentielWorld) {
     return waitForExpect(async () => {
       const identifiantProjet = this.lauréatWorld.identifiantProjet;
@@ -94,6 +94,34 @@ Alors(
       assert(expected.estAchevé, `Le projet n'est pas achevé`);
 
       expect(achèvement.dateAchèvementRéel.estÉgaleÀ(expected.dateAchèvementRéel)).to.be.true;
+    });
+  },
+);
+
+Alors(
+  `la date d'achèvement réel {string} devrait être consultable pour le projet lauréat`,
+  async function (this: PotentielWorld, date: string) {
+    return waitForExpect(async () => {
+      const identifiantProjet = this.lauréatWorld.identifiantProjet;
+
+      const achèvement = await mediator.send<Lauréat.Achèvement.ConsulterAchèvementQuery>({
+        type: 'Lauréat.Achèvement.Query.ConsulterAchèvement',
+        data: {
+          identifiantProjetValue: identifiantProjet.formatter(),
+        },
+      });
+
+      assert(Option.isSome(achèvement), `Aucun achèvement trouvé pour le projet`);
+      assert(achèvement.estAchevé, `Le projet n'est pas achevé`);
+
+      // const expected = this.lauréatWorld.achèvementWorld.mapToExpected();
+      // assert(expected.estAchevé, `Le projet n'est pas achevé`);
+
+      expect(
+        achèvement.dateAchèvementRéel.estÉgaleÀ(
+          DateTime.convertirEnValueType(new Date(date).toISOString()),
+        ),
+      ).to.be.true;
     });
   },
 );

--- a/packages/specifications/src/projet/lauréat/achèvement/stepDefinitions/achèvement.when.ts
+++ b/packages/specifications/src/projet/lauréat/achèvement/stepDefinitions/achèvement.when.ts
@@ -2,12 +2,12 @@ import { type DataTable, When as Quand } from '@cucumber/cucumber';
 import { assert } from 'chai';
 import { mediator } from 'mediateur';
 
-import type { Lauréat } from '@potentiel-domain/projet';
+import type { IdentifiantProjet, Lauréat } from '@potentiel-domain/projet';
 
 import { convertFixtureFileToReadableStream } from '../../../../helpers/convertFixtureFileToReadable.js';
 import type { PotentielWorld } from '../../../../potentiel.world.js';
 
-// #region Achèvement réel
+// #region Réel
 Quand(
   `le porteur transmet l'achèvement réel pour le projet {lauréat-éliminé}`,
   async function (this: PotentielWorld, statutProjet: 'lauréat' | 'éliminé') {
@@ -223,11 +223,9 @@ Quand(
     }
   },
 );
-// #region Achèvement réel
 
-// #region Date achèvement réelle
 Quand(
-  "le Cocontractant transmet la date d'achèvement réelle {string} pour le projet {lauréat-éliminé}",
+  "le Cocontractant transmet la date d'achèvement réel {string} pour le projet {lauréat-éliminé}",
   async function (
     this: PotentielWorld,
     dateAchèvementValue: string,
@@ -237,20 +235,7 @@ Quand(
       const { identifiantProjet } =
         statutProjet === 'lauréat' ? this.lauréatWorld : this.éliminéWorld;
 
-      const { dateAchèvement, transmiseLe, transmisePar } =
-        this.lauréatWorld.achèvementWorld.transmettreDateAchèvementFixture.créer({
-          dateAchèvement: dateAchèvementValue,
-        });
-
-      await mediator.send<Lauréat.Achèvement.TransmettreDateAchèvementUseCase>({
-        type: 'Lauréat.Achèvement.UseCase.TransmettreDateAchèvement',
-        data: {
-          identifiantProjetValue: identifiantProjet.formatter(),
-          dateAchèvementValue: dateAchèvement,
-          transmiseLeValue: transmiseLe,
-          transmiseParValue: transmisePar,
-        },
-      });
+      await transmettreDateAchèvement.call(this, identifiantProjet, dateAchèvementValue);
     } catch (error) {
       this.error = error as Error;
     }
@@ -258,7 +243,7 @@ Quand(
 );
 
 Quand(
-  "le Cocontractant corrige la date d'achèvement réelle {string} pour le projet {lauréat-éliminé}",
+  "le Cocontractant corrige la date d'achèvement réel au {string} pour le projet {lauréat-éliminé}",
   async function (
     this: PotentielWorld,
     dateAchèvementValue: string,
@@ -289,7 +274,7 @@ Quand(
 );
 
 Quand(
-  "le Cocontractant corrige la date d'achèvement réelle avec la même date pour le projet lauréat",
+  "le Cocontractant corrige la date d'achèvement réel avec la même date",
   async function (this: PotentielWorld) {
     try {
       const { identifiantProjet } = this.lauréatWorld;
@@ -316,8 +301,7 @@ Quand(
     }
   },
 );
-
-// #endregion Date achèvement réelle
+// #region Réel
 
 // #region Attestation de conformité
 Quand(
@@ -408,3 +392,24 @@ Quand(
   },
 );
 // #endregion Attestation de conformité
+
+export async function transmettreDateAchèvement(
+  this: PotentielWorld,
+  identifiantProjet: IdentifiantProjet.ValueType,
+  dateAchèvementValue?: string,
+) {
+  const { dateAchèvement, transmiseLe, transmisePar } =
+    this.lauréatWorld.achèvementWorld.transmettreDateAchèvementFixture.créer(
+      dateAchèvementValue ? { dateAchèvement: dateAchèvementValue } : undefined,
+    );
+
+  await mediator.send<Lauréat.Achèvement.TransmettreDateAchèvementUseCase>({
+    type: 'Lauréat.Achèvement.UseCase.TransmettreDateAchèvement',
+    data: {
+      identifiantProjetValue: identifiantProjet.formatter(),
+      dateAchèvementValue: dateAchèvement,
+      transmiseLeValue: transmiseLe,
+      transmiseParValue: transmisePar,
+    },
+  });
+}

--- a/packages/specifications/src/projet/lauréat/achèvement/stepDefinitions/achèvement.when.ts
+++ b/packages/specifications/src/projet/lauréat/achèvement/stepDefinitions/achèvement.when.ts
@@ -256,6 +256,67 @@ Quand(
     }
   },
 );
+
+Quand(
+  "le Cocontractant corrige la date d'achèvement réelle {string} pour le projet {lauréat-éliminé}",
+  async function (
+    this: PotentielWorld,
+    dateAchèvementValue: string,
+    statutProjet: 'lauréat' | 'éliminé',
+  ) {
+    try {
+      const { identifiantProjet } =
+        statutProjet === 'lauréat' ? this.lauréatWorld : this.éliminéWorld;
+
+      const { dateAchèvement, corrigéeLe, corrigéePar } =
+        this.lauréatWorld.achèvementWorld.corrigerDateAchèvementFixture.créer({
+          dateAchèvement: dateAchèvementValue,
+        });
+
+      await mediator.send<Lauréat.Achèvement.CorrigerDateAchèvementUseCase>({
+        type: 'Lauréat.Achèvement.UseCase.CorrigerDateAchèvement',
+        data: {
+          identifiantProjetValue: identifiantProjet.formatter(),
+          dateAchèvementValue: dateAchèvement,
+          corrigéeLeValue: corrigéeLe,
+          corrigéeParValue: corrigéePar,
+        },
+      });
+    } catch (error) {
+      this.error = error as Error;
+    }
+  },
+);
+
+Quand(
+  "le Cocontractant corrige la date d'achèvement réelle avec la même date pour le projet lauréat",
+  async function (this: PotentielWorld) {
+    try {
+      const { identifiantProjet } = this.lauréatWorld;
+
+      const achèvement = this.lauréatWorld.achèvementWorld.mapToExpected();
+      assert(achèvement.estAchevé, 'impossible de corriger si non achevé');
+
+      const { dateAchèvement, corrigéeLe, corrigéePar } =
+        this.lauréatWorld.achèvementWorld.corrigerDateAchèvementFixture.créer({
+          dateAchèvement: achèvement.dateAchèvementRéel.formatter(),
+        });
+
+      await mediator.send<Lauréat.Achèvement.CorrigerDateAchèvementUseCase>({
+        type: 'Lauréat.Achèvement.UseCase.CorrigerDateAchèvement',
+        data: {
+          identifiantProjetValue: identifiantProjet.formatter(),
+          dateAchèvementValue: dateAchèvement,
+          corrigéeLeValue: corrigéeLe,
+          corrigéeParValue: corrigéePar,
+        },
+      });
+    } catch (error) {
+      this.error = error as Error;
+    }
+  },
+);
+
 // #endregion Date achèvement réelle
 
 // #region Attestation de conformité

--- a/packages/specifications/src/projet/lauréat/achèvement/stepDefinitions/achèvement.when.ts
+++ b/packages/specifications/src/projet/lauréat/achèvement/stepDefinitions/achèvement.when.ts
@@ -243,19 +243,17 @@ Quand(
 );
 
 Quand(
-  "le Cocontractant corrige la date d'achèvement réel au {string} pour le projet {lauréat-éliminé}",
-  async function (
-    this: PotentielWorld,
-    dateAchèvementValue: string,
-    statutProjet: 'lauréat' | 'éliminé',
-  ) {
+  "le Cocontractant corrige la date d'achèvement réel pour le projet {lauréat-éliminé} avec :",
+  async function (this: PotentielWorld, statutProjet: 'lauréat' | 'éliminé', datatable: DataTable) {
     try {
       const { identifiantProjet } =
         statutProjet === 'lauréat' ? this.lauréatWorld : this.éliminéWorld;
 
+      const exemple = datatable.rowsHash();
+
       const { dateAchèvement, corrigéeLe, corrigéePar } =
         this.lauréatWorld.achèvementWorld.corrigerDateAchèvementFixture.créer({
-          dateAchèvement: dateAchèvementValue,
+          dateAchèvement: exemple["date d'achèvement"],
         });
 
       await mediator.send<Lauréat.Achèvement.CorrigerDateAchèvementUseCase>({

--- a/packages/specifications/src/projet/lauréat/achèvement/transmettreDateAchèvementRéel.feature
+++ b/packages/specifications/src/projet/lauréat/achèvement/transmettreDateAchèvementRéel.feature
@@ -1,6 +1,6 @@
 # language: fr
 @achèvement
-Fonctionnalité: Transmettre la date d'achèvement réelle
+Fonctionnalité: Transmettre la date d'achèvement réel
 
     Contexte:
         Etant donné le projet lauréat "Du boulodrome de Marseille" avec :
@@ -8,9 +8,9 @@ Fonctionnalité: Transmettre la date d'achèvement réelle
         Et un cahier des charges permettant la modification du projet
         Et la dreal "Dreal du sud" associée à la région du projet
 
-    Scénario: le Cocontractant transmet la date d'achèvement réelle pour le projet lauréat
-        Quand le Cocontractant transmet la date d'achèvement réelle "2025-11-14" pour le projet lauréat
-        Alors la date d'achèvement réelle devrait être consultable pour le projet lauréat
+    Scénario: le Cocontractant transmet la date d'achèvement réel pour le projet lauréat
+        Quand le Cocontractant transmet la date d'achèvement réel "2025-11-14" pour le projet lauréat
+        Alors la date d'achèvement réel devrait être consultable pour le projet lauréat
         Et le statut du projet lauréat devrait être "achevé"
         Et un email a été envoyé à la dreal avec :
             | sujet      | Potentiel - Du boulodrome de Marseille - Transmission de la date d'achèvement |
@@ -26,7 +26,7 @@ Fonctionnalité: Transmettre la date d'achèvement réelle
             | appel d'offres    | PPE2 - Petit PV Bâtiment |
             | période           | 1                        |
             | date notification | 2024-01-01               |
-        Quand le Cocontractant transmet la date d'achèvement réelle "2024-11-01" pour le projet lauréat
+        Quand le Cocontractant transmet la date d'achèvement réel "2024-11-01" pour le projet lauréat
         Alors il n'y a pas de tâche "rappel échéance achèvement à trois mois" planifiée pour le projet lauréat
         Et il n'y a pas de tâche "rappel échéance achèvement à deux mois" planifiée pour le projet lauréat
         Et il n'y a pas de tâche "rappel échéance achèvement à un mois" planifiée pour le projet lauréat
@@ -36,7 +36,7 @@ Fonctionnalité: Transmettre la date d'achèvement réelle
             | type GF            | avec-date-échéance |
             | date d'échéance    | 2050-12-01         |
             | date de validation | 2024-11-24         |
-        Quand le Cocontractant transmet la date d'achèvement réelle "2024-11-01" pour le projet lauréat
+        Quand le Cocontractant transmet la date d'achèvement réel "2024-11-01" pour le projet lauréat
         Alors il n'y a pas de tâche "échoir les garanties financières" planifiée pour le projet lauréat
 
     Scénario: les tâches planifiées "rappel échéance garanties financières à * mois" sont annulées quand la date d'achèvement est transmise
@@ -44,36 +44,36 @@ Fonctionnalité: Transmettre la date d'achèvement réelle
             | type GF            | avec-date-échéance |
             | date d'échéance    | 2050-12-01         |
             | date de validation | 2024-11-24         |
-        Quand le Cocontractant transmet la date d'achèvement réelle "2024-11-01" pour le projet lauréat
+        Quand le Cocontractant transmet la date d'achèvement réel "2024-11-01" pour le projet lauréat
         Alors il n'y a pas de tâche "rappel échéance garanties financières à un mois" planifiée pour le projet lauréat
         Alors il n'y a pas de tâche "rappel échéance garanties financières à deux mois" planifiée pour le projet lauréat
         Alors il n'y a pas de tâche "rappel échéance garanties financières à trois mois" planifiée pour le projet lauréat
 
     Scénario: les tâches porteur et planifiées de garanties financières en attente sont supprimées quand la date d'achèvement est transmise
         Etant donné des garanties financières en attente pour le projet lauréat
-        Quand le Cocontractant transmet la date d'achèvement réelle "2024-11-01" pour le projet lauréat
+        Quand le Cocontractant transmet la date d'achèvement réel "2024-11-01" pour le projet lauréat
         Alors une tâche indiquant de 'transmettre les garanties financières' n'est plus consultable dans la liste des tâches du porteur pour le projet
         Et il n'y a pas de tâche "rappel des garanties financières à transmettre" planifiée pour le projet lauréat
 
     Scénario: Impossible de transmettre une date d'achèvement pour un projet lauréat inexistant
         Etant donné le projet éliminé "Du boulodrome de Lyon"
-        Quand le Cocontractant transmet la date d'achèvement réelle "2025-11-14" pour le projet éliminé
+        Quand le Cocontractant transmet la date d'achèvement réel "2025-11-14" pour le projet éliminé
         Alors l'utilisateur devrait être informé que "Le projet lauréat n'existe pas"
 
     Scénario: Impossible de transmettre une date d'achèvement antérieure à la date de désignation du projet
-        Quand le Cocontractant transmet la date d'achèvement réelle "2023-01-01" pour le projet lauréat
+        Quand le Cocontractant transmet la date d'achèvement réel "2023-01-01" pour le projet lauréat
         Alors l'utilisateur devrait être informé que "La date d'achèvement ne peut pas être antérieure à la date de notification du projet"
 
     Scénario: Impossible de transmettre une date d'achèvement future
-        Quand le Cocontractant transmet la date d'achèvement réelle "2050-09-01" pour le projet lauréat
+        Quand le Cocontractant transmet la date d'achèvement réel "2050-09-01" pour le projet lauréat
         Alors l'utilisateur devrait être informé que "La date d'achèvement ne peut pas être dans le futur"
 
     Scénario: Impossible de transmettre une date d'achèvement pour un projet déjà achevé
         Etant donné l'achèvement réel transmis pour le projet lauréat
-        Quand le Cocontractant transmet la date d'achèvement réelle "2025-11-14" pour le projet lauréat
+        Quand le Cocontractant transmet la date d'achèvement réel "2025-11-14" pour le projet lauréat
         Alors l'utilisateur devrait être informé que "Le projet est déjà achevé"
 
     Scénario: Impossible de transmettre une date d'achèvement pour un projet abandonné
         Etant donné une demande d'abandon accordée pour le projet lauréat
-        Quand le Cocontractant transmet la date d'achèvement réelle "2025-11-14" pour le projet lauréat
+        Quand le Cocontractant transmet la date d'achèvement réel "2025-11-14" pour le projet lauréat
         Alors l'utilisateur devrait être informé que "Le projet est abandonné"


### PR DESCRIPTION
Dépend de la validation de la conception de  https://linear.app/startup-potentiel/issue/POT-2942/ajouter-les-dates-dachevement-reel-fournies-par-edf-oa