### PR TITLE
Afficher ou non le lien vers le formulaire de modification du gestionnaire selon le contexte et les permissions

### DIFF
--- a/packages/applications/ssr/src/app/laureats/[identifiant]/(détails)/raccordements/(dossier-de-raccordement)/demande-complete-raccordement/transmettre/TransmettreDemandeComplèteRaccordement.form.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/(détails)/raccordements/(dossier-de-raccordement)/demande-complete-raccordement/transmettre/TransmettreDemandeComplèteRaccordement.form.tsx
@@ -26,14 +26,14 @@ export type TransmettreDemandeComplèteRaccordementFormProps = {
   identifiantProjet: PlainType<IdentifiantProjet.RawType>;
   gestionnaireRéseauActuel: GestionnaireRéseauSelectProps['gestionnaireRéseauActuel'];
   listeGestionnairesRéseau: GestionnaireRéseauSelectProps['listeGestionnairesRéseau'];
-  aDéjàTransmisUneDemandeComplèteDeRaccordement: boolean;
+  ajouterLienVersLaModificationDuGestionnaire: boolean;
 };
 
 export const TransmettreDemandeComplèteRaccordementForm = ({
   identifiantProjet,
   gestionnaireRéseauActuel,
   listeGestionnairesRéseau,
-  aDéjàTransmisUneDemandeComplèteDeRaccordement,
+  ajouterLienVersLaModificationDuGestionnaire,
 }: TransmettreDemandeComplèteRaccordementFormProps) => {
   const [validationErrors, setValidationErrors] = useState<
     ValidationErrors<TransmettreDemandeComplèteRaccordementFormKeys>
@@ -70,7 +70,7 @@ export const TransmettreDemandeComplèteRaccordementForm = ({
         <div className="flex flex-col">
           <div className="flex gap-3">
             <legend className="font-bold">Gestionnaire réseau actuel</legend>
-            {aDéjàTransmisUneDemandeComplèteDeRaccordement ? null : (
+            {ajouterLienVersLaModificationDuGestionnaire && (
               <Link
                 href={Routes.Raccordement.modifierGestionnaireDeRéseau(identifiantProjet)}
                 aria-label="Modifier le gestionnaire de réseau"

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/(détails)/raccordements/(dossier-de-raccordement)/demande-complete-raccordement/transmettre/TransmettreDemandeComplèteRaccordement.page.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/(détails)/raccordements/(dossier-de-raccordement)/demande-complete-raccordement/transmettre/TransmettreDemandeComplèteRaccordement.page.tsx
@@ -12,6 +12,7 @@ export type TransmettreDemandeComplèteRaccordementPageProps = {
   gestionnaireRéseauActuel: TransmettreDemandeComplèteRaccordementFormProps['gestionnaireRéseauActuel'];
   identifiantProjet: TransmettreDemandeComplèteRaccordementFormProps['identifiantProjet'];
   aDéjàTransmisUneDemandeComplèteDeRaccordement: boolean;
+  ajouterLienVersLaModificationDuGestionnaire: boolean;
 };
 
 export const TransmettreDemandeComplèteRaccordementPage: FC<
@@ -21,6 +22,7 @@ export const TransmettreDemandeComplèteRaccordementPage: FC<
   gestionnaireRéseauActuel,
   identifiantProjet,
   aDéjàTransmisUneDemandeComplèteDeRaccordement,
+  ajouterLienVersLaModificationDuGestionnaire,
 }) => (
   <SectionPage title="Transmettre une demande complète de raccordement">
     {!aDéjàTransmisUneDemandeComplèteDeRaccordement && (
@@ -30,7 +32,7 @@ export const TransmettreDemandeComplèteRaccordementPage: FC<
       identifiantProjet={identifiantProjet}
       listeGestionnairesRéseau={listeGestionnairesRéseau}
       gestionnaireRéseauActuel={gestionnaireRéseauActuel}
-      aDéjàTransmisUneDemandeComplèteDeRaccordement={aDéjàTransmisUneDemandeComplèteDeRaccordement}
+      ajouterLienVersLaModificationDuGestionnaire={ajouterLienVersLaModificationDuGestionnaire}
     />
   </SectionPage>
 );

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/(détails)/raccordements/(dossier-de-raccordement)/demande-complete-raccordement/transmettre/page.tsx
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/(détails)/raccordements/(dossier-de-raccordement)/demande-complete-raccordement/transmettre/page.tsx
@@ -37,7 +37,7 @@ export default async function Page(props: PageProps) {
         decodeParameter(identifiant),
       ).formatter();
 
-      await getLauréatOrRedirect(identifiantProjet);
+      const lauréat = await getLauréatOrRedirect(identifiantProjet);
 
       const gestionnairesRéseau =
         await mediator.send<GestionnaireRéseau.ListerGestionnaireRéseauQuery>({
@@ -59,6 +59,23 @@ export default async function Page(props: PageProps) {
       const aDéjàTransmisUneDemandeComplèteDeRaccordement =
         Option.isSome(raccordements) && raccordements.dossiers.length > 0;
 
+      const peutModifierLeGestionnaire =
+        (lauréat.statut.estActif() &&
+          utilisateur.rôle.aLaPermission('raccordement.gestionnaire.modifier')) ||
+        (lauréat.statut.estAchevé() &&
+          utilisateur.rôle.aLaPermission('raccordement.gestionnaire.modifier-après-achèvement')) ||
+        (Option.isSome(raccordements) &&
+          !!raccordements.miseEnService &&
+          utilisateur.rôle.aLaPermission(
+            'raccordement.gestionnaire.modifier-après-mise-en-service',
+          ));
+
+      const ajouterLienVersLaModificationDuGestionnaire =
+        peutModifierLeGestionnaire &&
+        Option.isSome(gestionnaireRéseauActuel) &&
+        !gestionnaireRéseauActuel.identifiantGestionnaireRéseau.estInconnu() &&
+        !aDéjàTransmisUneDemandeComplèteDeRaccordement;
+
       return (
         <TransmettreDemandeComplèteRaccordementPage
           aDéjàTransmisUneDemandeComplèteDeRaccordement={
@@ -67,6 +84,7 @@ export default async function Page(props: PageProps) {
           identifiantProjet={mapToPlainObject(identifiantProjet)}
           listeGestionnairesRéseau={mapToPlainObject(gestionnairesRéseau.items)}
           gestionnaireRéseauActuel={mapToPlainObject(gestionnaireRéseauActuel)}
+          ajouterLienVersLaModificationDuGestionnaire={ajouterLienVersLaModificationDuGestionnaire}
         />
       );
     }),

--- a/packages/applications/ssr/src/app/laureats/[identifiant]/(détails)/raccordements/(raccordement-du-projet)/(détails)/_helpers/getGestionnaireRéseauAction.ts
+++ b/packages/applications/ssr/src/app/laureats/[identifiant]/(détails)/raccordements/(raccordement-du-projet)/(détails)/_helpers/getGestionnaireRéseauAction.ts
@@ -49,4 +49,15 @@ export const getGestionnaireRéseauAction = ({
       href: Routes.Raccordement.modifierGestionnaireDeRéseau(identifiantProjet),
     };
   }
+
+  if (
+    estProjetAchevé &&
+    estInconnuGestionnaire &&
+    rôle.aLaPermission('raccordement.gestionnaire.transmettre-après-achèvement')
+  ) {
+    return {
+      label: 'Renseigner',
+      href: Routes.Raccordement.modifierGestionnaireDeRéseau(identifiantProjet),
+    };
+  }
 };

--- a/packages/domain/utilisateur/src/role.valueType.ts
+++ b/packages/domain/utilisateur/src/role.valueType.ts
@@ -1301,6 +1301,7 @@ const policies = {
       ],
       'modifier-après-achèvement': [],
       'modifier-après-mise-en-service': [],
+      'transmettre-après-achèvement': [],
     },
   },
   actionnaire: {
@@ -1705,6 +1706,7 @@ const adminPolicies: ReadonlyArray<Policy> = [
   'raccordement.gestionnaire.modifier',
   'raccordement.gestionnaire.modifier-après-mise-en-service',
   'raccordement.gestionnaire.modifier-après-achèvement',
+  'raccordement.gestionnaire.transmettre-après-achèvement',
   'raccordement.demande-complète-raccordement.transmettre',
   'raccordement.demande-complète-raccordement.modifier',
   'raccordement.demande-complète-raccordement.modifier-après-mise-en-service',
@@ -2149,6 +2151,7 @@ const porteurProjetPolicies: ReadonlyArray<Policy> = [
 
   // Raccordement
   'raccordement.gestionnaire.modifier',
+  'raccordement.gestionnaire.transmettre-après-achèvement',
   'raccordement.demande-complète-raccordement.transmettre',
   'raccordement.demande-complète-raccordement.modifier',
   'raccordement.document-raccordement.transmettre',


### PR DESCRIPTION
- Projet achevé : afficher le lien de transmission pour les porteurs (besoin initial de l'issue)
- Formulaire DCR : afficher le lien vers la modification seulement si elle est permise (actuellement c'est seulement après avoir envoyé le formulaire que le porteur a une erreur, pas top comme expérience utilisateur) 