### PR TITLE
♻️ Utilisation du composant DSFR Notice plutôt que Alert

### DIFF
--- a/packages/applications/ssr/src/app/auth/signUp/SignUp.page.tsx
+++ b/packages/applications/ssr/src/app/auth/signUp/SignUp.page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import Alert from '@codegouvfr/react-dsfr/Alert';
+import Notice from '@codegouvfr/react-dsfr/Notice';
 import ProConnectButton from '@codegouvfr/react-dsfr/ProConnectButton';
 import { useRouter } from 'next/navigation';
 
@@ -36,12 +36,12 @@ export default function SignUpPage({ providers, callbackUrl, error }: SignUpPage
         </p>
 
         {error && (
-          <Alert
+          <Notice
             className="md:w-2/3"
-            severity="error"
-            small
+            title=""
+            severity="alert"
             description="Une erreur est survenue. Si le problème persiste vous pouvez nous contacter"
-            closable
+            isClosable
           />
         )}
         <div className="flex flex-col items-center lg:flex-row  lg:items-stretch gap-6 h-full">

--- a/packages/applications/ssr/src/app/candidatures/[identifiant]/corriger/CorrigerCandidature.page.tsx
+++ b/packages/applications/ssr/src/app/candidatures/[identifiant]/corriger/CorrigerCandidature.page.tsx
@@ -1,4 +1,4 @@
-import Alert from '@codegouvfr/react-dsfr/Alert';
+import Notice from '@codegouvfr/react-dsfr/Notice';
 
 import { Routes } from '@potentiel-applications/routes';
 import { IdentifiantProjet } from '@potentiel-domain/projet';
@@ -47,9 +47,9 @@ export const CorrigerCandidaturePage: React.FC<CorrigerCandidaturePageProps> = (
       rightColumn={{
         children: (
           <>
-            <Alert
+            <Notice
               severity="info"
-              small
+              title=""
               description={
                 <div className="flex flex-col gap-2">
                   <div>
@@ -66,9 +66,9 @@ export const CorrigerCandidaturePage: React.FC<CorrigerCandidaturePageProps> = (
               }
             />
             {estLauréat && (
-              <Alert
+              <Notice
                 severity="warning"
-                small
+                title=""
                 description={
                   <span>
                     Cette candidature étant déjà notifiée, veuillez utiliser la{' '}

--- a/packages/applications/ssr/src/app/candidatures/corriger-par-lot/CorrigerCandidaturesParLot.page.tsx
+++ b/packages/applications/ssr/src/app/candidatures/corriger-par-lot/CorrigerCandidaturesParLot.page.tsx
@@ -22,7 +22,7 @@ export const CorrigerCandidaturesParLotPage: FC<CorrigerCandidaturesParLotFormPr
       }}
       rightColumn={{
         children: (
-          <>
+          <div className="flex flex-col gap-4">
             <Notice
               severity="info"
               title=""
@@ -70,7 +70,7 @@ export const CorrigerCandidaturesParLotPage: FC<CorrigerCandidaturesParLotFormPr
                 </div>
               }
             />
-          </>
+          </div>
         ),
       }}
     />

--- a/packages/applications/ssr/src/app/candidatures/corriger-par-lot/CorrigerCandidaturesParLot.page.tsx
+++ b/packages/applications/ssr/src/app/candidatures/corriger-par-lot/CorrigerCandidaturesParLot.page.tsx
@@ -1,4 +1,4 @@
-import Alert from '@codegouvfr/react-dsfr/Alert';
+import Notice from '@codegouvfr/react-dsfr/Notice';
 import type { FC } from 'react';
 
 import { Routes } from '@potentiel-applications/routes';
@@ -23,9 +23,9 @@ export const CorrigerCandidaturesParLotPage: FC<CorrigerCandidaturesParLotFormPr
       rightColumn={{
         children: (
           <>
-            <Alert
+            <Notice
               severity="info"
-              small
+              title=""
               description={
                 <div className="flex flex-col gap-2 text-justify">
                   <span>Aucune notification ne sera envoyée suite à cet import.</span>
@@ -40,9 +40,9 @@ export const CorrigerCandidaturesParLotPage: FC<CorrigerCandidaturesParLotFormPr
                 </div>
               }
             />
-            <Alert
+            <Notice
               severity="info"
-              small
+              title=""
               description={
                 <div className="flex flex-col gap-2 text-justify">
                   <span>

--- a/packages/applications/ssr/src/app/candidatures/importer/(csv)/ImporterCandidaturesParCSV.form.tsx
+++ b/packages/applications/ssr/src/app/candidatures/importer/(csv)/ImporterCandidaturesParCSV.form.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import Alert from '@codegouvfr/react-dsfr/Alert';
+import Notice from '@codegouvfr/react-dsfr/Notice';
 import { type FC, useState } from 'react';
 
 import { Routes } from '@potentiel-applications/routes';
@@ -74,10 +74,10 @@ export const ImporterCandidaturesParCSVForm: FC<ImporterCandidaturesParCSVFormPr
             stateRelatedMessage={validationErrors['fichierImportCandidature']}
           />
         </Form>
-        <Alert
+        <Notice
           severity="info"
-          small
           className="flex-auto md:max-w-lg items-stretch mt-4"
+          title=""
           description={
             <div className="py-4 text-justify">
               Il est possible de corriger des candidat existants:

--- a/packages/applications/ssr/src/app/candidatures/importer/(demarche-simplifiée)/ImporterCandidaturesParDémarcheNumérique.form.tsx
+++ b/packages/applications/ssr/src/app/candidatures/importer/(demarche-simplifiée)/ImporterCandidaturesParDémarcheNumérique.form.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import Alert from '@codegouvfr/react-dsfr/Alert';
 import Checkbox from '@codegouvfr/react-dsfr/Checkbox';
+import Notice from '@codegouvfr/react-dsfr/Notice';
 import Table from '@codegouvfr/react-dsfr/Table';
 import { type FC, useState } from 'react';
 
@@ -72,10 +72,10 @@ export const ImporterCandidaturesParDémarcheNumériqueForm: FC<
             ]}
           />
         </Form>
-        <Alert
+        <Notice
           severity="info"
-          small
           className="flex-auto md:max-w-lg items-stretch mt-4"
+          title=""
           description={
             <div className="flex flex-col gap-2">
               <p>

--- a/packages/applications/ssr/src/app/candidatures/importer/ImporterCandidatures.form.tsx
+++ b/packages/applications/ssr/src/app/candidatures/importer/ImporterCandidatures.form.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import Alert from '@codegouvfr/react-dsfr/Alert';
 import Checkbox from '@codegouvfr/react-dsfr/Checkbox';
+import Notice from '@codegouvfr/react-dsfr/Notice';
 import Select from '@codegouvfr/react-dsfr/SelectNext';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { type FC, useCallback, useState } from 'react';
@@ -64,10 +64,9 @@ export const ImporterCandidaturesForm: FC<ImporterCandidaturesFormProps> = ({
   return (
     <div>
       {importMultipleAOEtPeriodesPossible && (
-        <Alert
+        <Notice
           severity="info"
           className="mb-4"
-          small
           title="Autoriser l'import avec plusieurs appel d'offres et périodes"
           description={
             <Checkbox

--- a/packages/applications/ssr/src/app/elimines/[identifiant]/recours/demander/DemanderRecours.page.tsx
+++ b/packages/applications/ssr/src/app/elimines/[identifiant]/recours/demander/DemanderRecours.page.tsx
@@ -1,4 +1,4 @@
-import Alert from '@codegouvfr/react-dsfr/Alert';
+import Notice from '@codegouvfr/react-dsfr/Notice';
 import type { FC } from 'react';
 
 import { Heading1 } from '@/components/atoms/headings';
@@ -17,9 +17,9 @@ export const DemanderRecoursPage: FC<DemanderRecoursPageProps> = ({ identifiantP
       rightColumn={{
         children: (
           <div>
-            <Alert
+            <Notice
               severity="info"
-              small
+              title=""
               description={
                 <div className="text-justify">
                   Toute réponse vous sera mise à disposition dans Potentiel et donnera lieu à une

--- a/packages/applications/ssr/src/app/global-error.tsx
+++ b/packages/applications/ssr/src/app/global-error.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import Alert from '@codegouvfr/react-dsfr/Alert';
+import Notice from '@codegouvfr/react-dsfr/Notice';
 import * as Sentry from '@sentry/nextjs';
 import { useEffect } from 'react';
 
@@ -17,7 +17,7 @@ export default function GlobalError({ error }: GlobalErrorProps) {
   return (
     <html lang="fr">
       <body>
-        <Alert
+        <Notice
           severity="warning"
           title="Erreur dans l'application"
           className="mb-6"

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/(détails)/modifier/ModifierLauréat.form.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/(détails)/modifier/ModifierLauréat.form.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import Alert from '@codegouvfr/react-dsfr/Alert';
+import Notice from '@codegouvfr/react-dsfr/Notice';
 import Tooltip from '@codegouvfr/react-dsfr/Tooltip';
 import type React from 'react';
 import { useState } from 'react';
@@ -79,9 +79,9 @@ export const ModifierLauréatForm: React.FC<ModifierLauréatFormProps> = ({
       }}
     >
       {!peutRegénérerAttestation && (
-        <Alert
+        <Notice
           severity="info"
-          small
+          title=""
           description={
             <div className="p-1">
               La période de l'appel d'offre de ce projet ne dispose pas de modèle d'attestation de
@@ -98,7 +98,7 @@ export const ModifierLauréatForm: React.FC<ModifierLauréatFormProps> = ({
         </FormRow>
         <input type={'hidden'} value={projet.identifiantProjet} name="identifiantProjet" />
         {validationErrors['identifiantProjet'] && (
-          <FormAlertError description={validationErrors['identifiantProjet']} />
+          <FormAlertError description={validationErrors['identifiantProjet']} title="" />
         )}
         <FormRow>
           <ProjectField

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/(détails)/raccordements/(dossier-de-raccordement)/[reference]/date-mise-en-service/DateMiseEnServiceAlert.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/(détails)/raccordements/(dossier-de-raccordement)/[reference]/date-mise-en-service/DateMiseEnServiceAlert.tsx
@@ -1,10 +1,10 @@
-import Alert from '@codegouvfr/react-dsfr/Alert';
+import Notice from '@codegouvfr/react-dsfr/Notice';
 
 import type { DateTime } from '@potentiel-domain/common';
 
 import { FormattedDate } from '@/components/atoms/FormattedDate';
 
-type Props = {
+type DateMiseEnServiceAlertProps = {
   dateDésignation: DateTime.RawType;
   intervalleDatesMeSDélaiCDC2022?: { min: DateTime.RawType; max: DateTime.RawType };
 };
@@ -12,44 +12,41 @@ type Props = {
 export const DateMiseEnServiceAlert = ({
   dateDésignation,
   intervalleDatesMeSDélaiCDC2022,
-}: Props) => {
-  return (
-    <Alert
-      severity="info"
-      small
-      description={
-        <div className="py-4 text-justify">
-          <ul className="flex flex-col gap-3">
-            <li>
-              La mise en service correspond à la mise en exploitation des ouvrages de raccordement
-              permettant la première injection sur le réseau d'électricité pour l'installation.
-            </li>
-            {intervalleDatesMeSDélaiCDC2022 && (
-              <li>
-                Si le projet{' '}
-                <span className="font-bold">
-                  a bénéficié du délai supplémentaire relatif du cahier des charges du 30/08/2022
-                </span>
-                , la saisie d'une date de mise en service non comprise entre le{' '}
-                <FormattedDate className="font-bold" date={intervalleDatesMeSDélaiCDC2022.min} /> et
-                le <FormattedDate className="font-bold" date={intervalleDatesMeSDélaiCDC2022.max} />{' '}
-                peut remettre en cause l'application de ce délai et entraîner une modification de la
-                date d'achèvement du projet.
-              </li>
-            )}
+}: DateMiseEnServiceAlertProps) => (
+  <Notice
+    severity="info"
+    title=""
+    description={
+      <div className="py-4 text-justify">
+        <ul className="flex flex-col gap-3">
+          <li>
+            La mise en service correspond à la mise en exploitation des ouvrages de raccordement
+            permettant la première injection sur le réseau d'électricité pour l'installation.
+          </li>
+          {intervalleDatesMeSDélaiCDC2022 && (
             <li>
               Si le projet{' '}
               <span className="font-bold">
-                n'a pas bénéficié du délai supplémentaire relatif du cahier des charges du
-                30/08/2022
+                a bénéficié du délai supplémentaire relatif du cahier des charges du 30/08/2022
               </span>
-              , la saisie d'une date de mise en service doit être comprise entre la date de
-              désignation du projet <FormattedDate className="font-bold" date={dateDésignation} />{' '}
-              et <span className="font-bold">ce jour</span>.
+              , la saisie d'une date de mise en service non comprise entre le{' '}
+              <FormattedDate className="font-bold" date={intervalleDatesMeSDélaiCDC2022.min} /> et
+              le <FormattedDate className="font-bold" date={intervalleDatesMeSDélaiCDC2022.max} />{' '}
+              peut remettre en cause l'application de ce délai et entraîner une modification de la
+              date d'achèvement du projet.
             </li>
-          </ul>
-        </div>
-      }
-    />
-  );
-};
+          )}
+          <li>
+            Si le projet{' '}
+            <span className="font-bold">
+              n'a pas bénéficié du délai supplémentaire relatif du cahier des charges du 30/08/2022
+            </span>
+            , la saisie d'une date de mise en service doit être comprise entre la date de
+            désignation du projet <FormattedDate className="font-bold" date={dateDésignation} /> et{' '}
+            <span className="font-bold">ce jour</span>.
+          </li>
+        </ul>
+      </div>
+    }
+  />
+);

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/(détails)/raccordements/(raccordement-du-projet)/(détails)/ModifierGestionnaireRéseauDuRaccordement.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/(détails)/raccordements/(raccordement-du-projet)/(détails)/ModifierGestionnaireRéseauDuRaccordement.tsx
@@ -1,4 +1,4 @@
-import Alert from '@codegouvfr/react-dsfr/Alert';
+import Notice from '@codegouvfr/react-dsfr/Notice';
 import type { FC } from 'react';
 
 import { Routes } from '@potentiel-applications/routes';
@@ -27,7 +27,7 @@ export const ModifierGestionnaireRéseauDuRaccordement: FC<
 }: ModifierGestionnaireRéseauDuRaccordementProps) => {
   if (Option.isNone(gestionnaireRéseau)) {
     return (
-      <Alert
+      <Notice
         severity="warning"
         title="Gestionnaire de réseau inconnu"
         className="mb-6"

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/abandon/[date]/DétailsAbandon.page.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/abandon/[date]/DétailsAbandon.page.tsx
@@ -1,4 +1,4 @@
-import Alert from '@codegouvfr/react-dsfr/Alert';
+import Notice from '@codegouvfr/react-dsfr/Notice';
 import type { FC } from 'react';
 
 import { DateTime, Email } from '@potentiel-domain/common';
@@ -206,9 +206,9 @@ const mapToInformationsComponents = ({
     <div className="flex flex-col gap-4">
       <Heading2>Informations</Heading2>
       {informations.includes('demande-abandon-pour-recandidature') && (
-        <Alert
+        <Notice
           severity="warning"
-          small
+          title=""
           description={
             <div>
               <div className="font-semibold mb-2">Demande d'abandon pour recandidature</div>

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/abandon/[date]/InfoBoxMainlevéeSiAbandonAccordé.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/abandon/[date]/InfoBoxMainlevéeSiAbandonAccordé.tsx
@@ -1,4 +1,4 @@
-import Alert from '@codegouvfr/react-dsfr/Alert';
+import Notice from '@codegouvfr/react-dsfr/Notice';
 
 import { Routes } from '@potentiel-applications/routes';
 
@@ -9,9 +9,9 @@ type Props = {
 };
 
 export const InfoBoxMainlevéeSiAbandonAccordé = ({ identifiantProjet }: Props) => (
-  <Alert
+  <Notice
     severity="info"
-    small
+    title=""
     description={
       <div className="p-3 flex flex-col">
         <span>

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/abandon/demander/DemanderAbandon.page.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/abandon/demander/DemanderAbandon.page.tsx
@@ -1,4 +1,4 @@
-import Alert from '@codegouvfr/react-dsfr/Alert';
+import Notice from '@codegouvfr/react-dsfr/Notice';
 import type { FC } from 'react';
 
 import type { Lauréat } from '@potentiel-domain/projet';
@@ -35,9 +35,9 @@ export const DemanderAbandonPage: FC<DemanderAbandonPageProps> = ({
       rightColumn={{
         children: (
           <div>
-            <Alert
+            <Notice
               severity="info"
-              small
+              title=""
               description={
                 <div className="text-justify">
                   {autoritéCompétenteText}

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/achevement/InfoAttestationConformité.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/achevement/InfoAttestationConformité.tsx
@@ -1,9 +1,9 @@
-import Alert from '@codegouvfr/react-dsfr/Alert';
+import Notice from '@codegouvfr/react-dsfr/Notice';
 
 export const InfoBoxAttestationConformité = () => (
-  <Alert
+  <Notice
     severity="info"
-    small
+    title=""
     description={
       <p className="p-3">
         Vous devez transmettre sur Potentiel la preuve, ainsi que la date de transmission au

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/achevement/attestation-conformite/transmettre/TransmettreAttestationConformité.page.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/achevement/attestation-conformite/transmettre/TransmettreAttestationConformité.page.tsx
@@ -1,4 +1,4 @@
-import Alert from '@codegouvfr/react-dsfr/Alert';
+import Notice from '@codegouvfr/react-dsfr/Notice';
 import type { FC } from 'react';
 
 import { Heading1 } from '@/components/atoms/headings';
@@ -29,9 +29,9 @@ export const TransmettreAttestationConformitéPage: FC<
       children: (
         <>
           <InfoBoxAttestationConformité />
-          <Alert
+          <Notice
             severity="warning"
-            small
+            title=""
             className="mb-4"
             description={
               <p className="p-3">

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/actionnaire/changement/[date]/InfoBoxDemandeEnCours.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/actionnaire/changement/[date]/InfoBoxDemandeEnCours.tsx
@@ -1,4 +1,4 @@
-import Alert from '@codegouvfr/react-dsfr/Alert';
+import Notice from '@codegouvfr/react-dsfr/Notice';
 import type { FC } from 'react';
 
 import { Routes } from '@potentiel-applications/routes';
@@ -14,9 +14,9 @@ export const InfoBoxDemandeEnCours: FC<InfoBoxDemandeEnCoursProps> = ({
   identifiantProjet,
   dateDemandeEnCours,
 }) => (
-  <Alert
+  <Notice
     severity="info"
-    small
+    title=""
     description={
       <div className="p-3">
         Une demande de changement d'actionnaire est en cours,{' '}

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/actionnaire/changement/demander/InfoxBoxDemandeActionnaire.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/actionnaire/changement/demander/InfoxBoxDemandeActionnaire.tsx
@@ -1,10 +1,10 @@
-import Alert from '@codegouvfr/react-dsfr/Alert';
+import Notice from '@codegouvfr/react-dsfr/Notice';
 import type { FC } from 'react';
 
 export const InfoBoxDemandeActionnaire: FC = () => (
-  <Alert
+  <Notice
     severity="info"
-    small
+    title=""
     description={
       <div className="p-3">
         Votre demande de changement d'actionnaire(s) nécessite une instruction si votre projet

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/cahier-des-charges/ChoisirCahierDesCharges.form.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/cahier-des-charges/ChoisirCahierDesCharges.form.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import Alert from '@codegouvfr/react-dsfr/Alert';
+import Notice from '@codegouvfr/react-dsfr/Notice';
 import RadioButtons from '@codegouvfr/react-dsfr/RadioButtons';
 import type React from 'react';
 import { useState } from 'react';
@@ -90,9 +90,9 @@ export const ChoisirCahierDesChargesForm: React.FC<ChoisirCahierDesChargesFormPr
         />
 
         {showAlerteDélaiCdc2022 && (
-          <Alert
+          <Notice
             severity="warning"
-            small
+            title=""
             className="mb-4"
             description={
               <>
@@ -112,7 +112,7 @@ export const ChoisirCahierDesChargesForm: React.FC<ChoisirCahierDesChargesFormPr
 
         <input type={'hidden'} value={identifiantProjet} name="identifiantProjet" />
         {validationErrors['identifiantProjet'] && (
-          <FormAlertError description={validationErrors['identifiantProjet']} />
+          <FormAlertError description={validationErrors['identifiantProjet']} title="" />
         )}
       </div>
     </Form>

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/cahier-des-charges/ChoisirCahierDesCharges.page.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/cahier-des-charges/ChoisirCahierDesCharges.page.tsx
@@ -1,4 +1,4 @@
-import Alert from '@codegouvfr/react-dsfr/Alert';
+import Notice from '@codegouvfr/react-dsfr/Notice';
 
 import { Link } from '@/components/atoms/LinkNoPrefetch';
 import { ColumnPageTemplate } from '@/components/templates/ColumnPage.template';
@@ -14,50 +14,48 @@ export const ChoisirCahierDesChargesPage: React.FC<ChoisirCahierDesChargesPagePr
   cahierDesCharges,
   cahiersDesChargesDisponibles,
   aBénéficiéDuDélaiCDC2022,
-}) => {
-  return (
-    <ColumnPageTemplate
-      leftColumn={{
-        children: (
-          <ChoisirCahierDesChargesForm
-            identifiantProjet={identifiantProjet}
-            cahierDesCharges={cahierDesCharges}
-            cahiersDesChargesDisponibles={cahiersDesChargesDisponibles}
-            aBénéficiéDuDélaiCDC2022={aBénéficiéDuDélaiCDC2022}
-          />
-        ),
-      }}
-      rightColumn={{
-        children: (
-          <div>
-            <Alert
-              severity="info"
-              small
-              description={
-                <div className="py-4 text-justify">
-                  Pour plus d'informations sur les cahiers des charges modificatifs, veuillez
-                  consulter cette&nbsp;
-                  <Link
-                    target="_blank"
-                    href="https://docs.potentiel.beta.gouv.fr/guide-dutilisation/gestion-de-mon-projet-sur-potentiel/cahiers-des-charges-modificatifs"
-                  >
-                    page d'aide
+}) => (
+  <ColumnPageTemplate
+    leftColumn={{
+      children: (
+        <ChoisirCahierDesChargesForm
+          identifiantProjet={identifiantProjet}
+          cahierDesCharges={cahierDesCharges}
+          cahiersDesChargesDisponibles={cahiersDesChargesDisponibles}
+          aBénéficiéDuDélaiCDC2022={aBénéficiéDuDélaiCDC2022}
+        />
+      ),
+    }}
+    rightColumn={{
+      children: (
+        <div>
+          <Notice
+            severity="info"
+            title=""
+            description={
+              <div className="py-4 text-justify">
+                Pour plus d'informations sur les cahiers des charges modificatifs, veuillez
+                consulter cette&nbsp;
+                <Link
+                  target="_blank"
+                  href="https://docs.potentiel.beta.gouv.fr/guide-dutilisation/gestion-de-mon-projet-sur-potentiel/cahiers-des-charges-modificatifs"
+                >
+                  page d'aide
+                </Link>
+                <br />
+                <span className="block mt-3">
+                  Les cahiers des charges disponibles pour votre appel d'offres, sont consultables
+                  sur&nbsp;
+                  <Link target="_blank" href={cahierDesCharges.appelOffre.cahiersDesChargesUrl}>
+                    cette page de la CRE
                   </Link>
-                  <br />
-                  <span className="block mt-3">
-                    Les cahiers des charges disponibles pour votre appel d'offres, sont consultables
-                    sur&nbsp;
-                    <Link target="_blank" href={cahierDesCharges.appelOffre.cahiersDesChargesUrl}>
-                      cette page de la CRE
-                    </Link>
-                    .
-                  </span>
-                </div>
-              }
-            />
-          </div>
-        ),
-      }}
-    />
-  );
-};
+                  .
+                </span>
+              </div>
+            }
+          />
+        </div>
+      ),
+    }}
+  />
+);

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/delai/InfoBoxDemandeDélai.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/delai/InfoBoxDemandeDélai.tsx
@@ -1,10 +1,10 @@
-import Alert from '@codegouvfr/react-dsfr/Alert';
+import Notice from '@codegouvfr/react-dsfr/Notice';
 import type { FC } from 'react';
 
 export const InfoBoxDemandeDélai: FC = () => (
-  <Alert
+  <Notice
     severity="info"
-    small
+    title=""
     description={
       <div className="p-1">
         Cette demande concerne les délais de <span className="font-semibold">force majeure</span>{' '}

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/delai/[date]/corriger/CorrigerDemandeDélai.page.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/delai/[date]/corriger/CorrigerDemandeDélai.page.tsx
@@ -1,4 +1,4 @@
-import Alert from '@codegouvfr/react-dsfr/Alert';
+import Notice from '@codegouvfr/react-dsfr/Notice';
 import type { FC } from 'react';
 
 import { DateTime } from '@potentiel-domain/common';
@@ -22,7 +22,9 @@ export const CorrigerDemandeDélaiPage: FC<CorrigerDemandeDélaiPageProps> = ({
 }) => (
   <>
     <Heading1>Corriger la demande de délai</Heading1>
-    <Alert
+    <Notice
+      severity="info"
+      title=""
       description={
         <div>
           La date d'achèvement prévisionnel actuelle est{' '}
@@ -32,8 +34,6 @@ export const CorrigerDemandeDélaiPage: FC<CorrigerDemandeDélaiPageProps> = ({
           />
         </div>
       }
-      severity="info"
-      small
     />
     <CorrigerDemandeDélaiForm
       identifiantProjet={identifiantProjet}

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/delai/demander/DemanderDélai.page.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/delai/demander/DemanderDélai.page.tsx
@@ -1,4 +1,4 @@
-import Alert from '@codegouvfr/react-dsfr/Alert';
+import Notice from '@codegouvfr/react-dsfr/Notice';
 import type { FC } from 'react';
 
 import { Lauréat } from '@potentiel-domain/projet';
@@ -19,7 +19,9 @@ export const DemanderDélaiPage: FC<DemanderDélaiPageProps> = ({
     heading={
       <>
         <Heading1>Demander un délai</Heading1>
-        <Alert
+        <Notice
+          severity="info"
+          title=""
           description={
             <div>
               La date d'achèvement prévisionnel actuelle est{' '}
@@ -31,8 +33,6 @@ export const DemanderDélaiPage: FC<DemanderDélaiPageProps> = ({
               />
             </div>
           }
-          severity="info"
-          small
         />
       </>
     }

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/fournisseur/changement/AlerteChangementÉvaluationCarbone.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/fournisseur/changement/AlerteChangementÉvaluationCarbone.tsx
@@ -1,4 +1,4 @@
-import Alert from '@codegouvfr/react-dsfr/Alert';
+import Notice from '@codegouvfr/react-dsfr/Notice';
 import type { FC } from 'react';
 
 import type { PlainType } from '@potentiel-domain/core';
@@ -13,10 +13,10 @@ export const AlerteChangementÉvaluationCarbone: FC<AlerteChangementÉvaluationC
   const noteECS = Lauréat.Fournisseur.NoteÉvaluationCarbone.bind(props);
 
   return noteECS.estDégradée() ? (
-    <Alert
+    <Notice
       className="mt-2"
       severity="warning"
-      small
+      title=""
       description={
         <div>
           Si la modification de la valeur de l'évaluation carbone était susceptible d'entrainer une

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/garanties-financieres/depot/modifier/ModifierDépôtGarantiesFinancières.page.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/garanties-financieres/depot/modifier/ModifierDépôtGarantiesFinancières.page.tsx
@@ -1,4 +1,4 @@
-import Alert from '@codegouvfr/react-dsfr/Alert';
+import Notice from '@codegouvfr/react-dsfr/Notice';
 import type { FC } from 'react';
 
 import { Heading1 } from '@/components/atoms/headings';
@@ -40,7 +40,7 @@ export const ModifierDépôtGarantiesFinancièresPage: FC<
       children: (
         <>
           {showWarning ? (
-            <Alert
+            <Notice
               severity="warning"
               className="mb-3"
               title=""

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/garanties-financieres/depot/soumettre/SoumettreDépôtGarantiesFinancières.page.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/garanties-financieres/depot/soumettre/SoumettreDépôtGarantiesFinancières.page.tsx
@@ -1,4 +1,4 @@
-import Alert from '@codegouvfr/react-dsfr/Alert';
+import Notice from '@codegouvfr/react-dsfr/Notice';
 import type { FC } from 'react';
 
 import { Heading1 } from '@/components/atoms/headings';
@@ -29,9 +29,9 @@ export const SoumettreDépôtGarantiesFinancièresPage: FC<
     }}
     rightColumn={{
       children: (
-        <Alert
+        <Notice
           severity="info"
-          small
+          title=""
           description={
             <p className="py-4">
               Une fois les garanties financières déposées dans Potentiel, la DREAL concernée recevra

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/garanties-financieres/mainlevee/demander/ChecklistMainlevée.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/garanties-financieres/mainlevee/demander/ChecklistMainlevée.tsx
@@ -1,5 +1,5 @@
 import { fr } from '@codegouvfr/react-dsfr';
-import Alert from '@codegouvfr/react-dsfr/Alert';
+import Notice from '@codegouvfr/react-dsfr/Notice';
 import ErrorPicto from '@codegouvfr/react-dsfr/picto/Error';
 import SuccessPicto from '@codegouvfr/react-dsfr/picto/Success';
 import clsx from 'clsx';
@@ -54,9 +54,9 @@ export const ChecklistMainlevée: FC<ChecklistMainlevéeProps> = ({
   identifiantProjet,
   prérequis,
 }) => (
-  <Alert
+  <Notice
     severity="info"
-    small
+    title=""
     description={
       <div className="p-3">
         Vous pouvez accéder à la demande de levée de vos garanties bancaires sur Potentiel si votre

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/garanties-financieres/mainlevee/demander/DemanderMainlevée.page.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/garanties-financieres/mainlevee/demander/DemanderMainlevée.page.tsx
@@ -1,4 +1,4 @@
-import Alert from '@codegouvfr/react-dsfr/Alert';
+import Notice from '@codegouvfr/react-dsfr/Notice';
 import Link from 'next/link';
 
 import { Routes } from '@potentiel-applications/routes';
@@ -39,7 +39,7 @@ export const DemanderMainlevéePage = ({
     rightColumn={{
       children:
         prérequisComplétés && motif === 'projet-achevé' ? (
-          <Alert
+          <Notice
             severity="info"
             title="Veuillez vérifier l’exactitude des pièces suivantes, déposées sur Potentiel :"
             description={

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/producteur/modifier/ModifierProducteur.page.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/producteur/modifier/ModifierProducteur.page.tsx
@@ -1,4 +1,4 @@
-import Alert from '@codegouvfr/react-dsfr/Alert';
+import Notice from '@codegouvfr/react-dsfr/Notice';
 import type { FC } from 'react';
 
 import { Heading1 } from '@/components/atoms/headings';
@@ -28,9 +28,9 @@ export const ModifierProducteurPage: FC<ModifierProducteurPageProps> = ({
     }}
     rightColumn={{
       children: (
-        <Alert
+        <Notice
           severity="info"
-          small
+          title=""
           description={
             <>
               <p>

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/puissance/changement/[date]/InfoBoxDemandeEnCours.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/puissance/changement/[date]/InfoBoxDemandeEnCours.tsx
@@ -1,4 +1,4 @@
-import Alert from '@codegouvfr/react-dsfr/Alert';
+import Notice from '@codegouvfr/react-dsfr/Notice';
 import type { FC } from 'react';
 
 import { Routes } from '@potentiel-applications/routes';
@@ -16,9 +16,9 @@ export const InfoBoxDemandeEnCours: FC<Props> = ({
   identifiantProjet,
   dateDemandeEnCours,
 }: Props) => (
-  <Alert
+  <Notice
     severity="info"
-    small
+    title=""
     description={
       <div className="p-3">
         Une demande de changement de puissance est en cours,{' '}

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/puissance/changement/demander/DemanderChangementPuissanceFormErrors.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/puissance/changement/demander/DemanderChangementPuissanceFormErrors.tsx
@@ -1,4 +1,4 @@
-import Alert from '@codegouvfr/react-dsfr/Alert';
+import Notice from '@codegouvfr/react-dsfr/Notice';
 
 import type { Lauréat } from '@potentiel-domain/projet';
 
@@ -18,9 +18,9 @@ export const DemanderChangementPuissanceFormErrors = ({
   return (
     <div>
       {ratioCdcActuel.dépassePuissanceMaxFamille() && (
-        <Alert
-          severity="error"
-          small
+        <Notice
+          severity="alert"
+          title=""
           description={
             <span>
               Les modifications de la puissance installée doivent être strictement inférieures au
@@ -35,9 +35,9 @@ export const DemanderChangementPuissanceFormErrors = ({
       {!ratioCdcActuel.dépassePuissanceMaxDuVolumeRéservé() &&
         !ratioCdcActuel.dépassePuissanceMaxFamille() &&
         ratioCdcActuel.dépasseRatiosChangementPuissance() && (
-          <Alert
+          <Notice
             severity="warning"
-            small
+            title=""
             description={
               <span>
                 Une autorisation est nécessaire si la modification de puissance est inférieure à{' '}
@@ -56,9 +56,9 @@ export const DemanderChangementPuissanceFormErrors = ({
         aChoisiCDC2022 &&
         !ratioCdcActuel.dépasseRatiosChangementPuissance() &&
         fourchetteRatioInitialEtCDC2022AlertMessage && (
-          <Alert
+          <Notice
             severity="warning"
-            small
+            title=""
             description={
               <div>
                 <strong>
@@ -74,9 +74,9 @@ export const DemanderChangementPuissanceFormErrors = ({
           />
         )}
       {ratioCdcActuel.dépassePuissanceMaxDuVolumeRéservé() && (
-        <Alert
-          severity="error"
-          small
+        <Notice
+          severity="alert"
+          title=""
           description={
             <span>
               Votre projet étant dans le volume réservé, les modifications de la puissance installée

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/puissance/changement/demander/InfoxBoxDemandePuissance.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/puissance/changement/demander/InfoxBoxDemandePuissance.tsx
@@ -1,4 +1,4 @@
-import Alert from '@codegouvfr/react-dsfr/Alert';
+import Notice from '@codegouvfr/react-dsfr/Notice';
 import type { FC } from 'react';
 
 type Props = {
@@ -7,9 +7,9 @@ type Props = {
 };
 
 export const InfoBoxDemandePuissance: FC<Props> = ({ min, max }) => (
-  <Alert
+  <Notice
     severity="info"
-    small
+    title=""
     description={
       <div className="p-3">
         Une autorisation est nécessaire si la modification de puissance est inférieure à{' '}

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/representant-legal/changement/[date]/(détails)/InfoBoxDemandeEnCours.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/representant-legal/changement/[date]/(détails)/InfoBoxDemandeEnCours.tsx
@@ -1,4 +1,4 @@
-import Alert from '@codegouvfr/react-dsfr/Alert';
+import Notice from '@codegouvfr/react-dsfr/Notice';
 import type { FC } from 'react';
 
 import { Link } from '@/components/atoms/LinkNoPrefetch';
@@ -6,9 +6,9 @@ import { Link } from '@/components/atoms/LinkNoPrefetch';
 type InfoBoxDemandeEnCourssProps = { lien: string };
 
 export const InfoBoxDemandeEnCours: FC<InfoBoxDemandeEnCourssProps> = ({ lien }) => (
-  <Alert
+  <Notice
     severity="info"
-    small
+    title=""
     description={
       <div className="p-3">
         Une demande de changement de représentant légal est en cours,{' '}

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/site-de-production/modifier/ModifierSiteDeProduction.form.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/site-de-production/modifier/ModifierSiteDeProduction.form.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import Alert from '@codegouvfr/react-dsfr/Alert';
 import Checkbox from '@codegouvfr/react-dsfr/Checkbox';
 import Input from '@codegouvfr/react-dsfr/Input';
+import Notice from '@codegouvfr/react-dsfr/Notice';
 import { type FC, useState } from 'react';
 
 import type { PlainType } from '@potentiel-domain/core';
@@ -152,10 +152,10 @@ export const ModifierSiteDeProductionForm: FC<ModifierSiteDeProductionFormProps>
       </div>
       {nécessiteLaConfirmationPourChangementDeRégion && (
         <>
-          <Alert
-            small
-            className="mt-8"
+          <Notice
             severity="warning"
+            className="mt-8"
+            title=""
             description={
               <p>
                 La gestion de ce projet sera transférée à la région{' '}

--- a/packages/applications/ssr/src/app/reclamer/RéclamerProjetsListItem.tsx
+++ b/packages/applications/ssr/src/app/reclamer/RéclamerProjetsListItem.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import Alert from '@codegouvfr/react-dsfr/Alert';
 import Button from '@codegouvfr/react-dsfr/Button';
 import Input from '@codegouvfr/react-dsfr/Input';
+import Notice from '@codegouvfr/react-dsfr/Notice';
 import Image from 'next/image';
 import { type FC, useState } from 'react';
 
@@ -137,10 +137,10 @@ const RéclamerProjetAvecPrixEtNuméroCREForm: FC<RéclamerProjetFormProps> = ({
           onValidationError: (validationErrors) => setValidationErrors(validationErrors),
           children: (
             <>
-              <Alert
+              <Notice
                 severity="info"
-                small
                 className="my-4 pr-2"
+                title=""
                 description={
                   <div className="flex flex-col gap-2">
                     <p>

--- a/packages/applications/ssr/src/app/reseaux/raccordements/importer/ImporterDatesMiseEnService.page.tsx
+++ b/packages/applications/ssr/src/app/reseaux/raccordements/importer/ImporterDatesMiseEnService.page.tsx
@@ -1,4 +1,4 @@
-import Alert from '@codegouvfr/react-dsfr/Alert';
+import Notice from '@codegouvfr/react-dsfr/Notice';
 import { Table } from '@codegouvfr/react-dsfr/Table';
 import type { FC } from 'react';
 
@@ -29,9 +29,9 @@ export const ImporterDatesMiseEnServicePage: FC<ImporterDatesMiseEnServicePagePr
       }}
       rightColumn={{
         children: (
-          <Alert
+          <Notice
             severity="info"
-            small
+            title=""
             description={
               <div className="py-4 text-justify">
                 <Table

--- a/packages/applications/ssr/src/app/reseaux/raccordements/references:corriger/CorrigerRéférencesDossier.page.tsx
+++ b/packages/applications/ssr/src/app/reseaux/raccordements/references:corriger/CorrigerRéférencesDossier.page.tsx
@@ -1,4 +1,4 @@
-import Alert from '@codegouvfr/react-dsfr/Alert';
+import Notice from '@codegouvfr/react-dsfr/Notice';
 import { Table } from '@codegouvfr/react-dsfr/Table';
 
 import { Heading1 } from '@/components/atoms/headings';
@@ -14,9 +14,9 @@ export const CorrigerRéférencesDossierPage = () => (
       }}
       rightColumn={{
         children: (
-          <Alert
+          <Notice
             severity="info"
-            small
+            title=""
             description={
               <div className="py-4 text-justify">
                 <Table

--- a/packages/applications/ssr/src/app/utilisateurs/inviter/InviterUtilisateur.page.tsx
+++ b/packages/applications/ssr/src/app/utilisateurs/inviter/InviterUtilisateur.page.tsx
@@ -1,4 +1,4 @@
-import Alert from '@codegouvfr/react-dsfr/Alert';
+import Notice from '@codegouvfr/react-dsfr/Notice';
 import type { FC } from 'react';
 
 import { Heading1 } from '@/components/atoms/headings';
@@ -31,9 +31,9 @@ export const InviterUtilisateurPage: FC<InviterUtilisateurPageProps> = ({
       }}
       rightColumn={{
         children: (
-          <Alert
-            small
+          <Notice
             severity="info"
+            title=""
             description="L'invitation d'un porteur de projet se fait depuis la page du projet."
           />
         ),

--- a/packages/applications/ssr/src/components/atoms/form/FormAlertError.tsx
+++ b/packages/applications/ssr/src/components/atoms/form/FormAlertError.tsx
@@ -1,8 +1,11 @@
-import Alert, { type AlertProps } from '@codegouvfr/react-dsfr/Alert';
+import Notice from '@codegouvfr/react-dsfr/Notice';
 import type { FC } from 'react';
 
-type FormAlertErrorProps = Omit<AlertProps.Small, 'small'>;
+type FormAlertErrorProps = {
+  title: string;
+  description: string;
+};
 
 export const FormAlertError: FC<FormAlertErrorProps> = ({ title, description }) => (
-  <Alert small closable severity="error" title={title} description={description} className="mb-4" />
+  <Notice isClosable severity="alert" title={title} description={description} className="mb-4" />
 );

--- a/packages/applications/ssr/src/components/atoms/form/FormFeedback.tsx
+++ b/packages/applications/ssr/src/components/atoms/form/FormFeedback.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Alert from '@codegouvfr/react-dsfr/Alert';
+import Notice from '@codegouvfr/react-dsfr/Notice';
 import type { FC } from 'react';
 import { useFormStatus } from 'react-dom';
 
@@ -46,10 +47,10 @@ export const FormFeedback: FC<FormFeedbackProps> = ({ formState }) => {
               />
             )}
             {errors.length > 0 && (
-              <Alert
-                small
-                closable
+              <Notice
+                isClosable
                 severity="warning"
+                title=""
                 description={
                   <>
                     <p>Certaines opérations ont rencontré les erreurs suivantes :</p>
@@ -72,19 +73,25 @@ export const FormFeedback: FC<FormFeedbackProps> = ({ formState }) => {
 
     case 'rate-limit-error':
     case 'domain-error':
-      return <FormAlertError description={formState.message} />;
+      return <FormAlertError description={formState.message} title="" />;
 
     case 'unknown-error':
-      return <FormAlertError description="Une erreur est survenue" />;
+      return <FormAlertError description="Une erreur est survenue" title="" />;
 
     case 'validation-error':
       return (
-        <FormAlertError description="Erreur lors de la validation des données du formulaire" />
+        <FormAlertError
+          description="Erreur lors de la validation des données du formulaire"
+          title=""
+        />
       );
 
     case 'csrf-error':
       return (
-        <FormAlertError description="L'intégrité des données n'a pas pu être vérifiée. Veuillez recharger la page et réessayer." />
+        <FormAlertError
+          description="L'intégrité des données n'a pas pu être vérifiée. Veuillez recharger la page et réessayer."
+          title=""
+        />
       );
 
     default:

--- a/packages/applications/ssr/src/components/atoms/form/FormFeedbackCsvColumnErrors.tsx
+++ b/packages/applications/ssr/src/components/atoms/form/FormFeedbackCsvColumnErrors.tsx
@@ -1,5 +1,5 @@
 import { fr } from '@codegouvfr/react-dsfr';
-import Alert from '@codegouvfr/react-dsfr/Alert';
+import Notice from '@codegouvfr/react-dsfr/Notice';
 import type { FC } from 'react';
 import { useFormStatus } from 'react-dom';
 
@@ -22,9 +22,8 @@ export const FormFeedbackCsvColumnErrors: FC<FormFeedbackCsvColumnErrorsProps> =
   }
 
   return (
-    <Alert
-      small
-      severity="error"
+    <Notice
+      severity="alert"
       title={
         status === 'csv-missing-column-error'
           ? `Des colonnes essentielles sont manquantes dans le fichier :`

--- a/packages/applications/ssr/src/components/atoms/form/FormFeedbackCsvErrors.tsx
+++ b/packages/applications/ssr/src/components/atoms/form/FormFeedbackCsvErrors.tsx
@@ -1,6 +1,6 @@
 import { fr } from '@codegouvfr/react-dsfr';
 import Accordion from '@codegouvfr/react-dsfr/Accordion';
-import Alert from '@codegouvfr/react-dsfr/Alert';
+import Notice from '@codegouvfr/react-dsfr/Notice';
 import type { FC } from 'react';
 import { useFormStatus } from 'react-dom';
 
@@ -34,9 +34,8 @@ export const FormFeedbackCsvLineErrors: FC<FormFeedbackCsvLineErrorsProps> = ({ 
   );
 
   return (
-    <Alert
-      small
-      severity="error"
+    <Notice
+      severity="alert"
       title={`Le fichier contient les erreurs suivantes :`}
       className="mt-6"
       description={

--- a/packages/applications/ssr/src/components/atoms/menu/DemandeEnCours.page.tsx
+++ b/packages/applications/ssr/src/components/atoms/menu/DemandeEnCours.page.tsx
@@ -1,5 +1,5 @@
-import Alert from '@codegouvfr/react-dsfr/Alert';
 import Button from '@codegouvfr/react-dsfr/Button';
+import Notice from '@codegouvfr/react-dsfr/Notice';
 
 import { Heading2 } from '../headings';
 
@@ -11,7 +11,7 @@ type Props = {
 export const DemandeEnCoursPage = ({ title, href }: Props) => (
   <div className="flex flex-col gap-6 w-full lg:min-h-96">
     <Heading2>Demande en cours</Heading2>
-    <Alert
+    <Notice
       severity="info"
       title={title}
       description="Une demande étant déjà en cours, vous ne pouvez plus faire de demande ou enregistrer une modification. Si cette demande est obsolète, vous pouvez l'annuler."


### PR DESCRIPTION
Il reste deux endroits où Alert est encore utilisé : 
- FormFeedback
- FormSuccessAlert

Je les ai laissé car le [composant Notice dsfr](https://components.react-dsfr.codegouv.studio/?path=/docs/components-notice--default) ne prévoit aucun style pour le cas du succès, et j'ai pas l'impression que ça soit la [volonté du composant ](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/bandeau-d-information-importante) non plus.