### PR TITLE
Découpage de la page historique en helpers testables + spec recours avec date d'accord

### DIFF
--- a/packages/applications/ssr/src/app/elimines/[identifiant]/recours/(historique)/events/mapToRecoursAccordéTimelineItemProps.tsx
+++ b/packages/applications/ssr/src/app/elimines/[identifiant]/recours/(historique)/events/mapToRecoursAccordéTimelineItemProps.tsx
@@ -12,7 +12,7 @@ export const mapToRecoursAccordéTimelineItemProps = ({
   const date = type === 'RecoursAccordé-V1' ? payload.accordéLe : payload.dateRéponseSignée;
 
   return {
-    date: payload.accordéLe,
+    date,
     title: `Demande de recours accordée${type === 'RecoursAccordé-V1' ? '' : ` à la date du ${formatDateToText(date)}`}`,
     actor: payload.accordéPar,
     file: {

--- a/packages/applications/ssr/src/app/elimines/[identifiant]/recours/[date]/DétailsRecours.page.tsx
+++ b/packages/applications/ssr/src/app/elimines/[identifiant]/recours/[date]/DétailsRecours.page.tsx
@@ -25,7 +25,6 @@ export type AvailableRecoursAction =
 
 export type DétailsRecoursPageProps = {
   identifiantProjet: string;
-  dateNotification: DateTime.RawType;
   recours: PlainType<Éliminé.Recours.ConsulterDemandeRecoursReadModel>;
   historique: Array<TimelineItemProps>;
   actions: ReadonlyArray<AvailableRecoursAction>;
@@ -33,7 +32,6 @@ export type DétailsRecoursPageProps = {
 
 export const DétailsRecoursPage: FC<DétailsRecoursPageProps> = ({
   identifiantProjet,
-  dateNotification,
   recours,
   historique,
   actions,
@@ -75,8 +73,6 @@ export const DétailsRecoursPage: FC<DétailsRecoursPageProps> = ({
           {mapToActionComponents({
             actions,
             identifiantProjet,
-            dateNotification,
-
             date: recours.demande.demandéLe,
           })}
         </>
@@ -88,7 +84,6 @@ export const DétailsRecoursPage: FC<DétailsRecoursPageProps> = ({
 type MapToActionsComponentsProps = {
   actions: ReadonlyArray<AvailableRecoursAction>;
   identifiantProjet: string;
-  dateNotification: DateTime.RawType;
   date: PlainType<DateTime.ValueType>;
 };
 
@@ -96,7 +91,6 @@ const mapToActionComponents = ({
   actions,
   identifiantProjet,
   date,
-  dateNotification,
 }: MapToActionsComponentsProps) => (
   <ActionsList actionsListLength={actions.length}>
     {(actions.includes('passer-en-instruction') || actions.includes('reprendre-instruction')) && (
@@ -106,11 +100,7 @@ const mapToActionComponents = ({
       />
     )}
     {actions.includes('accorder') && (
-      <AccorderRecours
-        identifiantProjet={identifiantProjet}
-        date={date}
-        dateNotification={dateNotification}
-      />
+      <AccorderRecours identifiantProjet={identifiantProjet} date={date} />
     )}
     {actions.includes('rejeter') && (
       <RejeterRecours identifiantProjet={identifiantProjet} date={date} />

--- a/packages/applications/ssr/src/app/elimines/[identifiant]/recours/[date]/accorder/AccorderRecours.form.tsx
+++ b/packages/applications/ssr/src/app/elimines/[identifiant]/recours/[date]/accorder/AccorderRecours.form.tsx
@@ -17,7 +17,6 @@ import { type AccorderRecoursFormKeys, accorderRecoursAction } from './accorderR
 type AccorderRecoursFormProps = {
   identifiantProjet: string;
   date: PlainType<DateTime.ValueType>;
-  dateNotification: DateTime.RawType;
 };
 
 export const AccorderRecours = ({ identifiantProjet, date }: AccorderRecoursFormProps) => {

--- a/packages/applications/ssr/src/app/elimines/[identifiant]/recours/[date]/accorder/AccorderRecours.form.tsx
+++ b/packages/applications/ssr/src/app/elimines/[identifiant]/recours/[date]/accorder/AccorderRecours.form.tsx
@@ -20,16 +20,12 @@ type AccorderRecoursFormProps = {
   dateNotification: DateTime.RawType;
 };
 
-export const AccorderRecours = ({
-  identifiantProjet,
-  date,
-  dateNotification,
-}: AccorderRecoursFormProps) => {
+export const AccorderRecours = ({ identifiantProjet, date }: AccorderRecoursFormProps) => {
   const [validationErrors, setValidationErrors] = useState<
     ValidationErrors<AccorderRecoursFormKeys>
   >({});
   const [isOpen, setIsOpen] = useState(false);
-
+  const { date: dateDemande } = date;
   return (
     <>
       <Button
@@ -57,7 +53,7 @@ export const AccorderRecours = ({
                 label={`Date de l'accord du recours`}
                 name="dateRéponseSignée"
                 hintText={`Saisir la date à laquelle le recours a réellement été accordé (date de la réponse signée). Elle tiendra lieu de date de désignation du lauréat.`}
-                min={dateNotification}
+                min={dateDemande}
                 max={DateTime.now().formatter()}
                 state={validationErrors['dateRéponseSignée'] ? 'error' : 'default'}
                 stateRelatedMessage={validationErrors['dateRéponseSignée']}
@@ -75,7 +71,7 @@ export const AccorderRecours = ({
 
               <DownloadDocument
                 className="mb-4"
-                url={Routes.Recours.téléchargerModèleRéponse(identifiantProjet, date.date)}
+                url={Routes.Recours.téléchargerModèleRéponse(identifiantProjet, dateDemande)}
                 format="docx"
                 label="Télécharger le modèle de réponse"
               />

--- a/packages/applications/ssr/src/app/elimines/[identifiant]/recours/[date]/page.tsx
+++ b/packages/applications/ssr/src/app/elimines/[identifiant]/recours/[date]/page.tsx
@@ -8,7 +8,6 @@ import { IdentifiantProjet, type Éliminé } from '@potentiel-domain/projet';
 import type { Role } from '@potentiel-domain/utilisateur';
 import { Option } from '@potentiel-libraries/monads';
 
-import { getProjetLauréatOuÉliminé } from '@/app/_helpers';
 import { decodeParameter } from '@/utils/decodeParameter';
 import { PageWithErrorHandling } from '@/utils/PageWithErrorHandling';
 import { withUtilisateur } from '@/utils/withUtilisateur';
@@ -30,8 +29,6 @@ export default async function Page(props: PageProps) {
         decodeParameter(identifiant),
       ).formatter();
       const dateDemande = decodeParameter(date);
-
-      const projet = await getProjetLauréatOuÉliminé(identifiantProjet);
 
       const recours = await mediator.send<Éliminé.Recours.ConsulterDemandeRecoursQuery>({
         type: 'Éliminé.Recours.Query.ConsulterDemandeRecours',
@@ -56,7 +53,6 @@ export default async function Page(props: PageProps) {
         <DétailsRecoursPage
           recours={mapToPlainObject(recours)}
           identifiantProjet={identifiantProjet}
-          dateNotification={(projet.lauréat ?? projet.éliminé).notifiéLe.formatter()}
           actions={mapToActions({
             role: utilisateur.rôle.nom,
             statut: recours.statut.statut,

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/(détails)/historique/_helpers/aUnRecoursAccordé.ts
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/(détails)/historique/_helpers/aUnRecoursAccordé.ts
@@ -1,0 +1,24 @@
+import { match, P } from 'ts-pattern';
+
+import type { Lauréat } from '@potentiel-domain/projet';
+
+export const aUnRecoursAccordé = (items: ReadonlyArray<Lauréat.HistoriqueListItemReadModels>) =>
+  items.some(
+    (item) =>
+      item.category === 'recours' &&
+      match(item)
+        .returnType<boolean>()
+        .with({ type: P.union('RecoursAccordé-V1', 'RecoursAccordé-V2') }, () => true)
+        .with(
+          {
+            type: P.union(
+              'RecoursDemandé-V1',
+              'RecoursAnnulé-V1',
+              'RecoursPasséEnInstruction-V1',
+              'RecoursRejeté-V1',
+            ),
+          },
+          () => false,
+        )
+        .exhaustive(),
+  );

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/(détails)/historique/_helpers/getHistoriqueTrié.ts
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/(détails)/historique/_helpers/getHistoriqueTrié.ts
@@ -1,0 +1,50 @@
+import type { Lauréat } from '@potentiel-domain/projet';
+
+import type { getLauréatInfos } from '@/app/_helpers';
+import type { TimelineItemProps } from '@/components/organisms/timeline';
+import { aUnRecoursAccordé } from './aUnRecoursAccordé';
+import { itemDoitÊtreAffiché } from './itemDoitEtreAffiché';
+import { mapToTimelineItemProps } from './mapToTimelineItemProps';
+import { trierParJourPuisOrdreDInsertion } from './trierParJourPuisOrdreDInsertion';
+
+type GetHistoriqueTriéProps = {
+  items: ReadonlyArray<Lauréat.HistoriqueListItemReadModels>;
+  unitéPuissance: string;
+  attestationDésignation: Awaited<ReturnType<typeof getLauréatInfos>>['attestationDésignation'];
+};
+
+/**
+ *
+ * Construit la liste des items affichés dans l'historique du lauréat, tous domaines
+ * confondus (éliminé, recours, garanties financières, raccordement, ...), à partir des
+ * évènements bruts renvoyés par ListerHistoriqueProjetQuery :
+ *
+ * 1. on retire les évènements techniques qui ne doivent jamais être affichés
+ * 2. on convertit chaque évènement en item d'affichage (TimelineItemProps)
+ * 3. on trie le résultat pour l'affichage (cf trierParJourPuisOrdreDInsertion)
+ *
+ */
+export const getHistoriqueTrié = ({
+  items,
+  unitéPuissance,
+  attestationDésignation,
+}: GetHistoriqueTriéProps): TimelineItemProps[] => {
+  const doitAfficherLienAttestationDésignation =
+    !aUnRecoursAccordé(items) && !!attestationDésignation;
+
+  const itemsAffichés = [...items]
+    .filter((item) => itemDoitÊtreAffiché(item, items))
+    // ordre d'insertion réel des évènements, causalement correct : sert de repère au tri
+    // final quand deux items affichent la même date métier (cf trierParJourPuisOrdreDInsertion)
+    .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
+    .map((item) =>
+      mapToTimelineItemProps({
+        readmodel: item,
+        unitéPuissance,
+        doitAfficherLienAttestationDésignation,
+      }),
+    )
+    .filter((item) => item !== undefined);
+
+  return trierParJourPuisOrdreDInsertion({ items: itemsAffichés, dateOf: (item) => item.date });
+};

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/(détails)/historique/_helpers/itemDoitEtreAffiché.ts
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/(détails)/historique/_helpers/itemDoitEtreAffiché.ts
@@ -21,7 +21,7 @@ export const itemDoitÊtreAffiché = (
   }
   // dans de rares cas de projets désignés hors Potentiel,
   // on a pas l'information de la date de notification du projet éliminé
-  // on préfère alors ne pas l'information fausse de la notification de l'éliminé
+  // on choisit de ne pas afficher une date erronnée de notification du projet éliminé
   if (event.category === 'éliminé' && event.type === 'ÉliminéNotifié-V1') {
     const lauréatNotifié = historique.find(isLauréatNotifié);
     if (lauréatNotifié && lauréatNotifié.payload.notifiéLe === event.payload.notifiéLe) {

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/(détails)/historique/_helpers/itemDoitEtreAffiché.ts
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/(détails)/historique/_helpers/itemDoitEtreAffiché.ts
@@ -1,0 +1,53 @@
+import { match } from 'ts-pattern';
+
+import type { HistoryRecord } from '@potentiel-domain/entity';
+import type { Lauréat } from '@potentiel-domain/projet';
+
+export const itemDoitÊtreAffiché = (
+  event: Lauréat.HistoriqueListItemReadModels,
+  historique: ReadonlyArray<Lauréat.HistoriqueListItemReadModels>,
+) => {
+  // on ne veut pas afficher dans l'historique complet les événements d'import de chaque domaine
+  // qui arrive après la désignation
+  if (event.type?.includes('Import')) {
+    return false;
+  }
+  // les événements candidature (ex: CandidatureNotifiée) sont présents dans l'historique
+  // brut (table domain_views.history partagée par tous les sous-agrégats) mais absents du
+  // type HistoriqueListItemReadModels (car on veut pas qu'ils le soient); ils sont déjà représentés dans l'historique
+  // lauréat/éliminé par LauréatNotifié/ÉliminéNotifié
+  if ((event.category as string) === 'candidature') {
+    return false;
+  }
+  // dans de rares cas de projets désignés hors Potentiel,
+  // on a pas l'information de la date de notification du projet éliminé
+  // on préfère alors ne pas l'information fausse de la notification de l'éliminé
+  if (event.category === 'éliminé' && event.type === 'ÉliminéNotifié-V1') {
+    const lauréatNotifié = historique.find(isLauréatNotifié);
+    if (lauréatNotifié && lauréatNotifié.payload.notifiéLe === event.payload.notifiéLe) {
+      return false;
+    }
+  }
+  return true;
+};
+
+const isLauréatNotifié = (
+  item: Lauréat.HistoriqueListItemReadModels,
+): item is HistoryRecord<
+  'lauréat',
+  Lauréat.LauréatNotifiéEvent | Lauréat.LauréatNotifiéV1Event
+> => {
+  if (item.category !== 'lauréat') {
+    return false;
+  }
+  return match(item)
+    .with({ type: 'LauréatNotifié-V1' }, () => true)
+    .with({ type: 'LauréatNotifié-V2' }, () => true)
+    .with({ type: 'CahierDesChargesChoisi-V1' }, () => false)
+    .with({ type: 'NomProjetModifié-V1' }, () => false)
+    .with({ type: 'SiteDeProductionModifié-V1' }, () => false)
+    .with({ type: 'NomEtLocalitéLauréatImportés-V1' }, () => false)
+    .with({ type: 'ChangementNomProjetEnregistré-V1' }, () => false)
+    .with({ type: 'StatutLauréatModifié-V1' }, () => false)
+    .exhaustive();
+};

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/(détails)/historique/_helpers/mapToTimelineItemProps.ts
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/(détails)/historique/_helpers/mapToTimelineItemProps.ts
@@ -1,0 +1,78 @@
+import { match } from 'ts-pattern';
+
+import type { Lauréat } from '@potentiel-domain/projet';
+
+import { mapToÉliminéTimelineItemProps } from '@/app/elimines/[identifiant]/(historique)/mapToÉliminéTimelineItemProps';
+import { mapToRecoursTimelineItemProps } from '@/app/elimines/[identifiant]/recours/(historique)/mapToRecoursTimelineItemProps';
+import type { TimelineItemProps } from '@/components/organisms/timeline/TimelineItem';
+import { mapToLauréatTimelineItemProps } from '../../../(historique)/mapToLauréatTimelineItemProps';
+import { mapToAbandonTimelineItemProps } from '../../../abandon/(historique)/mapToAbandonTimelineItemProps';
+import { mapToAchèvementTimelineItemProps } from '../../../achevement/(historique)/mapToAchèvementTimelineItemProps';
+import { mapToActionnaireTimelineItemProps } from '../../../actionnaire/(historique)/mapToActionnaireTimelineItemProps';
+import { mapToDélaiTimelineItemProps } from '../../../delai/(historique)/mapToDélaiTimelineItemProps';
+import { mapToFournisseurTimelineItemProps } from '../../../fournisseur/(historique)/mapToFournisseurTimelineItemProps';
+import { mapToGarantiesFinancièresTimelineItemProps } from '../../../garanties-financieres/(historique)/mapToGarantiesFinancièresTimelineItemProps';
+import { mapToInstallationTimelineItemProps } from '../../../installation/(historique)/mapToInstallationTimelineItemProps';
+import { mapToNatureDeLExploitationTimelineItemProps } from '../../../nature-de-l-exploitation/(historique)/mapToNatureDeLExploitationTimelineItemProps';
+import { mapToPowerPurchaseAgreementTimelineItemProps } from '../../../power-purchase-agreement/(historique)/mapToPowerPurchaseAgreementTimelineItemProps';
+import { mapToProducteurTimelineItemProps } from '../../../producteur/(historique)/mapToProducteurTimelineItemProps';
+import { mapToPuissanceTimelineItemProps } from '../../../puissance/(historique)/mapToPuissanceTimelineItemProps';
+import { mapToReprésentantLégalTimelineItemProps } from '../../../representant-legal/(historique)/mapToReprésentantLégalTimelineItemProps';
+import { mapToRaccordementTimelineItemProps } from '../../raccordements/(historique)/mapToRaccordementTimelineItemProps';
+import { mapCatégorieToIcon } from './catégories';
+
+type MapToTimelineItemProps = {
+  readmodel: Lauréat.HistoriqueListItemReadModels;
+  unitéPuissance: string;
+  doitAfficherLienAttestationDésignation: boolean;
+};
+
+export const mapToTimelineItemProps = ({
+  readmodel,
+  unitéPuissance,
+  doitAfficherLienAttestationDésignation,
+}: MapToTimelineItemProps) => {
+  const props = match(readmodel)
+    .returnType<TimelineItemProps | undefined>()
+    .with({ category: 'abandon' }, mapToAbandonTimelineItemProps)
+    .with({ category: 'recours' }, mapToRecoursTimelineItemProps)
+    .with({ category: 'actionnaire' }, mapToActionnaireTimelineItemProps)
+    .with({ category: 'représentant-légal' }, mapToReprésentantLégalTimelineItemProps)
+    .with({ category: 'lauréat' }, (readmodel) =>
+      mapToLauréatTimelineItemProps({
+        readmodel,
+        doitAfficherLienAttestationDésignation,
+      }),
+    )
+    .with({ category: 'éliminé' }, mapToÉliminéTimelineItemProps)
+    .with({ category: 'garanties-financieres' }, mapToGarantiesFinancièresTimelineItemProps)
+    .with({ category: 'producteur' }, mapToProducteurTimelineItemProps)
+    .with({ category: 'puissance' }, (readmodel) =>
+      mapToPuissanceTimelineItemProps({
+        event: readmodel,
+        unitéPuissance,
+      }),
+    )
+    .with({ category: 'achevement' }, mapToAchèvementTimelineItemProps)
+    .with({ category: 'raccordement' }, mapToRaccordementTimelineItemProps)
+    .with({ category: 'délai' }, mapToDélaiTimelineItemProps)
+    .with({ category: 'fournisseur' }, mapToFournisseurTimelineItemProps)
+    .with({ category: 'installation' }, mapToInstallationTimelineItemProps)
+    .with(
+      {
+        category: 'nature-de-l-exploitation',
+      },
+      mapToNatureDeLExploitationTimelineItemProps,
+    )
+    .with({ category: 'power-purchase-agreement' }, mapToPowerPurchaseAgreementTimelineItemProps)
+    .exhaustive(() => undefined);
+
+  if (props) {
+    return {
+      ...props,
+      icon: props.icon ?? {
+        id: mapCatégorieToIcon(readmodel.category),
+      },
+    };
+  }
+};

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/(détails)/historique/_helpers/trierParJourPuisOrdreDInsertion.test.ts
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/(détails)/historique/_helpers/trierParJourPuisOrdreDInsertion.test.ts
@@ -1,0 +1,47 @@
+import assert from 'node:assert';
+import { describe, test } from 'node:test';
+
+import { trierParJourPuisOrdreDInsertion } from './trierParJourPuisOrdreDInsertion';
+
+type Item = { label: string; date: string };
+
+const trierLabels = (items: ReadonlyArray<Item>) =>
+  trierParJourPuisOrdreDInsertion({ items, dateOf: (item) => item.date }).map((item) => item.label);
+
+describe('trierParJourPuisOrdreDInsertion', () => {
+  test('trie par date quand les jours calendaires sont différents', () => {
+    const items: Item[] = [
+      { label: 'accord', date: '2023-06-20T00:00:00.000Z' },
+      { label: 'notification', date: '2023-01-01T00:00:00.000Z' },
+      { label: 'demande', date: '2023-06-15T14:32:00.000Z' },
+    ];
+
+    assert.deepEqual(trierLabels(items), ['notification', 'demande', 'accord']);
+  });
+
+  test("conserve l'ordre d'entrée quand deux items tombent le même jour, même si l'instant exact est inversé", () => {
+    // Si la demande de recours (date calculée au moment de l'action) tombe le même jour que
+    // la date de la réponse signée pouvant être antidaté le meme jour que la demande (date picker avec heure à minuit (YYYY-MM-DDT00:00:00.000Z)
+    // alors il faut dans ce cas là utiliser l'ordre d'instertion
+    const items: Item[] = [
+      { label: 'demande', date: '2023-06-15T14:32:00.000Z' },
+      { label: 'accord', date: '2023-06-15T00:00:00.000Z' },
+    ];
+
+    assert.deepEqual(trierLabels(items), ['demande', 'accord']);
+  });
+
+  test('ne mute pas le tableau reçu en entrée', () => {
+    const items: Item[] = [
+      { label: 'b', date: '2023-06-20T00:00:00.000Z' },
+      { label: 'a', date: '2023-01-01T00:00:00.000Z' },
+    ];
+
+    trierParJourPuisOrdreDInsertion({ items, dateOf: (item) => item.date });
+
+    assert.deepEqual(
+      items.map((item) => item.label),
+      ['b', 'a'],
+    );
+  });
+});

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/(détails)/historique/_helpers/trierParJourPuisOrdreDInsertion.ts
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/(détails)/historique/_helpers/trierParJourPuisOrdreDInsertion.ts
@@ -1,0 +1,28 @@
+/**
+ *
+ * Trie par date métier (jour calendaire), et laisse le tri stable retomber sur l'ordre
+ * d'insertion réel (déjà correct puisque les évènements sont publiés dans l'ordre causal)
+ * quand deux items tombent le même jour. Nécessaire car certaines dates métier (ex : date
+ * de réponse signée d'un recours) peuvent être antidatées par un utilisateur, et se
+ * retrouver, à l'instant près, avant un évènement pourtant survenu réellement avant elle.
+ *
+ */
+type TrierParJourPuisOrdreDInsertionProps<T> = {
+  items: ReadonlyArray<T>;
+  dateOf: (item: T) => string;
+};
+
+export const trierParJourPuisOrdreDInsertion = <T>({
+  items,
+  dateOf,
+}: TrierParJourPuisOrdreDInsertionProps<T>) =>
+  [...items].sort((a, b) => {
+    const dateA = new Date(dateOf(a));
+    const dateB = new Date(dateOf(b));
+
+    if (dateA.toISOString().slice(0, 10) === dateB.toISOString().slice(0, 10)) {
+      return 0;
+    }
+
+    return dateA.getTime() - dateB.getTime();
+  });

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/(détails)/historique/page.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/(détails)/historique/page.tsx
@@ -1,39 +1,17 @@
 import { mediator } from 'mediateur';
 import type { Metadata } from 'next';
-import { match, P } from 'ts-pattern';
 import { z } from 'zod';
 
-import type { HistoryRecord } from '@potentiel-domain/entity';
 import { IdentifiantProjet, type Lauréat } from '@potentiel-domain/projet';
 import type { Role } from '@potentiel-domain/utilisateur';
 
 import { getLauréatInfos } from '@/app/_helpers';
-import { mapToÉliminéTimelineItemProps } from '@/app/elimines/[identifiant]/(historique)/mapToÉliminéTimelineItemProps';
-import { mapToRecoursTimelineItemProps } from '@/app/elimines/[identifiant]/recours/(historique)/mapToRecoursTimelineItemProps';
-import type { TimelineItemProps } from '@/components/organisms/timeline';
 import { decodeParameter } from '@/utils/decodeParameter';
 import type { IdentifiantParameter } from '@/utils/identifiantParameter';
 import { PageWithErrorHandling } from '@/utils/PageWithErrorHandling';
 import { withUtilisateur } from '@/utils/withUtilisateur';
-import { mapToLauréatTimelineItemProps } from '../../(historique)/mapToLauréatTimelineItemProps';
-import { mapToAbandonTimelineItemProps } from '../../abandon/(historique)/mapToAbandonTimelineItemProps';
-import { mapToAchèvementTimelineItemProps } from '../../achevement/(historique)/mapToAchèvementTimelineItemProps';
-import { mapToActionnaireTimelineItemProps } from '../../actionnaire/(historique)/mapToActionnaireTimelineItemProps';
-import { mapToDélaiTimelineItemProps } from '../../delai/(historique)/mapToDélaiTimelineItemProps';
-import { mapToFournisseurTimelineItemProps } from '../../fournisseur/(historique)/mapToFournisseurTimelineItemProps';
-import { mapToGarantiesFinancièresTimelineItemProps } from '../../garanties-financieres/(historique)/mapToGarantiesFinancièresTimelineItemProps';
-import { mapToInstallationTimelineItemProps } from '../../installation/(historique)/mapToInstallationTimelineItemProps';
-import { mapToNatureDeLExploitationTimelineItemProps } from '../../nature-de-l-exploitation/(historique)/mapToNatureDeLExploitationTimelineItemProps';
-import { mapToPowerPurchaseAgreementTimelineItemProps } from '../../power-purchase-agreement/(historique)/mapToPowerPurchaseAgreementTimelineItemProps';
-import { mapToProducteurTimelineItemProps } from '../../producteur/(historique)/mapToProducteurTimelineItemProps';
-import { mapToPuissanceTimelineItemProps } from '../../puissance/(historique)/mapToPuissanceTimelineItemProps';
-import { mapToReprésentantLégalTimelineItemProps } from '../../representant-legal/(historique)/mapToReprésentantLégalTimelineItemProps';
-import { mapToRaccordementTimelineItemProps } from '../raccordements/(historique)/mapToRaccordementTimelineItemProps';
-import {
-  categoriesDisponibles,
-  mapCatégorieToIcon,
-  mapCatégorieToLabel,
-} from './_helpers/catégories';
+import { categoriesDisponibles, mapCatégorieToLabel } from './_helpers/catégories';
+import { getHistoriqueTrié } from './_helpers/getHistoriqueTrié';
 import { type HistoriqueLauréatAction, HistoriqueLauréatPage } from './HistoriqueLauréat.page';
 
 type PageProps = IdentifiantParameter & {
@@ -69,30 +47,11 @@ export default async function Page(props: PageProps) {
         },
       });
 
-      const aUnRecoursAccordé = !!historique.items.find((item) => {
-        if (item.category !== 'recours') {
-          return false;
-        }
-
-        return match(item)
-          .returnType<boolean>()
-          .with({ type: P.union('RecoursAccordé-V1', 'RecoursAccordé-V2') }, () => true)
-          .with(
-            {
-              type: P.union(
-                'RecoursDemandé-V1',
-                'RecoursAnnulé-V1',
-                'RecoursPasséEnInstruction-V1',
-                'RecoursRejeté-V1',
-              ),
-            },
-            () => false,
-          )
-          .exhaustive();
+      const historiqueTrié = getHistoriqueTrié({
+        items: historique.items,
+        unitéPuissance: lauréat.unitéPuissance.formatter(),
+        attestationDésignation: lauréat.attestationDésignation,
       });
-
-      const doitAfficherLienAttestationDésignation =
-        !aUnRecoursAccordé && !!lauréat.attestationDésignation;
 
       const catégories = categoriesDisponibles
         .map((categorie) => ({
@@ -101,25 +60,12 @@ export default async function Page(props: PageProps) {
         }))
         .sort((a, b) => a.label.localeCompare(b.label, 'fr'));
 
-      const historiqueFilteredAndSorted = historique.items
-        .filter(filtrerImportsEtRecoursLegacy)
-        .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
-        .map((item) =>
-          mapToTimelineItemProps({
-            readmodel: item,
-            unitéPuissance: lauréat.unitéPuissance.formatter(),
-            doitAfficherLienAttestationDésignation,
-          }),
-        )
-        .filter((item) => item !== undefined)
-        .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
-
       return (
         <HistoriqueLauréatPage
           identifiantProjet={identifiantProjet}
           actions={mapToActions(utilisateur.rôle)}
           catégories={catégories}
-          historique={historiqueFilteredAndSorted}
+          historique={historiqueTrié}
         />
       );
     }),
@@ -134,103 +80,4 @@ const mapToActions = (rôle: Role.ValueType) => {
   }
 
   return actions;
-};
-
-const filtrerImportsEtRecoursLegacy = (
-  event: Lauréat.HistoriqueListItemReadModels,
-  _: number,
-  historique: Readonly<Lauréat.HistoriqueListItemReadModels[]>,
-) => {
-  // on ne veut pas afficher dans l'historique complet les événements d'import de chaque domaine
-  // qui arrive en rebond de la désignation
-  if (event.type?.includes('Import')) {
-    return false;
-  }
-  // dans de rares cas de projets désignés hors Potentiel,
-  // on a pas l'information de la date de notification du projetÉliminé
-  // on préfère alors ne pas l'information fausse de la notification de l'éliminé
-  if (event.category === 'éliminé' && event.type === 'ÉliminéNotifié-V1') {
-    const lauréatNotifié = historique.find(isLauréatNotifié);
-    if (lauréatNotifié && lauréatNotifié.payload.notifiéLe === event.payload.notifiéLe) {
-      return false;
-    }
-  }
-  return true;
-};
-
-const isLauréatNotifié = (
-  item: Lauréat.HistoriqueListItemReadModels,
-): item is HistoryRecord<
-  'lauréat',
-  Lauréat.LauréatNotifiéEvent | Lauréat.LauréatNotifiéV1Event
-> => {
-  if (item.category !== 'lauréat') {
-    return false;
-  }
-  return match(item)
-    .with({ type: 'LauréatNotifié-V1' }, () => true)
-    .with({ type: 'LauréatNotifié-V2' }, () => true)
-    .with({ type: 'CahierDesChargesChoisi-V1' }, () => false)
-    .with({ type: 'NomProjetModifié-V1' }, () => false)
-    .with({ type: 'SiteDeProductionModifié-V1' }, () => false)
-    .with({ type: 'NomEtLocalitéLauréatImportés-V1' }, () => false)
-    .with({ type: 'ChangementNomProjetEnregistré-V1' }, () => false)
-    .with({ type: 'StatutLauréatModifié-V1' }, () => false)
-    .exhaustive();
-};
-
-type MapToTimelineItemProps = {
-  readmodel: Lauréat.HistoriqueListItemReadModels;
-  unitéPuissance: string;
-  doitAfficherLienAttestationDésignation: boolean;
-};
-
-const mapToTimelineItemProps = ({
-  readmodel,
-  unitéPuissance,
-  doitAfficherLienAttestationDésignation,
-}: MapToTimelineItemProps) => {
-  const props = match(readmodel)
-    .returnType<TimelineItemProps | undefined>()
-    .with({ category: 'abandon' }, mapToAbandonTimelineItemProps)
-    .with({ category: 'recours' }, mapToRecoursTimelineItemProps)
-    .with({ category: 'actionnaire' }, mapToActionnaireTimelineItemProps)
-    .with({ category: 'représentant-légal' }, mapToReprésentantLégalTimelineItemProps)
-    .with({ category: 'lauréat' }, (readmodel) =>
-      mapToLauréatTimelineItemProps({
-        readmodel,
-        doitAfficherLienAttestationDésignation,
-      }),
-    )
-    .with({ category: 'éliminé' }, mapToÉliminéTimelineItemProps)
-    .with({ category: 'garanties-financieres' }, mapToGarantiesFinancièresTimelineItemProps)
-    .with({ category: 'producteur' }, mapToProducteurTimelineItemProps)
-    .with({ category: 'puissance' }, (readmodel) =>
-      mapToPuissanceTimelineItemProps({
-        event: readmodel,
-        unitéPuissance,
-      }),
-    )
-    .with({ category: 'achevement' }, mapToAchèvementTimelineItemProps)
-    .with({ category: 'raccordement' }, mapToRaccordementTimelineItemProps)
-    .with({ category: 'délai' }, mapToDélaiTimelineItemProps)
-    .with({ category: 'fournisseur' }, mapToFournisseurTimelineItemProps)
-    .with({ category: 'installation' }, mapToInstallationTimelineItemProps)
-    .with(
-      {
-        category: 'nature-de-l-exploitation',
-      },
-      mapToNatureDeLExploitationTimelineItemProps,
-    )
-    .with({ category: 'power-purchase-agreement' }, mapToPowerPurchaseAgreementTimelineItemProps)
-    .exhaustive(() => undefined);
-
-  if (props) {
-    return {
-      ...props,
-      icon: props.icon ?? {
-        id: mapCatégorieToIcon(readmodel.category),
-      },
-    };
-  }
 };

--- a/packages/domain/projet/src/éliminé/recours/recours.aggregate.ts
+++ b/packages/domain/projet/src/éliminé/recours/recours.aggregate.ts
@@ -1,6 +1,6 @@
 import { match, P } from 'ts-pattern';
 
-import { Email } from '@potentiel-domain/common';
+import { DateTime, Email } from '@potentiel-domain/common';
 import { AbstractAggregate } from '@potentiel-domain/core';
 
 import { GarantiesFinancières } from '../../lauréat/index.js';
@@ -20,6 +20,7 @@ import {
   AucunRecoursEnCours,
   DateRecoursAvantDateNotificationError,
   DateRecoursDansLeFuturError,
+  DateRéponseSignéeAntérieureÀDateDemandeRecours,
   RecoursDéjàEnInstructionAvecLeMêmeUtilisateurDgecError,
   ÉliminéInexistantError,
 } from './recours.error.js';
@@ -35,6 +36,8 @@ export class RecoursAggregate extends AbstractAggregate<RecoursEvent, 'recours',
     instruitPar: Email.ValueType;
   };
 
+  #dateDemande?: DateTime.ValueType;
+
   get éliminé() {
     return this.parent;
   }
@@ -45,18 +48,22 @@ export class RecoursAggregate extends AbstractAggregate<RecoursEvent, 'recours',
     identifiantUtilisateur,
     réponseSignée,
   }: AccorderOptions) {
-    this.vérifierQueDemandeRecoursExiste();
+    const dateDemande = this.vérifierQueDemandeRecoursExiste();
 
     if (dateRéponseSignée.estDansLeFutur()) {
       throw new DateRecoursDansLeFuturError();
     }
 
-    /**
-     *
-     * On compare avec l'heure de la réponse signée à midi pour être cohérent avec les dates de notifications. Cela permet d'éviter les erreurs de décalage horaire.
-     *
-     */
+    if (dateRéponseSignée.estJourAntérieurÀ(dateDemande)) {
+      throw new DateRéponseSignéeAntérieureÀDateDemandeRecours();
+    }
+
     if (dateRéponseSignée.estJourAntérieurÀ(this.éliminé.notifiéLe)) {
+      /**
+       *
+       * On compare avec l'heure de la réponse signée à midi pour être cohérent avec les dates de notifications. Cela permet d'éviter les erreurs de décalage horaire.
+       *
+       */
       throw new DateRecoursAvantDateNotificationError();
     }
 
@@ -231,8 +238,9 @@ export class RecoursAggregate extends AbstractAggregate<RecoursEvent, 'recours',
     this.instruction = undefined;
   }
 
-  private applyRecoursDemandéV1(_: RecoursDemandéEvent) {
+  private applyRecoursDemandéV1({ payload: { demandéLe } }: RecoursDemandéEvent) {
     this.#statut = StatutRecours.demandé;
+    this.#dateDemande = DateTime.convertirEnValueType(demandéLe);
   }
 
   private applyRecoursRejetéV1(_: RecoursRejetéEvent) {
@@ -249,9 +257,10 @@ export class RecoursAggregate extends AbstractAggregate<RecoursEvent, 'recours',
     };
   }
 
-  private vérifierQueDemandeRecoursExiste() {
-    if (!this.exists) {
+  private vérifierQueDemandeRecoursExiste(): DateTime.ValueType {
+    if (!this.exists || !this.#dateDemande) {
       throw new AucunRecoursEnCours();
     }
+    return this.#dateDemande;
   }
 }

--- a/packages/domain/projet/src/éliminé/recours/recours.error.ts
+++ b/packages/domain/projet/src/éliminé/recours/recours.error.ts
@@ -28,3 +28,9 @@ export class ÉliminéInexistantError extends AggregateNotFoundError {
     super(`Le projet éliminé n'existe pas`);
   }
 }
+
+export class DateRéponseSignéeAntérieureÀDateDemandeRecours extends InvalidOperationError {
+  constructor() {
+    super(`La date d'accord du recours ne peut pas être antérieure à la date de la demande`);
+  }
+}

--- a/packages/specifications/src/projet/éliminé/recours/accorderRecours.feature
+++ b/packages/specifications/src/projet/éliminé/recours/accorderRecours.feature
@@ -45,13 +45,24 @@ Fonctionnalité: Accorder la demande de recours d'un projet éliminé
             | motif | recours-accordé |
         Et les garanties financières actuelles ne devraient pas être consultables
 
-    Scénario: la dgec accorde le recours d'un projet éliminé avec une date d'accord le même jour que la désignation du projet
+    Scénario: la dgec accorde le recours d'un projet éliminé avec une date d'accord le même jour que la désignation du projet et que la demande de recours
         Etant donné le projet éliminé "Du boulodrome de Bordeaux" avec :
             | appel d'offres    | PPE2 - Sol |
             | date notification | 2023-01-01 |
-        Et une demande de recours en cours pour le projet éliminé
+        Et une demande de recours en cours pour le projet éliminé avec :
+            | date de la demande | 2023-01-01 |
         Quand la dgec accorde le recours pour le projet éliminé avec :
             | date d'accord du recours | 2023-01-01 |
+        Alors le recours du projet éliminé devrait être accordé
+
+    Scénario: la dgec accorde le recours d'un projet éliminé avec une date d'accord le même jour que la demande de recours
+        Etant donné le projet éliminé "Du boulodrome de Bordeaux" avec :
+            | appel d'offres    | PPE2 - Sol |
+            | date notification | 2023-01-01 |
+        Et une demande de recours en cours pour le projet éliminé avec :
+            | date de la demande | 2023-06-15 |
+        Quand la dgec accorde le recours pour le projet éliminé avec :
+            | date d'accord du recours | 2023-06-15 |
         Alors le recours du projet éliminé devrait être accordé
 
 
@@ -73,7 +84,8 @@ Fonctionnalité: Accorder la demande de recours d'un projet éliminé
             | appel d'offres    | PPE2 - Sol |
             | date notification | 2023-01-01 |
         Et la dreal "Dreal de Paris" associée à la région du projet
-        Et une demande de recours en cours pour le projet éliminé
+        Et une demande de recours en cours pour le projet éliminé avec :
+            | date de la demande | 2022-01-01 |
         Quand la dgec accorde le recours pour le projet éliminé avec :
             | date d'accord du recours | 2022-10-10 |
         Alors la dgec devrait être informé que "La date d'accord du recours ne peut pas antérieure à la date de notification du projet"

--- a/packages/specifications/src/projet/éliminé/recours/accorderRecours.feature
+++ b/packages/specifications/src/projet/éliminé/recours/accorderRecours.feature
@@ -61,6 +61,13 @@ Fonctionnalité: Accorder la demande de recours d'un projet éliminé
             | date d'accord du recours | 2100-10-10 |
         Alors la dgec devrait être informé que "La date d'accord du recours ne peut pas être dans le futur"
 
+    Scénario: Impossible d'accorder le recours d'un projet éliminé avec une date antérieure à la date de la demande
+        Etant donné une demande de recours en cours pour le projet éliminé avec :
+            | date de la demande | 2026-08-12 |
+        Quand la dgec accorde le recours pour le projet éliminé avec :
+            | date d'accord du recours | 2026-08-10 |
+        Alors la dgec devrait être informé que "La date d'accord du recours ne peut pas être antérieure à la date de la demande"
+
     Scénario: Impossible d'accorder le recours d'un projet éliminé avec une date d'accord antérieure à la date de notification du projet
         Etant donné le projet éliminé "Du boulodrome de Paris" avec :
             | appel d'offres    | PPE2 - Sol |

--- a/packages/specifications/src/projet/éliminé/recours/fixtures/accorderRecours.fixture.ts
+++ b/packages/specifications/src/projet/éliminé/recours/fixtures/accorderRecours.fixture.ts
@@ -43,15 +43,31 @@ export class AccorderRecoursFixture
   créer(
     partialData: Partial<AccorderRecours> & {
       dateNotification: string;
+      dateDemande?: string;
     },
   ): Readonly<AccorderRecours> {
+    /**
+     *
+     * Reproduit l'invariant RecoursAggregate.accorder (dateRéponseSignée ne peut être
+     * antérieure ni à la demande ni à la notification) : la date d'accord par défaut est
+     * tirée après la plus tardive des deux, pour ne pas générer un jeu de données incohérent.
+     *
+     */
+    const dateAuPlusTôtPossible = partialData.dateDemande
+      ? DateTime.convertirEnValueType(partialData.dateDemande).estUltérieureÀ(
+          DateTime.convertirEnValueType(partialData.dateNotification),
+        )
+        ? partialData.dateDemande
+        : partialData.dateNotification
+      : partialData.dateNotification;
+
     const fixture: AccorderRecours = {
       accordéLe: faker.date.soon().toISOString(),
       accordéPar: faker.internet.email(),
       réponseSignée: faker.potentiel.document(),
       dateAccord: faker.date
         .between({
-          from: new Date(partialData.dateNotification),
+          from: new Date(dateAuPlusTôtPossible),
           to: new Date(),
         })
         .toISOString(),

--- a/packages/specifications/src/projet/éliminé/recours/stepDefinitions/recours.given.ts
+++ b/packages/specifications/src/projet/éliminé/recours/stepDefinitions/recours.given.ts
@@ -66,7 +66,7 @@ async function créerDemandeRecours(this: PotentielWorld, dateDemande?: DateTime
   const { raison, demandéLe, demandéPar, pièceJustificative } =
     this.éliminéWorld.recoursWorld.demanderRecoursFixture.créer({
       demandéPar: this.utilisateurWorld.porteurFixture.email,
-      demandéLe: dateDemande,
+      ...(dateDemande && { demandéLe: dateDemande }),
     });
 
   await mediator.send<Éliminé.Recours.DemanderRecoursUseCase>({

--- a/packages/specifications/src/projet/éliminé/recours/stepDefinitions/recours.given.ts
+++ b/packages/specifications/src/projet/éliminé/recours/stepDefinitions/recours.given.ts
@@ -1,6 +1,7 @@
-import { Given as EtantDonné } from '@cucumber/cucumber';
+import { type DataTable, Given as EtantDonné } from '@cucumber/cucumber';
 import { mediator } from 'mediateur';
 
+import { DateTime } from '@potentiel-domain/common';
 import type { Éliminé } from '@potentiel-domain/projet';
 
 import { convertFixtureFileToReadableStream } from '../../../../helpers/convertFixtureFileToReadable.js';
@@ -8,9 +9,22 @@ import type { PotentielWorld } from '../../../../potentiel.world.js';
 import { accorderRecours } from './recours.when.js';
 
 EtantDonné(
-  /une demande de recours en cours pour le projet éliminé/,
+  /une demande de recours en cours pour le projet éliminé$/,
   async function (this: PotentielWorld) {
     await créerDemandeRecours.call(this);
+  },
+);
+
+EtantDonné(
+  /une demande de recours en cours pour le projet éliminé avec :$/,
+  async function (this: PotentielWorld, datatable: DataTable) {
+    const exemple = datatable.rowsHash();
+    await créerDemandeRecours.call(
+      this,
+      exemple['date de la demande']
+        ? DateTime.convertirEnValueType(new Date(exemple['date de la demande'])).formatter()
+        : undefined,
+    );
   },
 );
 
@@ -46,12 +60,13 @@ EtantDonné(
   },
 );
 
-async function créerDemandeRecours(this: PotentielWorld) {
+async function créerDemandeRecours(this: PotentielWorld, dateDemande?: DateTime.RawType) {
   const identifiantProjet = this.éliminéWorld.identifiantProjet.formatter();
 
   const { raison, demandéLe, demandéPar, pièceJustificative } =
     this.éliminéWorld.recoursWorld.demanderRecoursFixture.créer({
       demandéPar: this.utilisateurWorld.porteurFixture.email,
+      demandéLe: dateDemande,
     });
 
   await mediator.send<Éliminé.Recours.DemanderRecoursUseCase>({

--- a/packages/specifications/src/projet/éliminé/recours/stepDefinitions/recours.when.ts
+++ b/packages/specifications/src/projet/éliminé/recours/stepDefinitions/recours.when.ts
@@ -142,6 +142,7 @@ export async function accorderRecours(this: PotentielWorld, dateAccordSpécifiqu
   } = this.éliminéWorld.recoursWorld.accorderRecoursFixture.créer({
     accordéPar: this.utilisateurWorld.validateurFixture.email,
     dateNotification: this.éliminéWorld.notifierEliminéFixture.notifiéLe,
+    dateDemande: this.éliminéWorld.recoursWorld.demanderRecoursFixture.demandéLe,
     ...(dateAccordSpécifique && { dateAccord: dateAccordSpécifique }),
   });
 


### PR DESCRIPTION
- **✅ Impossible d'accorder le recours d'un projet éliminé avec une date antérieure à la date de la demande**
- **🎨 Découpage de la page historique en helpers testables + spec recours avec date d'accord**
