### PR TITLE
Modifier la couleur du badge lauréat achevé

### DIFF
--- a/packages/applications/ssr/src/components/molecules/projet/lauréat/StatutLauréatBadge.tsx
+++ b/packages/applications/ssr/src/components/molecules/projet/lauréat/StatutLauréatBadge.tsx
@@ -8,7 +8,7 @@ const convertStatutLauréatToBadgeSeverity: Record<
   StatutLauréatBadgeProps['statut'],
   AlertProps.Severity
 > = {
-  actif: 'success',
+  actif: 'info',
   abandonné: 'warning',
   achevé: 'success',
 };


### PR DESCRIPTION
objectif : différencier les badges actif et achevé