### PR TITLE
🐛 Modifier lauréat : rendre les champs requis vraiment requis

### DIFF
--- a/packages/applications/ssr/src/app/laureats/[identifiant]/(détails)/modifier/ModifierLauréat.form.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/(détails)/modifier/ModifierLauréat.form.tsx
@@ -175,7 +175,7 @@ export const ModifierLauréatForm: React.FC<ModifierLauréatFormProps> = ({
             label="Actionnaire(s)"
             name="sociétéMère"
             validationErrors={validationErrors}
-            required
+            required={candidature.sociétéMère !== ''}
           />
         </FormRow>
         <LocalitéField

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/(détails)/modifier/components/fields/LocalitéField.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/(détails)/modifier/components/fields/LocalitéField.tsx
@@ -43,7 +43,6 @@ export const LocalitéField = ({ candidature, lauréat, validationErrors }: Loca
           label="Adresse 2"
           name="adresse2"
           validationErrors={validationErrors}
-          required
         />
       </FormRow>
     </div>

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/(détails)/modifier/components/fields/generic/ProjectField.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/(détails)/modifier/components/fields/generic/ProjectField.tsx
@@ -57,6 +57,7 @@ export const ProjectField = <T extends string | number | undefined>({
             ...getInputTypeNativeProps(candidature),
             ...nativeInputProps,
             value: candidatureValue,
+            required,
             onChange: (ev) => {
               setCandidatureValue(ev.target.value as T);
               if (linked) {
@@ -83,6 +84,7 @@ export const ProjectField = <T extends string | number | undefined>({
             ...getInputTypeNativeProps(candidature),
             ...nativeInputProps,
             value: lauréatValue,
+            required,
             onChange: (ev) => {
               setLauréatValue(ev.target.value as T);
               if (linked) {


### PR DESCRIPTION
Besoin initial : rendre la suppression de l'actionnaire à la candidature impossible
Puis j'ai remarqué que les champs requis ne l'étaient pas vraiment 